### PR TITLE
fix: multipart upload on instructeurs import & acceptation avec PJ

### DIFF
--- a/app/views/administrateurs/groupe_instructeurs/_edit.html.haml
+++ b/app/views/administrateurs/groupe_instructeurs/_edit.html.haml
@@ -25,7 +25,7 @@
 
   - csv_max_size = Administrateurs::GroupeInstructeursController::CSV_MAX_SIZE
   - if procedure.publiee?
-    = form_tag import_admin_procedure_groupe_instructeurs_path(procedure), method: :post, html: { multipart: true, class: "mt-4 form" } do
+    = form_tag import_admin_procedure_groupe_instructeurs_path(procedure), method: :post, multipart: true, class: "mt-4 form" do
       = label_tag t('.csv_import.title')
       %p.notice
         = t('.csv_import.notice_1')

--- a/app/views/instructeurs/dossiers/_state_button_motivation.html.haml
+++ b/app/views/instructeurs/dossiers/_state_button_motivation.html.haml
@@ -3,7 +3,7 @@
     %span.icon{ class: popup_class }
     #{popup_title}
 
-  = form_tag(terminer_instructeur_dossier_path(dossier.procedure, dossier), data: { turbo: true, turbo_confirm: confirm }, method: :post, html: { multipart: true, class: 'form' }) do
+  = form_tag(terminer_instructeur_dossier_path(dossier.procedure, dossier), data: { turbo: true, turbo_confirm: confirm }, method: :post, multipart: true, class: 'form') do
     - if title == 'Accepter'
       = text_area :dossier, :motivation, class: 'motivation-text-area', placeholder: placeholder, required: false
       - if dossier.attestation_template&.activated?


### PR DESCRIPTION
Les options html dans un `form_tag` ne doivent pas être définies sous la clé `html` mais directement à la "racine".

Fix régression introduite dans #7958

https://sentry.io/organizations/demarches-simplifiees/issues/3788729281/?project=1429550&query=content_type&referrer=issue-stream&statsPeriod=14d