### PR TITLE
amelioration(administrateur/carte-email): la carte des emails affiche en permanence à configurer

### DIFF
--- a/app/components/procedure/card/emails_component.rb
+++ b/app/components/procedure/card/emails_component.rb
@@ -1,6 +1,16 @@
 class Procedure::Card::EmailsComponent < ApplicationComponent
+  CUSTOMIZABLE_COUNT = 5
+
   def initialize(procedure:)
     @procedure = procedure
+  end
+
+  def customized_progress
+    "#{customized_count} / #{CUSTOMIZABLE_COUNT}"
+  end
+
+  def fully_customized?
+    customized_count == CUSTOMIZABLE_COUNT
   end
 
   private
@@ -13,5 +23,15 @@ class Procedure::Card::EmailsComponent < ApplicationComponent
       @procedure.errors.messages_for(:refused_mail),
       @procedure.errors.messages_for(:without_continuation_mail)
     ].flatten.to_sentence
+  end
+
+  def customized_count
+    [
+      @procedure.initiated_mail,
+      @procedure.received_mail,
+      @procedure.closed_mail,
+      @procedure.refused_mail,
+      @procedure.without_continuation_mail
+    ].map { |mail| mail&.updated_at }.compact.size
   end
 end

--- a/app/components/procedure/card/emails_component/emails_component.html.haml
+++ b/app/components/procedure/card/emails_component/emails_component.html.haml
@@ -5,10 +5,16 @@
         - if error_messages.present?
           %span.icon.refuse
           %p.fr-tile-status-error À modifier
+        - elsif fully_customized?
+          %span.icon.accept
+          %p.fr-tile-status-todo Validé
         - else
           %span.icon.clock
           %p.fr-tile-status-todo À configurer
       %div
-        %h3.fr-h6.fr-mt-10v= t('.title')
+        .line-count.fr-my-1w
+          %p.fr-tag= customized_progress
+
+        %h3.fr-h6= t('.title')
         %p.fr-tile-subtitle Notifications automatiques
       %p.fr-btn.fr-btn--tertiary= t('views.shared.actions.edit')


### PR DESCRIPTION
see: https://secure.helpscout.net/conversation/2091620797/2007424?folderId=1653799

<img width="254" alt="Screen Shot 2022-12-08 at 3 33 42 PM" src="https://user-images.githubusercontent.com/125964/206481761-d9f1d766-9bec-469d-b951-e1115273b7ac.png">
<img width="264" alt="Screen Shot 2022-12-08 at 3 33 14 PM" src="https://user-images.githubusercontent.com/125964/206481766-e15a9ef5-e86b-48d6-9a88-9e65683b569d.png">
