### PR TITLE
amelioration(archive.nom-de-fichier): ameliore le nom du fichier d'une archive mensuelle pour eviter les confusion

### DIFF
--- a/app/services/procedure_archive_service.rb
+++ b/app/services/procedure_archive_service.rb
@@ -36,7 +36,12 @@ class ProcedureArchiveService
   private
 
   def zip_root_folder(archive)
-    "procedure-#{@procedure.id}-#{archive.id}"
+    zip_filename = archive.filename(@procedure)
+
+    [
+      File.basename(zip_filename, File.extname(zip_filename)),
+      archive.id
+    ].join("-")
   end
 
   def self.attachments_from_champs_piece_justificative(champs)

--- a/spec/services/procedure_archive_service_spec.rb
+++ b/spec/services/procedure_archive_service_spec.rb
@@ -32,11 +32,11 @@ describe ProcedureArchiveService do
           files = ZipTricks::FileReader.read_zip_structure(io: f)
 
           structure = [
-            "procedure-#{procedure.id}-#{archive.id}/",
-            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/",
-            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/pieces_justificatives/",
-            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/pieces_justificatives/attestation-dossier--05-03-2021-00-00-#{dossier.attestation.pdf.id % 10000}.pdf",
-            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/export-#{dossier.id}-05-03-2021-00-00-#{dossier.id}.pdf"
+            "#{service.send(:zip_root_folder, archive)}/",
+            "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/",
+            "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/pieces_justificatives/",
+            "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/pieces_justificatives/attestation-dossier--05-03-2021-00-00-#{dossier.attestation.pdf.id % 10000}.pdf",
+            "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/export-#{dossier.id}-05-03-2021-00-00-#{dossier.id}.pdf"
           ]
           expect(files.map(&:filename)).to match_array(structure)
         end
@@ -52,11 +52,11 @@ describe ProcedureArchiveService do
         archive.file.open do |f|
           files = ZipTricks::FileReader.read_zip_structure(io: f)
           structure = [
-            "procedure-#{procedure.id}-#{archive.id}/",
-            "procedure-#{procedure.id}-#{archive.id}/-LISTE-DES-FICHIERS-EN-ERREURS.txt",
-            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/",
-            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/pieces_justificatives/",
-            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/export-#{dossier.id}-05-03-2021-00-00-#{dossier.id}.pdf"
+            "#{service.send(:zip_root_folder, archive)}/",
+            "#{service.send(:zip_root_folder, archive)}/-LISTE-DES-FICHIERS-EN-ERREURS.txt",
+            "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/",
+            "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/pieces_justificatives/",
+            "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/export-#{dossier.id}-05-03-2021-00-00-#{dossier.id}.pdf"
           ]
           expect(files.map(&:filename)).to match_array(structure)
         end
@@ -99,16 +99,16 @@ describe ProcedureArchiveService do
           archive.file.open do |f|
             zip_entries = ZipTricks::FileReader.read_zip_structure(io: f)
             structure = [
-              "procedure-#{procedure.id}-#{archive.id}/",
-              "procedure-#{procedure.id}-#{archive.id}/-LISTE-DES-FICHIERS-EN-ERREURS.txt",
-              "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/",
-              "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/export-dossier-05-03-2020-00-00-1.pdf",
-              "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/pieces_justificatives/",
-              "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/export-#{dossier.id}-05-03-2021-00-00-#{dossier.id}.pdf"
+              "#{service.send(:zip_root_folder, archive)}/",
+              "#{service.send(:zip_root_folder, archive)}/-LISTE-DES-FICHIERS-EN-ERREURS.txt",
+              "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/",
+              "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/export-dossier-05-03-2020-00-00-1.pdf",
+              "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/pieces_justificatives/",
+              "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/export-#{dossier.id}-05-03-2021-00-00-#{dossier.id}.pdf"
             ]
             expect(zip_entries.map(&:filename)).to match_array(structure)
             zip_entries.map do |entry|
-              next unless entry.filename == "procedure-#{procedure.id}-#{archive.id}/-LISTE-DES-FICHIERS-EN-ERREURS.txt"
+              next unless entry.filename == "#{service.send(:zip_root_folder, archive)}/-LISTE-DES-FICHIERS-EN-ERREURS.txt"
               extracted_content = ""
               extractor = entry.extractor_from(f)
               extracted_content << extractor.extract(1024 * 1024) until extractor.eof?
@@ -133,15 +133,15 @@ describe ProcedureArchiveService do
         archive.file.open do |f|
           files = ZipTricks::FileReader.read_zip_structure(io: f)
           structure = [
-            "procedure-#{procedure.id}-#{archive.id}/",
-            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/",
-            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/pieces_justificatives/",
-            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/pieces_justificatives/attestation-dossier--05-03-2020-00-00-#{dossier.attestation.pdf.id % 10000}.pdf",
-            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/export-#{dossier.id}-05-03-2020-00-00-#{dossier.id}.pdf",
-            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier_2020.id}/",
-            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier_2020.id}/export-#{dossier_2020.id}-05-03-2020-00-00-#{dossier_2020.id}.pdf",
-            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier_2020.id}/pieces_justificatives/",
-            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier_2020.id}/pieces_justificatives/attestation-dossier--05-03-2020-00-00-#{dossier_2020.attestation.pdf.id % 10000}.pdf"
+            "#{service.send(:zip_root_folder, archive)}/",
+            "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/",
+            "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/pieces_justificatives/",
+            "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/pieces_justificatives/attestation-dossier--05-03-2020-00-00-#{dossier.attestation.pdf.id % 10000}.pdf",
+            "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/export-#{dossier.id}-05-03-2020-00-00-#{dossier.id}.pdf",
+            "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier_2020.id}/",
+            "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier_2020.id}/export-#{dossier_2020.id}-05-03-2020-00-00-#{dossier_2020.id}.pdf",
+            "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier_2020.id}/pieces_justificatives/",
+            "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier_2020.id}/pieces_justificatives/attestation-dossier--05-03-2020-00-00-#{dossier_2020.attestation.pdf.id % 10000}.pdf"
           ]
           expect(files.map(&:filename)).to match_array(structure)
         end


### PR DESCRIPTION
# contexte : ETQ admin, j'ai l'impression que le téléchargement de mes archives est coupé avant la fin

# solution
ETQ mfo, j'ai essayé de faire du controle qualité. Lorsque je télécharge plusieurs archives (ex: 12) d'une démarche, le nom des fichiers une fois extrait est sous la forme procedure-{procedure_id}-{archive-id}. C'est confusant pour se retrouver de quelle archive correspond a quelle mois. J'ai l'impression que c'est la confusion faite sur ce ticket helpscout : 
https://secure.helpscout.net/conversation/2042765255/1994063