### PR TITLE
amélioration(object storage): mettre les objects dans des sous repertoires

### DIFF
--- a/config/initializers/active_storage_blob.rb
+++ b/config/initializers/active_storage_blob.rb
@@ -1,7 +1,6 @@
 Rails.application.config.to_prepare do
   require 'active_storage/blob'
   ActiveStorage::Blob.class_eval do
-
     before_create :set_prefixed_key, if: :prefixed_key?
 
     def set_prefixed_key
@@ -22,11 +21,11 @@ Rails.application.config.to_prepare do
     def migrate_to_prefixed_key
       old_key = key.dup
       new_key = ActiveStorage::Blob.make_prefixed_key(old_key)
-      service.client.copy_object(source_container_name = service.container,
-                                 source_object_name = old_key,
-                                 target_container_name = service.container,
+      service.client.copy_object(service.container,
+                                 old_key,
+                                 service.container,
                                  new_key,
-                                 headers = {"Content-Type" => self.content_type})
+                                 { "Content-Type" => self.content_type })
       update_columns(key: new_key, prefixed_key: true)
       service.delete(old_key)
     rescue Fog::OpenStack::Storage::NotFound

--- a/config/initializers/active_storage_blob.rb
+++ b/config/initializers/active_storage_blob.rb
@@ -12,6 +12,25 @@ Rails.application.config.to_prepare do
       ENV['OBJECT_STORAGE_BLOB_PREFIXED_KEY'].present?
     end
 
+    # see : https://docs.openstack.org/api-ref/object-store/?expanded=copy-object-detail
+    # active storage open stack does not expose the copy method
+    # but fog-openstack-1.0.11 does (a layer below)
+    # copy_object
+    #   def copy_object(source_container_name, source_object_name, target_container_name, target_object_name, options = {})
+    #     ....
+    #   end
+    def migrate_to_prefixed_key
+      old_key = key.dup
+      new_key = ActiveStorage::Blob.make_prefixed_key(old_key)
+      service.client.copy_object(source_container_name = service.container,
+                                 source_object_name = old_key,
+                                 target_container_name = service.container,
+                                 new_key,
+                                 headers = {"Content-Type" => self.content_type})
+      update_columns(key: new_key, prefixed_key: true)
+      service.delete(old_key)
+    rescue Fog::OpenStack::Storage::NotFound
+    end
 
     class << self
       def generate_unique_secure_token(length: MINIMUM_TOKEN_LENGTH)

--- a/config/initializers/active_storage_blob.rb
+++ b/config/initializers/active_storage_blob.rb
@@ -41,16 +41,7 @@ Rails.application.config.to_prepare do
       end
 
       def make_prefixed_key(key)
-        [segment, key].join('/')
+        [key[0..1], key[2..3], key].join('/')
       end
-
-      def segment
-        [rand_a_to_z, rand_a_to_z].join('')
-      end
-
-      def rand_a_to_z
-        ('a'..'z').to_a.sample
-      end
-    end
   end
 end

--- a/config/initializers/active_storage_blob.rb
+++ b/config/initializers/active_storage_blob.rb
@@ -1,0 +1,38 @@
+Rails.application.config.to_prepare do
+  require 'active_storage/blob'
+  ActiveStorage::Blob.class_eval do
+
+    before_create :set_prefixed_key, if: :prefixed_key?
+
+    def set_prefixed_key
+      self.prefixed_key = true
+    end
+
+    def prefixed_key?
+      ENV['OBJECT_STORAGE_BLOB_PREFIXED_KEY'].present?
+    end
+
+
+    class << self
+      def generate_unique_secure_token(length: MINIMUM_TOKEN_LENGTH)
+        if ENV['OBJECT_STORAGE_BLOB_PREFIXED_KEY'].present?
+          make_prefixed_key(super(length: length))
+        else
+          super(length: length)
+        end
+      end
+
+      def make_prefixed_key(key)
+        [segment, key].join('/')
+      end
+
+      def segment
+        [rand_a_to_z, rand_a_to_z].join('')
+      end
+
+      def rand_a_to_z
+        ('a'..'z').to_a.sample
+      end
+    end
+  end
+end

--- a/db/migrate/20221114143216_add_migrated_to_active_storage_blobs.rb
+++ b/db/migrate/20221114143216_add_migrated_to_active_storage_blobs.rb
@@ -1,0 +1,5 @@
+class AddMigratedToActiveStorageBlobs < ActiveRecord::Migration[6.1]
+  def change
+    add_column :active_storage_blobs, :prefixed_key, :boolean
+  end
+end

--- a/db/migrate/20221114143935_add_index_on_migrated_to_active_storage_blobs.rb
+++ b/db/migrate/20221114143935_add_index_on_migrated_to_active_storage_blobs.rb
@@ -1,0 +1,7 @@
+class AddIndexOnMigratedToActiveStorageBlobs < ActiveRecord::Migration[6.1]
+  include Database::MigrationHelpers
+  disable_ddl_transaction!
+  def up
+    add_concurrent_index :active_storage_blobs, [:prefixed_key]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_10_100759) do
+ActiveRecord::Schema.define(version: 2022_11_14_143935) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -46,8 +46,10 @@ ActiveRecord::Schema.define(version: 2022_11_10_100759) do
     t.string "key", null: false
     t.integer "lock_version"
     t.text "metadata"
