### PR TITLE
Us/poc multiple passer en instruction

### DIFF
--- a/app/components/dossiers/batch_alert_component/batch_alert_component.en.yml
+++ b/app/components/dossiers/batch_alert_component/batch_alert_component.en.yml
@@ -1,13 +1,25 @@
 en:
-  finish:
-    title: The bulk action is finished
-    text:
-      one: 1/1 file has been archived
-      other: "%{success_count}/%{count} files have been archived"
-  in_progress:
-    title: A bulk action is processing
-    text_success:
-      one: 1/1 is being archived
-      other: "%{progress_count}/%{count} files have been archived"
+  archiver:
+    finish:
+      title: The bulk action is finished
+      text:
+        one: 1/1 file has been archived
+        other: "%{success_count}/%{count} files have been archived"
+    in_progress:
+      title: A bulk action is processing
+      text_success:
+        one: 1/1 is being archived
+        other: "%{progress_count}/%{count} files have been archived"
+  passer_en_instruction:
+    finish:
+      title: The bulk action is finished
+      text:
+        one: 1/1 file has been changed to instructing
+        other: "%{success_count}/%{count} files have been changed to instructing"
+    in_progress:
+      title: A bulk action is processing
+      text_success:
+        one: 1/1 is being changed to instructing
+        other: "%{progress_count}/%{count} files have been changed to instructing"
   link_text: Refresh this webpage
   after_link_text: to check if the process is over.

--- a/app/components/dossiers/batch_alert_component/batch_alert_component.fr.yml
+++ b/app/components/dossiers/batch_alert_component/batch_alert_component.fr.yml
@@ -1,13 +1,25 @@
 fr:
-  finish:
-    title: L'action de masse est terminée
-    text_success:
-      one: 1 dossier a été archivé
-      other: "%{success_count}/%{count} dossiers ont été archivés"
-  in_progress:
-    title: Une action de masse est en cours
-    text_success:
-      one: 1 dossier sera archivé
-      other: "%{progress_count}/%{count} dossiers ont été archivés"
+  archiver:
+    finish:
+      title: L'action de masse est terminée
+      text_success:
+        one: 1 dossier a été archivé
+        other: "%{success_count}/%{count} dossiers ont été archivés"
+    in_progress:
+      title: Une action de masse est en cours
+      text_success:
+        one: 1 dossier sera archivé
+        other: "%{progress_count}/%{count} dossiers ont été archivés"
+  passer_en_instruction:
+    finish:
+      title: L'action de masse est terminée
+      text_success:
+        one: 1 dossier a été passé en instruction
+        other: "%{success_count}/%{count} dossiers ont été passés en instruction"
+    in_progress:
+      title: Une action de masse est en cours
+      text_success:
+        one: 1 dossier sera passé en instruction
+        other: "%{progress_count}/%{count} dossiers ont été passés en instruction"
   link_text: Recharger la page
   after_link_text: pour voir si l'opération est finie.

--- a/app/components/dossiers/batch_alert_component/batch_alert_component.html.haml
+++ b/app/components/dossiers/batch_alert_component/batch_alert_component.html.haml
@@ -1,15 +1,15 @@
 .fr-mb-5v
   - if @batch.finished_at.present?
-    = render Dsfr::AlertComponent.new(title: t('.finish.title'), state: (@batch.failed_dossier_ids.size.positive? ? :warning : :success), heading_level: 'h2') do |c|
+    = render Dsfr::AlertComponent.new(title: t(".#{batch.operation}.finish.title"), state: (@batch.failed_dossier_ids.size.positive? ? :warning : :success), heading_level: 'h2') do |c|
       - c.body do
         %p
-          = t('.finish.text_success', count: @batch.total_count, success_count: @batch.success_dossier_ids.size)
+          = t(".#{batch.operation}.finish.text_success", count: @batch.total_count, success_count: @batch.success_dossier_ids.size)
 
 
   - else
-    = render Dsfr::AlertComponent.new(title: t('.in_progress.title'), state: :info, heading_level: 'h2') do |c|
+    = render Dsfr::AlertComponent.new(title: t(".#{batch.operation}.in_progress.title"), state: :info, heading_level: 'h2') do |c|
       - c.body do
