### PR TITLE
fix(procedure): rattrape la donnée manquante relative à la duree de conservation

### DIFF
--- a/lib/tasks/deployment/20221121163201_clean_invalid_procedures.rake
+++ b/lib/tasks/deployment/20221121163201_clean_invalid_procedures.rake
@@ -1,0 +1,17 @@
+namespace :after_party do
+  desc 'Deployment task: clean_invalid_procedures'
+  task clean_invalid_procedures: :environment do
+    puts "Running deploy task 'clean_invalid_procedures'"
+
+    Procedure.with_discarded.where(duree_conservation_etendue_par_ds: nil)
+      .update_all(duree_conservation_etendue_par_ds: false)
+
+    Procedure.with_discarded.where(max_duree_conservation_dossiers_dans_ds: nil)
+      .update_all(max_duree_conservation_dossiers_dans_ds: Procedure::NEW_MAX_DUREE_CONSERVATION)
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
Certaines procédures n'ont pas les attributs de durée de conservation étendue remplis.
On les reprends en leur mettant une valeur minimale suivant la logique présente dans 
`db/migrate/20221006161143_re_backfill_procedure_max_duree_conservation_dossiers.rb`