### PR TITLE
feat(graphql): make demarche schema public

### DIFF
--- a/app/controllers/api/v2/graphql_controller.rb
+++ b/app/controllers/api/v2/graphql_controller.rb
@@ -60,8 +60,10 @@ class API::V2::GraphqlController < API::V2::BaseController
       else
         {}
       end
-    when Hash, ActionController::Parameters
+    when Hash
       ambiguous_param
+    when ActionController::Parameters
+      ambiguous_param.to_unsafe_h
     when nil
       {}
     else

--- a/app/graphql/api/v2/stored_query.rb
+++ b/app/graphql/api/v2/stored_query.rb
@@ -177,6 +177,16 @@ class API::V2::StoredQuery
     }
   }
 
+  query getDemarcheDescriptor(
+    $demarche: FindDemarcheInput!
+    $includeRevision: Boolean = false
+    $includeService: Boolean = false
+  ) {
+    demarcheDescriptor(demarche: $demarche) {
+      ...DemarcheDescriptorFragment
+    }
+  }
+
   fragment ServiceFragment on Service {
     nom
     siret

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -1495,6 +1495,18 @@ type File {
   url: URL!
 }
 
+input FindDemarcheInput @oneOf {
+  """
+  ID de la démarche.
+  """
+  id: ID
+
+  """
+  Numero de la démarche.
+  """
+  number: Int
+}
+
 interface GeoArea {
   description: String
   geometry: GeoJSON!
@@ -2045,6 +2057,12 @@ type Query {
     """
     number: Int!
   ): Demarche!
+  demarcheDescriptor(
+    """
+    La démarche.
+    """
+    demarche: FindDemarcheInput!
+  ): DemarcheDescriptor
 
   """
   Informations sur un dossier d’une démarche.

--- a/app/graphql/types/demarche_descriptor_type.rb
+++ b/app/graphql/types/demarche_descriptor_type.rb
@@ -1,6 +1,13 @@
 module Types
   class DemarcheDescriptorType < Types::BaseObject
     field_class BaseField
+
+    class FindDemarcheInput < Types::BaseInputObject
+      one_of
+      argument :number, Int, "Numero de la démarche.", required: false
+      argument :id, ID, "ID de la démarche.", required: false
+    end
+
     description "Une démarche (métadonnées)
 Ceci est une version abrégée du type `Demarche`, qui n’expose que les métadonnées.
 Cela évite l’accès récursif aux dossiers."
@@ -87,11 +94,8 @@ Cela évite l’accès récursif aux dossiers."
     end
 
     def self.authorized?(object, context)
-      if object.is_a?(ProcedureRevision)
-        context.authorized_demarche?(object.procedure)
-      else
-        context.authorized_demarche?(object)
-      end
+      procedure = object.is_a?(ProcedureRevision) ? object.procedure : object
+      procedure.opendata? || context.authorized_demarche?(procedure)
     end
 
     private

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -14,10 +14,21 @@ module Types
       argument :number, Int, "Numéro du groupe instructeur.", required: true
     end
 
+    field :demarche_descriptor, DemarcheDescriptorType, null: true do
+      argument :demarche, DemarcheDescriptorType::FindDemarcheInput, "La démarche.", required: true
+    end
+
     field :demarches_publiques, DemarcheDescriptorType.connection_type, null: false, internal: true
 
     def demarches_publiques
       Procedure.opendata.includes(draft_revision: :procedure, published_revision: :procedure)
+    end
+
+    def demarche_descriptor(demarche:)
+      demarche_number = demarche.number.presence || ApplicationRecord.id_from_typed_id(demarche.id)
+      Procedure
+        .includes(draft_revision: :procedure, published_revision: :procedure)
+        .find_by(id: demarche_number)
     end
 
     def demarche(number:)

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -902,6 +902,63 @@ describe API::V2::GraphqlController do
         end
       end
 
+      context 'getDemarcheDescriptor' do
+        let(:operation_name) { 'getDemarcheDescriptor' }
+
+        context 'find by number' do
+          let(:variables) { { demarche: { number: procedure.id } } }
+
+          it {
+            expect(gql_errors).to be_nil
+            expect(gql_data[:demarcheDescriptor][:id]).to eq(procedure.to_typed_id)
+          }
+        end
+
+        context 'find by id' do
+          let(:variables) { { demarche: { id: procedure.to_typed_id } } }
+
+          it {
+            expect(gql_errors).to be_nil
+            expect(gql_data[:demarcheDescriptor][:id]).to eq(procedure.to_typed_id)
+          }
+        end
+
+        context 'not opendata' do
+          let(:variables) { { demarche: { id: procedure.to_typed_id } } }
+
+          before { procedure.update(opendata: false) }
+
+          it {
+            expect(gql_errors).to be_nil
+            expect(gql_data[:demarcheDescriptor][:id]).to eq(procedure.to_typed_id)
+          }
+        end
+
+        context 'without authorization token' do
+          let(:authorization_header) { nil }
+
+          context 'opendata' do
+            let(:variables) { { demarche: { id: procedure.to_typed_id } } }
+
+            it {
+              expect(gql_errors).to be_nil
+              expect(gql_data[:demarcheDescriptor][:id]).to eq(procedure.to_typed_id)
+            }
+          end
+
+          context 'not opendata' do
+            let(:variables) { { demarche: { id: procedure.to_typed_id } } }
+
+            before { procedure.update(opendata: false) }
+
+            it {
+              expect(gql_errors).not_to be_nil
+              expect(gql_errors.first[:message]).to eq('An object of type DemarcheDescriptor was hidden due to permissions')
+            }
+          end
+        end
+      end
+
       context 'mutation' do
         let(:query_id) { 'ds-mutation-v2' }
 


### PR DESCRIPTION
On devrait exposer un endpoint sur l'API qui permet de récupérer la structure d'une démarche. Seules les démarches en open data sont visibles sans token.