### PR TITLE
fix(rna): date_creation may be null

### DIFF
--- a/app/schemas/association.json
+++ b/app/schemas/association.json
@@ -14,8 +14,15 @@
       "type": "string"
     },
     "association_date_creation": {
-      "type": "string",
-      "format": "date"
+      "anyOf": [
+        {
+          "type": "string",
+          "format": "date"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "association_date_declaration": {
       "type": "string",
@@ -229,7 +236,6 @@
   "required": [
     "association_titre",
     "association_rna",
-    "association_date_creation",
     "association_date_declaration",
     "association_date_publication"
   ]

--- a/spec/lib/api_entreprise/rna_adapter_spec.rb
+++ b/spec/lib/api_entreprise/rna_adapter_spec.rb
@@ -29,7 +29,6 @@ describe APIEntreprise::RNAAdapter do
       expect(subject["association_rna"]).to eq('W595001988')
       expect(subject["association_titre"]).to eq('UN SUR QUATRE')
       expect(subject["association_objet"]).to eq("valoriser, transmettre et partager auprès des publics les plus larges possibles, les bienfaits de l'immigration, la richesse de la diversité et la curiosité de l'autre autrement")
-      expect(subject["association_date_creation"]).to eq('2014-01-23')
       expect(subject["association_date_declaration"]).to eq('2014-01-24')
       expect(subject["association_date_publication"]).to eq('2014-02-08')
     end


### PR DESCRIPTION
Closes #7975


A priori les cas où ça peut être null sont déjà gérés dans l'interface et l'API.