### PR TITLE
feat(dossier): prefill yes no and checkbox champs

### DIFF
--- a/app/models/champs/boolean_champ.rb
+++ b/app/models/champs/boolean_champ.rb
@@ -20,16 +20,36 @@
 #  parent_id                      :bigint
 #  type_de_champ_id               :integer
 #
-class Champs::CheckboxChamp < Champs::BooleanChamp
-  def true?
-    value == 'on'
+class Champs::BooleanChamp < Champ
+  def search_terms
+    if true?
+      [libelle]
+    end
+  end
+
+  def to_s
+    processed_value
+  end
+
+  def for_tag
+    processed_value
   end
 
   def for_export
-    true? ? 'on' : 'off'
+    processed_value
   end
 
-  def mandatory_blank?
-    mandatory? && (blank? || !true?)
+  def true?
+    raise NotImplemented
+  end
+
+  def for_api_v2
+    true? ? 'true' : 'false'
+  end
+
+  private
+
+  def processed_value
+    true? ? 'Oui' : 'Non'
   end
 end

--- a/app/models/champs/checkbox_champ.rb
+++ b/app/models/champs/checkbox_champ.rb
@@ -21,6 +21,8 @@
 #  type_de_champ_id               :integer
 #
 class Champs::CheckboxChamp < Champs::BooleanChamp
+  validates :value, inclusion: ["on", "off"], allow_nil: true, allow_blank: false
+
   def true?
     value == 'on'
   end

--- a/app/models/champs/yes_no_champ.rb
+++ b/app/models/champs/yes_no_champ.rb
@@ -20,36 +20,10 @@
 #  parent_id                      :bigint
 #  type_de_champ_id               :integer
 #
-class Champs::YesNoChamp < Champ
-  def search_terms
-    if true?
-      [libelle]
-    end
-  end
-
-  def to_s
-    processed_value
-  end
-
-  def for_tag
-    processed_value
-  end
-
-  def for_export
-    processed_value
-  end
+class Champs::YesNoChamp < Champs::BooleanChamp
+  validates :value, inclusion: ["true", "false"], allow_nil: true, allow_blank: false
 
   def true?
     value == 'true'
-  end
-
-  def for_api_v2
-    true? ? 'true' : 'false'
-  end
-
-  private
-
-  def processed_value
-    true? ? 'Oui' : 'Non'
   end
 end

--- a/app/models/prefill_params.rb
+++ b/app/models/prefill_params.rb
@@ -33,7 +33,8 @@ class PrefillParams
   class PrefillValue
     NEED_VALIDATION_TYPES_DE_CHAMPS = [
       TypeDeChamp.type_champs.fetch(:decimal_number),
-      TypeDeChamp.type_champs.fetch(:integer_number)
+      TypeDeChamp.type_champs.fetch(:integer_number),
+      TypeDeChamp.type_champs.fetch(:yes_no)
     ]
 
     attr_reader :champ, :value

--- a/app/models/prefill_params.rb
+++ b/app/models/prefill_params.rb
@@ -34,7 +34,8 @@ class PrefillParams
     NEED_VALIDATION_TYPES_DE_CHAMPS = [
       TypeDeChamp.type_champs.fetch(:decimal_number),
       TypeDeChamp.type_champs.fetch(:integer_number),
-      TypeDeChamp.type_champs.fetch(:yes_no)
+      TypeDeChamp.type_champs.fetch(:yes_no),
+      TypeDeChamp.type_champs.fetch(:checkbox)
     ]
 
     attr_reader :champ, :value

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -260,7 +260,8 @@ class TypeDeChamp < ApplicationRecord
       TypeDeChamp.type_champs.fetch(:email),
       TypeDeChamp.type_champs.fetch(:phone),
       TypeDeChamp.type_champs.fetch(:iban),
-      TypeDeChamp.type_champs.fetch(:yes_no)
+      TypeDeChamp.type_champs.fetch(:yes_no),
+      TypeDeChamp.type_champs.fetch(:checkbox)
     ])
   end
 

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -259,7 +259,8 @@ class TypeDeChamp < ApplicationRecord
       TypeDeChamp.type_champs.fetch(:integer_number),
       TypeDeChamp.type_champs.fetch(:email),
       TypeDeChamp.type_champs.fetch(:phone),
-      TypeDeChamp.type_champs.fetch(:iban)
+      TypeDeChamp.type_champs.fetch(:iban),
+      TypeDeChamp.type_champs.fetch(:yes_no)
     ])
   end
 

--- a/spec/models/champs/checkbox_champ_spec.rb
+++ b/spec/models/champs/checkbox_champ_spec.rb
@@ -1,8 +1,40 @@
 describe Champs::CheckboxChamp do
