### PR TITLE
amelioration(attestation.et.mail): clarifie les problèmes de tag sur les attestations & mail

### DIFF
--- a/app/assets/stylesheets/02_utils.scss
+++ b/app/assets/stylesheets/02_utils.scss
@@ -61,6 +61,10 @@
   width: 5px;
 }
 
+.list-style-type-none {
+  list-style-type: none;
+}
+
 .empty-text {
   font-size: 20px;
   font-weight: bold;

--- a/app/assets/stylesheets/dsfr.scss
+++ b/app/assets/stylesheets/dsfr.scss
@@ -3,7 +3,8 @@
 // override default transparent background on inputs & font-size to 16px by default
 input,
 textarea,
-select {
+select,
+.procedure-form__column--form .fr-input { //FIXME when DSFR is DONE
   background: $white;
   font-size: 1em;
 }

--- a/app/assets/stylesheets/dsfr.scss
+++ b/app/assets/stylesheets/dsfr.scss
@@ -4,7 +4,8 @@
 input,
 textarea,
 select,
-.procedure-form__column--form .fr-input { //FIXME when DSFR is DONE
+// FIXME when DSFR is DONE
+.form-ds-fr-white .fr-input {
   background: $white;
   font-size: 1em;
 }

--- a/app/components/dsfr/input_component.rb
+++ b/app/components/dsfr/input_component.rb
@@ -1,0 +1,76 @@
+class Dsfr::InputComponent < ApplicationComponent
+  def initialize(form:, attribute:, input_type:, opts: {}, required: true)
+    @form = form
+    @attribute = attribute
+    @input_type = input_type
+    @opts = opts
+    @required = required
+  end
+
+  def input_opts
+    @opts[:class] = class_names(map_array_to_hash_with_true(@opts[:class])
+                                  .merge('fr-input': true,
+                                         'fr-mb-0': true,
+                                         'fr-input--error': errors_on_attribute?))
+
+    if errors_on_attribute?
+      @opts = @opts.deep_merge(aria: {
+        describedby: error_message_id,
+                                       invalid: true
+      })
+    end
+    if @required
+      @opts[:required] = true
+    end
+    @opts
+  end
+
+  # add invalid class on input when input is invalid
+  # and and valid on input only if another input is invalid
+  def input_group_class_names
+    class_names('fr-input-group': true,
+                "fr-input-group--error": errors_on_attribute?,
+                "fr-input-group--valid": !errors_on_attribute? && errors_on_another_attribute?)
+  end
+
+  # tried to inline it within the template, but failed miserably with a double render
+  def label
+    label = @form.object.class.human_attribute_name(@attribute)
+
+    if @required
+      label += tag.span(" *", class: 'mandatory')
+    end
+    label
+  end
+
+  def errors_on_attribute?
+    @form.object.errors.has_key?(attribute_or_rich_body)
+  end
+
+  def error_message_id
+    dom_id(@form.object, @attribute)
+  end
+
+  def error_messages
+    @form.object.errors.full_messages_for(attribute_or_rich_body)
+  end
+
+  private
+
+  def errors_on_another_attribute?
+    !@form.object.errors.empty?
+  end
+
+  def attribute_or_rich_body
+    case @input_type
+    when :rich_text_area
+      @attribute.to_s.sub(/\Arich_/, '').to_sym
+    else
+      @attribute
+    end
+  end
+
+  def map_array_to_hash_with_true(array_or_string_or_nil)
+    Array(array_or_string_or_nil).to_h { [_1, true] }
+  end
+end

--- a/app/components/dsfr/input_component/input_component.html.haml
+++ b/app/components/dsfr/input_component/input_component.html.haml
@@ -7,8 +7,8 @@
     - if error_messages.size == 1
       %p.fr-error-text{ id: error_message_id }= error_messages.first
     - else
-      %div.fr-error-text{ id: error_message_id }
-        %ul
+      .fr-error-text{ id: error_message_id }
+        %ul.list-style-type-none.fr-pl-0
           - error_messages.map do |error_message|
             %li= error_message
 

--- a/app/components/dsfr/input_component/input_component.html.haml
+++ b/app/components/dsfr/input_component/input_component.html.haml
@@ -1,0 +1,14 @@
+%div{ class: input_group_class_names }
+  = @form.label @attribute, label.html_safe, class: "fr-label"
+
+  = @form.send(@input_type, @attribute, input_opts)
+
+  - if errors_on_attribute?
+    - if error_messages.size == 1
+      %p.fr-error-text{ id: error_message_id }= error_messages.first
+    - else
+      %div.fr-error-text{ id: error_message_id }
+        %ul
+          - error_messages.map do |error_message|
+            %li= error_message
+

--- a/app/controllers/administrateurs/attestation_templates_controller.rb
+++ b/app/controllers/administrateurs/attestation_templates_controller.rb
@@ -18,7 +18,7 @@ module Administrateurs
 
         redirect_to edit_admin_procedure_attestation_template_path(@procedure)
       else
-        flash.now.alert = "Le modèle de l’attestation contient des erreurs et n'a pas pu être enregistré, veuillez les corriger."
+        flash.now.alert = "Le modèle de l’attestation contient des erreurs et n'a pas pu être enregistré. Veuiller les corriger"
 
         render :edit
       end

--- a/app/controllers/administrateurs/attestation_templates_controller.rb
+++ b/app/controllers/administrateurs/attestation_templates_controller.rb
@@ -14,11 +14,11 @@ module Administrateurs
       @attestation_template = @procedure.attestation_template
 
       if @attestation_template.update(activated_attestation_params)
-        flash.notice = "Le model de l’attestation a bien été modifiée"
+        flash.notice = "Le modèle de l’attestation a bien été modifié"
 
         redirect_to edit_admin_procedure_attestation_template_path(@procedure)
       else
-        flash.now.alert = @attestation_template.errors.full_messages
+        flash.now.alert = "Le modèle de l’attestation contient des erreurs et n'a pas pu être enregistré, veuillez les corriger."
 
         render :edit
       end
@@ -28,7 +28,7 @@ module Administrateurs
       @attestation_template = build_attestation_template(activated_attestation_params)
 
       if @attestation_template.save
-        flash.notice = "Le model de l’attestation a bien été enregistrée"
+        flash.notice = "Le modèle de l’attestation a bien été enregistré"
 
         redirect_to edit_admin_procedure_attestation_template_path(@procedure)
       else

--- a/app/controllers/administrateurs/mail_templates_controller.rb
+++ b/app/controllers/administrateurs/mail_templates_controller.rb
@@ -25,7 +25,7 @@ module Administrateurs
         flash.notice = "Email mis à jour"
         redirect_to edit_admin_procedure_mail_template_path(mail_template.procedure_id, params[:id])
       else
-        flash.now.alert = mail_template.errors.full_messages
+        flash.now.alert = "L’email contient des erreurs et n’a pas pu être enregistré, veuillez les corriger."
         mail_template.rich_body = mail_template.body
 
         @mail_template = mail_template

--- a/app/controllers/administrateurs/mail_templates_controller.rb
+++ b/app/controllers/administrateurs/mail_templates_controller.rb
@@ -25,7 +25,7 @@ module Administrateurs
         flash.notice = "Email mis à jour"
         redirect_to edit_admin_procedure_mail_template_path(mail_template.procedure_id, params[:id])
       else
-        flash.now.alert = "L’email contient des erreurs et n’a pas pu être enregistré, veuillez les corriger."
+        flash.now.alert = "L’email contient des erreurs et n’a pas pu être enregistré. Veuiller les corriger"
         mail_template.rich_body = mail_template.body
 
         @mail_template = mail_template

--- a/app/models/concerns/tags_substitution_concern.rb
+++ b/app/models/concerns/tags_substitution_concern.rb
@@ -269,12 +269,12 @@ module TagsSubstitutionConcern
   end
 
   def champ_public_tags(dossier: nil)
-    types_de_champ = (dossier || procedure.active_revision).types_de_champ_public
+    types_de_champ = (dossier || procedure.active_revision).types_de_champ_public.not_condition
     types_de_champ_tags(types_de_champ, Dossier::SOUMIS)
   end
 
   def champ_private_tags(dossier: nil)
-    types_de_champ = (dossier || procedure.active_revision).types_de_champ_private
+    types_de_champ = (dossier || procedure.active_revision).types_de_champ_private.not_condition
     types_de_champ_tags(types_de_champ, Dossier::INSTRUCTION_COMMENCEE)
   end
 

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -164,6 +164,7 @@ class TypeDeChamp < ApplicationRecord
   scope :private_only, -> { where(private: true) }
   scope :repetition, -> { where(type_champ: type_champs.fetch(:repetition)) }
   scope :not_repetition, -> { where.not(type_champ: type_champs.fetch(:repetition)) }
+  scope :not_condition, -> { where(condition: nil) }
   scope :fillable, -> { where.not(type_champ: [type_champs.fetch(:header_section), type_champs.fetch(:explication)]) }
 
   scope :dubious, -> {

--- a/app/validators/tags_validator.rb
+++ b/app/validators/tags_validator.rb
@@ -43,8 +43,8 @@ class TagsValidator < ActiveModel::EachValidator
   private
 
   def add_errors(record, attribute, message, tags)
-    tags.each do |tag|
-      record.errors.add(attribute, message, tag: tag)
+    if tags.present?
+      record.errors.add(attribute, message, count: tags.size, tags: tags.join(', '))
     end
   end
 

--- a/app/views/administrateurs/attestation_templates/_informations.html.haml
+++ b/app/views/administrateurs/attestation_templates/_informations.html.haml
@@ -2,10 +2,15 @@
 
 = render Dsfr::InputComponent.new(form: f, attribute: :body, input_type: :text_area, opts: { rows: '6', placeholder: 'Description de la démarche, destinataires, etc. '})
 
-#tags-table
-  %h2.add-tag-title
+#tags-table.clearfix.fr-mt-3w
+  %h2.fr-h3
     Insérer une balise
-  %p.notice
+
+  = render Dsfr::AlertComponent.new(state: :info, title: "Balises sur le conditionnel", heading_level: 'h3') do |c|
+    - c.body do
+      Les balises pour les champs conditionnés ne sont pour le moment pas supportées.
+
+  %p.notice.fr-mt-3w
     Copiez-collez les balises ci-dessous pour afficher automatiquement l’information souhaitée.
   .head
     .tag Balise

--- a/app/views/administrateurs/attestation_templates/_informations.html.haml
+++ b/app/views/administrateurs/attestation_templates/_informations.html.haml
@@ -1,12 +1,6 @@
-= f.label :title do
-  Titre de l'attestation
-  %span.mandatory *
-= f.text_field :title, class: 'form-control', placeholder: 'Titre de l’attestation'
+= render Dsfr::InputComponent.new(form: f, attribute: :title, input_type: :text_field, opts: {})
 
-= f.label :body do
-  Corps du document
-  %span.mandatory *
-= f.text_area :body, rows: '6', placeholder: 'Description de la démarche, destinataires, etc. ', class: 'form-control'
+= render Dsfr::InputComponent.new(form: f, attribute: :body, input_type: :text_area, opts: { rows: '6', placeholder: 'Description de la démarche, destinataires, etc. '})
 
 #tags-table
   %h2.add-tag-title
@@ -40,6 +34,4 @@
   %br
   Dimensions conseillées : au minimum 500 px de largeur ou de hauteur, poids maximum : 0,5 Mo.
 
-= f.label :footer do
-  Pied de page
-= f.text_field :footer, class: 'form-control', maxlength: 190, size: nil
+= render Dsfr::InputComponent.new(form: f, attribute: :footer, input_type: :text_field, opts: { maxlength: 190, size: nil }, required: false)

--- a/app/views/administrateurs/attestation_templates/edit.html.haml
+++ b/app/views/administrateurs/attestation_templates/edit.html.haml
@@ -9,7 +9,7 @@
   .procedure-form__columns.container
     = form_for @attestation_template,
       url: admin_procedure_attestation_template_path(@procedure),
-      html: { multipart: true, class: 'form procedure-form__column--form' } do |f|
+      html: { multipart: true, class: 'form form-ds-fr-white procedure-form__column--form' } do |f|
 
       %h1.page-title
         Délivrance d’attestation

--- a/app/views/administrateurs/mail_templates/_form.html.haml
+++ b/app/views/administrateurs/mail_templates/_form.html.haml
@@ -2,11 +2,18 @@
 
 = render Dsfr::InputComponent.new(form: f, attribute: :rich_body, input_type: :rich_text_area, opts: { class: 'fr-mb-4vh'})
 
-#tags-table{ 'data-controller': 'trix' }
-  %h2.add-tag-title
+
+#tags-table.clearfix.fr-mt-3w{ 'data-controller': 'trix' }
+  %h2.fr-h3
     Insérer une balise
-  %p.notice
+
+  = render Dsfr::AlertComponent.new(state: :info, title: "Balises sur le conditionnel", heading_level: 'h3') do |c|
+    - c.body do
+      Les balises pour les champs conditionnés ne sont pour le moment pas supportées.
+
+  %p.notice.fr-mt-3w
     Copiez-collez les balises ci-dessous pour afficher automatiquement l’information souhaitée.
+
   .head
     .tag Balise
     .description Description

--- a/app/views/administrateurs/mail_templates/_form.html.haml
+++ b/app/views/administrateurs/mail_templates/_form.html.haml
@@ -1,12 +1,6 @@
-= f.label :subject do
-  Objet de l'email
-  %span.mandatory *
-= f.text_field :subject, required: true
+= render Dsfr::InputComponent.new(form: f, attribute: :subject, input_type: :text_field, opts: {})
 
-= f.label :body do
-  Corps de l'email
-  %span.mandatory *
-= f.rich_text_area :rich_body, required: true, class: "mb-4"
+= render Dsfr::InputComponent.new(form: f, attribute: :rich_body, input_type: :rich_text_area, opts: { class: 'fr-mb-4vh'})
 
 #tags-table{ 'data-controller': 'trix' }
   %h2.add-tag-title

--- a/app/views/administrateurs/mail_templates/edit.html.haml
+++ b/app/views/administrateurs/mail_templates/edit.html.haml
@@ -14,7 +14,7 @@
     = form_for @mail_template,
       url: admin_procedure_mail_template_path(@procedure, @mail_template.class.const_get(:SLUG)),
       method: :put,
-      html: { class: 'form procedure-form__column--form' } do |f|
+      html: { class: 'form form-ds-fr-white procedure-form__column--form' } do |f|
 
       %h1.page-title= @mail_template.class.const_get(:DISPLAYED_NAME)
       = render partial: 'form', locals: { f: f, tags: @mail_template.tags }

--- a/config/locales/models/attestation_template/fr.yml
+++ b/config/locales/models/attestation_template/fr.yml
@@ -7,21 +7,30 @@ fr:
         title: Titre de l’attestation
         body: Contenu de l’attestation
         footer: Pied de page
+
     errors:
       models:
         attestation_template:
+          tags_errors: &tags_errors
+            champ_missing:
+              one: contient la balise "%{tags}" qui n’existe pas. Supprimer la balise
+              other: contient  %{count} balises (%{tags}) qui n’existent pas. Supprimer les balises
+            champ_missing_in_draft_revision:
+              one: contient la balise "%{tags}" qui a été supprimée mais la suppression n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
+              other: contient  %{count} balises (%{tags}) qui ont été supprimées mais la suppression n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
+            champ_missing_in_published_revision:
+              one: contient la balise "%{tags}" qui n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
+              other: contient  %{count} balises (%{tags}) qui ne sont pas encore publiées. Publier la nouvelle version de la démarche et recommencer
+            champ_missing_in_published_and_draft_revision:
+              one: contient la balise "%{tags}" qui a été supprimée. Supprimer la balise
+              other: contient  %{count} balises (%{tags}) qui ont été supprimées. Supprimer les balises
+            champ_missing_in_previous_revision:
+              one: contient la balise "%{tags}" qui n’existe pas sur un des dossiers en cours de traitement. Supprimer la balise
+              other: contient %{count} balises (%{tags}) qui n’existent pas sur un des dossiers en cours de traitement. Supprimer les balises
           attributes:
             title:
-              format: Le titre de l’attestation %{message}
-              champ_missing: contient la balise "%{tag}" qui n’existe pas, veuillez la supprimer.
-              champ_missing_in_draft_revision: contient la balise "%{tag}" qui a été supprimée mais la suppression n’est pas encore publiée.
-              champ_missing_in_published_revision: contient la balise "%{tag}" qui n’est pas encore publiée.
-              champ_missing_in_published_and_draft_revision: contient la balise "%{tag}" qui a été supprimée.
-              champ_missing_in_previous_revision: contient la balise "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement.
+              format: Le champ « Titre de l’attestation » %{message}
+              <<: *tags_errors
             body:
-              format: Le contenu de l’attestation %{message}
-              champ_missing: contient la balise "%{tag}" qui n’existe pas, veuillez la supprimer.
-              champ_missing_in_draft_revision: contient la balise "%{tag}" qui a été supprimée mais la suppression n’est pas encore publiée.
-              champ_missing_in_published_revision: contient la balise "%{tag}" qui n’est pas encore publiée.
-              champ_missing_in_published_and_draft_revision: contient la balise "%{tag}" qui a été supprimée.
-              champ_missing_in_previous_revision: contient la balise "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement.
+              format: Le champ « Contenu de l’attestation » %{message}
+              <<: *tags_errors

--- a/config/locales/models/attestation_template/fr.yml
+++ b/config/locales/models/attestation_template/fr.yml
@@ -1,20 +1,27 @@
 fr:
   activerecord:
+    models:
+      attestation_template: 'Attestation'
+    attributes:
+      attestation_template:
+        title: Titre de l’attestation
+        body: Contenu de l’attestation
+        footer: Pied de page
     errors:
       models:
         attestation_template:
           attributes:
             title:
-              format: Le titre du modèle de l’attestation %{message}
-              champ_missing: réfère au champ "%{tag}" qui n’existe pas
-              champ_missing_in_draft_revision: réfère au champ "%{tag}" qui a été supprimé mais la suppression n’est pas encore publiée
-              champ_missing_in_published_revision: réfère au champ "%{tag}" qui n’est pas encore publié
-              champ_missing_in_published_and_draft_revision: réfère au champ "%{tag}" qui a été supprimé
-              champ_missing_in_previous_revision: réfère au champ "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement
+              format: Le titre de l’attestation %{message}
+              champ_missing: contient la balise "%{tag}" qui n’existe pas, veuillez la supprimer.
+              champ_missing_in_draft_revision: contient la balise "%{tag}" qui a été supprimée mais la suppression n’est pas encore publiée.
+              champ_missing_in_published_revision: contient la balise "%{tag}" qui n’est pas encore publiée.
+              champ_missing_in_published_and_draft_revision: contient la balise "%{tag}" qui a été supprimée.
+              champ_missing_in_previous_revision: contient la balise "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement.
             body:
-              format: Le contenu du modèle de l’attestation %{message}
-              champ_missing: réfère au champ "%{tag}" qui n’existe pas
-              champ_missing_in_draft_revision: réfère au champ "%{tag}" qui a été supprimé mais la suppression n’est pas encore publiée
-              champ_missing_in_published_revision: réfère au champ "%{tag}" qui n’est pas encore publié
-              champ_missing_in_published_and_draft_revision: réfère au champ "%{tag}" qui a été supprimé
-              champ_missing_in_previous_revision: réfère au champ "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement
+              format: Le contenu de l’attestation %{message}
+              champ_missing: contient la balise "%{tag}" qui n’existe pas, veuillez la supprimer.
+              champ_missing_in_draft_revision: contient la balise "%{tag}" qui a été supprimée mais la suppression n’est pas encore publiée.
+              champ_missing_in_published_revision: contient la balise "%{tag}" qui n’est pas encore publiée.
+              champ_missing_in_published_and_draft_revision: contient la balise "%{tag}" qui a été supprimée.
+              champ_missing_in_previous_revision: contient la balise "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement.

--- a/config/locales/models/closed_mail/fr.yml
+++ b/config/locales/models/closed_mail/fr.yml
@@ -1,20 +1,24 @@
 fr:
   activerecord:
+    attributes:
+      mails/closed_mail:
+        subject: Objet de l’email
+        rich_body: Corps de l’email
     errors:
       models:
         mails/closed_mail:
           attributes:
             subject:
-              format: Le titre de l’email de notification d’acceptation de dossier %{message}
-              champ_missing: réfère au champ "%{tag}" qui n’existe pas
-              champ_missing_in_draft_revision: réfère au champ "%{tag}" qui a été supprimé mais la suppression n’est pas encore publiée
-              champ_missing_in_published_revision: réfère au champ "%{tag}" qui n’est pas encore publié
-              champ_missing_in_published_and_draft_revision: réfère au champ "%{tag}" qui a été supprimé
-              champ_missing_in_previous_revision: réfère au champ "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement
+              format: L’objet de l’email %{message}
+              champ_missing: contient la balise "%{tag}" qui n’existe pas, veuillez la supprimer.
+              champ_missing_in_draft_revision: contient la balise "%{tag}" qui a été supprimée mais la suppression n’est pas encore publiée.
+              champ_missing_in_published_revision: contient la balise "%{tag}" qui n’est pas encore publiée.
+              champ_missing_in_published_and_draft_revision: contient la balise "%{tag}" qui a été supprimée.
+              champ_missing_in_previous_revision: contient la balise "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement.
             body:
-              format: Le contenu de l’email de notification d’acceptation de dossier %{message}
-              champ_missing: réfère au champ "%{tag}" qui n’existe pas
-              champ_missing_in_draft_revision: réfère au champ "%{tag}" qui a été supprimé mais la suppression n’est pas encore publiée
-              champ_missing_in_published_revision: réfère au champ "%{tag}" qui n’est pas encore publié
-              champ_missing_in_published_and_draft_revision: réfère au champ "%{tag}" qui a été supprimé
-              champ_missing_in_previous_revision: réfère au champ "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement
+              format: Le corps de l’email %{message}
+              champ_missing: contient la balise "%{tag}" qui n’existe pas, veuillez la supprimer.
+              champ_missing_in_draft_revision: contient la balise "%{tag}" qui a été supprimée mais la suppression n’est pas encore publiée.
+              champ_missing_in_published_revision: contient la balise "%{tag}" qui n’est pas encore publiée.
+              champ_missing_in_published_and_draft_revision: contient la balise "%{tag}" qui a été supprimée.
+              champ_missing_in_previous_revision: contient la balise "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement.

--- a/config/locales/models/closed_mail/fr.yml
+++ b/config/locales/models/closed_mail/fr.yml
@@ -7,18 +7,26 @@ fr:
     errors:
       models:
         mails/closed_mail:
+          tags_errors: &tags_errors
+            champ_missing:
+              one: contient la balise "%{tags}" qui n’existe pas. Supprimer la balise
+              other: contient  %{count} balises (%{tags}) qui n’existent pas. Supprimer les balises
+            champ_missing_in_draft_revision:
+              one: contient la balise "%{tags}" qui a été supprimée mais la suppression n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
+              other: contient  %{count} balises (%{tags}) qui ont été supprimées mais la suppression n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
+            champ_missing_in_published_revision:
+              one: contient la balise "%{tags}" qui n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
+              other: contient  %{count} balises (%{tags}) qui ne sont pas encore publiées. Publier la nouvelle version de la démarche et recommencer
+            champ_missing_in_published_and_draft_revision:
+              one: contient la balise "%{tags}" qui a été supprimée. Supprimer la balise
+              other: contient  %{count} balises (%{tags}) qui ont été supprimées. Supprimer les balises
+            champ_missing_in_previous_revision:
+              one: contient la balise "%{tags}" qui n’existe pas sur un des dossiers en cours de traitement. Supprimer la balise
+              other: contient %{count} balises (%{tags}) qui n’existent pas sur un des dossiers en cours de traitement. Supprimer les balises
           attributes:
             subject:
-              format: L’objet de l’email %{message}
-              champ_missing: contient la balise "%{tag}" qui n’existe pas, veuillez la supprimer.
-              champ_missing_in_draft_revision: contient la balise "%{tag}" qui a été supprimée mais la suppression n’est pas encore publiée.
-              champ_missing_in_published_revision: contient la balise "%{tag}" qui n’est pas encore publiée.
-              champ_missing_in_published_and_draft_revision: contient la balise "%{tag}" qui a été supprimée.
-              champ_missing_in_previous_revision: contient la balise "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement.
+              format: Le champ « Objet de l’email » %{message}
+              <<: *tags_errors
             body:
-              format: Le corps de l’email %{message}
-              champ_missing: contient la balise "%{tag}" qui n’existe pas, veuillez la supprimer.
-              champ_missing_in_draft_revision: contient la balise "%{tag}" qui a été supprimée mais la suppression n’est pas encore publiée.
-              champ_missing_in_published_revision: contient la balise "%{tag}" qui n’est pas encore publiée.
-              champ_missing_in_published_and_draft_revision: contient la balise "%{tag}" qui a été supprimée.
-              champ_missing_in_previous_revision: contient la balise "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement.
+              format: Le champ « Corps de l’email » %{message}
+              <<: *tags_errors

--- a/config/locales/models/initiated_mail/fr.yml
+++ b/config/locales/models/initiated_mail/fr.yml
@@ -7,18 +7,26 @@ fr:
     errors:
       models:
         mails/initiated_mail:
+          tags_errors: &tags_errors
+            champ_missing:
+              one: contient la balise "%{tags}" qui n’existe pas. Supprimer la balise
+              other: contient  %{count} balises (%{tags}) qui n’existent pas. Supprimer les balises
+            champ_missing_in_draft_revision:
+              one: contient la balise "%{tags}" qui a été supprimée mais la suppression n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
+              other: contient  %{count} balises (%{tags}) qui ont été supprimées mais la suppression n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
+            champ_missing_in_published_revision:
+              one: contient la balise "%{tags}" qui n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
+              other: contient  %{count} balises (%{tags}) qui ne sont pas encore publiées. Publier la nouvelle version de la démarche et recommencer
+            champ_missing_in_published_and_draft_revision:
+              one: contient la balise "%{tags}" qui a été supprimée. Supprimer la balise
+              other: contient  %{count} balises (%{tags}) qui ont été supprimées. Supprimer les balises
+            champ_missing_in_previous_revision:
+              one: contient la balise "%{tags}" qui n’existe pas sur un des dossiers en cours de traitement. Supprimer la balise
+              other: contient %{count} balises (%{tags}) qui n’existent pas sur un des dossiers en cours de traitement. Supprimer les balises
           attributes:
             subject:
-              format: L’objet de l’email %{message}
-              champ_missing: contient la balise "%{tag}" qui n’existe pas, veuillez la supprimer.
-              champ_missing_in_draft_revision: contient la balise "%{tag}" qui a été supprimée mais la suppression n’est pas encore publiée.
-              champ_missing_in_published_revision: contient la balise "%{tag}" qui n’est pas encore publiée.
-              champ_missing_in_published_and_draft_revision: contient la balise "%{tag}" qui a été supprimée.
-              champ_missing_in_previous_revision: contient la balise "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement.
+              format: Le champ « Objet de l’email » %{message}
+              <<: *tags_errors
             body:
-              format: Le corps de l’email %{message}
-              champ_missing: contient la balise "%{tag}" qui n’existe pas, veuillez la supprimer.
-              champ_missing_in_draft_revision: contient la balise "%{tag}" qui a été supprimé mais la suppression n’est pas encore publiée.
-              champ_missing_in_published_revision: contient la balise "%{tag}" qui n’est pas encore publié.
-              champ_missing_in_published_and_draft_revision: contient la balise "%{tag}" qui a été supprimé.
-              champ_missing_in_previous_revision: contient la balise "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement.
+              format: Le champ « Corps de l’email » %{message}
+              <<: *tags_errors

--- a/config/locales/models/initiated_mail/fr.yml
+++ b/config/locales/models/initiated_mail/fr.yml
@@ -1,20 +1,24 @@
 fr:
   activerecord:
+    attributes:
+      mails/initiated_mail:
+        subject: Objet de l’email
+        rich_body: Corps de l’email
     errors:
       models:
         mails/initiated_mail:
           attributes:
             subject:
-              format: Le titre de l’email de notification de passage du dossier en instruction %{message}
-              champ_missing: réfère au champ "%{tag}" qui n’existe pas
-              champ_missing_in_draft_revision: réfère au champ "%{tag}" qui a été supprimé mais la suppression n’est pas encore publiée
-              champ_missing_in_published_revision: réfère au champ "%{tag}" qui n’est pas encore publié
-              champ_missing_in_published_and_draft_revision: réfère au champ "%{tag}" qui a été supprimé
-              champ_missing_in_previous_revision: réfère au champ "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement
+              format: L’objet de l’email %{message}
+              champ_missing: contient la balise "%{tag}" qui n’existe pas, veuillez la supprimer.
+              champ_missing_in_draft_revision: contient la balise "%{tag}" qui a été supprimée mais la suppression n’est pas encore publiée.
+              champ_missing_in_published_revision: contient la balise "%{tag}" qui n’est pas encore publiée.
+              champ_missing_in_published_and_draft_revision: contient la balise "%{tag}" qui a été supprimée.
+              champ_missing_in_previous_revision: contient la balise "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement.
             body:
-              format: Le contenu de l’email de notification de passage du dossier en instruction %{message}
-              champ_missing: réfère au champ "%{tag}" qui n’existe pas
-              champ_missing_in_draft_revision: réfère au champ "%{tag}" qui a été supprimé mais la suppression n’est pas encore publiée
-              champ_missing_in_published_revision: réfère au champ "%{tag}" qui n’est pas encore publié
-              champ_missing_in_published_and_draft_revision: réfère au champ "%{tag}" qui a été supprimé
-              champ_missing_in_previous_revision: réfère au champ "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement
+              format: Le corps de l’email %{message}
+              champ_missing: contient la balise "%{tag}" qui n’existe pas, veuillez la supprimer.
+              champ_missing_in_draft_revision: contient la balise "%{tag}" qui a été supprimé mais la suppression n’est pas encore publiée.
+              champ_missing_in_published_revision: contient la balise "%{tag}" qui n’est pas encore publié.
+              champ_missing_in_published_and_draft_revision: contient la balise "%{tag}" qui a été supprimé.
+              champ_missing_in_previous_revision: contient la balise "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement.

--- a/config/locales/models/received_mail/fr.yml
+++ b/config/locales/models/received_mail/fr.yml
@@ -1,20 +1,24 @@
 fr:
   activerecord:
+    attributes:
+      mails/received_mail:
+        subject: Objet de l’email
+        rich_body: Corps de l’email
     errors:
       models:
         mails/received_mail:
           attributes:
             subject:
-              format: Le titre de l’email de notification de dépot de dossier %{message}
-              champ_missing: réfère au champ "%{tag}" qui n’existe pas
-              champ_missing_in_draft_revision: réfère au champ "%{tag}" qui a été supprimé mais la suppression n’est pas encore publiée
-              champ_missing_in_published_revision: réfère au champ "%{tag}" qui n’est pas encore publié
-              champ_missing_in_published_and_draft_revision: réfère au champ "%{tag}" qui a été supprimé
-              champ_missing_in_previous_revision: réfère au champ "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement
+              format: L’objet de l’email l’email %{message}
+              champ_missing: contient la balise "%{tag}" qui n’existe pas, veuillez la supprimer.
+              champ_missing_in_draft_revision: contient la balise "%{tag}" qui a été supprimée mais la suppression n’est pas encore publiée.
+              champ_missing_in_published_revision: contient la balise "%{tag}" qui n’est pas encore publiée.
+              champ_missing_in_published_and_draft_revision: contient la balise "%{tag}" qui a été supprimée.
+              champ_missing_in_previous_revision: contient la balise "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement.
             body:
-              format: Le contenu de l’email de notification de dépot de dossier %{message}
-              champ_missing: réfère au champ "%{tag}" qui n’existe pas
-              champ_missing_in_draft_revision: réfère au champ "%{tag}" qui a été supprimé mais la suppression n’est pas encore publiée
-              champ_missing_in_published_revision: réfère au champ "%{tag}" qui n’est pas encore publié
-              champ_missing_in_published_and_draft_revision: réfère au champ "%{tag}" qui a été supprimé
-              champ_missing_in_previous_revision: réfère au champ "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement
+              format: Le corps de l’email %{message}
+              champ_missing: contient la balise "%{tag}" qui n’existe pas.
+              champ_missing_in_draft_revision: contient la balise "%{tag}" qui a été supprimée mais la suppression n’est pas encore publiée.
+              champ_missing_in_published_revision: contient la balise "%{tag}" qui n’est pas encore publiée.
+              champ_missing_in_published_and_draft_revision: contient la balise "%{tag}" qui a été supprimée.
+              champ_missing_in_previous_revision: contient la balise "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement.

--- a/config/locales/models/received_mail/fr.yml
+++ b/config/locales/models/received_mail/fr.yml
@@ -7,18 +7,26 @@ fr:
     errors:
       models:
         mails/received_mail:
+          tags_errors: &tags_errors
+            champ_missing:
+              one: contient la balise "%{tags}" qui n’existe pas. Supprimer la balise
+              other: contient  %{count} balises (%{tags}) qui n’existent pas. Supprimer les balises
+            champ_missing_in_draft_revision:
+              one: contient la balise "%{tags}" qui a été supprimée mais la suppression n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
+              other: contient  %{count} balises (%{tags}) qui ont été supprimées mais la suppression n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
+            champ_missing_in_published_revision:
+              one: contient la balise "%{tags}" qui n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
+              other: contient  %{count} balises (%{tags}) qui ne sont pas encore publiées. Publier la nouvelle version de la démarche et recommencer
+            champ_missing_in_published_and_draft_revision:
+              one: contient la balise "%{tags}" qui a été supprimée. Supprimer la balise
+              other: contient  %{count} balises (%{tags}) qui ont été supprimées. Supprimer les balises
+            champ_missing_in_previous_revision:
+              one: contient la balise "%{tags}" qui n’existe pas sur un des dossiers en cours de traitement. Supprimer la balise
+              other: contient %{count} balises (%{tags}) qui n’existent pas sur un des dossiers en cours de traitement. Supprimer les balises
           attributes:
             subject:
-              format: L’objet de l’email l’email %{message}
-              champ_missing: contient la balise "%{tag}" qui n’existe pas, veuillez la supprimer.
-              champ_missing_in_draft_revision: contient la balise "%{tag}" qui a été supprimée mais la suppression n’est pas encore publiée.
-              champ_missing_in_published_revision: contient la balise "%{tag}" qui n’est pas encore publiée.
-              champ_missing_in_published_and_draft_revision: contient la balise "%{tag}" qui a été supprimée.
-              champ_missing_in_previous_revision: contient la balise "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement.
+              format: Le champ « Objet de l’email » %{message}
+              <<: *tags_errors
             body:
-              format: Le corps de l’email %{message}
-              champ_missing: contient la balise "%{tag}" qui n’existe pas.
-              champ_missing_in_draft_revision: contient la balise "%{tag}" qui a été supprimée mais la suppression n’est pas encore publiée.
-              champ_missing_in_published_revision: contient la balise "%{tag}" qui n’est pas encore publiée.
-              champ_missing_in_published_and_draft_revision: contient la balise "%{tag}" qui a été supprimée.
-              champ_missing_in_previous_revision: contient la balise "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement.
+              format: Le champ « Corps de l’email » %{message}
+              <<: *tags_errors

--- a/config/locales/models/refused_mail/fr.yml
+++ b/config/locales/models/refused_mail/fr.yml
@@ -7,18 +7,26 @@ fr:
     errors:
       models:
         mails/refused_mail:
+          tags_errors: &tags_errors
+            champ_missing:
+              one: contient la balise "%{tags}" qui n’existe pas. Supprimer la balise
+              other: contient  %{count} balises (%{tags}) qui n’existent pas. Supprimer les balises
+            champ_missing_in_draft_revision:
+              one: contient la balise "%{tags}" qui a été supprimée mais la suppression n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
+              other: contient  %{count} balises (%{tags}) qui ont été supprimées mais la suppression n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
+            champ_missing_in_published_revision:
+              one: contient la balise "%{tags}" qui n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
+              other: contient  %{count} balises (%{tags}) qui ne sont pas encore publiées. Publier la nouvelle version de la démarche et recommencer
+            champ_missing_in_published_and_draft_revision:
+              one: contient la balise "%{tags}" qui a été supprimée. Supprimer la balise
+              other: contient  %{count} balises (%{tags}) qui ont été supprimées. Supprimer les balises
+            champ_missing_in_previous_revision:
+              one: contient la balise "%{tags}" qui n’existe pas sur un des dossiers en cours de traitement. Supprimer la balise
+              other: contient %{count} balises (%{tags}) qui n’existent pas sur un des dossiers en cours de traitement. Supprimer les balises
           attributes:
             subject:
-              format: L’objet de l’email %{message}
-              champ_missing: contient la balise "%{tag}" qui n’existe pas, veuillez la supprimer.
-              champ_missing_in_draft_revision: contient la balise "%{tag}" qui a été supprimée mais la suppression n’est pas encore publiée.
-              champ_missing_in_published_revision: contient la balise "%{tag}" qui n’est pas encore publiée.
-              champ_missing_in_published_and_draft_revision: contient la balise "%{tag}" qui a été supprimée.
-              champ_missing_in_previous_revision: contient la balise "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement.
+              format: Le champ « Objet de l’email » %{message}
+              <<: *tags_errors
             body:
-              format: Le contenu de l’email de notification de refus de dossier %{message}
-              champ_missing: contient la balise "%{tag}" qui n’existe pas, veuillez la supprimer.
-              champ_missing_in_draft_revision: contient la balise "%{tag}" qui a été supprimée mais la suppression n’est pas encore publiée.
-              champ_missing_in_published_revision: contient la balise "%{tag}" qui n’est pas encore publiée.
-              champ_missing_in_published_and_draft_revision: contient la balise "%{tag}" qui a été supprimée.
-              champ_missing_in_previous_revision: contient la balise "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement.
+              format: Le champ « Corps de l’email » %{message}
+              <<: *tags_errors

--- a/config/locales/models/refused_mail/fr.yml
+++ b/config/locales/models/refused_mail/fr.yml
@@ -1,20 +1,24 @@
 fr:
   activerecord:
+    attributes:
+       mails/refused_mail:
+        subject: Objet de l’email
+        rich_body: Corps de l’email
     errors:
       models:
         mails/refused_mail:
           attributes:
             subject:
-              format: Le titre de l’email de notification de refus de dossier %{message}
-              champ_missing: réfère au champ "%{tag}" qui n’existe pas
-              champ_missing_in_draft_revision: réfère au champ "%{tag}" qui a été supprimé mais la suppression n’est pas encore publiée
-              champ_missing_in_published_revision: réfère au champ "%{tag}" qui n’est pas encore publié
-              champ_missing_in_published_and_draft_revision: réfère au champ "%{tag}" qui a été supprimé
-              champ_missing_in_previous_revision: réfère au champ "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement
+              format: L’objet de l’email %{message}
+              champ_missing: contient la balise "%{tag}" qui n’existe pas, veuillez la supprimer.
+              champ_missing_in_draft_revision: contient la balise "%{tag}" qui a été supprimée mais la suppression n’est pas encore publiée.
+              champ_missing_in_published_revision: contient la balise "%{tag}" qui n’est pas encore publiée.
+              champ_missing_in_published_and_draft_revision: contient la balise "%{tag}" qui a été supprimée.
+              champ_missing_in_previous_revision: contient la balise "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement.
             body:
               format: Le contenu de l’email de notification de refus de dossier %{message}
-              champ_missing: réfère au champ "%{tag}" qui n’existe pas
-              champ_missing_in_draft_revision: réfère au champ "%{tag}" qui a été supprimé mais la suppression n’est pas encore publiée
-              champ_missing_in_published_revision: réfère au champ "%{tag}" qui n’est pas encore publiée
-              champ_missing_in_published_and_draft_revision: réfère au champ "%{tag}" qui a été supprimé
-              champ_missing_in_previous_revision: réfère au champ "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement
+              champ_missing: contient la balise "%{tag}" qui n’existe pas, veuillez la supprimer.
+              champ_missing_in_draft_revision: contient la balise "%{tag}" qui a été supprimée mais la suppression n’est pas encore publiée.
+              champ_missing_in_published_revision: contient la balise "%{tag}" qui n’est pas encore publiée.
+              champ_missing_in_published_and_draft_revision: contient la balise "%{tag}" qui a été supprimée.
+              champ_missing_in_previous_revision: contient la balise "%{tag}" qui n’existe pas sur un des dossiers en cours de traitement.

--- a/spec/controllers/administrateurs/attestation_templates_controller_spec.rb
+++ b/spec/controllers/administrateurs/attestation_templates_controller_spec.rb
@@ -180,7 +180,7 @@ describe Administrateurs::AttestationTemplatesController, type: :controller do
         expect(procedure.attestation_template.logo.download).to eq(logo2.read)
         expect(procedure.attestation_template.signature.download).to eq(signature2.read)
         expect(response).to redirect_to edit_admin_procedure_attestation_template_path(procedure)
-        expect(flash.notice).to eq("Le modèle de l’attestation a bien été modifiée")
+        expect(flash.notice).to eq("Le modèle de l’attestation a bien été modifié")
       end
     end
 
@@ -233,32 +233,33 @@ describe Administrateurs::AttestationTemplatesController, type: :controller do
 
       context 'with invalid tag' do
         let(:body) { 'body --yolo--' }
-        it { expect(flash.alert).to eq("Le modèle de l’attestation contient des erreurs et n'a pas pu être enregistré, veuillez les corriger.") }
+        it { expect(flash.alert).to eq("Le modèle de l’attestation contient des erreurs et n'a pas pu être enregistré. Veuiller les corriger") }
       end
 
       context 'with removed champ' do
         render_views
         let(:body) { "body --#{removed_type_de_champ.libelle}--" }
-        it { expect(response.body).to have_content("Le contenu de l’attestation contient la balise \"#{removed_type_de_champ.libelle}\" qui a été supprimée mais la suppression n’est pas encore publiée.") }
+
+        it { expect(response.body).to have_content("Le champ « Contenu de l’attestation » contient la balise \"#{removed_type_de_champ.libelle}\" qui a été supprimée mais la suppression n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer") }
       end
 
       context 'with removed and published' do
         render_views
         let(:body) { "body --#{removed_and_published_type_de_champ.libelle}--" }
-        it { expect(response.body).to have_content("Le contenu de l’attestation contient la balise \"#{removed_and_published_type_de_champ.libelle}\" qui a été supprimée.") }
+        it { expect(response.body).to have_content("Le champ « Contenu de l’attestation » contient la balise \"#{removed_and_published_type_de_champ.libelle}\" qui a été supprimée.") }
       end
 
       context 'with new champ missing on dossier submitted on previous revision' do
         render_views
         let(:dossier) { create(:dossier, :en_construction, procedure: procedure, revision: procedure.revisions.first) }
         let(:body) { "body --#{new_type_de_champ.libelle}--" }
-        it { expect(response.body).to have_content("Le contenu de l’attestation contient la balise \"#{new_type_de_champ.libelle}\" qui n’existe pas sur un des dossiers en cours de traitement") }
+        it { expect(response.body).to have_content("Le champ « Contenu de l’attestation » contient la balise \"#{new_type_de_champ.libelle}\" qui n’existe pas sur un des dossiers en cours de traitement") }
       end
 
       context 'with champ on draft' do
         render_views
         let(:body) { "body --#{draft_type_de_champ.libelle}--" }
-        it { expect(response.body).to have_content("Le contenu de l’attestation contient la balise \"#{draft_type_de_champ.libelle}\" qui n’est pas encore publiée") }
+        it { expect(response.body).to have_content("Le champ « Contenu de l’attestation » contient la balise \"#{draft_type_de_champ.libelle}\" qui n’est pas encore publiée") }
       end
     end
   end

--- a/spec/controllers/administrateurs/attestation_templates_controller_spec.rb
+++ b/spec/controllers/administrateurs/attestation_templates_controller_spec.rb
@@ -115,7 +115,7 @@ describe Administrateurs::AttestationTemplatesController, type: :controller do
         expect(procedure.attestation_template.logo.download).to eq(logo2.read)
         expect(procedure.attestation_template.signature.download).to eq(signature2.read)
         expect(response).to redirect_to edit_admin_procedure_attestation_template_path(procedure)
-        expect(flash.notice).to eq("Le model de l’attestation a bien été enregistrée")
+        expect(flash.notice).to eq("Le modèle de l’attestation a bien été enregistré")
       end
     end
 

--- a/spec/controllers/administrateurs/attestation_templates_controller_spec.rb
+++ b/spec/controllers/administrateurs/attestation_templates_controller_spec.rb
@@ -180,7 +180,7 @@ describe Administrateurs::AttestationTemplatesController, type: :controller do
         expect(procedure.attestation_template.logo.download).to eq(logo2.read)
         expect(procedure.attestation_template.signature.download).to eq(signature2.read)
         expect(response).to redirect_to edit_admin_procedure_attestation_template_path(procedure)
-        expect(flash.notice).to eq("Le model de l’attestation a bien été modifiée")
+        expect(flash.notice).to eq("Le modèle de l’attestation a bien été modifiée")
       end
     end
 
@@ -233,33 +233,32 @@ describe Administrateurs::AttestationTemplatesController, type: :controller do
 
       context 'with invalid tag' do
         let(:body) { 'body --yolo--' }
-
-        it { expect(flash.alert).to eq(['Le contenu du modèle de l’attestation réfère au champ "yolo" qui n’existe pas']) }
+        it { expect(flash.alert).to eq("Le modèle de l’attestation contient des erreurs et n'a pas pu être enregistré, veuillez les corriger.") }
       end
 
       context 'with removed champ' do
+        render_views
         let(:body) { "body --#{removed_type_de_champ.libelle}--" }
-
-        it { expect(flash.alert).to eq(["Le contenu du modèle de l’attestation réfère au champ \"#{removed_type_de_champ.libelle}\" qui a été supprimé mais la suppression n’est pas encore publiée"]) }
+        it { expect(response.body).to have_content("Le contenu de l’attestation contient la balise \"#{removed_type_de_champ.libelle}\" qui a été supprimée mais la suppression n’est pas encore publiée.") }
       end
 
       context 'with removed and published' do
+        render_views
         let(:body) { "body --#{removed_and_published_type_de_champ.libelle}--" }
-
-        it { expect(flash.alert).to eq(["Le contenu du modèle de l’attestation réfère au champ \"#{removed_and_published_type_de_champ.libelle}\" qui a été supprimé"]) }
+        it { expect(response.body).to have_content("Le contenu de l’attestation contient la balise \"#{removed_and_published_type_de_champ.libelle}\" qui a été supprimée.") }
       end
 
       context 'with new champ missing on dossier submitted on previous revision' do
+        render_views
         let(:dossier) { create(:dossier, :en_construction, procedure: procedure, revision: procedure.revisions.first) }
         let(:body) { "body --#{new_type_de_champ.libelle}--" }
-
-        it { expect(flash.alert).to eq(["Le contenu du modèle de l’attestation réfère au champ \"#{new_type_de_champ.libelle}\" qui n’existe pas sur un des dossiers en cours de traitement"]) }
+        it { expect(response.body).to have_content("Le contenu de l’attestation contient la balise \"#{new_type_de_champ.libelle}\" qui n’existe pas sur un des dossiers en cours de traitement") }
       end
 
       context 'with champ on draft' do
+        render_views
         let(:body) { "body --#{draft_type_de_champ.libelle}--" }
-
-        it { expect(flash.alert).to eq(["Le contenu du modèle de l’attestation réfère au champ \"#{draft_type_de_champ.libelle}\" qui n’est pas encore publié"]) }
+        it { expect(response.body).to have_content("Le contenu de l’attestation contient la balise \"#{draft_type_de_champ.libelle}\" qui n’est pas encore publiée") }
       end
     end
   end

--- a/spec/controllers/administrateurs/mail_templates_controller_spec.rb
+++ b/spec/controllers/administrateurs/mail_templates_controller_spec.rb
@@ -73,7 +73,7 @@ describe Administrateurs::MailTemplatesController, type: :controller do
 
       it do
         expect(subject.body).not_to eq(mail_body)
-        expect(response.body).to match("Le contenu de l’email de notification de passage du dossier en instruction réfère au champ \"numéro\" qui n’existe pas")
+        expect(response.body).to match("Le corps de l’email contient la balise &quot;numéro&quot; qui n’existe pas, veuillez la supprimer.")
       end
     end
   end

--- a/spec/controllers/administrateurs/mail_templates_controller_spec.rb
+++ b/spec/controllers/administrateurs/mail_templates_controller_spec.rb
@@ -73,7 +73,7 @@ describe Administrateurs::MailTemplatesController, type: :controller do
 
       it do
         expect(subject.body).not_to eq(mail_body)
-        expect(response.body).to match("Le corps de l’email contient la balise &quot;numéro&quot; qui n’existe pas, veuillez la supprimer.")
+        expect(response.body).to match("Le champ « Corps de l’email » contient la balise &quot;numéro&quot; qui n’existe pas. Supprimer la balise")
       end
     end
   end

--- a/spec/models/concern/tags_substitution_concern_spec.rb
+++ b/spec/models/concern/tags_substitution_concern_spec.rb
@@ -465,6 +465,23 @@ describe TagsSubstitutionConcern, type: :model do
 
       it { is_expected.to include(include({ libelle: 'public' })) }
     end
+
+    context 'when generating document for dossier having conditional' do
+      include Logic
+      let(:state) { Dossier.states.fetch(:en_construction) }
+      let(:stable_id) { 1234 }
+      let(:condition) { ds_eq(champ_value(stable_id), constant(true)) }
+
+      let(:types_de_champ_public) do
+        [
+          { type: :text, libelle: 'public' },
+          { type: :text, libelle: 'conditional', condition: condition }
+        ]
+      end
+
+      it { is_expected.to include(include({ libelle: 'public' })) }
+      it { is_expected.not_to include(include({ libelle: 'conditional' })) }
+    end
   end
 
   describe 'used_tags_for' do

--- a/spec/models/mail_template_spec.rb
+++ b/spec/models/mail_template_spec.rb
@@ -38,7 +38,7 @@ describe Mails::InitiatedMail, type: :model do
     context 'template with invalid tag' do
       let(:email_body) { 'foo --numéro du -- bar' }
 
-      it { expect(subject.errors.full_messages).to eq(["Le contenu de l’email de notification de passage du dossier en instruction réfère au champ \"numéro du\" qui n’existe pas"]) }
+      it { expect(subject.errors.full_messages).to eq(["Le corps de l’email contient la balise \"numéro du\" qui n’existe pas, veuillez la supprimer."]) }
     end
 
     context 'template with unpublished tag' do
@@ -48,7 +48,7 @@ describe Mails::InitiatedMail, type: :model do
         procedure.draft_revision.add_type_de_champ(type_champ: :integer_number, libelle: 'age')
       end
 
-      it { expect(subject.errors.full_messages).to eq(["Le contenu de l’email de notification de passage du dossier en instruction réfère au champ \"age\" qui n’est pas encore publié"]) }
+      it { expect(subject.errors.full_messages).to eq(["Le corps de l’email contient la balise \"age\" qui n’est pas encore publié."]) }
     end
 
     context 'template with removed but unpublished tag' do
@@ -58,7 +58,7 @@ describe Mails::InitiatedMail, type: :model do
         procedure.draft_revision.remove_type_de_champ(type_de_champ.stable_id)
       end
 
-      it { expect(subject.errors.full_messages).to eq(["Le contenu de l’email de notification de passage du dossier en instruction réfère au champ \"nom\" qui a été supprimé mais la suppression n’est pas encore publiée"]) }
+      it { expect(subject.errors.full_messages).to eq(["Le corps de l’email contient la balise \"nom\" qui a été supprimé mais la suppression n’est pas encore publiée."]) }
     end
 
     context 'template with removed tag' do
@@ -69,7 +69,7 @@ describe Mails::InitiatedMail, type: :model do
         procedure.publish_revision!
       end
 
-      it { expect(subject.errors.full_messages).to eq(["Le contenu de l’email de notification de passage du dossier en instruction réfère au champ \"nom\" qui a été supprimé"]) }
+      it { expect(subject.errors.full_messages).to eq(["Le corps de l’email contient la balise \"nom\" qui a été supprimé."]) }
     end
 
     context 'template with new tag and old dossier' do
@@ -81,7 +81,7 @@ describe Mails::InitiatedMail, type: :model do
         procedure.publish_revision!
       end
 
-      it { expect(subject.errors.full_messages).to eq(["Le contenu de l’email de notification de passage du dossier en instruction réfère au champ \"age\" qui n’existe pas sur un des dossiers en cours de traitement"]) }
+      it { expect(subject.errors.full_messages).to eq(["Le corps de l’email contient la balise \"age\" qui n’existe pas sur un des dossiers en cours de traitement."]) }
     end
   end
 end

--- a/spec/models/mail_template_spec.rb
+++ b/spec/models/mail_template_spec.rb
@@ -38,7 +38,7 @@ describe Mails::InitiatedMail, type: :model do
     context 'template with invalid tag' do
       let(:email_body) { 'foo --numéro du -- bar' }
 
-      it { expect(subject.errors.full_messages).to eq(["Le corps de l’email contient la balise \"numéro du\" qui n’existe pas, veuillez la supprimer."]) }
+      it { expect(subject.errors.full_messages).to eq(["Le champ « Corps de l’email » contient la balise \"numéro du\" qui n’existe pas. Supprimer la balise"]) }
     end
 
     context 'template with unpublished tag' do
@@ -48,7 +48,7 @@ describe Mails::InitiatedMail, type: :model do
         procedure.draft_revision.add_type_de_champ(type_champ: :integer_number, libelle: 'age')
       end
 
-      it { expect(subject.errors.full_messages).to eq(["Le corps de l’email contient la balise \"age\" qui n’est pas encore publié."]) }
+      it { expect(subject.errors.full_messages).to eq(["Le champ « Corps de l’email » contient la balise \"age\" qui n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer"]) }
     end
 
     context 'template with removed but unpublished tag' do
@@ -58,7 +58,7 @@ describe Mails::InitiatedMail, type: :model do
         procedure.draft_revision.remove_type_de_champ(type_de_champ.stable_id)
       end
 
-      it { expect(subject.errors.full_messages).to eq(["Le corps de l’email contient la balise \"nom\" qui a été supprimé mais la suppression n’est pas encore publiée."]) }
+      it { expect(subject.errors.full_messages).to eq(["Le champ « Corps de l’email » contient la balise \"nom\" qui a été supprimée mais la suppression n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer"]) }
     end
 
     context 'template with removed tag' do
@@ -69,7 +69,7 @@ describe Mails::InitiatedMail, type: :model do
         procedure.publish_revision!
       end
 
-      it { expect(subject.errors.full_messages).to eq(["Le corps de l’email contient la balise \"nom\" qui a été supprimé."]) }
+      it { expect(subject.errors.full_messages).to eq(["Le champ « Corps de l’email » contient la balise \"nom\" qui a été supprimée. Supprimer la balise"]) }
     end
 
     context 'template with new tag and old dossier' do
@@ -81,7 +81,7 @@ describe Mails::InitiatedMail, type: :model do
         procedure.publish_revision!
       end
 
-      it { expect(subject.errors.full_messages).to eq(["Le corps de l’email contient la balise \"age\" qui n’existe pas sur un des dossiers en cours de traitement."]) }
+      it { expect(subject.errors.full_messages).to eq(["Le champ « Corps de l’email » contient la balise \"age\" qui n’existe pas sur un des dossiers en cours de traitement. Supprimer la balise"]) }
     end
   end
 end

--- a/spec/system/administrateurs/procedure_attestation_template_spec.rb
+++ b/spec/system/administrateurs/procedure_attestation_template_spec.rb
@@ -29,11 +29,12 @@ describe 'As an administrateur, I want to manage the procedure’s attestation',
 
       # now process to enable attestation
       find_attestation_card.click
-      fill_in "Titre de l'attestation", with: 'BOOM'
-      fill_in "Corps du document", with: 'BOOM'
+      fill_in "Titre de l’attestation", with: 'BOOM'
+      fill_in "Contenu de l'attestation", with: 'BOOM'
       find('.toggle-switch-control').click
       click_on 'Enregistrer'
-      page.find(".alert-success", text: "Le model de l’attestation a bien été enregistrée")
+
+      page.find(".alert-success", text: "Le modèle de l’attestation a bien été enregistré")
 
       # check attestation
       visit admin_procedure_path(procedure)
@@ -49,7 +50,7 @@ describe 'As an administrateur, I want to manage the procedure’s attestation',
       find_attestation_card.click
       find('.toggle-switch-control').click
       click_on 'Enregistrer'
-      page.find(".alert-success", text: "Le model de l’attestation a bien été modifiée")
+      page.find(".alert-success", text: "Le modèle de l’attestation a bien été modifié")
 
       # check attestation is now disabled
       visit admin_procedure_path(procedure)

--- a/spec/system/administrateurs/procedure_attestation_template_spec.rb
+++ b/spec/system/administrateurs/procedure_attestation_template_spec.rb
@@ -30,7 +30,7 @@ describe 'As an administrateur, I want to manage the procedure’s attestation',
       # now process to enable attestation
       find_attestation_card.click
       fill_in "Titre de l’attestation", with: 'BOOM'
-      fill_in "Contenu de l'attestation", with: 'BOOM'
+      fill_in "Contenu de l’attestation", with: 'BOOM'
       find('.toggle-switch-control').click
       click_on 'Enregistrer'
 


### PR DESCRIPTION
# 1. Ajout d'un composant DSFR pour afficher les erreurs sous les inputs . see: https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/8289/commits/7eab0a49fc0d16966c7d509e359805b3489940c4

sur les attestations
> <img width="1201" alt="Screen Shot 2022-12-15 at 4 21 40 PM" src="https://user-images.githubusercontent.com/125964/207899076-c09a65b9-b999-45ca-bdb6-bb87b8dc6050.png">

sur les mails 
> <img width="1217" alt="Screen Shot 2022-12-15 at 4 22 05 PM" src="https://user-images.githubusercontent.com/125964/207899059-9a393d8e-6698-4c7b-b9f2-c6b4ca47d590.png">

# 2. Ajout du warning concernant le non support des tags pour le conditionnel see: https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/8289/commits/b3b7ef48edfbe9b13fe2f35a722f9176248b9668

<img width="562" alt="Screen Shot 2022-12-15 at 5 07 10 PM" src="https://user-images.githubusercontent.com/125964/207912899-ac61a095-7ba1-427b-b194-140cbde57e7a.png">

