### PR TITLE
feat(prefill): add possible values

### DIFF
--- a/app/assets/stylesheets/prefill_descriptions_edit.scss
+++ b/app/assets/stylesheets/prefill_descriptions_edit.scss
@@ -1,0 +1,9 @@
+.prefill-description {
+  table {
+    table-layout: fixed;
+
+    th {
+      width: 25%;
+    }
+  }
+}

--- a/app/models/prefill_description.rb
+++ b/app/models/prefill_description.rb
@@ -37,10 +37,14 @@ class PrefillDescription < SimpleDelegator
   private
 
   def prefilled_champs_for_link
-    prefilled_champs.map { |type_de_champ| ["champ_#{type_de_champ.to_typed_id}", type_de_champ.libelle] }.to_h
+    prefilled_champs.map { |type_de_champ| ["champ_#{type_de_champ.to_typed_id}", example_value(type_de_champ)] }.to_h
   end
 
   def prefilled_champs_for_query
-    prefilled_champs.map { |type_de_champ| "\"champ_#{type_de_champ.to_typed_id}\": \"#{type_de_champ.libelle}\"" } .join(', ')
+    prefilled_champs.map { |type_de_champ| "\"champ_#{type_de_champ.to_typed_id}\": \"#{example_value(type_de_champ)}\"" } .join(', ')
+  end
+
+  def example_value(type_de_champ)
+    I18n.t("views.prefill_descriptions.edit.examples.#{type_de_champ.type_champ}")
   end
 end

--- a/app/models/prefill_description.rb
+++ b/app/models/prefill_description.rb
@@ -15,7 +15,7 @@ class PrefillDescription < SimpleDelegator
   end
 
   def types_de_champ
-    active_revision.types_de_champ_public
+    active_revision.types_de_champ_public.fillable
   end
 
   def include?(type_de_champ_id)

--- a/app/views/prefill_descriptions/_types_de_champs.html.haml
+++ b/app/views/prefill_descriptions/_types_de_champs.html.haml
@@ -1,44 +1,44 @@
 = turbo_frame_tag "#{dom_id(@prefill_description)}_types_de_champs" do
-  .card
-    .card-title
-      %span.icon.edit
-      = t("views.prefill_descriptions.edit.champs_title")
+  .fr-grid-row.fr-grid-row--gutters.fr-py-5w
+    - prefill_description.types_de_champ.each do |type_de_champ|
+      .fr-col-md-6.fr-col-12
+        .card
+          .card-title.flex.justify-between.align-center
+            = type_de_champ.libelle
+            = form_for prefill_description, url: prefill_description_path(prefill_description.path), data: { turbo: true } do |f|
+              - if prefill_description.include?(type_de_champ.id)
+                - (prefill_description.selected_type_de_champ_ids - [type_de_champ.id.to_s]).each do |id|
+                  = f.hidden_field :selected_type_de_champ_ids, value: id, multiple: true
+                = f.submit t("views.prefill_descriptions.edit.champ_remove"), class: 'fr-btn fr-btn--secondary fr-btn--md'
+              - elsif type_de_champ.prefillable?
+                - (prefill_description.selected_type_de_champ_ids + [type_de_champ.id.to_s]).each do |id|
+                  = f.hidden_field :selected_type_de_champ_ids, value: id, multiple: true
+                = f.submit t("views.prefill_descriptions.edit.champ_add"), class: 'fr-btn fr-btn--md'
+              - else
+                %button.fr-btn.fr-btn--secondary{ disabled: true }
+                  = t("views.prefill_descriptions.edit.champ_unavailable")
 
-    %table.table.hoverable
-      %thead
-        %tr
-          %th
-            = t("views.prefill_descriptions.edit.champ_id")
-          %th
-            = t("views.prefill_descriptions.edit.champ_type")
-          %th
-            = t("views.prefill_descriptions.edit.champ_libelle")
-          %th
-            = t("views.prefill_descriptions.edit.champ_description")
-          %th
-            = t("views.prefill_descriptions.edit.champ_prefill")
+          = type_de_champ.description
 