-  let(:checkbox) { Champs::CheckboxChamp.new(value: value) }
+  describe '#valid?' do
+    subject { build(:champ_checkbox, value: value).tap(&:valid?) }
+
+    context "when the value is 'on'" do
+      let(:value) { 'on' }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when the value is 'off'" do
+      let(:value) { 'off' }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when the value is nil" do
+      let(:value) { nil }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when the value is blank" do
+      let(:value) { "" }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context "when the value is something else" do
+      let(:value) { "something else" }
+
+      it { is_expected.not_to be_valid }
+    end
+  end
 
   describe '#to_s' do
-    subject { checkbox.to_s }
+    subject { Champs::CheckboxChamp.new(value: value).to_s }
 
     context 'when the value is on' do
       let(:value) { 'on' }

--- a/spec/models/champs/yes_no_champ_spec.rb
+++ b/spec/models/champs/yes_no_champ_spec.rb
@@ -1,4 +1,38 @@
 describe Champs::YesNoChamp do
+  describe '#valid?' do
+    subject { build(:champ_yes_no, value: value).tap(&:valid?) }
+
+    context "when the value is 'true'" do
+      let(:value) { 'true' }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when the value is 'false'" do
+      let(:value) { 'false' }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when the value is nil" do
+      let(:value) { nil }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when the value is blank" do
+      let(:value) { "" }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context "when the value is something else" do
+      let(:value) { "something else" }
+
+      it { is_expected.not_to be_valid }
+    end
+  end
+
   describe '#to_s' do
     subject { Champs::YesNoChamp.new(value: value).to_s }
 

--- a/spec/models/prefill_params_spec.rb
+++ b/spec/models/prefill_params_spec.rb
@@ -89,6 +89,8 @@ RSpec.describe PrefillParams do
     it_behaves_like "a champ public value that is authorized", :type_de_champ_email, "value"
     it_behaves_like "a champ public value that is authorized", :type_de_champ_phone, "value"
     it_behaves_like "a champ public value that is authorized", :type_de_champ_iban, "value"
+    it_behaves_like "a champ public value that is authorized", :type_de_champ_yes_no, "true"
+    it_behaves_like "a champ public value that is authorized", :type_de_champ_yes_no, "false"
 
     it_behaves_like "a champ public value that is unauthorized", :type_de_champ_decimal_number, "non decimal string"
     it_behaves_like "a champ public value that is unauthorized", :type_de_champ_integer_number, "non integer string"

--- a/spec/models/prefill_params_spec.rb
+++ b/spec/models/prefill_params_spec.rb
@@ -91,6 +91,8 @@ RSpec.describe PrefillParams do
     it_behaves_like "a champ public value that is authorized", :type_de_champ_iban, "value"
     it_behaves_like "a champ public value that is authorized", :type_de_champ_yes_no, "true"
     it_behaves_like "a champ public value that is authorized", :type_de_champ_yes_no, "false"
+    it_behaves_like "a champ public value that is authorized", :type_de_champ_checkbox, "on"
+    it_behaves_like "a champ public value that is authorized", :type_de_champ_checkbox, "off"
 
     it_behaves_like "a champ public value that is unauthorized", :type_de_champ_decimal_number, "non decimal string"
     it_behaves_like "a champ public value that is unauthorized", :type_de_champ_integer_number, "non integer string"

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -243,11 +243,11 @@ describe TypeDeChamp do
     it_behaves_like "a prefillable type de champ", :type_de_champ_phone
     it_behaves_like "a prefillable type de champ", :type_de_champ_iban
     it_behaves_like "a prefillable type de champ", :type_de_champ_yes_no
+    it_behaves_like "a prefillable type de champ", :type_de_champ_checkbox
 
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_number
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_communes
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_dossier_link
-    it_behaves_like "a non-prefillable type de champ", :type_de_champ_checkbox
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_titre_identite
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_civilite
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_date

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -242,6 +242,7 @@ describe TypeDeChamp do
     it_behaves_like "a prefillable type de champ", :type_de_champ_email
     it_behaves_like "a prefillable type de champ", :type_de_champ_phone
     it_behaves_like "a prefillable type de champ", :type_de_champ_iban
+    it_behaves_like "a prefillable type de champ", :type_de_champ_yes_no
 
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_number
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_communes
@@ -249,7 +250,6 @@ describe TypeDeChamp do
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_checkbox
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_titre_identite
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_civilite
-    it_behaves_like "a non-prefillable type de champ", :type_de_champ_yes_no
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_date
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_datetime
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_drop_down_list


### PR DESCRIPTION
Depends on #8320 

On permet le préremplissage des champs de type  `yes_no` et `checkbox`. 

Par exemple : 

`http://localhost:3000/commencer/test-2?champ_Q2hhbXAtMg%3D%3D=true&champ_Q2hhbXAtNg%3D%3D=on`

Va produire : 

![image](https://user-images.githubusercontent.com/1193334/208390853-a05d5301-f710-40df-9aa3-1251fa8b3484.png)