### PR TITLE
Us/cleanup ops account

### DIFF
--- a/app/controllers/manager/team_accounts_controller.rb
+++ b/app/controllers/manager/team_accounts_controller.rb
@@ -1,0 +1,18 @@
+module Manager
+  class TeamAccountsController < Manager::ApplicationController
+    def index
+      @records_per_page = params[:records_per_page] || "10"
+      resources = User.marked_as_team_account
+        .order(created_at: :asc)
+        .page(params[:_page])
+        .per(@records_per_page)
+      page = Administrate::Page::Collection.new(dashboard)
+
+      render locals: {
+        resources: resources,
+        page: page,
+        show_search_bar: false
+      }
+    end
+  end
+end

--- a/app/dashboards/team_account_dashboard.rb
+++ b/app/dashboards/team_account_dashboard.rb
@@ -1,0 +1,60 @@
+require "administrate/base_dashboard"
+
+class TeamAccountDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    email: Field::String,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+    current_sign_in_at: Field::DateTime,
+    last_sign_in_at: Field::DateTime,
+    dossiers: Field::HasMany,
+    procedures: Field::HasMany,
+    administrateur: Field::HasOne,
+    instructeur: Field::HasOne
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = [
+    :email,
+    :administrateur,
+    :instructeur,
+    :last_sign_in_at,
+    :current_sign_in_at
+
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = [
+    :dossiers,
+    :procedures,
+    :id,
+    :email,
+    :current_sign_in_at,
+    :last_sign_in_at,
+    :created_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = [].freeze
+
+  # Overwrite this method to customize how users are displayed
+  # across all pages of the admin dashboard.
+  #
+  def display_resource(user)
+    user.email
+  end
+end

--- a/app/dashboards/team_account_dashboard.rb
+++ b/app/dashboards/team_account_dashboard.rb
@@ -31,7 +31,6 @@ class TeamAccountDashboard < Administrate::BaseDashboard
     :instructeur,
     :last_sign_in_at,
     :current_sign_in_at
-
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES

--- a/app/models/team_account.rb
+++ b/app/models/team_account.rb
@@ -1,0 +1,4 @@
+class TeamAccount
+  extend ActiveModel::Naming
+  extend ActiveModel::Translation
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,7 @@
 #  reset_password_token         :string
 #  sign_in_count                :integer          default(0), not null
 #  siret                        :string
+#  team_account                 :boolean          default(FALSE)
 #  unconfirmed_email            :text
 #  unlock_token                 :string
 #  created_at                   :datetime
@@ -61,7 +62,7 @@ class User < ApplicationRecord
   accepts_nested_attributes_for :france_connect_information
 
   default_scope { eager_load(:instructeur, :administrateur, :expert) }
-
+  scope :marked_as_team_account, -> { where('email ilike ?', "%@beta.gouv.fr") }
   before_validation -> { sanitize_email(:email) }
 
   validate :does_not_merge_on_self, if: :requested_merge_into_id_changed?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,8 @@ Rails.application.routes.draw do
 
     resources :zones, only: [:index, :show]
 
+    resources :team_accounts, only: [:index, :show]
+
     resources :dubious_procedures, only: [:index]
     resources :outdated_procedures, only: [:index] do
       patch :bulk_update, on: :collection

--- a/db/migrate/20221104071959_add_team_account_to_users.rb
+++ b/db/migrate/20221104071959_add_team_account_to_users.rb
@@ -1,0 +1,6 @@
+class AddTeamAccountToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :team_account, :boolean
+    change_column_default :users, :team_account, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_20_094031) do
+ActiveRecord::Schema.define(version: 2022_11_04_071959) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -770,6 +770,7 @@ ActiveRecord::Schema.define(version: 2022_10_20_094031) do
     t.integer "sign_in_count", default: 0, null: false
     t.string "unlock_token"
     t.datetime "updated_at"
+    t.boolean "team_account", default: false
     t.index ["email"], name: "index_super_admins_on_email", unique: true
     t.index ["reset_password_token"], name: "index_super_admins_on_reset_password_token", unique: true
     t.index ["unlock_token"], name: "index_super_admins_on_unlock_token", unique: true

--- a/lib/tasks/deployment/20221104122104_backfill_users_team_account.rake
+++ b/lib/tasks/deployment/20221104122104_backfill_users_team_account.rake
@@ -1,0 +1,13 @@
+namespace :after_party do
+  desc 'Deployment task: backfill_users_team_account'
+  task backfill_users_team_account: :environment do
+    User.marked_as_team_account.joins(:administrateur).in_batches do |batch|
+      batch.update_all(team_account: true)
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
#8000 

autre tentative pour identifier les comptes administrateur historique sur la plateforme afin de faire du nettoyage manuel

on marque tous les comptes beta.gouv.fr avec un admin. de la on pourra naviguer et netoyer les liaisons d'admin

<img width="1424" alt="Screen Shot 2022-11-04 at 10 40 18 AM" src="https://user-images.githubusercontent.com/125964/199941933-3c4ebee2-d32f-4f9e-a34a-e54d608bf2e3.png">
