### PR TITLE
ETQ admin, je peux exporter la liste des demarches (filtrées ou non)

### DIFF
--- a/app/assets/stylesheets/all_demarches.scss
+++ b/app/assets/stylesheets/all_demarches.scss
@@ -28,4 +28,10 @@
 .main-filter-header {
   display: flex;
   justify-content: space-between;
+  align-items: flex-end;
+
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+  }
 }

--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -332,6 +332,14 @@ module Administrateurs
       @procedure = Procedure.includes(draft_revision: { revision_types_de_champ_public: :type_de_champ }).find(@procedure.id)
     end
 
+    def detail
+      @procedure = Procedure.find(params[:id])
+      render turbo_stream: [
+        turbo_stream.remove("procedure_detail_#{@procedure.id}"),
+        turbo_stream.replace("procedure_#{@procedure.id}", partial: "detail", locals: { procedure: @procedure, show_detail: params[:show_detail] })
+      ]
+    end
+
     def all
       @filter = ProceduresFilter.new(current_administrateur, params)
       all_procedures = filter_procedures(@filter)

--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -346,7 +346,7 @@ module Administrateurs
     private
 
     def filter_procedures(filter)
-      procedures_result = Procedure.joins(:procedures_zones).publiees_ou_closes
+      procedures_result = Procedure.joins(:procedures_zones).distinct.publiees_ou_closes
       procedures_result = procedures_result.where(procedures_zones: { zone_id: filter.zone_ids }) if filter.zone_ids.present?
       procedures_result = procedures_result.where(aasm_state: filter.statuses) if filter.statuses.present?
       procedures_result = procedures_result.where('published_at >= ?', filter.from_publication_date) if filter.from_publication_date.present?

--- a/app/models/procedure_detail.rb
+++ b/app/models/procedure_detail.rb
@@ -1,0 +1,9 @@
+class ProcedureDetail < OpenStruct
+  include SpreadsheetArchitect
+
+  def spreadsheet_columns
+    [:id, :libelle, :published_at, :aasm_state, :admin_count].map do |attribute|
+      [I18n.t(attribute, scope: 'activerecord.attributes.procedure_export'), attribute]
+    end
+  end
+end

--- a/app/models/procedures_filter.rb
+++ b/app/models/procedures_filter.rb
@@ -60,4 +60,14 @@ class ProceduresFilter
       params.to_h.merge(filter => new_filter)
     end
   end
+
+  def to_s
+    filters = []
+    filters << selected_zones&.map { |zone| zone.current_label.parameterize }
+    filters << libelle&.parameterize
+    filters << email
+    filters << "from-#{from_publication_date}" if from_publication_date
+    filters << statuses
+    filters.compact.join('-')
+  end
 end

--- a/app/views/administrateurs/procedures/_detail.html.haml
+++ b/app/views/administrateurs/procedures/_detail.html.haml
@@ -1,0 +1,21 @@
+%tr.procedure{ id: "procedure_#{procedure.id}" }
+  %td
+    = button_to detail_admin_procedure_path(procedure["id"]), params: show_detail ? {} : { show_detail: true }, method: :get, title: 'Cacher les détails', class: [ show_detail ? 'fr-icon-subtract-line':'fr-icon-add-line', "fr-icon--sm fr-mr-1w fr-mb-1w fr-text-action-high--blue-france fr-btn fr-btn--tertiary-no-outline"] do
+      Cacher les détails
+  %td= procedure.libelle
+  %td= procedure.id
+  %td= procedure.administrateurs.count
+  %td= t procedure.aasm_state, scope: 'activerecord.attributes.procedure.aasm_state'
+  %td= l(procedure.published_at, format: :message_date_without_time)
+
+- if show_detail
+  %tr.procedure{ id: "procedure_detail_#{procedure.id}" }
+    %td.fr-highlight--beige-gris-galet{ colspan: '6' }
+      .fr-container
+        .fr-grid-row
+          .fr-col-6
+            - procedure.zones.uniq.each do |zone|
+              = zone.label_at(procedure.published_or_created_at)
+          .fr-col-6
+            - procedure.administrateurs.uniq.each do |admin|
+              = admin.email

