### PR TITLE
fix(schema): champs.prefilled default

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -220,7 +220,7 @@ ActiveRecord::Schema.define(version: 2022_12_05_144624) do
     t.string "external_id"
     t.string "fetch_external_data_exceptions", array: true
     t.bigint "parent_id"
-    t.boolean "prefilled", default: false
+    t.boolean "prefilled"
     t.boolean "private", default: false, null: false
     t.datetime "rebased_at"
     t.integer "row"

--- a/spec/models/concern/dossier_prefillable_concern_spec.rb
+++ b/spec/models/concern/dossier_prefillable_concern_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe DossierPrefillableConcern do
         end
 
         it "still marks it as prefilled" do
-          expect { fill }.to change { dossier.champs_public.first.prefilled }.from(false).to(true)
+          expect { fill }.to change { dossier.champs_public.first.prefilled }.from(nil).to(true)
         end
       end
     end


### PR DESCRIPTION
J'ai remarqué que le schéma contient une erreur par rapport à une migration récente : l'attribut `prefilled` de `champ` ne devrait pas avoir de valeur par défaut. C'est une erreur introduite par #8145.

![image](https://user-images.githubusercontent.com/1193334/207555702-dde67d55-0fd4-4be6-becd-89a07e38eba7.png)

Je corrige cette erreur dans cette PR.