### PR TITLE
refactor(dossier): improuve dossiers_safe_scope on batch operation

### DIFF
--- a/app/models/batch_operation.rb
+++ b/app/models/batch_operation.rb
@@ -40,10 +40,10 @@ class BatchOperation < ApplicationRecord
   }
 
   def dossiers_safe_scope(dossier_ids = self.dossier_ids)
-    query = Dossier.joins(:procedure)
-      .where(procedure: { id: instructeur.procedures.ids })
-      .where(id: dossier_ids)
+    query = instructeur
+      .dossiers
       .visible_by_administration
+      .where(id: dossier_ids)
     case operation
     when BatchOperation.operations.fetch(:archiver) then
       query.not_archived.state_termine


### PR DESCRIPTION
Un instructeur devrait avoir accès uniquement aux dossiers de ses groupes instructeurs