### PR TITLE
feat(instructeurs): list archiver email

### DIFF
--- a/app/views/instructeurs/dossiers/_archived_block.html.haml
+++ b/app/views/instructeurs/dossiers/_archived_block.html.haml
@@ -1,0 +1,2 @@
+.tab-title Archivé
+%p.tab-paragraph= t(".archived", date: l(archived_at), email: archived_by)

--- a/app/views/instructeurs/dossiers/personnes_impliquees.html.haml
+++ b/app/views/instructeurs/dossiers/personnes_impliquees.html.haml
@@ -15,3 +15,7 @@
   = render partial: 'instructeurs/dossiers/personnes_impliquees_block', locals: { emails_collection: @invites_emails, title: "Personnes invitées à consulter ce dossier", blank: "Aucune personne n’a été invitée à consulter ce dossier" }
 
   = render partial: 'instructeurs/dossiers/decisions_rendues_block', locals: { traitements: @dossier.traitements }
+
+  - if @dossier.archived? && @dossier.archived_at.present?
+    = render partial: 'instructeurs/dossiers/archived_block', locals: @dossier.slice(:archived_by, :archived_at)
+

--- a/config/locales/views/instructeurs/fr.yml
+++ b/config/locales/views/instructeurs/fr.yml
@@ -23,3 +23,5 @@ fr:
         accepte: "Accepté"
         refuse: "Refusé"
         sans_suite: "Classé sans suite"
+      archived_block:
+        archived: "Ce dossier a été archivé le %{date} par %{email}"


### PR DESCRIPTION
demande rapide du support: on affiche l'email de l'instructeur ayant archivé un dossier dans l'onglet "personnes impliquées"

![Capture d’écran 2022-11-28 à 13 03 35](https://user-images.githubusercontent.com/150279/204273281-86bb1d4d-7769-4cde-a756-4deac96200bd.png)