-        %p= t('.in_progress.text_success', count: @batch.total_count, progress_count: @batch.progress_count)
+        %p= t(".#{batch.operation}.in_progress.text_success", count: @batch.total_count, progress_count: @batch.progress_count)
 
         %p
           = link_to t('.link_text'), instructeur_procedure_path(@procedure, statut: params["statut"]), data: { action: 'turbo-poll#refresh' }

--- a/app/components/dossiers/batch_operation_component.rb
+++ b/app/components/dossiers/batch_operation_component.rb
@@ -21,4 +21,11 @@ class Dossiers::BatchOperationComponent < ApplicationComponent
     end
     options
   end
+
+  def icons
+    {
+      archiver: 'fr-icon-folder-2-line',
+      passer_en_instruction: 'fr-icon-edit-line'
+    }
+  end
 end

--- a/app/components/dossiers/batch_operation_component.rb
+++ b/app/components/dossiers/batch_operation_component.rb
@@ -7,7 +7,7 @@ class Dossiers::BatchOperationComponent < ApplicationComponent
   end
 
   def render?
-    @statut == 'traites'
+    @statut == 'traites' || 'suivis'
   end
 
   def available_operations
@@ -15,9 +15,10 @@ class Dossiers::BatchOperationComponent < ApplicationComponent
     case @statut
     when 'traites' then
       options.push [t(".operations.archiver"), BatchOperation.operations.fetch(:archiver)]
+    when 'suivis' then
+      options.push [t(".operations.passer_en_instruction"), BatchOperation.operations.fetch(:passer_en_instruction)]
     else
     end
-
     options
   end
 end

--- a/app/components/dossiers/batch_operation_component/batch_operation_component.en.yml
+++ b/app/components/dossiers/batch_operation_component/batch_operation_component.en.yml
@@ -1,3 +1,4 @@
 fr:
   operations:
     archiver: 'Archive selected files'
+    passer_en_instruction: 'Change selected files to instructing'

--- a/app/components/dossiers/batch_operation_component/batch_operation_component.fr.yml
+++ b/app/components/dossiers/batch_operation_component/batch_operation_component.fr.yml
@@ -1,3 +1,4 @@
 fr:
   operations:
     archiver: 'Archiver les dossiers sélectionnés'
+    passer_en_instruction: 'Passer en instruction les dossiers sélectionnés'

--- a/app/components/dossiers/batch_operation_component/batch_operation_component.html.haml
+++ b/app/components/dossiers/batch_operation_component/batch_operation_component.html.haml
@@ -1,4 +1,4 @@
 = form_for(BatchOperation.new, url: instructeur_batch_operations_path(procedure_id: procedure.id), method: :post, id: dom_id(BatchOperation.new), html: { class: 'flex justify-end' }, data: { "batch-operation-target" => "form"}) do |form|
   .flex.align-center
     - available_operations.each do |opt|
-      = form.button opt[0], class: "fr-btn fr-btn--icon-left fr-icon-folder-2-line", disabled: :disabled, name: "#{form.object_name}[operation]", data: { "batch-operation-target" => "submit", "submitter-operation" => opt[1]}
+      = form.button opt[0], class: ['fr-btn fr-btn--icon-left', icons[opt[1].to_sym]], disabled: :disabled, name: "#{form.object_name}[operation]", data: { "batch-operation-target" => "submit", "submitter-operation" => opt[1]}

--- a/app/controllers/instructeurs/batch_operations_controller.rb
+++ b/app/controllers/instructeurs/batch_operations_controller.rb
@@ -4,7 +4,8 @@ module Instructeurs
     before_action :ensure_ownership!
 
     def create
-      BatchOperation.safe_create!(batch_operation_params)
+      batch = BatchOperation.safe_create!(batch_operation_params)
+      flash[:alert] = "Le traitement de masse n'a pas été lancé. Vérifiez que l'action demandée est possible pour les dossiers sélectionnés" if batch.blank?
       redirect_back(fallback_location: instructeur_procedure_url(@procedure.id))
     end
 

--- a/spec/components/dossiers/batch_alert_component_spec.rb
+++ b/spec/components/dossiers/batch_alert_component_spec.rb
@@ -1,5 +1,4 @@
 RSpec.describe Dossiers::BatchAlertComponent, type: :component do
-
   let(:instructeur) { create(:instructeur) }
   let(:procedure) { create(:procedure) }
 

