### PR TITLE
fix(apiv1):  piece_justificative continue to returns a single attachment

### DIFF
--- a/app/models/champs/piece_justificative_champ.rb
+++ b/app/models/champs/piece_justificative_champ.rb
@@ -49,10 +49,12 @@ class Champs::PieceJustificativeChamp < Champ
   def for_api
     return nil unless piece_justificative_file.attached?
 
-    piece_justificative_file.filter_map do |attachment|
-      if attachment.virus_scanner.safe? || attachment.virus_scanner.pending?
-        attachment.service_url
-      end
+    # API v1 don't support multiple PJ
+    attachment = piece_justificative_file.first
+    return nil if attachment.nil?
+
+    if attachment.virus_scanner.safe? || attachment.virus_scanner.pending?
+      attachment.service_url
     end
   end
 end

--- a/app/services/pieces_justificatives_service.rb
+++ b/app/services/pieces_justificatives_service.rb
@@ -46,14 +46,12 @@ class PiecesJustificativesService
 
   def self.serialize_champs_as_pjs(dossier)
     dossier.champs_public.filter { |champ| champ.type_de_champ.old_pj }.map do |champ|
-      champ.for_api&.map do |content_url|
-        {
-          created_at: champ.created_at&.in_time_zone('UTC'),
-          type_de_piece_justificative_id: champ.type_de_champ.old_pj[:stable_id],
-          content_url:,
-          user: champ.dossier.user
-        }
-      end
+      {
+        created_at: champ.created_at&.in_time_zone('UTC'),
+        type_de_piece_justificative_id: champ.type_de_champ.old_pj[:stable_id],
+        content_url: champ.for_api,
+        user: champ.dossier.user
+      }
     end.flatten
   end
 

--- a/spec/models/champs/piece_justificative_champ_spec.rb
+++ b/spec/models/champs/piece_justificative_champ_spec.rb
@@ -61,17 +61,17 @@ describe Champs::PieceJustificativeChamp do
 
     context 'when file is safe' do
       let(:status) { ActiveStorage::VirusScanner::SAFE }
-      it { is_expected.to match_array([include("/rails/active_storage/disk/")]) }
+      it { is_expected.to include("/rails/active_storage/disk/") }
     end
 
     context 'when file is not scanned' do
       let(:status) { ActiveStorage::VirusScanner::PENDING }
-      it { is_expected.to match_array([include("/rails/active_storage/disk/")]) }
+      it { is_expected.to include("/rails/active_storage/disk/") }
     end
 
     context 'when file is infected' do
       let(:status) { ActiveStorage::VirusScanner::INFECTED }
-      it { is_expected.to eq([]) }
+      it { is_expected.to be_nil }
     end
   end
 end

--- a/spec/serializers/champ_serializer_spec.rb
+++ b/spec/serializers/champ_serializer_spec.rb
@@ -7,7 +7,7 @@ describe ChampSerializer do
       let(:champ) { create(:champ_piece_justificative) }
 
       it {
-        expect(subject[:value]).to match_array([a_string_matching('/rails/active_storage/disk/')])
+        expect(subject[:value]).to a_string_matching('/rails/active_storage/disk/')
       }
     end
 


### PR DESCRIPTION
J'ai juste un doute: est-ce que le dossier serializer (qui appelle ces méthodes) n'est plus qu'utilisé dans le contexte de l'api v1 ? De ce que je vois oui, mais pas facile d'être 100% sûr