### PR TITLE
bug : améliorer l'affichage de la raison sociale pour les entreprises individuelles

### DIFF
--- a/app/lib/api_entreprise/entreprise_adapter.rb
+++ b/app/lib/api_entreprise/entreprise_adapter.rb
@@ -11,6 +11,9 @@ class APIEntreprise::EntrepriseAdapter < APIEntreprise::Adapter
 
     if params.present? && valid_params?(params)
       params[:date_creation] = Time.zone.at(params[:date_creation]).to_datetime if params[:date_creation].present?
+      if params[:raison_sociale].present? && is_individual_entreprise?(params[:forme_juridique_code])
+        params[:raison_sociale] = humanize_raison_sociale(params[:raison_sociale])
+      end
       params.transform_keys { |k| :"entreprise_#{k}" }
     else
       {}
@@ -41,5 +44,25 @@ class APIEntreprise::EntrepriseAdapter < APIEntreprise::Adapter
     when 'A' then 'actif'
     when 'F' then 'fermé'
     end
+  end
+
+  def humanize_raison_sociale(params_raison_sociale)
+    # see SIREN official spec : https://sirene.fr/sirene/public/variable/syr-nomen-long
+    splitted_raison_sociale = params_raison_sociale.split(/[*,\/]/)
+
+    nom_patronymique = splitted_raison_sociale.first
+    prenom = splitted_raison_sociale.last.titleize.strip
+
+    if splitted_raison_sociale.count == 3
+      nom_usage = splitted_raison_sociale.second
+      raison_sociale = "#{prenom} #{nom_usage} (#{nom_patronymique})"
+    else
+      raison_sociale = "#{prenom} #{nom_patronymique}"
+    end
+    raison_sociale
+  end
+
+  def is_individual_entreprise?(forme_juridique_code)
+    forme_juridique_code == "1000"
   end
 end

--- a/spec/fixtures/files/api_entreprise/entreprise_individual.json
+++ b/spec/fixtures/files/api_entreprise/entreprise_individual.json
@@ -1,0 +1,86 @@
+{
+  "entreprise": {
+    "siren": "909700890",
+    "capital_social": null,
+    "numero_tva_intracommunautaire": "FR19909700890",
+    "forme_juridique": "Entrepreneur individuel",
+    "forme_juridique_code": "1000",
+    "nom_commercial": "",
+    "procedure_collective": false,
+    "enseigne": null,
+    "libelle_naf_entreprise": "Ingénierie, études techniques",
+    "naf_entreprise": "7112B",
+    "raison_sociale": "LE LOUARN*LE LOUARN SMAIL/MARINE  /",
+    "siret_siege_social": "90970089000025",
+    "code_effectif_entreprise": null,
+    "date_creation": 1643151600,
+    "nom": "LE LOUARN",
+    "prenom": "MARINE",
+    "date_radiation": null,
+    "categorie_entreprise": null,
+    "tranche_effectif_salarie_entreprise": {
+      "de": null,
+      "a": null,
+      "code": null,
+      "date_reference": null,
+      "intitule": null
+    },
+    "mandataires_sociaux": [],
+    "etat_administratif": {
+      "value": "A",
+      "date_cessation": null
+    },
+    "diffusable_commercialement": true
+  },
+  "etablissement_siege": {
+    "siege_social": true,
+    "siret": "90970089000025",
+    "naf": "7112B",
+    "libelle_naf": "Ingénierie, études techniques",
+    "date_mise_a_jour": 1657592059,
+    "tranche_effectif_salarie_etablissement": {
+      "de": null,
+      "a": null,
+      "code": null,
+      "date_reference": null,
+      "intitule": null
+    },
+    "date_creation_etablissement": 1646694000,
+    "region_implantation": {
+      "code": "84",
+      "value": "Auvergne-Rhône-Alpes"
+    },
+    "commune_implantation": {
+      "code": "42218",
+      "value": "Saint-Étienne"
+    },
+    "pays_implantation": {
+      "code": "FR",
+      "value": "FRANCE"
+    },
+    "diffusable_commercialement": true,
+    "enseigne": null,
+    "adresse": {
+      "l1": "MADAME MARINE LE LOUARN SMAIL",
+      "l2": null,
+      "l3": null,
+      "l4": "4 RUE ETIENNE MIMARD",
+      "l5": null,
+      "l6": "42000 SAINT-ETIENNE",
+      "l7": "FRANCE",
+      "numero_voie": "4",
+      "type_voie": "RUE",
+      "nom_voie": "ETIENNE MIMARD",
+      "complement_adresse": null,
+      "code_postal": "42000",
+      "localite": "SAINT-ETIENNE",
+      "code_insee_localite": "42218",
+      "cedex": null
+    },
+    "etat_administratif": {
+      "value": "A",
+      "date_fermeture": null
+    }
+  },
+  "gateway_error": false
+}

--- a/spec/lib/api_entreprise/entreprise_adapter_spec.rb
+++ b/spec/lib/api_entreprise/entreprise_adapter_spec.rb
@@ -103,4 +103,20 @@ describe APIEntreprise::EntrepriseAdapter do
       expect { subject }.to raise_error(APIEntreprise::API::Error::RequestFailed)
     end
   end
+
+  context "when individual" do
+    let(:siren) { '909700890' }
+    let(:body) { File.read('spec/fixtures/files/api_entreprise/entreprise_individual.json') }
+    let(:status) { 200 }
+
+    context 'Attributs Entreprises' do
+      it 'L\'entreprise contient bien un forme_juridique_code' do
+        expect(subject[:entreprise_forme_juridique_code]).to eq('1000')
+      end
+
+      it 'L\'entreprise contient bien une raison_sociale' do
+        expect(subject[:entreprise_raison_sociale]).to eq('Marine LE LOUARN SMAIL (LE LOUARN)')
+      end
+    end
+  end
 end


### PR DESCRIPTION
#7974 

Ajout d'une méthode dans l'entreprise_adapter pour retravailler le format de la raison sociale renvoyé par l'api.

> LE LOUARN*LE LOUARN SMAIL/MARINE  /
> devient -> Marine LE LOUARN SMAIL (LE LOUARN)

Je me suis posée la question s'il fallait faire une after_party pour modifier les données existantes, mais comme il s'agit d'une amélioration plutot "cosmétique" et qu'il y a 138K d'entreprises individuelles en base (merci @E-L-T pour le chiffre)  , ça semble être un chantier trop lourd pour un gain faible.