-      %tbody
-        - prefill_description.types_de_champ.each do |type_de_champ|
-          %tr
-            %td
-              = type_de_champ.to_typed_id
-            %td
-              = t("activerecord.attributes.type_de_champ.type_champs.#{type_de_champ.type_champ}")
-            %td
-              = type_de_champ.libelle
-            %td
-              = type_de_champ.description
-            %td.text-center
-              = form_for prefill_description, url: prefill_description_path(prefill_description.path), data: { turbo: true } do |f|
-                - if prefill_description.include?(type_de_champ.id)
-                  - (prefill_description.selected_type_de_champ_ids - [type_de_champ.id.to_s]).each do |id|
-                    = f.hidden_field :selected_type_de_champ_ids, value: id, multiple: true
-                  = f.submit t("views.prefill_descriptions.edit.champ_remove"), class: 'fr-btn fr-btn--secondary fr-btn--md'
-                - elsif type_de_champ.prefillable?
-                  - (prefill_description.selected_type_de_champ_ids + [type_de_champ.id.to_s]).each do |id|
-                    = f.hidden_field :selected_type_de_champ_ids, value: id, multiple: true
-                  = f.submit t("views.prefill_descriptions.edit.champ_add"), class: 'fr-btn fr-btn--md'
-                - else
-                  %button.fr-btn.fr-btn--secondary{ disabled: true }
-                    = t("views.prefill_descriptions.edit.champ_unavailable")
+          %table.table.vertical
+            %tbody
+              %tr
+                %th
+                  = t("views.prefill_descriptions.edit.champ_id")
+                %td
+                  = type_de_champ.to_typed_id
+              %tr
+                %th
+                  = t("views.prefill_descriptions.edit.champ_type")
+                %td
+                  = t("activerecord.attributes.type_de_champ.type_champs.#{type_de_champ.type_champ}")
+              %tr
+                %th
+                  = t("views.prefill_descriptions.edit.possible_values.title")
+                %td
+                  = t("views.prefill_descriptions.edit.possible_values.#{type_de_champ.type_champ}")
+              %tr
+                %th
+                  = t("views.prefill_descriptions.edit.examples.title")
+                %td
+                  = t("views.prefill_descriptions.edit.examples.#{type_de_champ.type_champ}")

--- a/app/views/prefill_descriptions/edit.html.haml
+++ b/app/views/prefill_descriptions/edit.html.haml
@@ -3,7 +3,7 @@
 - content_for :footer do
   = render partial: "root/footer"
 
-.container
+.container.prefill-description
   .two-columns.procedure-context
     .columns-container
       .column.procedure-preview

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -105,15 +105,33 @@ en:
       edit:
         intro_html: "You'd like to allow your users to <strong>create a prefilled file</strong>, with data you already have, for the procedure « %{libelle} »."
         info: Add the fields you want to prefill, thanks to the table below. Once it's over, copy the prefill link, replace the values and share the link.
-        champs_title: Fields
         champ_id: ID
         champ_type: Type
-        champ_libelle: Label
-        champ_description: Description
-        champ_prefill: Prefillable
         champ_add: Add
         champ_remove: Remove
         champ_unavailable: Unavailable
+        possible_values:
+          title: Values
+          text: A short text
+          textarea: A long text
+          decimal_number: A decimal number
+          integer_number: An integer number
+          email: An email address
+          phone: A phone number
+          iban: An Iban number
+          yes_no: '"true" for Yes, "false" pour No'
+          checkbox: '"on" to check, "off" to uncheck'
+        examples:
+          title: Example
+          text: Short text
+          textarea: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          decimal_number: 3.14
+          integer_number: 42
+          email: personne@fournisseur.fr
+          phone: 0612345678
+          iban: FR7611315000011234567890138
+          yes_no: "true"
+          checkbox: "on"
         prefill_link_title: Prefill link (GET)
         prefill_link_info: Use the button to copy the link, then remplace the values with your data.
         prefill_link_too_long: Warning, the prefill link is too long and may not work on all browsers.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -95,15 +95,33 @@ fr:
       edit:
         intro_html: "Vous souhaitez permettre à vos usager·ères la <strong>création d'un dossier prérempli</strong>, à partir de données dont vous disposez déjà, pour la démarche « %{libelle} »."
         info: Pour cela, ajoutez les champs que vous souhaitez préremplir, grâce au tableau ci-dessous. Lorsque vous avez terminé, il ne vous reste plus qu'à copier le lien de préremplissage, à remplacer les valeurs et à le partager.
-        champs_title: Champs de la démarche
         champ_id: ID
         champ_type: Type
-        champ_libelle: Libellé
-        champ_description: Description
-        champ_prefill: Préremplissable
         champ_add: Ajouter
         champ_remove: Retirer
         champ_unavailable: Indisponible
+        possible_values:
+          title: Valeurs
+          text: Un texte court
+          textarea: Un texte long
+          decimal_number: Un nombre décimal
+          integer_number: Un nombre entier
+          email: Une adresse email
+          phone: Un numéro de téléphone
+          iban: Un numéro Iban
+          yes_no: '"true" pour Oui, "false" pour Non'
+          checkbox: '"on" pour coché, "off" pour décoché'
+        examples:
+          title: Exemple
+          text: Texte court
+          textarea: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          decimal_number: 3.14
+          integer_number: 42
+          email: personne@fournisseur.fr
+          phone: 0612345678
+          iban: FR7611315000011234567890138
+          yes_no: "true"
+          checkbox: "on"
         prefill_link_title: Lien de préremplissage (GET)
         prefill_link_info: Copiez le lien grâce au bouton ci-dessous et remplacez les valeurs par les données dont vous disposez.
         prefill_link_too_long: Attention, ce lien de préremplissage est trop long et risque de ne pas fonctionner sur certains navigateurs.