+    t.boolean "prefixed_key"
     t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+    t.index ["prefixed_key"], name: "index_active_storage_blobs_on_prefixed_key"
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|

--- a/lib/tasks/deployment/20221114143356_backfill_prefixed_key_on_active_storage_blobs.rake
+++ b/lib/tasks/deployment/20221114143356_backfill_prefixed_key_on_active_storage_blobs.rake
@@ -1,0 +1,19 @@
+namespace :after_party do
+  desc 'Deployment task: backfill_migrated_on_active_storage_blobs'
+  task backfill_prefixed_key_on_active_storage_blobs: :environment do
+    puts "Running deploy task 'backfill_prefixed_key_on_active_storage_blobs'"
+
+    if ENV['OBJECT_STORAGE_BLOB_PREFIXED_KEY'].present?
+      blobs_to_migrate = ActiveStorage::Blob.where(prefixed_key: nil)
+      progress = ProgressReport.new(blobs_to_migrate.count)
+      blobs_to_migrate.find_each do |blob|
+        blob.migrate_to_prefixed_key
+        progress.inc
+      end
+      progress.finish
+    end
+
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/models/active_storage/blob_spec.rb
+++ b/spec/models/active_storage/blob_spec.rb
@@ -1,0 +1,31 @@
+describe ActiveStorage::Blob, type: :model do
+  subject do
+    ActiveStorage::Blob.create_before_direct_upload!(filename: 'test.png',
+                                                     byte_size: 1010,
+                                                     checksum: '12123',
+                                                     content_type: 'text/plain')
+  end
+
+  context 'OBJECT_STORAGE_BLOB_PREFIXED_KEY=something' do
+    before { allow(ENV).to receive(:[]).with('OBJECT_STORAGE_BLOB_PREFIXED_KEY').and_return('enabled')}
+
+    it 'creates a direct upload with segments' do
+      expect(subject.key.split('/').size).to eq(3)
+    end
+    it 'creates is marked as prefixed_key' do
+      expect(subject.prefixed_key).to eq(true)
+    end
+  end
+
+  context 'OBJECT_STORAGE_BLOB_PREFIXED_KEY inexistant' do
+    before { allow(ENV).to receive('OBJECT_STORAGE_BLOB_PREFIXED_KEY').and_return(nil)}
+
+    it 'creates a direct upload without segments' do
+      expect(subject.key.split('/').size).to eq(1)
+    end
+
+    it 'creates a not prefixed_key' do
+      expect(subject.prefixed_key).to eq(nil)
+    end
+  end
+end

--- a/spec/models/active_storage/blob_spec.rb
+++ b/spec/models/active_storage/blob_spec.rb
@@ -7,10 +7,10 @@ describe ActiveStorage::Blob, type: :model do
   end
 
   context 'OBJECT_STORAGE_BLOB_PREFIXED_KEY=something' do
-    before { allow(ENV).to receive(:[]).with('OBJECT_STORAGE_BLOB_PREFIXED_KEY').and_return('enabled')}
+    before { allow(ENV).to receive(:[]).with('OBJECT_STORAGE_BLOB_PREFIXED_KEY').and_return('enabled') }
 
     it 'creates a direct upload with segments' do
-      expect(subject.key.split('/').size).to eq(3)
+      expect(subject.key.split('/').size).to eq(2)
     end
     it 'creates is marked as prefixed_key' do
       expect(subject.prefixed_key).to eq(true)
@@ -18,7 +18,7 @@ describe ActiveStorage::Blob, type: :model do
   end
 
   context 'OBJECT_STORAGE_BLOB_PREFIXED_KEY inexistant' do
-    before { allow(ENV).to receive('OBJECT_STORAGE_BLOB_PREFIXED_KEY').and_return(nil)}
+    before { allow(ENV).to receive('OBJECT_STORAGE_BLOB_PREFIXED_KEY').and_return(nil) }
 
     it 'creates a direct upload without segments' do
       expect(subject.key.split('/').size).to eq(1)


### PR DESCRIPTION
attention, pr les tests elle sort de pending for review. pas besoin de review pr le moment 

# TODO
- [ ] mettre les data dans des buckets dedies. bucket pj, bucket opslog, bucket bills
- [ ] prefixer chaque clé par l'année, + le rand des deux premier charactere
- [ ] paralleliser la copie des pjs

# contexte ; nos outils de backup de l'object storage saturent
cf: issue: https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/7966

# solution ; suffisante
on mets les fichiers dans un segment de la forme [a-z]{2} ; ca donne 676 segments pour rebasculer environs 45M objects.

# point tech 
on pourrait aussi imaginer "scoper" les PJs ex: 
* mettre les PJs de type `Champs::*` dans path `champs/[a-z]{2}/` (voir un bucket specifique)
* mettre les PJs de type "ops_log" dans path `ops_log/aaaa/mm/dd` (voir un bucket specifique)
* mettre le reste des PJs ailleurs ex : `autres/` (voir un bucket specifique)

Je me demande si on a pas mieux a faire maintenant et attendre ce type de besoin.
Ps: si on souhaite utiliser un bon nom de bucket, c'est le moment
