### PR TITLE
Chaque lien est-il explicite (hors cas particuliers) ?

### DIFF
--- a/app/views/users/dossiers/demande.html.haml
+++ b/app/views/users/dossiers/demande.html.haml
@@ -10,5 +10,5 @@
 
   .container
     - if !@dossier.read_only?
-      = link_to t('views.users.dossiers.demande.edit_dossier'), modifier_dossier_path(@dossier), class: 'button accepted edit-form', 'title'=> "Vous pouvez modifier votre dossier tant qu'il n'est passé en instruction"
+      = link_to t('views.users.dossiers.demande.edit_dossier'), modifier_dossier_path(@dossier), class: 'button accepted edit-form', title: "Modifier mon dossier tant qu'il n'est pas passé en instruction"
       .clearfix

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -269,7 +269,7 @@ fr:
         show:
           header:
             edit_dossier: Modifier mon dossier
-            edit_dossier_title: "Modifier mon dossier - Vous pouvez modifier votre dossier tant qu’il n’est passé en instruction"
+            edit_dossier_title: "Modifier mon dossier - Vous pouvez modifier votre dossier tant qu’il n’est pas passé en instruction"
             summary: "Résumé"
             request: "Demande"
             mailbox: "Messagerie"


### PR DESCRIPTION
Ce changement adresse l'issue #6775

- Objectif : Rendre les liens plus explicite.

- Suggestion : 

`Modifier mon dossier tant qu'il n'est passé en instruction` 
devient ⬇️  : 
`Modifier mon dossier tant qu'il n'est pas passé en instruction`