### PR TITLE
style: fix old webkits radio & checkbox appearance

### DIFF
--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -15,6 +15,7 @@
   color: $black;
   text-align: center;
   -webkit-appearance: none;
+  background-image: none; // Remove DSFR underline
 
   &:hover:not(:disabled) {
     cursor: pointer;

--- a/app/assets/stylesheets/dsfr.scss
+++ b/app/assets/stylesheets/dsfr.scss
@@ -13,16 +13,23 @@ select {
   font-weight: bold;
 }
 
-// fix firefox < 80 not supporting "appearance: auto" on inputs
+// Fix firefox < 80, Safari < 15.4, Chrome < 83 not supporting "appearance: auto" on inputs
+// This rule was set by DSFR for DSFR design, but broke our legacy forms.
 // scss-lint:disable DuplicateProperty
 input[type="checkbox"] {
   -moz-appearance: checkbox;
   -moz-appearance: auto;
+
+  -webkit-appearance: checkbox;
+  -webkit-appearance: auto;
 }
 
 input[type="radio"] {
   -moz-appearance: radio;
   -moz-appearance: auto;
+
+  -webkit-appearance: radio;
+  -webkit-appearance: auto;
 }
 // scss-lint:enable DuplicateProperty
 

--- a/app/views/shared/dossiers/_demande.html.haml
+++ b/app/views/shared/dossiers/_demande.html.haml
@@ -30,7 +30,7 @@
 
       - if profile == 'usager' && !dossier.read_only?
         .flex.row-reverse
-          = link_to t('views.shared.dossiers.demande.edit_identity'), identite_dossier_path(dossier), class: 'button'
+          = link_to t('views.shared.dossiers.demande.edit_identity'), identite_dossier_path(dossier), class: 'fr-btn fr-btn--tertiary'
 
   .tab-title= t('views.shared.dossiers.demande.form')
   - champs = dossier.champs_public.includes(:type_de_champ)


### PR DESCRIPTION
Aussi un fix additionnel sur le style de boutons legacy: on enlève l'effet souligné.


Je n'ai pas réussi à reproduire un bug remonté sur Safari pour le champ commune: des utilisateurs semblent ne pas être en mesure de faire persister la commune alors qu'elle a bien été validée. (Testé juqu'à Safari 12 avec succès)