--- a/spec/components/dossiers/batch_alert_component_spec.rb
+++ b/spec/components/dossiers/batch_alert_component_spec.rb
@@ -1,58 +1,116 @@
 RSpec.describe Dossiers::BatchAlertComponent, type: :component do
-  let(:component) do
-    described_class.new(
-      batch: batch_operation,
-      procedure: procedure
-    )
-  end
+
   let(:instructeur) { create(:instructeur) }
   let(:procedure) { create(:procedure) }
-  let!(:dossier) { create(:dossier, :accepte, procedure: procedure) }
-  let!(:dossier_2) { create(:dossier, :accepte, procedure: procedure) }
-  let!(:batch_operation) { create(:batch_operation, operation: :archiver, dossiers: [dossier, dossier_2], instructeur: instructeur) }
 
   subject { render_inline(component).to_html }
 
-  context 'in_progress' do
-    before {
-       batch_operation.track_processed_dossier(true, dossier)
-       batch_operation.reload
-     }
+  describe 'archiver' do
+    let(:component) do
+      described_class.new(
+        batch: batch_operation,
+        procedure: procedure
+      )
+    end
+    let!(:dossier) { create(:dossier, :accepte, procedure: procedure) }
+    let!(:dossier_2) { create(:dossier, :accepte, procedure: procedure) }
+    let!(:batch_operation) { create(:batch_operation, operation: :archiver, dossiers: [dossier, dossier_2], instructeur: instructeur) }
+    context 'in_progress' do
+      before {
+         batch_operation.track_processed_dossier(true, dossier)
+         batch_operation.reload
+       }
 
-    it { is_expected.to have_selector('.fr-alert--info') }
-    it { is_expected.to have_text("Une action de masse est en cours") }
-    it { is_expected.to have_text("1/2 dossiers ont été archivés") }
+      it { is_expected.to have_selector('.fr-alert--info') }
+      it { is_expected.to have_text("Une action de masse est en cours") }
+      it { is_expected.to have_text("1/2 dossiers ont été archivés") }
+    end
+
+    context 'finished and success' do
+      before {
+         batch_operation.track_processed_dossier(true, dossier)
+         batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.reload
+       }
+
+      it { is_expected.to have_selector('.fr-alert--success') }
+      it { is_expected.to have_text("L'action de masse est terminée") }
+      it { is_expected.to have_text("2 dossiers ont été archivés") }
+      it { expect(batch_operation.seen_at).to eq(nil) }
+    end
+
+    context 'finished and fail' do
+      before {
+        batch_operation.track_processed_dossier(false, dossier)
+        batch_operation.track_processed_dossier(true, dossier_2)
+        batch_operation.reload
+      }
+
+      it { is_expected.to have_selector('.fr-alert--warning') }
+      it { is_expected.to have_text("L'action de masse est terminée") }
+      it { is_expected.to have_text("1/2 dossiers ont été archivés") }
+      it { expect(batch_operation.seen_at).to eq(nil) }
+
+      it 'does not display alert on the next render' do
+        render_inline(component).to_html
+        expect(batch_operation.seen_at).not_to eq(nil)
+        expect(subject).not_to have_text("1 dossier n'a pas été archivé")
+      end
+    end
   end
 
-  context 'finished and success' do
-    before {
-       batch_operation.track_processed_dossier(true, dossier)
-       batch_operation.track_processed_dossier(true, dossier_2)
-       batch_operation.reload
-     }
+  describe 'passer_en_instruction' do
+    let(:component) do
+      described_class.new(
+        batch: batch_operation,
+        procedure: procedure
+      )
+    end
+    let!(:dossier) { create(:dossier, :en_construction, procedure: procedure) }
+    let!(:dossier_2) { create(:dossier, :en_construction, procedure: procedure) }
+    let!(:batch_operation) { create(:batch_operation, operation: :passer_en_instruction, dossiers: [dossier, dossier_2], instructeur: instructeur) }
 
-    it { is_expected.to have_selector('.fr-alert--success') }
-    it { is_expected.to have_text("L'action de masse est terminée") }
-    it { is_expected.to have_text("2 dossiers ont été archivés") }
-    it { expect(batch_operation.seen_at).to eq(nil) }
-  end
+    context 'in_progress' do
+      before {
+         batch_operation.track_processed_dossier(true, dossier)
+         batch_operation.reload
+       }
 
