### PR TITLE
fix(clone-rescue): when record was invalid

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -333,8 +333,8 @@ module Users
       cloned_dossier = @dossier.clone
       flash.notice = t('users.dossiers.cloned_success')
       redirect_to brouillon_dossier_path(cloned_dossier)
-    rescue ActiveRecord::ActiveRecordError => e
-      flash.alert = e.errors.full_messages
+    rescue ActiveRecord::RecordInvalid => e
+      flash.alert = e.record.errors.full_messages
       redirect_to dossier_path(@dossier)
     end
 


### PR DESCRIPTION
Fix rescue 
https://sentry.io/organizations/demarches-simplifiees/issues/3783215566/?project=1429550&query=is%3Aunresolved&referrer=issue-stream

(J'arrive pas à créer en test un dossier invalide sans écrire 20 lignes de code)