### PR TITLE
En tant qu'admin, je peux filtrer la liste de toutes les démarches par date de publication

### DIFF
--- a/app/javascript/controllers/autosubmit_controller.ts
+++ b/app/javascript/controllers/autosubmit_controller.ts
@@ -1,5 +1,6 @@
 import { ApplicationController } from './application_controller';
 import { toggle } from '@utils';
+const AUTOSUBMIT_DEBOUNCE_DELAY = 5000;
 
 export class AutosubmitController extends ApplicationController {
   static targets = ['form', 'spinner'];
@@ -10,6 +11,11 @@ export class AutosubmitController extends ApplicationController {
   submit() {
     this.formTarget.requestSubmit();
   }
+
+  debouncedSubmit() {
+    this.debounce(this.submit, AUTOSUBMIT_DEBOUNCE_DELAY);
+  }
+
   connect() {
     this.onGlobal('turbo:submit-start', () => {
       toggle(this.spinnerTarget);

--- a/app/models/procedures_filter.rb
+++ b/app/models/procedures_filter.rb
@@ -5,7 +5,7 @@ class ProceduresFilter
 
   def initialize(admin, params)
     @admin = admin
-    @params = params.permit(zone_ids: [], statuses: [])
+    @params = params.permit(:from_publication_date, zone_ids: [], statuses: [])
   end
 
   def admin_zones
@@ -28,6 +28,14 @@ class ProceduresFilter
     params[:statuses].compact_blank if params[:statuses].present?
   end
 
+  def from_publication_date
+    return if params[:from_publication_date].blank?
+
+    Date.parse(params[:from_publication_date])
+  rescue Date::Error
+    nil
+  end
+
   def zone_filtered?(zone_id)
     zone_ids&.map(&:to_i)&.include?(zone_id)
   end
@@ -36,9 +44,13 @@ class ProceduresFilter
     statuses&.include?(status)
   end
 
-  def without(filter, value)
-    new_filter = params.to_h[filter] - [value.to_s]
-    params.to_h.merge(filter => new_filter)
+  def without(filter, value = nil)
+    if value.nil?
+      params.to_h.except(filter)
+    else
+      new_filter = params.to_h[filter] - [value.to_s]
+      params.to_h.merge(filter => new_filter)
+    end
   end
 
   def procedures_result
@@ -46,6 +58,7 @@ class ProceduresFilter
     @procedures_result = Procedure.joins(:procedures_zones).publiees_ou_closes
     @procedures_result = @procedures_result.where(procedures_zones: { zone_id: zone_ids }) if zone_ids.present?
     @procedures_result = @procedures_result.where(aasm_state: statuses) if statuses.present?
+    @procedures_result = @procedures_result.where('published_at >= ?', from_publication_date) if from_publication_date.present?
     @procedures_result = @procedures_result.page(params[:page]).per(ITEMS_PER_PAGE).order(published_at: :desc)
   end
 end

--- a/app/models/procedures_filter.rb
+++ b/app/models/procedures_filter.rb
@@ -5,7 +5,7 @@ class ProceduresFilter
 
   def initialize(admin, params)
     @admin = admin
-    @params = params.permit(:from_publication_date, zone_ids: [], statuses: [])
+    @params = params.permit(:page, :from_publication_date, zone_ids: [], statuses: [])
   end
 
   def admin_zones

--- a/app/views/administrateurs/procedures/all.html.haml
+++ b/app/views/administrateurs/procedures/all.html.haml
@@ -50,7 +50,7 @@
                 .fr-input-group.hidden{ 'data-expand-target': 'content' }
                   = f.label 'from_publication_date', 'Depuis', class: 'fr-label'
                   .fr-input-wrap.fr-fi-calendar-line
-                    = f.date_field 'from_publication_date', value: @filter.from_publication_date, class: 'fr-input', 'data-action': 'blur->autosubmit#submit'
+                    = f.date_field 'from_publication_date', value: @filter.from_publication_date, class: 'fr-input', 'data-action': 'blur->autosubmit#submit change->autosubmit#debouncedSubmit'
 
               %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
                 .fr-mb-1w

--- a/app/views/administrateurs/procedures/all.html.haml
+++ b/app/views/administrateurs/procedures/all.html.haml
@@ -42,6 +42,16 @@
                     .fr-checkbox-group.fr-ml-2w
                       = b.check_box(checked: @filter.zone_filtered?(b.value), 'data-action': 'autosubmit#submit')
                       = b.label(class: 'fr-label') { b.text }
+              %li.fr-py-2w{ 'data-controller': "expand" }
+                .fr-mb-1w.fr-pl-2w
+                  %button{ 'data-action': 'click->expand#toggle' }
+                    %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
+                    Date de publication
+                .fr-input-group.hidden{ 'data-expand-target': 'content' }
+                  = f.label 'from_publication_date', 'Depuis', class: 'fr-label'
+                  .fr-input-wrap.fr-fi-calendar-line
+                    = f.date_field 'from_publication_date', value: @filter.from_publication_date, class: 'fr-input', 'data-action': 'blur->autosubmit#submit'
+
               %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
                 .fr-mb-1w
                   %button{ 'data-action': 'expand#toggle' }
@@ -67,6 +77,9 @@
               .selected-statuses.fr-mb-2w
                 - @filter.statuses.each do |status|
                   = link_to status, all_admin_procedures_path(@filter.without(:statuses, status)), class: 'fr-tag fr-tag--dismiss fr-mb-1w'
+            - if @filter.from_publication_date.present?
+              .selected-from-publication-date.fr-mb-2w
+                = link_to "Depuis #{l(@filter.from_publication_date)}", all_admin_procedures_path(@filter.without(:from_publication_date)), class: 'fr-tag fr-tag--dismiss fr-mb-1w'
             = paginate @filter.procedures_result, views_prefix: 'administrateurs'
             %thead
               %tr

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -137,6 +137,20 @@ describe Administrateurs::ProceduresController, type: :controller do
         expect(assigns(:filter).procedures_result).not_to include(procedure1)
       end
     end
+
+    context 'after specific date' do
+      let(:after) { Date.new(2022, 06, 30) }
+      let!(:procedure1) { create(:procedure, :published, published_at: after + 1.day) }
+      let!(:procedure2) { create(:procedure, :published, published_at: after + 2.days) }
+      let!(:procedure3) { create(:procedure, :published, published_at: after - 1.day) }
+
+      it 'display only procedures published after specific date' do
+        get :all, params: { from_publication_date: after }
+        expect(assigns(:filter).procedures_result).to include(procedure1)
+        expect(assigns(:filter).procedures_result).to include(procedure2)
+        expect(assigns(:filter).procedures_result).not_to include(procedure3)
+      end
+    end
   end
 
   describe 'POST #search' do


### PR DESCRIPTION
Avec cette PR, un admin peut filtrer la liste de toutes les démarches publiés à partir d'une certaine date.

![ds-date-pub](https://user-images.githubusercontent.com/1111966/200578727-989f1c3a-7057-4b6c-9f64-fdd02faec409.png)
