### PR TITLE
fix(api-v1): dossier -> avis -> piece_justificative_file_attachment relation

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -280,7 +280,7 @@ class Dossier < ApplicationRecord
       .includes(commentaires: { piece_jointe_attachment: :blob },
         justificatif_motivation_attachment: :blob,
         attestation: [],
-        avis: { piece_justificative_file_attachments: :blob },
+        avis: { piece_justificative_file_attachment: :blob },
         traitement: [],
         etablissement: [],
         individual: [],

--- a/spec/controllers/api/v1/dossiers_controller_spec.rb
+++ b/spec/controllers/api/v1/dossiers_controller_spec.rb
@@ -316,6 +316,14 @@ describe API::V1::DossiersController do
           it { expect(subject.first[:email]).to eq 'plop@plip.com' }
         end
 
+        describe 'avis' do
+          let!(:avis) { create(:avis, dossier: dossier) }
+
+          subject { super()[:avis] }
+
+          it { expect(subject[0][:introduction]).to eq(avis.introduction) }
+        end
+
         describe 'etablissement' do
           let(:field_list) {
             [


### PR DESCRIPTION
Fix chargement d'un dossier en api v1 pour un dossier ayant un avis

https://sentry.io/organizations/demarches-simplifiees/issues/3788783328/?project=1429550&query=is%3Aunresolved&referrer=issue-stream

NB: la relation `piece_justificative_file_attachment` est peut-être inutile dans ce scope car on ne la sérialise pas dans la réponse