--- a/app/views/administrateurs/procedures/administrateurs.html.haml
+++ b/app/views/administrateurs/procedures/administrateurs.html.haml
@@ -9,7 +9,7 @@
 
       = f.label 'email', 'Recercher des administrateurs par email', class: 'fr-label'
       = f.search_field 'email', size: 40, class: 'fr-input'
-    .switch= link_to 'Voir la liste des démarches', all_admin_procedures_path(@filter.params), class: 'fr-btn fr-btn--secondary'
+    .actions= link_to 'Voir la liste des démarches', all_admin_procedures_path(@filter.params), class: 'fr-btn fr-btn--secondary'
   .fr-table.fr-table--bordered
     %table#all-admins
       %caption

--- a/app/views/administrateurs/procedures/all.html.haml
+++ b/app/views/administrateurs/procedures/all.html.haml
@@ -10,6 +10,7 @@
       = f.label :libelle, 'Rechercher des démarches par libellé', class: 'fr-label'
       = f.search_field 'libelle', size: 40, class: 'fr-input'
     .switch= link_to 'Voir la liste des administrateurs', administrateurs_admin_procedures_path(@filter.params), class: 'fr-btn fr-btn--secondary'
+    .switch= link_to 'Exporter les résultats', all_admin_procedures_path(@filter.params.merge(format: :xlsx)), class: 'fr-btn fr-btn--secondary'
   .fr-table.fr-table--bordered
     %table#all-demarches
       %caption
@@ -43,19 +44,9 @@
           %tr.procedure{ 'data-action': 'click->expand#toggle' }
             %td
               %button.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-mb-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
-            %td= procedure.libelle
-            %td= procedure.id
-            %td= procedure.administrateurs.count
-            %td= t procedure.aasm_state, scope: 'activerecord.attributes.procedure.aasm_state'
-            %td= l(procedure.published_at, format: :message_date_without_time)
-          %tr.hidden{ 'data-expand-target': 'content' }
-            %td.fr-highlight--beige-gris-galet{ colspan: '6' }
-              .fr-container
-                .fr-grid-row
-                  .fr-col-6
-                    - procedure.zones.uniq.each do |zone|
-                      = zone.label_at(procedure.published_or_created_at)
-                  .fr-col-6
-                    - procedure.administrateurs.uniq.each do |admin|
-                      = admin.email
+            %td= procedure["libelle"]
+            %td= procedure["id"]
+            %td= procedure["admin_count"]
+            %td= t procedure["aasm_state"], scope: 'activerecord.attributes.procedure.aasm_state'
+            %td= l(procedure["published_at"], format: :message_date_without_time)
     .fr-mt-2w= paginate @procedures, views_prefix: 'administrateurs'

--- a/app/views/administrateurs/procedures/all.html.haml
+++ b/app/views/administrateurs/procedures/all.html.haml
@@ -46,9 +46,9 @@
             %td
               = button_to detail_admin_procedure_path(procedure["id"]), params: { show_detail: true}, method: :get, title: 'Afficher details', class: "fr-icon-add-line fr-icon--sm fr-mr-1w fr-mb-1w fr-text-action-high--blue-france fr-btn fr-btn--tertiary-no-outline" do
                 Afficher details procedure
-            %td= procedure["libelle"]
-            %td= procedure["id"]
-            %td= procedure["admin_count"]
-            %td= t procedure["aasm_state"], scope: 'activerecord.values.procedure.aasm_state'
-            %td= l(procedure["published_at"], format: :message_date_without_time)
+            %td= procedure.libelle
+            %td= procedure.id
+            %td= procedure.admin_count
+            %td= t procedure.aasm_state, scope: 'activerecord.values.procedure.aasm_state'
+            %td= l(procedure.published_at, format: :message_date_without_time)
     .fr-mt-2w= paginate @procedures, views_prefix: 'administrateurs'

