### PR TITLE
style(instructeurs): dossiers table with dropdown DSFR

### DIFF
--- a/app/components/dossiers/export_component/export_component.html.haml
+++ b/app/components/dossiers/export_component/export_component.html.haml
@@ -1,5 +1,5 @@
 %span.dropdown{ data: { controller: 'menu-button' } }
-  %button.button.dropdown-button{ data: { menu_button_target: 'button' } }
+  %button.fr-btn.fr-btn--secondary.fr-btn--sm.dropdown-button{ data: { menu_button_target: 'button' } }
     - if @count.nil?
       = t(".download_all")
     - else

--- a/app/components/dossiers/filter_component/filter_component.html.haml
+++ b/app/components/dossiers/filter_component/filter_component.html.haml
@@ -9,5 +9,4 @@
     %input#value{ type: field_type, name: :value, maxlength: ProcedurePresentation::FILTERS_VALUE_MAX_LENGTH, disabled: field_id.nil? ? true : false }
 
   = hidden_field_tag :statut, statut
-  %br
-  = submit_tag t('.add_filter'), class: 'button'
+  = submit_tag t('.add_filter'), class: 'fr-btn fr-btn--secondary fr-mt-2w'

--- a/app/models/procedure_presentation.rb
+++ b/app/models/procedure_presentation.rb
@@ -233,9 +233,10 @@ class ProcedurePresentation < ApplicationRecord
   end
 
   def human_value_for_filter(filter)
-    case filter[TABLE]
-    when TYPE_DE_CHAMP, TYPE_DE_CHAMP_PRIVATE
+    if [TYPE_DE_CHAMP, TYPE_DE_CHAMP_PRIVATE].include?(filter[TABLE])
       find_type_de_champ(filter[COLUMN]).dynamic_type.filter_to_human(filter['value'])
+    elsif filter['column'] == 'state'
+      Dossier.human_attribute_name("state.#{filter['value']}")
     else
       filter['value']
     end

--- a/app/views/instructeurs/procedures/_dossiers_filter.html.haml
+++ b/app/views/instructeurs/procedures/_dossiers_filter.html.haml
@@ -1,5 +1,5 @@
 %span.dropdown{ data: { controller: 'menu-button', popover: 'true' } }
-  %button.button.dropdown-button{ data: { menu_button_target: 'button' } }
+  %button.fr-btn.fr-btn--secondary.fr-btn--sm.fr-mr-1w.dropdown-button{ data: { menu_button_target: 'button' } }
     = t('views.instructeurs.dossiers.filters.title')
   #filter-menu.dropdown-content.left-aligned.fade-in-down{ data: { menu_button_target: 'menu' } }
     = render Dossiers::FilterComponent.new(procedure: procedure, procedure_presentation: @procedure_presentation, statut: statut)

--- a/app/views/instructeurs/procedures/_dossiers_filter.html.haml
+++ b/app/views/instructeurs/procedures/_dossiers_filter.html.haml
@@ -6,11 +6,10 @@
 
 - current_filters.group_by { |filter| filter['table'] }.each_with_index do |(table, filters), i|
   - if i > 0
-    et
+    = " et "
   - filters.each_with_index do |filter, i|
     - if i > 0
-      ou
-    %span.filter
-      = link_to remove_filter_instructeur_procedure_path(procedure, { statut: statut, field: "#{filter['table']}/#{filter['column']}", value: filter['value'] }) do
-        %img.close-icon{ src: image_url("close.svg") }
+      = " ou "
+    = link_to remove_filter_instructeur_procedure_path(procedure, { statut: statut, field: "#{filter['table']}/#{filter['column']}", value: filter['value'] }),
+      class: "fr-tag fr-tag--dismiss fr-mb-1w", aria: { label: "Retirer le filtre #{filter['column']}" } do
       = "#{filter['label'].truncate(50)} : #{procedure_presentation.human_value_for_filter(filter)}"

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -94,7 +94,7 @@
 
                 %th.action-col.follow-col
                   %span.dropdown{ data: { controller: 'menu-button', popover: 'true' } }
-                    %button.button.dropdown-button{ data: { menu_button_target: 'button' } }
+                    %button.fr-btn.fr-btn--sm.fr-btn--secondary.dropdown-button{ data: { menu_button_target: 'button' } }
                       = t('views.instructeurs.dossiers.personalize')
                     #custom-menu.dropdown-content.fade-in-down{ data: { menu_button_target: 'menu' } }
                       = form_tag update_displayed_fields_instructeur_procedure_path(@procedure), method: :patch, class: 'dropdown-form large columns-form' do

--- a/spec/models/procedure_presentation_spec.rb
+++ b/spec/models/procedure_presentation_spec.rb
@@ -784,6 +784,14 @@ describe ProcedurePresentation do
         expect(subject).to eq("oui")
       end
     end
+
+    context 'when filter is state' do
+      let(:filters) { { "suivis" => [{ "table" => "self", "column" => "state", "value" => "en_construction" }] } }
+
+      it 'should get i18n value' do
+        expect(subject).to eq("En construction")
+      end
+    end
   end
 
   describe "#add_filter" do

--- a/spec/system/instructeurs/procedure_filters_spec.rb
+++ b/spec/system/instructeurs/procedure_filters_spec.rb
@@ -126,7 +126,7 @@ describe "procedure filters" do
   end
 
   def remove_filter(filter_value)
-    find(:xpath, "(//span[contains(@class, 'filter')]/a[contains(@href, '#{CGI.escape(filter_value)}')])[1]").click
+    click_link text: filter_value
   end
 
   def add_filter(column_name, filter_value)


### PR DESCRIPTION
Encore un peu de cosmétique sur le tableau dossiers des instructeurs : 


- Convertit quelques éléments de dropdown du tableau instructeurs au dsfr, ainsi que les filtres.
- humanize  (utilise la traduction) le nom du `state` quand il est affiché dans les filtres (`en_construction` => `En construction`

<img width="1149" alt="Capture d’écran 2022-12-14 à 23 19 18" src="https://user-images.githubusercontent.com/150279/207727400-311109ea-a9b6-4276-ae19-90244d41af18.png">
