### PR TITLE
chore: instructions sur le transfert de dossier plus précises

### DIFF
--- a/app/controllers/users/transfers_controller.rb
+++ b/app/controllers/users/transfers_controller.rb
@@ -5,6 +5,7 @@ module Users
 
       if transfer.valid?
         transfer.save!
+        flash.notice = t("users.dossiers.transferer.notice_sent")
         redirect_to dossiers_path
       else
         flash.alert = transfer.errors.full_messages

--- a/app/views/users/dossiers/transferer.html.haml
+++ b/app/views/users/dossiers/transferer.html.haml
@@ -1,9 +1,16 @@
-.container.mt-4
-  - dossier = @transfer.dossiers.first
-  Transferer le dossier #{dossier_display_state(dossier.state, lower: true)} nº #{@dossier.id} déposé par #{demandeur_dossier(dossier)} le #{try_format_date(dossier.created_at)} vers le compte d‘un autre usager :
+.fr-container.fr-mt-3w
+  .fr-grid-row
+    .fr-col-lg-8.fr-col-offset-lg-2
+      %h1.fr-h2 Transférer votre dossier
+      %p Vous vous apprêtez à transférer le dossier #{dossier_display_state(@dossier.state, lower: true)} nº #{@dossier.id} déposé par #{demandeur_dossier(@dossier)} le #{try_format_date(@dossier.created_at)} vers le compte d’un autre usager.
 
-  = form_for @transfer, url: transfers_path, html: { class: 'form mt-2' } do |f|
-    = f.label :email, 'Email du compte destinataire'
-    = f.email_field :email, required: true
-    = f.hidden_field :dossier, value: dossier.id
-    = f.submit "Envoyer la demande de transfert", class: 'button primary'
+      .fr-highlight
+        %p Une fois la demande de transfert acceptée, le dossier sera associé au compte du destinataire et <strong>vous ne pourrez plus y accéder</strong>.
+
+      = form_for @transfer, url: transfers_path, class: "fr-mt-4w" do |f|
+        .fr-input-group
+          = f.label :email, 'Email du compte destinataire', class: "fr-label"
+          = f.email_field :email, required: true, class: "fr-input", autocomplete: "email"
+
+        = f.hidden_field :dossier, value: @dossier.id
+        = f.submit "Envoyer la demande de transfert", class: 'fr-btn'

--- a/app/views/users/dossiers/transferer.html.haml
+++ b/app/views/users/dossiers/transferer.html.haml
@@ -1,16 +1,20 @@
 .fr-container.fr-mt-3w
   .fr-grid-row
     .fr-col-lg-8.fr-col-offset-lg-2
-      %h1.fr-h2 Transférer votre dossier
-      %p Vous vous apprêtez à transférer le dossier #{dossier_display_state(@dossier.state, lower: true)} nº #{@dossier.id} déposé par #{demandeur_dossier(@dossier)} le #{try_format_date(@dossier.created_at)} vers le compte d’un autre usager.
+
+      %h1.fr-h2= t(".title")
+      %p= t(".detail", number: @dossier.id,
+        state: dossier_display_state(@dossier.state, lower: true),
+        demandeur: demandeur_dossier(@dossier),
+        created_at: try_format_date(@dossier.created_at))
 
       .fr-highlight
-        %p Une fois la demande de transfert acceptée, le dossier sera associé au compte du destinataire et <strong>vous ne pourrez plus y accéder</strong>.
+        %p= t(".irrevocable_html").html_safe
 
       = form_for @transfer, url: transfers_path, class: "fr-mt-4w" do |f|
         .fr-input-group
-          = f.label :email, 'Email du compte destinataire', class: "fr-label"
+          = f.label :email, t('.email_label'), class: "fr-label"
           = f.email_field :email, required: true, class: "fr-input", autocomplete: "email"
 
         = f.hidden_field :dossier, value: @dossier.id
-        = f.submit "Envoyer la demande de transfert", class: 'fr-btn'
+        = f.submit t('.submit'), class: 'fr-btn'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -250,7 +250,7 @@ fr:
           start_other_dossier: "Commencer un autre dossier vide"
           clone: "Dupliquer ce dossier"
           delete_dossier: "Supprimer le dossier"
-          transfer_dossier: "Transferer le dossier"
+          transfer_dossier: "Transférer le dossier"
           edit_draft: "Modifier le brouillon"
           actions: "Actions"
       sessions:

--- a/config/locales/views/users/dossier_transfer/en.yml
+++ b/config/locales/views/users/dossier_transfer/en.yml
@@ -8,3 +8,4 @@ en:
         irrevocable_html: Once the transfer request is accepted, the file will be associated with the recipient's account and <strong>you will no longer be able to access it</strong>.
         email_label: Email of the recipient account
         submit: Send transfer request
+        notice_sent: The transfer request has been sent successfully