--- a/app/views/administrateurs/procedures/all.html.haml
+++ b/app/views/administrateurs/procedures/all.html.haml
@@ -49,6 +49,6 @@
             %td= procedure["libelle"]
             %td= procedure["id"]
             %td= procedure["admin_count"]
-            %td= t procedure["aasm_state"], scope: 'activerecord.attributes.procedure.aasm_state'
+            %td= t procedure["aasm_state"], scope: 'activerecord.values.procedure.aasm_state'
             %td= l(procedure["published_at"], format: :message_date_without_time)
     .fr-mt-2w= paginate @procedures, views_prefix: 'administrateurs'

--- a/app/views/administrateurs/procedures/all.html.haml
+++ b/app/views/administrateurs/procedures/all.html.haml
@@ -40,11 +40,12 @@
           %th{ scope: 'col' } Administrateurs
           %th{ scope: 'col' } Statut
           %th{ scope: 'col' } Date
-      - @procedures.each do |procedure|
-        %tbody{ 'data-controller': 'expand' }
-          %tr.procedure{ 'data-action': 'click->expand#toggle' }
+      %tbody{ 'data-turbo': 'true' }
+        - @procedures.each do |procedure|
+          %tr.procedure{ id: "procedure_#{procedure['id']}" }
             %td
-              %button.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-mb-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
+              = button_to detail_admin_procedure_path(procedure["id"]), params: { show_detail: true}, method: :get, title: 'Afficher details', class: "fr-icon-add-line fr-icon--sm fr-mr-1w fr-mb-1w fr-text-action-high--blue-france fr-btn fr-btn--tertiary-no-outline" do
+                Afficher details procedure
             %td= procedure["libelle"]
             %td= procedure["id"]
             %td= procedure["admin_count"]

--- a/app/views/administrateurs/procedures/all.html.haml
+++ b/app/views/administrateurs/procedures/all.html.haml
@@ -1,6 +1,6 @@
 - content_for :results do
   .main-filter-header.fr-my-3w
-    = form_with(url: all_admin_procedures_path, method: :get, html: {'data-autosubmit-target': 'form', role: 'search' }) do |f|
+    = form_with(url: all_admin_procedures_path, method: :get, html: {'data-autosubmit-target': 'form', role: 'search', class: 'search' }) do |f|
       - @filter.zone_ids&.each do |zone_id|
         = hidden_field_tag 'zone_ids[]', zone_id
       - @filter.statuses&.each do |status|
@@ -8,9 +8,10 @@
       = hidden_field_tag 'from_publication_date', @filter.from_publication_date if @filter.from_publication_date.present?
 
       = f.label :libelle, 'Rechercher des démarches par libellé', class: 'fr-label'
-      = f.search_field 'libelle', size: 40, class: 'fr-input'
-    .switch= link_to 'Voir la liste des administrateurs', administrateurs_admin_procedures_path(@filter.params), class: 'fr-btn fr-btn--secondary'
-    .switch= link_to 'Exporter les résultats', all_admin_procedures_path(@filter.params.merge(format: :xlsx)), class: 'fr-btn fr-btn--secondary'
+      = f.search_field 'libelle', size: 30, class: 'fr-input'
+    .actions
+      .link.fr-mx-1w= link_to 'Voir les administrateurs', administrateurs_admin_procedures_path(@filter.params), class: 'fr-btn fr-btn--secondary'
+      .link.fr-mx-1w= link_to 'Exporter les résultats', all_admin_procedures_path(@filter.params.merge(format: :xlsx)), class: 'fr-btn fr-btn--secondary'
   .fr-table.fr-table--bordered
     %table#all-demarches
       %caption

