### PR TITLE
fix(invitation): don't fail when dossier is hidden & user signed on another account

### DIFF
--- a/spec/controllers/targeted_user_links_controller_spec.rb
+++ b/spec/controllers/targeted_user_links_controller_spec.rb
@@ -102,6 +102,13 @@ describe TargetedUserLinksController, type: :controller do
           expect(response).to redirect_to(root_path)
           expect(flash[:error]).to match(/dossier n'est plus accessible/)
         end
+
+        it 'redirect nicely also when user is signed on another account' do
+          sign_in(create(:expert).user)
+          get :show, params: { id: targeted_user_link.id }
+          expect(response).to redirect_to(root_path)
+          expect(flash[:error]).to match(/dossier n'est plus accessible/)
+        end
       end
     end
 


### PR DESCRIPTION
Suite de 45994ff567ca7d316e7b2b2cd5046e07f63d8c8a qui ne couvrait pas tous les cas d'erreurs

Cf https://sentry.io/organizations/demarches-simplifiees/issues/3422144920/events/e1c83ea74dbc410ea22aa17ef29fb329/?project=1429550


Au reviewer qui me lira : au vu du nombre d'erreurs assez élevé, je me demande s'il n'y a pas un soucis d'UX ou de workflow quelque part car pourquoi un utilisateur qui invite quelqu'un d'autre pour compléter le dossier, le rendrait ensuite invisible avant activation du lien ? (ce qui rend l'invitation invalide)?