### PR TITLE
Remove categories_type_de_champ feature flag

### DIFF
--- a/app/components/types_de_champ_editor/champ_component.rb
+++ b/app/components/types_de_champ_editor/champ_component.rb
@@ -56,32 +56,22 @@ class TypesDeChampEditor::ChampComponent < ApplicationComponent
   end
 
   def types_of_type_de_champ
-    if feature_enabled?(:categories_type_de_champ)
-      cat_scope = "activerecord.attributes.type_de_champ.categorie"
-      tdc_scope = "activerecord.attributes.type_de_champ.type_champs"
+    cat_scope = "activerecord.attributes.type_de_champ.categorie"
+    tdc_scope = "activerecord.attributes.type_de_champ.type_champs"
 
-      TypeDeChamp.type_champs
-        .keys
-        .filter(&method(:filter_type_champ))
-        .filter(&method(:filter_featured_type_champ))
-        .filter(&method(:filter_block_type_champ))
-        .group_by { TypeDeChamp::TYPE_DE_CHAMP_TO_CATEGORIE.fetch(_1.to_sym) }
-        .sort_by { |k, _v| TypeDeChamp::CATEGORIES.find_index(k) }
-        .to_h do |cat, tdc|
-          [
-            t(cat, scope: cat_scope),
-            tdc.map { [t(_1, scope: tdc_scope), _1] }
-          ]
-        end
-    else
-      TypeDeChamp.type_champs
-        .keys
-        .filter(&method(:filter_type_champ))
-        .filter(&method(:filter_featured_type_champ))
-        .filter(&method(:filter_block_type_champ))
-        .map { |type_champ| [t("activerecord.attributes.type_de_champ.type_champs.#{type_champ}"), type_champ] }
-        .sort_by(&:first)
-    end
+    TypeDeChamp.type_champs
+      .keys
+      .filter(&method(:filter_type_champ))
+      .filter(&method(:filter_featured_type_champ))
+      .filter(&method(:filter_block_type_champ))
+      .group_by { TypeDeChamp::TYPE_DE_CHAMP_TO_CATEGORIE.fetch(_1.to_sym) }
+      .sort_by { |k, _v| TypeDeChamp::CATEGORIES.find_index(k) }
+      .to_h do |cat, tdc|
+        [
+          t(cat, scope: cat_scope),
+          tdc.map { [t(_1, scope: tdc_scope), _1] }
+        ]
+      end
   end
 
   def piece_justificative_options(form)

--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
@@ -19,10 +19,7 @@
               %span.sr-only  Déplacer le champ vers le bas
           .cell.flex.justify-start.column.flex-grow
             = form.label :type_champ, "Type de champ", for: dom_id(type_de_champ, :type_champ)
-            - if feature_enabled?(:categories_type_de_champ)
-              = form.select :type_champ, grouped_options_for_select(types_of_type_de_champ, type_de_champ.type_champ), {}, class: 'small-margin small inline width-100', id: dom_id(type_de_champ, :type_champ)
-            - else
-              = form.select :type_champ, types_of_type_de_champ, {}, class: 'small-margin small inline width-100', id: dom_id(type_de_champ, :type_champ)
+            = form.select :type_champ, grouped_options_for_select(types_of_type_de_champ, type_de_champ.type_champ), {}, class: 'small-margin small inline width-100', id: dom_id(type_de_champ, :type_champ)
         .flex.column.justify-start.flex-grow
           .cell
             .flex.align-center

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -21,7 +21,6 @@ end
 features = [
   :administrateur_web_hook,
   :api_particulier,
-  :categories_type_de_champ,
   :dossier_pdf_vide,
   :expert_not_allowed_to_invite,
   :hide_instructeur_email,

--- a/spec/system/administrateurs/procedure_creation_spec.rb
+++ b/spec/system/administrateurs/procedure_creation_spec.rb
@@ -38,6 +38,7 @@ describe 'Creating a new procedure', js: true do
       fill_in 'Libellé du champ', with: 'libelle de champ'
       blur
       expect(page).to have_content('Formulaire enregistré')
+      expect(page).to have_selector('select > optgroup', count: 7)
 
       add_champ
       expect(page).to have_selector('.type-de-champ', count: 1)
@@ -67,21 +68,6 @@ describe 'Creating a new procedure', js: true do
       champs_card = find('.fr-tile', text: 'Champs du formulaire')
       expect(champs_card).to have_selector('.icon.refuse')
       expect(champs_card).to have_content('À modifier')
-    end
-  end
-
-  context 'with feature activated' do
-    let(:procedure) { create(:procedure, :with_service, administrateur: administrateur) }
-    before { Flipper.enable(:categories_type_de_champ, administrateur.user) }
-    after { Flipper.disable(:categories_type_de_champ, administrateur.user) }
-
-    it 'types de champ are grouped by categories ' do
-      visit champs_admin_procedure_path(procedure)
-
-      add_champ(remove_flash_message: true)
-      select('Bloc répétable', from: 'Type de champ')
-
-      expect(page).to have_selector('select > optgroup', count: 7)
     end
   end
 end


### PR DESCRIPTION
Cette PR enlève le feature flag sur les catégories de types de champ.
La feature était déjà activée pour tout le monde en production, donc il n'y a pas de changement de comportement  