--- a/app/views/administrateurs/procedures/detail.turbo_stream.haml
+++ b/app/views/administrateurs/procedures/detail.turbo_stream.haml
@@ -1,0 +1,1 @@
+= turbo_stream.after("procedure_#{@procedure.id}", partial: "detail", locals: { procedure: @procedure })

--- a/config/locales/models/procedure/en.yml
+++ b/config/locales/models/procedure/en.yml
@@ -27,6 +27,12 @@ en:
         without_continuation_mail: File sorted with no further action notification email
         attestation_template: Attestation template
         draft_revision: The form
+      procedure_export:
+        id: Id
+        libelle: Libelle
+        published_at: Publication date
+        aasm_state: Status
+        admin_count: Administrators count
     errors:
       models:
         procedure:

--- a/config/locales/models/procedure/fr.yml
+++ b/config/locales/models/procedure/fr.yml
@@ -10,6 +10,11 @@ fr:
         organisation: Organisme
         duree_conservation_dossiers_dans_ds: Durée de conservation des dossiers sur demarches-simplifiees.fr (choisi par un usager)
         max_duree_conservation_dossiers_dans_ds: Durée de conservation des dossiers maximum (autorisé par un super admin de DS)
+        id: Id
+        libelle: Libelle
+        published_at: 'Date de publication'
+        aasm_state: 'Statut'
+        admin_count: 'Nb administrateurs'
         aasm_state:
           brouillon: Brouillon
           publiee: Publiée
@@ -27,6 +32,12 @@ fr:
         without_continuation_mail: L’email de notification de classement sans suite de dossier
         attestation_template: Le modèle d’attestation
         draft_revision: Le formulaire
+      procedure_export:
+        id: Id
+        libelle: Libelle
+        published_at: 'Date de publication'
+        aasm_state: 'Statut'
+        admin_count: 'Nb administrateurs'
     errors:
       models:
         procedure:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -440,6 +440,7 @@ Rails.application.routes.draw do
       end
 
       member do
+        get 'detail'
         get 'apercu'
         get 'champs'
         get 'zones'

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -95,6 +95,16 @@ describe Administrateurs::ProceduresController, type: :controller do
 
     it { expect(subject.status).to eq(200) }
 
+    context 'for export' do
+      subject { get :all, format: :xlsx }
+
+      it 'exports result in xlsx' do
+        allow(SpreadsheetArchitect).to receive(:to_xlsx)
+        subject
+        expect(SpreadsheetArchitect).to have_received(:to_xlsx)
+      end
+    end
+
     it 'display published or closed procedures' do
       subject
       expect(values_for_field(assigns(:procedures), "id")).to include(published_procedure.id)

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -97,13 +97,13 @@ describe Administrateurs::ProceduresController, type: :controller do
 
     it 'display published or closed procedures' do
       subject
-      expect(assigns(:procedures)).to include(published_procedure)
-      expect(assigns(:procedures)).to include(closed_procedure)
+      expect(values_for_field(assigns(:procedures), "id")).to include(published_procedure.id)
+      expect(values_for_field(assigns(:procedures), "id")).to include(closed_procedure.id)
     end
 
     it 'doesn’t display draft procedures' do
       subject
-      expect(assigns(:procedures)).not_to include(draft_procedure)
+      expect(values_for_field(assigns(:procedures), "id")).not_to include(draft_procedure.id)
     end
 
     context "for specific zones" do
@@ -116,8 +116,8 @@ describe Administrateurs::ProceduresController, type: :controller do
 
       it 'display only procedures for specified zones' do
         subject
-        expect(assigns(:procedures)).to include(procedure2)
-        expect(assigns(:procedures)).not_to include(procedure1)
+        expect(values_for_field(assigns(:procedures), "id")).to include(procedure2.id)
+        expect(values_for_field(assigns(:procedures), "id")).not_to include(procedure1.id)
       end
     end
 
@@ -127,14 +127,14 @@ describe Administrateurs::ProceduresController, type: :controller do
 
       it 'display only published procedures' do
         get :all, params: { statuses: ['publiee'] }