--- a/spec/controllers/prefillings_controller_spec.rb
+++ b/spec/controllers/prefillings_controller_spec.rb
@@ -68,8 +68,14 @@ describe PrefillDescriptionsController, type: :controller do
 
       it "includes the prefill URL" do
         expect(response.body).to include(commencer_path(path: procedure.path))
-        expect(response.body).to include({ "champ_#{type_de_champ.to_typed_id}" => type_de_champ.libelle }.to_query)
-        expect(response.body).to include({ "champ_#{type_de_champ_to_add.to_typed_id}" => type_de_champ_to_add.libelle }.to_query)
+        expect(response.body).to include(
+          {
+            "champ_#{type_de_champ.to_typed_id}" => I18n.t("views.prefill_descriptions.edit.examples.#{type_de_champ.type_champ}")
+          }.to_query
+        )
+        expect(response.body).to include({
+          "champ_#{type_de_champ_to_add.to_typed_id}" => I18n.t("views.prefill_descriptions.edit.examples.#{type_de_champ_to_add.type_champ}")
+        }.to_query)
       end
     end
 
@@ -81,8 +87,12 @@ describe PrefillDescriptionsController, type: :controller do
 
       it "includes the prefill URL" do
         expect(response.body).to include(commencer_path(path: procedure.path))
-        expect(response.body).to include({ "champ_#{type_de_champ.to_typed_id}" => type_de_champ.libelle }.to_query)
-        expect(response.body).not_to include({ "champ_#{type_de_champ_to_remove.to_typed_id}" => type_de_champ_to_remove.libelle }.to_query)
+        expect(response.body).to include({
+          "champ_#{type_de_champ.to_typed_id}" => I18n.t("views.prefill_descriptions.edit.examples.#{type_de_champ.type_champ}")
+        }.to_query)
+        expect(response.body).not_to include({
+          "champ_#{type_de_champ_to_remove.to_typed_id}" => I18n.t("views.prefill_descriptions.edit.examples.#{type_de_champ_to_remove.type_champ}")
+        }.to_query)
       end
     end
 

--- a/spec/models/prefill_description_spec.rb
+++ b/spec/models/prefill_description_spec.rb
@@ -21,6 +21,17 @@ RSpec.describe PrefillDescription, type: :model do
     let(:prefill_description) { described_class.new(procedure) }
 
     it { expect(prefill_description.types_de_champ).to match([type_de_champ]) }
+
+    shared_examples "filters out non fillable types de champ" do |type_de_champ_name|
+      context "when the procedure has a #{type_de_champ_name} champ" do
+        let(:non_fillable_type_de_champ) { create(type_de_champ_name, procedure: procedure) }
+
+        it { expect(prefill_description.types_de_champ).not_to include(non_fillable_type_de_champ) }
+      end
+    end
+
+    it_behaves_like "filters out non fillable types de champ", :type_de_champ_header_section
+    it_behaves_like "filters out non fillable types de champ", :type_de_champ_explication
   end
 
   describe '#include?' do

--- a/spec/models/prefill_description_spec.rb
+++ b/spec/models/prefill_description_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe PrefillDescription, type: :model do
       expect(prefill_description.prefill_link).to eq(
         commencer_url(
           path: procedure.path,
-          "champ_#{type_de_champ.to_typed_id}" => type_de_champ.libelle
+          "champ_#{type_de_champ.to_typed_id}" => I18n.t("views.prefill_descriptions.edit.examples.#{type_de_champ.type_champ}")
         )
       )
     end

--- a/spec/models/prefill_description_spec.rb
+++ b/spec/models/prefill_description_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe PrefillDescription, type: :model do
     before { prefill_description.update(selected_type_de_champ_ids: create_list(:type_de_champ_text, type_de_champs_count, procedure: procedure).map(&:id)) }
 
     context 'when the prefill link is too long' do
-      let(:type_de_champs_count) { 60 }
+      let(:type_de_champs_count) { 65 }
 
       it { expect(too_long).to eq(true) }
     end

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -246,8 +246,8 @@ describe TypeDeChamp do
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_number
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_communes
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_dossier_link
-    it_behaves_like "a non-prefillable type de champ", :type_de_champ_titre_identite
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_checkbox
+    it_behaves_like "a non-prefillable type de champ", :type_de_champ_titre_identite
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_civilite
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_yes_no
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_date


### PR DESCRIPTION
Sur la page de description du préremplissage d'une démarche, met à jour la vue afin d'afficher les valeurs possibles pour un champ donné, ainsi qu'un exemple.

![image](https://user-images.githubusercontent.com/1193334/208629148-ae68637f-3ca1-4ad8-ba80-e5e1320fcbf9.png)
