### PR TITLE
Fix procedure with active group and routing nil

### DIFF
--- a/lib/tasks/deployment/20221109124456_update_procedure_with_active_group_and_routing_nil.rake
+++ b/lib/tasks/deployment/20221109124456_update_procedure_with_active_group_and_routing_nil.rake
@@ -1,0 +1,17 @@
+namespace :after_party do
+  desc 'Deployment task: update_procedure_with_active_group_and_routing_nil'
+  task update_procedure_with_active_group_and_routing_nil: :environment do
+    puts "Running deploy task 'update_procedure_with_active_group_and_routing_nil'"
+
+    # Put your task implementation HERE.
+    Procedure.where(routing_enabled: nil).filter do |p|
+      p.groupe_instructeurs.actif.count > 1
+    end.each do |p|
+      p.update(routing_enabled: true)
+    end
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
Il y a 741 procédures avec au moins deux groupes actifs et dont le champ `routing_enabled` vaut `nil`.
(j'avais juste checké pour la valeur `false` :sob: ).
Je les mets à jour pour passer la valeur à `true` 