### PR TITLE
fix(pj_template): proxy template url so their links are non expirable

### DIFF
--- a/app/components/dsfr/download_component.rb
+++ b/app/components/dsfr/download_component.rb
@@ -5,12 +5,19 @@ class Dsfr::DownloadComponent < ApplicationComponent
   attr_reader :html_class
   attr_reader :name
 
-  def initialize(attachment:, name: nil)
+  def initialize(attachment:, name: nil, url: nil)
     @attachment = attachment
     @name = name || attachment.filename.to_s
+    @url = url
   end
 
   def title
     t(".title", filename: attachment.filename.to_s)
+  end
+
+  def url
+    return @url if @url.present?
+
+    helpers.url_for(@attachment.blob)
   end
 end

--- a/app/components/dsfr/download_component/download_component.html.haml
+++ b/app/components/dsfr/download_component/download_component.html.haml
@@ -1,6 +1,6 @@
 .fr-download
   %p
-    = link_to url_for(attachment.blob), download: "", class: "fr-download__link", title: title do
+    = link_to url, download: "", class: "fr-download__link", title: title do
       = name
       %span.fr-download__detail
         = helpers.download_details(attachment)

--- a/app/components/editable_champ/piece_justificative_component/piece_justificative_component.html.haml
+++ b/app/components/editable_champ/piece_justificative_component/piece_justificative_component.html.haml
@@ -4,4 +4,4 @@
 = render Attachment::MultipleComponent.new(champ: @champ, attached_file: @champ.piece_justificative_file, form_object_name: @form.object_name, user_can_destroy:, user_can_download:, max:) do |c|
   - if @champ.type_de_champ.piece_justificative_template&.attached?
     - c.with_template do
-      = render partial: "shared/piece_justificative_template", locals: { attachment: @champ.type_de_champ.piece_justificative_template }
+      = render partial: "shared/piece_justificative_template", locals: { champ: @champ }

--- a/app/components/editable_champ/titre_identite_component/titre_identite_component.html.haml
+++ b/app/components/editable_champ/titre_identite_component/titre_identite_component.html.haml
@@ -1,5 +1,5 @@
 - user_can_destroy = !@champ.mandatory? || @champ.dossier.brouillon?
 
 - if @champ.type_de_champ.piece_justificative_template&.attached?
-  = render partial: "shared/piece_justificative_template", locals: { attachment: @champ.type_de_champ.piece_justificative_template }
+  = render partial: "shared/piece_justificative_template", locals: { champ: @champ }
 = render Attachment::EditComponent.new(champ: @form.object, attached_file: @champ.piece_justificative_file, attachment: @champ.piece_justificative_file[0], form_object_name: @form.object_name, user_can_destroy:)

--- a/app/controllers/champs/piece_justificative_controller.rb
+++ b/app/controllers/champs/piece_justificative_controller.rb
@@ -17,6 +17,10 @@ class Champs::PieceJustificativeController < ApplicationController
     end
   end
 
+  def template
+    redirect_to @champ.type_de_champ.piece_justificative_template.blob
+  end
+
   private
 
   def set_champ

--- a/app/views/shared/_piece_justificative_template.html.haml
+++ b/app/views/shared/_piece_justificative_template.html.haml
@@ -1,4 +1,4 @@
-= render Dsfr::DownloadComponent.new(attachment: attachment, name: "Modèle à télécharger") do |c|
+= render Dsfr::DownloadComponent.new(attachment: champ.type_de_champ.piece_justificative_template, url: champs_piece_justificative_template_path(champ), name: "Modèle à télécharger") do |c|
   - if administrateur_signed_in?
     - c.with_right do
       %span.fr-ml-2w.fr-text--xs.fr-text-mention--grey.visible-on-previous-hover

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -168,6 +168,7 @@ Rails.application.routes.draw do
 
     get ':champ_id/piece_justificative', to: 'piece_justificative#show', as: :piece_justificative
     put ':champ_id/piece_justificative', to: 'piece_justificative#update', as: :attach_piece_justificative
+    get ':champ_id/piece_justificative/template', to: 'piece_justificative#template', as: :piece_justificative_template
   end
 
   resources :attachments, only: [:show, :destroy]

--- a/spec/controllers/champs/piece_justificative_controller_spec.rb
+++ b/spec/controllers/champs/piece_justificative_controller_spec.rb
@@ -66,4 +66,39 @@ describe Champs::PieceJustificativeController, type: :controller do
       end
     end
   end
+
+  describe '#template' do
+    before { Timecop.freeze }
+    after { Timecop.return }
+
+    subject do
+      get :template, params: {
+        champ_id: champ.id
+      }
+    end
+
+    context "user signed in" do
+      before { sign_in user }
+
+      it 'redirects to the template' do
+        subject
+        expect(response).to redirect_to(champ.type_de_champ.piece_justificative_template.blob)
+      end
+    end
+
+    context "another user signed in" do
+      before { sign_in create(:user) }
+
+      it "should not share template url" do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "user anonymous" do
+      it 'does not redirect to the template' do
+        subject
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Seuls les utilisateurs connectés peuvent passer par ce "proxy", qui est une url privée car liée à l'id du champ, donc non partageable avec d'autres utilisateurs mêmes connectés.

Closes #7920
