### PR TITLE
feat(web-console): allow private & loopback ranges

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -3,6 +3,10 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Web console
+  # Allow private & loopback ranges
+  config.web_console.permissions = ['10.0.0.0/8', '127.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16', '192.0.0.0/24', '::1']
+
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.


### PR DESCRIPTION
# Résumé

<!-- décrire en quelques phrases la problématique adressée -->

Il se peut que `web-console` ait besoin de répondre sur une autre IP que `127.0.0.1`, dans le cas d'un environnement de développement dockerisé par exemple.
```
Cannot render console from 172.17.0.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1
```

Cette PR se propose d'autoriser toutes les plages d'IP privées.

mots-clés : IP, range, webconsole

fixes à référencer / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`