### PR TITLE
chore(bin/update): allow to ignore automatic webdriver update 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Selenium::WebDriver::Chrome.path = "/Applications/Brave Browser.app/Contents/Mac
 Webdrivers::Chromedriver.required_version = "103.0.5060.53"
 ```
 
+Il peut être également pertinent de désactiver la mise à jour automatique du webdriver
+en définissant une variable d'environnement `SKIP_UPDATE_WEBDRIVER` lors de l'exécution de `bin/update`.
+
 ### Création des rôles de la base de données
 
 Les informations nécessaire à l'initialisation de la base doivent être pré-configurées à la main grâce à la procédure suivante :

--- a/bin/update
+++ b/bin/update
@@ -19,8 +19,12 @@ FileUtils.chdir APP_ROOT do
   system! 'bin/yarn install'
   system! 'bin/yarn clean'
 
-  puts "\n== Updating webdrivers =="
-  system! 'RAILS_ENV=test bin/rails webdrivers:chromedriver:update'
+  if ENV["SKIP_UPDATE_WEBDRIVER"]
+    puts "\n== Ignoring webdrivers update because of local configuration. You may need to update it manually.=="
+  else
+    puts "\n== Updating webdrivers =="
+    system! 'RAILS_ENV=test bin/rails webdrivers:chromedriver:update'
+  end
 
   puts "\n== Updating database =="
   system! 'bin/rails db:migrate'


### PR DESCRIPTION
J'utilise `Brave` à la place de `Chrome` et `bin/update` échoue lors de la mise à jour du webdriver. J'ajoute la possibilité de désactiver cette dernière grâce à la variable d'env `SKIP_UPDATE_WEBDRIVER` (que je place dans mon `.envrc`)