-  context 'finished and fail' do
-    before {
-      batch_operation.track_processed_dossier(false, dossier)
-      batch_operation.track_processed_dossier(true, dossier_2)
-      batch_operation.reload
-    }
+      it { is_expected.to have_selector('.fr-alert--info') }
+      it { is_expected.to have_text("Une action de masse est en cours") }
+      it { is_expected.to have_text("1/2 dossiers ont été passés en instruction") }
+    end
 
-    it { is_expected.to have_selector('.fr-alert--warning') }
-    it { is_expected.to have_text("L'action de masse est terminée") }
-    it { is_expected.to have_text("1/2 dossiers ont été archivés") }
-    it { expect(batch_operation.seen_at).to eq(nil) }
+    context 'finished and success' do
+      before {
+         batch_operation.track_processed_dossier(true, dossier)
+         batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.reload
+       }
 
-    it 'does not display alert on the next render' do
-      render_inline(component).to_html
-      expect(batch_operation.seen_at).not_to eq(nil)
-      expect(subject).not_to have_text("1 dossier n'a pas été archivé")
+      it { is_expected.to have_selector('.fr-alert--success') }
+      it { is_expected.to have_text("L'action de masse est terminée") }
+      it { is_expected.to have_text("2 dossiers ont été passés en instruction") }
+      it { expect(batch_operation.seen_at).to eq(nil) }
+    end
+
+    context 'finished and fail' do
+      before {
+        batch_operation.track_processed_dossier(false, dossier)
+        batch_operation.track_processed_dossier(true, dossier_2)
+        batch_operation.reload
+      }
+
+      it { is_expected.to have_selector('.fr-alert--warning') }
+      it { is_expected.to have_text("L'action de masse est terminée") }
+      it { is_expected.to have_text("1/2 dossiers ont été passés en instruction") }
+      it { expect(batch_operation.seen_at).to eq(nil) }
+
+      it 'does not display alert on the next render' do
+        render_inline(component).to_html
+        expect(batch_operation.seen_at).not_to eq(nil)
+        expect(subject).not_to have_text("1 dossier n'a pas passé en instruction")
+      end
     end
   end
 end

--- a/spec/components/dossiers/batch_operation_component_spec.rb
+++ b/spec/components/dossiers/batch_operation_component_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe Dossiers::BatchOperationComponent, type: :component do
     it { is_expected.to have_selector('button') }
   end
 
+  subject { render_inline(component).to_html }
+  context 'statut suivis' do
+    let(:statut) { 'suivis' }
+    it { is_expected.to have_selector('button') }
+  end
+
   context 'statut tous' do
     let(:statut) { 'tous' }
     it { is_expected.not_to have_selector('button') }

--- a/spec/controllers/instructeurs/batch_operations_controller_spec.rb
+++ b/spec/controllers/instructeurs/batch_operations_controller_spec.rb
@@ -43,5 +43,14 @@ describe Instructeurs::BatchOperationsController, type: :controller do
         expect { subject }.to have_enqueued_job(BatchOperationEnqueueAllJob).with(BatchOperation.last)
       end
     end
+
+    context 'fails with no dossiers' do
+      let(:dossier) { create(:dossier, :en_instruction, procedure: procedure) }
+
+      it 'does not create a batch operation if no dossiers' do
+        expect { subject }.not_to change { instructeur.batch_operations.count }
+        expect(flash.alert).to eq("Le traitement de masse n'a pas été lancé. Vérifiez que l'action demandée est possible pour les dossiers sélectionnés")
+      end
+    end
   end
 end

--- a/spec/factories/batch_operation.rb
+++ b/spec/factories/batch_operation.rb
@@ -17,5 +17,16 @@ FactoryBot.define do
         ]
       end
     end
+
+    trait :passer_en_instruction do
+      operation { BatchOperation.operations.fetch(:passer_en_instruction) }
+      after(:build) do |batch_operation, evaluator|
+        procedure = create(:simple_procedure, :published, instructeurs: [evaluator.invalid_instructeur.presence || batch_operation.instructeur], administrateurs: [create(:administrateur)])
+        batch_operation.dossiers = [
+          create(:dossier, :with_individual, :en_construction, procedure: procedure),
+          create(:dossier, :with_individual, :en_construction, procedure: procedure)
+        ]
+      end
+    end
   end
 end