-        expect(assigns(:procedures)).to include(procedure1)
-        expect(assigns(:procedures)).not_to include(procedure2)
+        expect(values_for_field(assigns(:procedures), "id")).to include(procedure1.id)
+        expect(values_for_field(assigns(:procedures), "id")).not_to include(procedure2.id)
       end
 
       it 'display only closed procedures' do
         get :all, params: { statuses: ['close'] }
-        expect(assigns(:procedures)).to include(procedure2)
-        expect(assigns(:procedures)).not_to include(procedure1)
+        expect(values_for_field(assigns(:procedures), "id")).to include(procedure2.id)
+        expect(values_for_field(assigns(:procedures), "id")).not_to include(procedure1.id)
       end
     end
 
@@ -146,9 +146,9 @@ describe Administrateurs::ProceduresController, type: :controller do
 
       it 'display only procedures published after specific date' do
         get :all, params: { from_publication_date: after }
-        expect(assigns(:procedures)).to include(procedure1)
-        expect(assigns(:procedures)).to include(procedure2)
-        expect(assigns(:procedures)).not_to include(procedure3)
+        expect(values_for_field(assigns(:procedures), "id")).to include(procedure1.id)
+        expect(values_for_field(assigns(:procedures), "id")).to include(procedure2.id)
+        expect(values_for_field(assigns(:procedures), "id")).not_to include(procedure3.id)
       end
     end
 
@@ -159,9 +159,9 @@ describe Administrateurs::ProceduresController, type: :controller do
 
       it 'returns procedures with specific terms in libelle' do
         get :all, params: { libelle: 'entrepreneur' }
-        expect(assigns(:procedures)).to include(procedure2)
-        expect(assigns(:procedures)).to include(procedure3)
-        expect(assigns(:procedures)).not_to include(procedure1)
+        expect(values_for_field(assigns(:procedures), "id")).to include(procedure2.id)
+        expect(values_for_field(assigns(:procedures), "id")).to include(procedure3.id)
+        expect(values_for_field(assigns(:procedures), "id")).not_to include(procedure1.id)
       end
     end
   end
@@ -942,5 +942,11 @@ describe Administrateurs::ProceduresController, type: :controller do
       it { expect(procedure.discarded?).to be_falsy }
       it { expect(procedure.dossiers.first.hidden_by_administration_at).to be_nil }
     end
+  end
+end
+
+def values_for_field(array, field)
+  array.map do |procedure|
+    procedure[field]
   end
 end

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -99,21 +99,21 @@ describe Administrateurs::ProceduresController, type: :controller do
       subject { get :all, format: :xlsx }
 
       it 'exports result in xlsx' do
-        allow(SpreadsheetArchitect).to receive(:to_xlsx)
+        allow(ProcedureDetail).to receive(:to_xlsx)
         subject
-        expect(SpreadsheetArchitect).to have_received(:to_xlsx)
+        expect(ProcedureDetail).to have_received(:to_xlsx)
       end
     end
 
     it 'display published or closed procedures' do
       subject
-      expect(values_for_field(assigns(:procedures), "id")).to include(published_procedure.id)
-      expect(values_for_field(assigns(:procedures), "id")).to include(closed_procedure.id)
+      expect(assigns(:procedures).any? { |p| p.id == published_procedure.id }).to be_truthy
+      expect(assigns(:procedures).any? { |p| p.id == closed_procedure.id }).to be_truthy
     end
 
     it 'doesn’t display draft procedures' do
       subject
-      expect(values_for_field(assigns(:procedures), "id")).not_to include(draft_procedure.id)
+      expect(assigns(:procedures).any? { |p| p.id == draft_procedure.id }).to be_falsey
     end
 
     context "for specific zones" do
@@ -126,8 +126,8 @@ describe Administrateurs::ProceduresController, type: :controller do
 
       it 'display only procedures for specified zones' do
         subject
