### PR TITLE
fix(notifications) : réintégrer les pastilles dans les tableaux avec actions multiples

### DIFF
--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -123,6 +123,9 @@
                         = check_box_tag :"batch_operation[dossier_ids][]", p.dossier_id, true, disabled: true, id: dom_id(BatchOperation.new, "checkbox_#{p.dossier_id}"), aria: {label: t('views.instructeurs.dossiers.batch_operation.disabled')}
                       - else
                         = check_box_tag :"batch_operation[dossier_ids][]", p.dossier_id, false, data: { "batch-operation-target" => "input", "action" => "batch-operation#onCheckOne"}, form: dom_id(BatchOperation.new), id: dom_id(BatchOperation.new, "checkbox_#{p.dossier_id}"), aria: {label: t('views.instructeurs.dossiers.batch_operation.enabled')}
+
+                      - if @not_archived_notifications_dossier_ids.include?(p.dossier_id)
+                        %span.notifications{ 'aria-label': 'notifications' }
                     - else
                       - if p.hidden_by_administration_at.present?
                         %span.cell-link


### PR DESCRIPTION
<img width="409" alt="Capture d’écran 2022-12-07 à 16 20 17" src="https://user-images.githubusercontent.com/6756627/206219069-c1b18cd3-ff3c-4ecd-b37e-c02e023162a1.png">
