### PR TITLE
add a label for api and export for sensitive data as titre_identite_champ

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -2085,6 +2085,7 @@ type TextChamp implements Champ {
 }
 
 type TitreIdentiteChamp implements Champ {
+  filled: Boolean!
   grantType: TitreIdentiteGrantType!
   id: ID!
 

--- a/app/graphql/types/champs/titre_identite_champ_type.rb
+++ b/app/graphql/types/champs/titre_identite_champ_type.rb
@@ -8,9 +8,14 @@ module Types::Champs
     end
 
     field :grant_type, TitreIdentiteGrantTypeType, null: false
+    field :filled, Boolean, null: false
 
     def grant_type
       TypesDeChamp::TitreIdentiteTypeDeChamp::PIECE_JUSTIFICATIVE
+    end
+
+    def filled
+      object.piece_justificative_file.attached?
     end
   end
 end

--- a/app/models/champs/titre_identite_champ.rb
+++ b/app/models/champs/titre_identite_champ.rb
@@ -41,6 +41,6 @@ class Champs::TitreIdentiteChamp < Champ
   end
 
   def for_api
-    piece_justificative_file.attached? ? "présent" : "absent"
+    nil
   end
 end

--- a/app/models/champs/titre_identite_champ.rb
+++ b/app/models/champs/titre_identite_champ.rb
@@ -37,10 +37,10 @@ class Champs::TitreIdentiteChamp < Champ
   end
 
   def for_export
-    nil
+    piece_justificative_file.attached? ? "présent" : "absent"
   end
 
   def for_api
-    nil
+    piece_justificative_file.attached? ? "présent" : "absent"
   end
 end

--- a/spec/graphql/dossier_spec.rb
+++ b/spec/graphql/dossier_spec.rb
@@ -158,6 +158,30 @@ RSpec.describe Types::DossierType, type: :graphql do
     }
   end
 
+  describe 'dossier with titre identite filled' do
+    let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :titre_identite }]) }
+    let(:dossier) { create(:dossier, :accepte, :with_populated_champs, procedure: procedure) }
+
+    let(:query) { DOSSIER_WITH_TITRE_IDENTITE_QUERY }
+    let(:variables) { { number: dossier.id } }
+
+    it {
+      expect(data[:dossier][:champs][0][:filled]).to eq(true)
+    }
+  end
+
+  describe 'dossier with titre identite not filled' do
+    let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :titre_identite }]) }
+    let(:dossier) { create(:dossier, :accepte, procedure: procedure) }
+
+    let(:query) { DOSSIER_WITH_TITRE_IDENTITE_QUERY }
+    let(:variables) { { number: dossier.id } }
+
+    it {
+      expect(data[:dossier][:champs][0][:filled]).to eq(false)
+    }
+  end
+
   DOSSIER_QUERY = <<-GRAPHQL
   query($number: Int!) {
     dossier(number: $number) {
@@ -255,6 +279,23 @@ RSpec.describe Types::DossierType, type: :graphql do
           rows {
             champs { id }
           }
+        }
+      }
+    }
+  }
+  GRAPHQL
+
+  DOSSIER_WITH_TITRE_IDENTITE_QUERY = <<-GRAPHQL
+  query($number: Int!) {
+    dossier(number: $number) {
+      id
+      number
+      champs {
+        id
+        label
+        __typename
+        ... on TitreIdentiteChamp {
+          filled
         }
       }
     }

--- a/spec/models/champs/titre_identite_champ_spec.rb
+++ b/spec/models/champs/titre_identite_champ_spec.rb
@@ -11,17 +11,4 @@ describe Champs::TitreIdentiteChamp do
       it { is_expected.to eq('absent') }
     end
   end
-
-  describe '#for_api' do
-    let(:champ_titre_identite) { create(:champ_titre_identite) }
-
-    subject { champ_titre_identite.for_api }
-
-    it { is_expected.to eq('présent') }
-
-    context 'without attached file' do
-      before { champ_titre_identite.piece_justificative_file.purge }
-      it { is_expected.to eq('absent') }
-    end
-  end
 end

--- a/spec/models/champs/titre_identite_champ_spec.rb
+++ b/spec/models/champs/titre_identite_champ_spec.rb
@@ -1,0 +1,27 @@
+describe Champs::TitreIdentiteChamp do
+  describe "#for_export" do
+    let(:champ_titre_identite) { create(:champ_titre_identite) }
+
+    subject { champ_titre_identite.for_export }
+
+    it { is_expected.to eq('présent') }
+
+    context 'without attached file' do
+      before { champ_titre_identite.piece_justificative_file.purge }
+      it { is_expected.to eq('absent') }
+    end
+  end
+
+  describe '#for_api' do
+    let(:champ_titre_identite) { create(:champ_titre_identite) }
+
+    subject { champ_titre_identite.for_api }
+
+    it { is_expected.to eq('présent') }
+
+    context 'without attached file' do
+      before { champ_titre_identite.piece_justificative_file.purge }
+      it { is_expected.to eq('absent') }
+    end
+  end
+end


### PR DESCRIPTION
issue #7719 

> ETQ instructeur je souhaite savoir dans les exports si les PJ sensibles ont été saisies ou non
> Dans ces colonnes (et l'API) on peut indiquer un libellé "présent" / "absent" (ou plus pertinent)