### PR TITLE
ETQ admin, je peux supprimer le filtre statut de la liste de toutes les démarches

### DIFF
--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -331,16 +331,7 @@ module Administrateurs
     end
 
     def all
-      @admin_zones = current_administrateur.zones
-      @other_zones = Zone.all - @admin_zones
-      @zone_ids = params[:zone_ids].filter(&:present?) if params[:zone_ids]
-      @selected_zones = @zone_ids.map { |id| Zone.find(id) } if @zone_ids.present?
-      @statuses = params[:statuses].filter(&:present?) if params[:statuses]
-
-      @procedures = Procedure.joins(:procedures_zones).publiees_ou_closes
-      @procedures = @procedures.where(procedures_zones: { zone_id: @zone_ids }) if @zone_ids.present?
-      @procedures = @procedures.where(aasm_state: @statuses) if @statuses.present?
-      @procedures = @procedures.page(params[:page]).per(ITEMS_PER_PAGE).order(published_at: :desc)
+      @filter = ProceduresFilter.new(current_administrateur, params)
     end
 
     private

--- a/app/models/procedures_filter.rb
+++ b/app/models/procedures_filter.rb
@@ -1,0 +1,51 @@
+class ProceduresFilter
+  attr_reader :admin, :params
+
+  ITEMS_PER_PAGE = 25
+
+  def initialize(admin, params)
+    @admin = admin
+    @params = params.permit(zone_ids: [], statuses: [])
+  end
+
+  def admin_zones
+    @admin_zones ||= admin.zones
+  end
+
+  def other_zones
+    @other_zones ||= Zone.all - admin_zones
+  end
+
+  def zone_ids
+    params[:zone_ids].compact_blank if params[:zone_ids].present?
+  end
+
+  def selected_zones
+    Zone.where(id: zone_ids) if zone_ids.present?
+  end
+
+  def statuses
+    params[:statuses].compact_blank if params[:statuses].present?
+  end
+
+  def zone_filtered?(zone_id)
+    zone_ids&.map(&:to_i)&.include?(zone_id)
+  end
+
+  def status_filtered?(status)
+    statuses&.include?(status)
+  end
+
+  def without(filter, value)
+    new_filter = params.to_h[filter] - [value.to_s]
+    params.to_h.merge(filter => new_filter)
+  end
+
+  def procedures_result
+    return @procedures_result if @procedures_result
+    @procedures_result = Procedure.joins(:procedures_zones).publiees_ou_closes
+    @procedures_result = @procedures_result.where(procedures_zones: { zone_id: zone_ids }) if zone_ids.present?
+    @procedures_result = @procedures_result.where(aasm_state: statuses) if statuses.present?
+    @procedures_result = @procedures_result.page(params[:page]).per(ITEMS_PER_PAGE).order(published_at: :desc)
+  end
+end

--- a/app/views/administrateurs/procedures/all.html.haml
+++ b/app/views/administrateurs/procedures/all.html.haml
@@ -28,9 +28,9 @@
                     %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
                     Mes zones
                 .fr-ml-1w{ 'data-expand-target': 'content' }
-                  = f.collection_check_boxes :zone_ids, @admin_zones, :id, :current_label, include_hidden: false do |b|
+                  = f.collection_check_boxes :zone_ids, @filter.admin_zones, :id, :current_label, include_hidden: false do |b|
                     .fr-checkbox-group.fr-ml-2w
-                      = b.check_box(checked: @zone_ids&.map(&:to_i)&.include?(b.value), 'data-action': 'autosubmit#submit')
+                      = b.check_box(checked: @filter.zone_filtered?(b.value), 'data-action': 'autosubmit#submit')
                       = b.label(class: 'fr-label') { b.text }
               %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
                 .fr-mb-1w
@@ -38,35 +38,36 @@
                     %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
                     Autres zones
                 .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
