### PR TITLE
Fix procedure with only inactive group

### DIFF
--- a/lib/tasks/deployment/20221109115352_update_procedure_with_only_inactive_instructor_group.rake
+++ b/lib/tasks/deployment/20221109115352_update_procedure_with_only_inactive_instructor_group.rake
@@ -1,0 +1,17 @@
+namespace :after_party do
+  desc 'Deployment task: update_procedure_with_only_inactive_instructor_group'
+  task update_procedure_with_only_inactive_instructor_group: :environment do
+    puts "Running deploy task 'update_procedure_with_only_inactive_instructor_group'"
+
+    # Put your task implementation HERE.
+    Procedure.all.filter do |p|
+      p.groupe_instructeurs.actif.count == 0
+    end.each do |p|
+      p.groupe_instructeurs.first.update(closed: false)
+    end
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
PR pour corriger un bug suite aux modifications sur le routage.
Voir https://sentry.io/organizations/demarches-simplifiees/issues/3729347938/?environment=production&project=1429550&query=is%3Aunresolved&referrer=issue-stream

En production il y a 9 démarches avec routage désactivé et un seul groupe qui est inactif. Ça pose problème parce que maintenant le groupe d'instructeur par défaut doit forcément être actif.
L'after party réactive le groupe pour ces procédures
