### PR TITLE
feat(revision): allow more dossiers to rebase

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -4,20 +4,4 @@ class AdminController < ApplicationController
   def index
     redirect_to(admin_procedures_path)
   end
-
-  def retrieve_procedure
-    id = params[:procedure_id] || params[:id]
-
-    @procedure = current_administrateur.procedures.find(id)
-
-  rescue ActiveRecord::RecordNotFound
-    flash.alert = 'Démarche inexistante'
-    redirect_to admin_procedures_path, status: 404
-  end
-
-  def reset_procedure
-    if @procedure.brouillon?
-      @procedure.reset!
-    end
-  end
 end

--- a/app/controllers/administrateurs/administrateur_controller.rb
+++ b/app/controllers/administrateurs/administrateur_controller.rb
@@ -13,9 +13,7 @@ module Administrateurs
     end
 
     def reset_procedure
-      if @procedure.brouillon? || @procedure.draft_changed?
-        @procedure.reset!
-      end
+      @procedure.reset!
     end
 
     def ensure_not_super_admin!

--- a/app/controllers/administrateurs/conditions_controller.rb
+++ b/app/controllers/administrateurs/conditions_controller.rb
@@ -3,6 +3,7 @@ module Administrateurs
     include Logic
 
     before_action :retrieve_procedure, :retrieve_coordinate_and_uppers
+    after_action :reset_procedure
 
     def update
       condition = condition_form.to_condition

--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -4,6 +4,7 @@ module Administrateurs
 
     before_action :retrieve_procedure, only: [:champs, :annotations, :modifications, :edit, :zones, :monavis, :update_monavis, :jeton, :update_jeton, :publication, :publish, :transfert, :close, :allow_expert_review, :experts_require_administrateur_invitation, :reset_draft]
     before_action :draft_valid?, only: [:apercu]
+    after_action :reset_procedure, only: [:update]
 
     ITEMS_PER_PAGE = 25
 
@@ -139,7 +140,6 @@ module Administrateurs
           render 'edit'
         end
       elsif @procedure.brouillon?
-        reset_procedure
         flash.notice = 'Démarche modifiée. Tous les dossiers de cette démarche ont été supprimés.'
         redirect_to admin_procedure_path(id: @procedure.id)
       else

--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -1,6 +1,7 @@
 module Administrateurs
   class TypesDeChampController < AdministrateurController
     before_action :retrieve_procedure
+    after_action :reset_procedure, only: [:create, :update, :destroy]
 
     def create
       type_de_champ = draft.add_type_de_champ(type_de_champ_create_params)
@@ -10,7 +11,6 @@ module Administrateurs
         @created = champ_component_from(@coordinate, focused: true)
         @morphed = champ_components_starting_at(@coordinate, 1)
 
-        reset_procedure
         flash.notice = "Formulaire enregistré"
       else
         flash.alert = type_de_champ.errors.full_messages
@@ -24,7 +24,6 @@ module Administrateurs
         @coordinate = draft.coordinate_for(type_de_champ)
         @morphed = champ_components_starting_at(@coordinate)
 
-        reset_procedure
         flash.notice = "Formulaire enregistré"
       else
         flash.alert = type_de_champ.errors.full_messages
@@ -69,7 +68,6 @@ module Administrateurs
 
     def destroy
       @coordinate = draft.remove_type_de_champ(params[:stable_id])
-      reset_procedure
       flash.notice = "Formulaire enregistré"
 
       if @coordinate.present?

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -783,7 +783,7 @@ class Procedure < ApplicationRecord
     end
     dossiers
       .state_not_termine
-      .find_each { |dossier| DossierRebaseJob.perform_later(dossier) }
+      .find_each(&:rebase_later)
   end
 
   def reset_draft_revision!

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -252,7 +252,7 @@ class ProcedureRevision < ApplicationRecord
       end
 
       added = (to_sids - from_sids).map do |sid|
-        { model: :type_de_champ, op: :add, label: to_h[sid].libelle, private: to_h[sid].private?, _position: to_sids.index(sid), stable_id: sid }
+        { model: :type_de_champ, op: :add, label: to_h[sid].libelle, private: to_h[sid].private?, mandatory: to_h[sid].mandatory?, _position: to_sids.index(sid), stable_id: sid }
       end
 
       kept = from_sids.intersection(to_sids)

--- a/spec/models/procedure_revision_spec.rb
+++ b/spec/models/procedure_revision_spec.rb
@@ -433,6 +433,7 @@ describe ProcedureRevision do
             op: :add,
             label: "Un champ text",
             private: false,
+            mandatory: false,
             stable_id: new_tdc.stable_id
           }
         ])


### PR DESCRIPTION
Cette PR autorise le rebase de dossiers dans plus de cas. Notamment on autorise toujours de rebase les changements sur les annotations privées ce qui résout beaucoup de cas au support.