### PR TITLE
Un bloc repetable optionnel ne doit pas afficher de bloc par défaut #7482 

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -186,6 +186,18 @@
 
   .add-row {
     margin-bottom: $default-fields-spacer;
+    color: #FFFFFF;
+    border-color: $green;
+    background-color: $green;
+
+    &:hover:not(:disabled) {
+      color: $green;
+      background-color: #FFFFFF;
+    }
+
+    span {
+      font-size: 20px;
+    }
   }
 
   input[type=checkbox] {

--- a/app/models/types_de_champ/repetition_type_de_champ.rb
+++ b/app/models/types_de_champ/repetition_type_de_champ.rb
@@ -2,7 +2,7 @@ class TypesDeChamp::RepetitionTypeDeChamp < TypesDeChamp::TypeDeChampBase
   def build_champ(params)
     revision = params[:revision]
     champ = super
-    champ.add_row(revision)
+    champ.add_row(revision) if @type_de_champ.mandatory?
     champ
   end
 

--- a/app/views/shared/dossiers/editable_champs/_repetition.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_repetition.html.haml
@@ -4,5 +4,5 @@
 
 .actions{ 'data-turbo': 'true' }
   = link_to champs_repetition_path(champ.id), data: { turbo_method: :post }, class: 'button add-row' do
-    %span.icon.add
+    %span +
     Ajouter un élément pour « #{champ.libelle} »

--- a/spec/factories/type_de_champ.rb
+++ b/spec/factories/type_de_champ.rb
@@ -163,6 +163,7 @@ FactoryBot.define do
     end
     factory :type_de_champ_repetition do
       type_champ { TypeDeChamp.type_champs.fetch(:repetition) }
+      mandatory { true }
 
       transient do
         types_de_champ { [] }

--- a/spec/models/concern/tags_substitution_concern_spec.rb
+++ b/spec/models/concern/tags_substitution_concern_spec.rb
@@ -178,6 +178,7 @@ describe TagsSubstitutionConcern, type: :model do
         repetition = dossier.champs
           .find { |champ| champ.libelle == 'Répétition' }
         repetition.add_row(dossier.revision)
+        repetition.add_row(dossier.revision)
         paul_champs, pierre_champs = repetition.rows
 
         paul_champs.first.update(value: 'Paul')

--- a/spec/models/dossier_rebase_concern_spec.rb
+++ b/spec/models/dossier_rebase_concern_spec.rb
@@ -364,7 +364,7 @@ describe Dossier do
     context 'with a procedure with a repetition' do
       let!(:procedure) do
         create(:procedure).tap do |p|
-          repetition = p.draft_revision.add_type_de_champ(type_champ: :repetition, libelle: 'p1')
+          repetition = p.draft_revision.add_type_de_champ(type_champ: :repetition, libelle: 'p1', mandatory: true)
           p.draft_revision.add_type_de_champ(type_champ: :text, libelle: 'c1', parent_id: repetition.stable_id)
           p.draft_revision.add_type_de_champ(type_champ: :text, libelle: 'c2', parent_id: repetition.stable_id)
           p.publish!
@@ -377,7 +377,7 @@ describe Dossier do
 
       context 'when a child tdc is added in the middle' do
         before do
-          added_tdc = procedure.draft_revision.add_type_de_champ(type_champ: :text, libelle: 'c3', parent_id: repetition_stable_id)
+          added_tdc = procedure.draft_revision.add_type_de_champ(type_champ: :text, libelle: 'c3', parent_id: repetition_stable_id, mandatory: true)
           procedure.draft_revision.move_type_de_champ(added_tdc.stable_id, 1)
         end
 


### PR DESCRIPTION
Suites aux discussions: 
* le bouton reste en dessous du bloc car c'est quand on a fini de remplir le bloc que l'on a envie d'utiliser le bouton (cf remarque d'Olivier)
* le bouton passe en vert mais on peut facilement le faire revenir à un design bouton secondaire. D'autant que dans cette configuration, l'icone 'plus' ne peut pas etre utilisée du fait de sa couleur noire. 