--- a/spec/jobs/batch_operation_process_one_job_spec.rb
+++ b/spec/jobs/batch_operation_process_one_job_spec.rb
@@ -26,9 +26,9 @@ describe BatchOperationProcessOneJob, type: :job do
     context 'when operation is "archiver"' do
       it 'archives the dossier in the batch' do
         expect { subject.perform_now }
-        .to change { dossier_job.reload.archived? }
-        .from(false)
-        .to(true)
+          .to change { dossier_job.reload.archived? }
+          .from(false)
+          .to(true)
       end
     end
 
@@ -40,9 +40,9 @@ describe BatchOperationProcessOneJob, type: :job do
 
       it 'changes the dossier to en_instruction in the batch' do
         expect { subject.perform_now }
-        .to change { dossier_job.reload.en_instruction? }
-        .from(false)
-        .to(true)
+          .to change { dossier_job.reload.en_instruction? }
+          .from(false)
+          .to(true)
       end
     end
 

--- a/spec/jobs/batch_operation_process_one_job_spec.rb
+++ b/spec/jobs/batch_operation_process_one_job_spec.rb
@@ -23,6 +23,29 @@ describe BatchOperationProcessOneJob, type: :job do
       expect(batch_operation.reload.failed_dossier_ids).to eq([dossier_job.id])
     end
 
+    context 'when operation is "archiver"' do
+      it 'archives the dossier in the batch' do
+        expect { subject.perform_now }
+        .to change { dossier_job.reload.archived? }
+        .from(false)
+        .to(true)
+      end
+    end
+
+    context 'when operation is "passer_en_instruction"' do
+      let(:batch_operation) do
+        create(:batch_operation, :passer_en_instruction,
+                                 options.merge(instructeur: create(:instructeur)))
+      end
+
+      it 'changes the dossier to en_instruction in the batch' do
+        expect { subject.perform_now }
+        .to change { dossier_job.reload.en_instruction? }
+        .from(false)
+        .to(true)
+      end
+    end
+
     context 'when the dossier is out of sync (ie: someone applied a transition somewhere we do not know)' do
       let(:instructeur) { create(:instructeur) }
       let(:procedure) { create(:simple_procedure, instructeurs: [instructeur]) }

--- a/spec/models/batch_operation_spec.rb
+++ b/spec/models/batch_operation_spec.rb
@@ -60,13 +60,6 @@ describe BatchOperation, type: :model do
           .from([])
           .to([dossier.id])
       end
-
-      it 'changes the state' do
-        expect { batch_operation.track_processed_dossier(true, dossier) }
-          .to change { dossier.state }
-          .from('accepte')
-          .to('archive')
-      end
     end
 
     context 'when it succeed after a failure' do

--- a/spec/models/batch_operation_spec.rb
+++ b/spec/models/batch_operation_spec.rb
@@ -186,7 +186,7 @@ describe BatchOperation, type: :model do
     let(:instructeur) { create(:instructeur) }
     let(:procedure) { create(:simple_procedure, instructeurs: [instructeur]) }
     let(:dossier_2) { create(:dossier, :accepte, procedure: procedure) }
-    subject { BatchOperation.safe_create!(instructeur: instructeur, operation: :archiver, dossier_ids: [dossier.id, dossier_2.id,]) }
+    subject { BatchOperation.safe_create!(instructeur: instructeur, operation: :archiver, dossier_ids: [dossier.id, dossier_2.id]) }
 
     context 'success with divergent list of dossier_ids' do
       let(:dossier) { create(:dossier, :accepte, :with_individual, archived: true, procedure: procedure) }


### PR DESCRIPTION
Dans la suite de la mise en place des actions de masse, nous devions mettre en place l'action "accepter", mais on ne peut accepter un dossier sans l'avoir passer en instruction. Il semblait donc plus logique pour l'utilisateur·ice que cette action soit développée et déployée avant.

<img width="1135" alt="Capture d’écran 2022-12-12 à 10 35 56" src="https://user-images.githubusercontent.com/6756627/207011679-0eacd93d-1a69-4575-bea1-c0a71fbafdac.png">

