### PR TITLE
fix: escape characters when showing page title

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,7 +7,7 @@
     = csrf_meta_tags
 
     %title
-      = content_for?(:title) ? "#{yield(:title)} · #{APPLICATION_NAME}" : APPLICATION_NAME
+      = content_for?(:title) ? "#{sanitize(yield(:title))} · #{APPLICATION_NAME}" : APPLICATION_NAME
 
     = favicon_link_tag(image_url("#{FAVICON_16PX_SRC}"), type: "image/png", sizes: "16x16")
     = favicon_link_tag(image_url("#{FAVICON_32PX_SRC}"), type: "image/png", sizes: "32x32")

--- a/spec/system/users/dossier_creation_spec.rb
+++ b/spec/system/users/dossier_creation_spec.rb
@@ -9,7 +9,8 @@ describe 'Creating a new dossier:' do
     end
 
     context 'when the procedure has identification by individual' do
-      let(:procedure) { create(:procedure, :published, :for_individual, :with_service, ask_birthday: ask_birthday) }
+      let(:libelle) { "[title] with characters to escape : '@*^$" }
+      let(:procedure) { create(:procedure, :published, :for_individual, :with_service, ask_birthday: ask_birthday, libelle: libelle) }
       let(:ask_birthday) { false }
       let(:expected_birthday) { nil }
 
@@ -19,6 +20,7 @@ describe 'Creating a new dossier:' do
 
         expect(page).to have_current_path identite_dossier_path(user.reload.dossiers.last)
         expect(page).to have_procedure_description(procedure)
+        expect(page).to have_title(libelle)
 
         choose 'Monsieur'
         fill_in 'individual_nom',    with: 'Nom'


### PR DESCRIPTION
closes #7709 

Sur plusieurs pages, on corrige l'affichage du titre **en tooltip** de la page lorsqu'il contient des caractères spéciaux.

# Avant

![image](https://user-images.githubusercontent.com/1193334/203513103-47a4d08d-f606-4cd4-9394-76b7a698cac8.png)

# Après

![image](https://user-images.githubusercontent.com/1193334/203513223-d689b10a-d9af-4a66-9049-aa1e99927daf.png)


