### PR TITLE
fix(annuaire-education): schema less strict

### DIFF
--- a/app/schemas/etablissement-annuaire-education.json
+++ b/app/schemas/etablissement-annuaire-education.json
@@ -167,14 +167,12 @@
   "required": [
     "identifiant_de_l_etablissement",
     "nom_etablissement",
-    "type_contrat_prive",
     "nom_commune",
     "code_commune",
     "libelle_academie",
     "code_academie",
     "libelle_nature",
     "code_nature",
-    "adresse_1",
     "code_postal",
     "libelle_region",
     "code_region"

--- a/app/views/shared/champs/annuaire_education/_show.html.haml
+++ b/app/views/shared/champs/annuaire_education/_show.html.haml
@@ -35,7 +35,8 @@
       %tr
         %th.libelle Adresse :
         %td
-          = champ.data['adresse_1']
+          - if champ.data['adresse_1'].present?
+            = champ.data['adresse_1']
           %br
           = "#{champ.data['code_postal']} #{champ.data['nom_commune']}"
           %br


### PR DESCRIPTION
Ces attributs ne sont pas toujours retournés pour quelques établissements et font échouer les jobs : 

- `adresse_1`
- `type_contrat_prive`

Fix https://sentry.io/organizations/demarches-simplifiees/issues/3328955794/events/147affe4b73b43a391c257b97d298bb9/?project=1429550