-                  = f.collection_check_boxes :zone_ids, @other_zones, :id, :current_label, include_hidden: false do |b|
+                  = f.collection_check_boxes :zone_ids, @filter.other_zones, :id, :current_label, include_hidden: false do |b|
                     .fr-checkbox-group.fr-ml-2w
-                      = b.check_box(checked: @zone_ids&.map(&:to_i)&.include?(b.value), 'data-action': 'autosubmit#submit')
+                      = b.check_box(checked: @filter.zone_filtered?(b.value), 'data-action': 'autosubmit#submit')
                       = b.label(class: 'fr-label') { b.text }
               %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
+                .fr-mb-1w
                   %button{ 'data-action': 'expand#toggle' }
                     %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
                     Statut
                 .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
                   = f.collection_check_boxes :statuses, ['publiee', 'close'], :to_s, :to_s, include_hidden: false do |b|
                     .fr-checkbox-group.fr-ml-2w
-                      = b.check_box(checked: @statuses&.include?(b.value), 'data-action': 'autosubmit#submit')
+                      = b.check_box(checked: @filter.status_filtered?(b.value), 'data-action': 'autosubmit#submit')
                       = b.label(class: 'fr-label') { t b.text, scope: 'activerecord.attributes.procedure.aasm_state' }
 
       .fr-col-9
         .fr-table.fr-table--bordered
           %table#all-demarches
             %caption
-              = "#{@procedures.total_count} démarches"
+              = "#{@filter.procedures_result.total_count} démarches"
               %span.hidden.fr-icon-ball-pen-fill{ 'aria-hidden': 'true', 'data-autosubmit-target': 'spinner' }
-            - if @selected_zones
+            - if @filter.selected_zones.present?
               .selected-zones.fr-mb-2w
-                - @selected_zones.each do |zone|
-                  = link_to zone.current_label, all_admin_procedures_path(zone_ids: @selected_zones.map(&:id) - [zone.id]), class: 'fr-tag fr-tag--dismiss fr-mb-1w'
-            - if @statuses
+                - @filter.selected_zones.each do |zone|
+                  = link_to zone.current_label, all_admin_procedures_path(@filter.without(:zone_ids, zone.id)), class: 'fr-tag fr-tag--dismiss fr-mb-1w'
+            - if @filter.statuses.present?
               .selected-statuses.fr-mb-2w
-                - @statuses.each do |status|
+                - @filter.statuses.each do |status|
                   %p.fr-tag.fr-mb-1w.fr--background-alt-blue-france= status
-            = paginate @procedures, views_prefix: 'administrateurs'
+            = paginate @filter.procedures_result, views_prefix: 'administrateurs'
             %thead
               %tr
                 %th{ scope: 'col' }
@@ -75,7 +76,7 @@
                 %th{ scope: 'col' } Administrateurs
                 %th{ scope: 'col' } Statut
                 %th{ scope: 'col' } Date
-            - @procedures.each do |procedure|
+            - @filter.procedures_result.each do |procedure|
               %tbody{ 'data-controller': 'expand' }
                 %tr.procedure{ 'data-action': 'click->expand#toggle' }
                   %td
@@ -95,4 +96,4 @@
                         .fr-col-6
                           - procedure.administrateurs.uniq.each do |admin|
                             = admin.email
-          .fr-mt-2w= paginate @procedures, views_prefix: 'administrateurs'
+          .fr-mt-2w= paginate @filter.procedures_result, views_prefix: 'administrateurs'

--- a/app/views/administrateurs/procedures/all.html.haml
+++ b/app/views/administrateurs/procedures/all.html.haml
@@ -23,8 +23,8 @@
                   %span.fr-icon-arrow-go-back-line Réinitialiser
             %ul
               %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
-                .fr-mb-1w{ 'data-action': 'click->expand#toggle' }
-                  %button
+                .fr-mb-1w
+                  %button{ 'data-action': 'expand#toggle' }
                     %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
                     Mes zones
                 .fr-ml-1w{ 'data-expand-target': 'content' }