-        expect(values_for_field(assigns(:procedures), "id")).to include(procedure2.id)
-        expect(values_for_field(assigns(:procedures), "id")).not_to include(procedure1.id)
+        expect(assigns(:procedures).any? { |p| p.id == procedure2.id }).to be_truthy
+        expect(assigns(:procedures).any? { |p| p.id == procedure1.id }).to be_falsey
       end
     end
 
@@ -137,14 +137,14 @@ describe Administrateurs::ProceduresController, type: :controller do
 
       it 'display only published procedures' do
         get :all, params: { statuses: ['publiee'] }
-        expect(values_for_field(assigns(:procedures), "id")).to include(procedure1.id)
-        expect(values_for_field(assigns(:procedures), "id")).not_to include(procedure2.id)
+        expect(assigns(:procedures).any? { |p| p.id == procedure1.id }).to be_truthy
+        expect(assigns(:procedures).any? { |p| p.id == procedure2.id }).to be_falsey
       end
 
       it 'display only closed procedures' do
         get :all, params: { statuses: ['close'] }
-        expect(values_for_field(assigns(:procedures), "id")).to include(procedure2.id)
-        expect(values_for_field(assigns(:procedures), "id")).not_to include(procedure1.id)
+        expect(assigns(:procedures).any? { |p| p.id == procedure2.id }).to be_truthy
+        expect(assigns(:procedures).any? { |p| p.id == procedure1.id }).to be_falsey
       end
     end
 
@@ -156,9 +156,9 @@ describe Administrateurs::ProceduresController, type: :controller do
 
       it 'display only procedures published after specific date' do
         get :all, params: { from_publication_date: after }
-        expect(values_for_field(assigns(:procedures), "id")).to include(procedure1.id)
-        expect(values_for_field(assigns(:procedures), "id")).to include(procedure2.id)
-        expect(values_for_field(assigns(:procedures), "id")).not_to include(procedure3.id)
+        expect(assigns(:procedures).any? { |p| p.id == procedure1.id }).to be_truthy
+        expect(assigns(:procedures).any? { |p| p.id == procedure2.id }).to be_truthy
+        expect(assigns(:procedures).any? { |p| p.id == procedure3.id }).to be_falsey
       end
     end
 
@@ -169,9 +169,9 @@ describe Administrateurs::ProceduresController, type: :controller do
 
       it 'returns procedures with specific terms in libelle' do
         get :all, params: { libelle: 'entrepreneur' }
-        expect(values_for_field(assigns(:procedures), "id")).to include(procedure2.id)
-        expect(values_for_field(assigns(:procedures), "id")).to include(procedure3.id)
-        expect(values_for_field(assigns(:procedures), "id")).not_to include(procedure1.id)
+        expect(assigns(:procedures).any? { |p| p.id == procedure2.id }).to be_truthy
+        expect(assigns(:procedures).any? { |p| p.id == procedure3.id }).to be_truthy
+        expect(assigns(:procedures).any? { |p| p.id == procedure1.id }).to be_falsey
       end
     end
   end
@@ -952,11 +952,5 @@ describe Administrateurs::ProceduresController, type: :controller do
       it { expect(procedure.discarded?).to be_falsy }
       it { expect(procedure.dossiers.first.hidden_by_administration_at).to be_nil }
     end
-  end
-end
-
-def values_for_field(array, field)
-  array.map do |procedure|
-    procedure[field]
   end
 end


### PR DESCRIPTION
# Contenu de la PR

Cette PR 
- corrige un bug dans le résultat de la liste des démarches (qui étaient en double)
- ameliore les performances pour calculer le nombre d'admins par démarche
- permet aux administrateurs d'exporter au format xlsx la liste de toutes les démarches (eventuellement filtrées)

# Aperçu écran

![ds-export](https://user-images.githubusercontent.com/1111966/205646593-13612afc-ef2e-476d-b338-1c4852238d19.png)

close #8112 