--- a/config/locales/views/users/dossier_transfer/en.yml
+++ b/config/locales/views/users/dossier_transfer/en.yml
@@ -1,0 +1,10 @@
+---
+en:
+  users:
+    dossiers:
+      transferer:
+        title: Transfer your file
+        detail: "You are about to transfer the %{state} file #%{number} filed by %{demandeur} on %{created_at} to another user's account."
+        irrevocable_html: Once the transfer request is accepted, the file will be associated with the recipient's account and <strong>you will no longer be able to access it</strong>.
+        email_label: Email of the recipient account
+        submit: Send transfer request

--- a/config/locales/views/users/dossier_transfer/fr.yml
+++ b/config/locales/views/users/dossier_transfer/fr.yml
@@ -1,0 +1,10 @@
+---
+fr:
+  users:
+    dossiers:
+      transferer:
+        title: Transférer votre dossier
+        detail: Vous vous apprêtez à transférer le dossier %{state} nº %{number} déposé par %{demandeur} le %{created_at} vers le compte d’un autre usager.
+        irrevocable_html: Une fois la demande de transfert acceptée, le dossier sera associé au compte du destinataire et <strong>vous ne pourrez plus y accéder</strong>.
+        email_label: Email du compte destinataire
+        submit: Envoyer la demande de transfert

--- a/config/locales/views/users/dossier_transfer/fr.yml
+++ b/config/locales/views/users/dossier_transfer/fr.yml
@@ -8,3 +8,4 @@ fr:
         irrevocable_html: Une fois la demande de transfert acceptée, le dossier sera associé au compte du destinataire et <strong>vous ne pourrez plus y accéder</strong>.
         email_label: Email du compte destinataire
         submit: Envoyer la demande de transfert
+        notice_sent: L'invitation au transfert a été envoyée avec succès

--- a/config/locales/views/users/profil/fr.yml
+++ b/config/locales/views/users/profil/fr.yml
@@ -7,7 +7,7 @@ fr:
         new_email_address: Nouvelle adresse email
         your_email: Votre email est actuellement
         change_address: Changer mon adresse
-        transfer_title: Transferer tous vos dossiers
+        transfer_title: Transférer tous vos dossiers
         transfer_explication_html: "<p>Cette fonctionnalité vous permet de changer le propriétaire de tous vos dossiers. C’est généralement utile lors d’un changement de poste ou si vous souhaitez fusionner plusieurs comptes.</p>
     <p>Adresse email du destinataire de tous vos dossiers</p>"
         waiting_transfers: "Transfert en attente :"

--- a/spec/system/users/transfer_dossier_spec.rb
+++ b/spec/system/users/transfer_dossier_spec.rb
@@ -13,11 +13,11 @@ describe 'Transfer dossier:' do
   scenario 'the user can transfer dossier to another user' do
     within(:css, "tr[data-dossier-id=\"#{dossier.id}\"]") do
       click_on 'Actions'
-      click_on 'Transferer le dossier'
+      click_on 'Transférer le dossier'
     end
 
     expect(page).to have_current_path(transferer_dossier_path(dossier))
-    expect(page).to have_content("Transferer le dossier en construction nº #{dossier.id}")
+    expect(page).to have_content("transférer le dossier en construction nº #{dossier.id}")
     fill_in 'Email du compte destinataire', with: other_user.email
     click_on 'Envoyer la demande de transfert'
 

--- a/spec/views/users/dossiers/_dossier_actions.html.haml_spec.rb
+++ b/spec/views/users/dossiers/_dossier_actions.html.haml_spec.rb
@@ -7,7 +7,7 @@ describe 'users/dossiers/dossier_actions.html.haml', type: :view do
 
   it { is_expected.to have_link('Commencer un autre dossier', href: commencer_url(path: procedure.path)) }
   it { is_expected.to have_link('Supprimer le dossier', href: delete_dossier_dossier_path(dossier)) }
-  it { is_expected.to have_link('Transferer le dossier', href: transferer_dossier_path(dossier)) }
+  it { is_expected.to have_link('Transférer le dossier', href: transferer_dossier_path(dossier)) }
 
   context 'when the dossier is termine' do
     let(:dossier) { create(:dossier, :accepte, procedure: procedure) }


### PR DESCRIPTION

Ça remonte au support qu'il n'est pas toujours clair que le transfert d'un dossier signifie la perte de son accès après acceptation de l'invitation. On rajoute donc une phrase dans ce sens.
https://mattermost.incubateur.net/betagouv/pl/zcgt94p6qjri7m84o6d168dcty

Au passage, conversion du form au dsfr + extraction i18n

![Capture d’écran 2022-11-24 à 19 18 01](https://user-images.githubusercontent.com/150279/203847021-9c1eba52-54ec-4e04-baa0-630902933376.png)