@@ -33,8 +33,8 @@
                       = b.check_box(checked: @zone_ids&.map(&:to_i)&.include?(b.value), 'data-action': 'autosubmit#submit')
                       = b.label(class: 'fr-label') { b.text }
               %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
-                .fr-mb-1w{ 'data-action': 'click->expand#toggle' }
-                  %button
+                .fr-mb-1w
+                  %button{ 'data-action': 'expand#toggle' }
                     %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
                     Autres zones
                 .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
@@ -43,8 +43,7 @@
                       = b.check_box(checked: @zone_ids&.map(&:to_i)&.include?(b.value), 'data-action': 'autosubmit#submit')
                       = b.label(class: 'fr-label') { b.text }
               %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
-                .fr-mb-1w{ 'data-action': 'click->expand#toggle' }
-                  %button
+                  %button{ 'data-action': 'expand#toggle' }
                     %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
                     Statut
                 .fr-ml-1w.hidden{ 'data-expand-target': 'content' }

--- a/app/views/administrateurs/procedures/all.html.haml
+++ b/app/views/administrateurs/procedures/all.html.haml
@@ -66,7 +66,7 @@
             - if @filter.statuses.present?
               .selected-statuses.fr-mb-2w
                 - @filter.statuses.each do |status|
-                  %p.fr-tag.fr-mb-1w.fr--background-alt-blue-france= status
+                  = link_to status, all_admin_procedures_path(@filter.without(:statuses, status)), class: 'fr-tag fr-tag--dismiss fr-mb-1w'
             = paginate @filter.procedures_result, views_prefix: 'administrateurs'
             %thead
               %tr

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -97,13 +97,13 @@ describe Administrateurs::ProceduresController, type: :controller do
 
     it 'display published or closed procedures' do
       subject
-      expect(assigns(:procedures)).to include(published_procedure)
-      expect(assigns(:procedures)).to include(closed_procedure)
+      expect(assigns(:filter).procedures_result).to include(published_procedure)
+      expect(assigns(:filter).procedures_result).to include(closed_procedure)
     end
 
     it 'doesn’t display draft procedures' do
       subject
-      expect(assigns(:procedures)).not_to include(draft_procedure)
+      expect(assigns(:filter).procedures_result).not_to include(draft_procedure)
     end
 
     context "for specific zones" do
@@ -116,8 +116,8 @@ describe Administrateurs::ProceduresController, type: :controller do
 
       it 'display only procedures for specified zones' do
         subject
-        expect(assigns(:procedures)).to include(procedure2)
-        expect(assigns(:procedures)).not_to include(procedure1)
+        expect(assigns(:filter).procedures_result).to include(procedure2)
+        expect(assigns(:filter).procedures_result).not_to include(procedure1)
       end
     end
 
@@ -127,14 +127,14 @@ describe Administrateurs::ProceduresController, type: :controller do
 
       it 'display only published procedures' do
         get :all, params: { statuses: ['publiee'] }
-        expect(assigns(:procedures)).to include(procedure1)
-        expect(assigns(:procedures)).not_to include(procedure2)
+        expect(assigns(:filter).procedures_result).to include(procedure1)
+        expect(assigns(:filter).procedures_result).not_to include(procedure2)
       end
 
       it 'display only closed procedures' do
         get :all, params: { statuses: ['close'] }
-        expect(assigns(:procedures)).to include(procedure2)
-        expect(assigns(:procedures)).not_to include(procedure1)
+        expect(assigns(:filter).procedures_result).to include(procedure2)
+        expect(assigns(:filter).procedures_result).not_to include(procedure1)
       end
     end
   end


### PR DESCRIPTION
Cette PR 
- permet à un administrateur de supprimer le filtre statut de la liste de toutes les démarches
- améliore l'accessibiltié de la page qui liste toutes les démarches
- extrait la classe ProceduresFilter du controller ProceduresController