### PR TITLE
Add prefill api to rack_attack

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -17,6 +17,12 @@ class Rack::Attack
     end
   end
 
+  throttle('/api/public/v1/dossiers/ip', limit: 5, period: 20.seconds) do |req|
+    if req.path == '/api/public/v1/dossiers' && req.post? && rack_attack_enabled?
+      req.remote_ip
+    end
+  end
+
   Rack::Attack.safelist('allow from localhost') do |req|
     IPService.ip_trusted?(req.remote_ip)
   end


### PR DESCRIPTION
Micro PR destinée à ouvrir le dialogue sur le rate_limiting de l'API prefilling, histoire de ne pas laisser la porte grande ouverte.

Vous aviez parlé de quelque chose d'existant au niveau des load_balancers. Ca semble nécessaire d'explorer ça ? Vous pourriez me guider un peu ?