### PR TITLE
Remove feature flag opendata

### DIFF
--- a/app/jobs/concerns/datagouv_cron_schedulable_concern.rb
+++ b/app/jobs/concerns/datagouv_cron_schedulable_concern.rb
@@ -2,7 +2,7 @@ module DatagouvCronSchedulableConcern
   extend ActiveSupport::Concern
   class_methods do
     def schedulable?
-      ENV.fetch('OPENDATA_ENABLED', nil) == 'enabled'
+      Rails.application.config.ds_opendata_enabled
     end
   end
 end

--- a/app/jobs/cron/datagouv/export_and_publish_demarches_publiques_job.rb
+++ b/app/jobs/cron/datagouv/export_and_publish_demarches_publiques_job.rb
@@ -1,9 +1,6 @@
 class Cron::Datagouv::ExportAndPublishDemarchesPubliquesJob < Cron::CronJob
+  include DatagouvCronSchedulableConcern
   self.schedule_expression = "every month at 4:00"
-
-  def self.schedulable?
-    false
-  end
 
   def perform(*args)
     gzip_filepath = [

--- a/app/views/administrateurs/procedures/_informations.html.haml
+++ b/app/views/administrateurs/procedures/_informations.html.haml
@@ -62,7 +62,7 @@
 = f.label :lien_dpo, 'Lien ou email pour contacter le Délégué à la Protection des Données (DPO)'
 = f.text_field :lien_dpo, class: 'form-control'
 
-- if @procedure.feature_enabled?(:opendata)
+- if Rails.application.config.ds_opendata_enabled
   %h3.header-subsection= t(:opendata_header, scope: [:administrateurs, :informations])
   %p.notice= t(:opendata_notice_html, scope: [:administrateurs, :informations])
   %p.notice= t(:opendata, scope: [:administrateurs, :informations])

--- a/config/application.rb
+++ b/config/application.rb
@@ -75,6 +75,8 @@ module TPS
       status_visible_duration: 6000
     }
 
+    config.ds_opendata_enabled = ENV.fetch('OPENDATA_ENABLED', nil) == 'enabled'
+
     config.skylight.probes += [:graphql]
 
     # Custom Configuration

--- a/spec/jobs/cron/datagouv/export_and_publish_demarches_publiques_job_spec.rb
+++ b/spec/jobs/cron/datagouv/export_and_publish_demarches_publiques_job_spec.rb
@@ -27,15 +27,15 @@ RSpec.describe Cron::Datagouv::ExportAndPublishDemarchesPubliquesJob, type: :job
   end
 
   describe '#schedulable?' do
-    context "when ENV['OPENDATA_ENABLED'] == 'enabled'" do
+    context "when Rails.application.config.ds_opendata_enabled == 'enabled'" do
       it 'is schedulable' do
-        ENV['OPENDATA_ENABLED'] = 'enabled'
+        Rails.application.config.ds_opendata_enabled = 'enabled'
         expect(Cron::Datagouv::ExportAndPublishDemarchesPubliquesJob.schedulable?).to be_truthy
       end
     end
-    context "when ENV['OPENDATA_ENABLED'] != 'enabled'" do
+    context "when Rails.application.config.ds_opendata_enabled != 'enabled'" do
       it 'is schedulable' do
-        ENV['OPENDATA_ENABLED'] = nil
+        Rails.application.config.ds_opendata_enabled = nil
         expect(Cron::Datagouv::ExportAndPublishDemarchesPubliquesJob.schedulable?).to be_falsy
       end
     end

--- a/spec/jobs/cron/datagouv/export_and_publish_demarches_publiques_job_spec.rb
+++ b/spec/jobs/cron/datagouv/export_and_publish_demarches_publiques_job_spec.rb
@@ -28,13 +28,13 @@ RSpec.describe Cron::Datagouv::ExportAndPublishDemarchesPubliquesJob, type: :job
 
   describe '#schedulable?' do
     context "when ENV['OPENDATA_ENABLED'] == 'enabled'" do
-      it 'is not schedulable' do
+      it 'is schedulable' do
         ENV['OPENDATA_ENABLED'] = 'enabled'
-        expect(Cron::Datagouv::ExportAndPublishDemarchesPubliquesJob.schedulable?).to be_falsy
+        expect(Cron::Datagouv::ExportAndPublishDemarchesPubliquesJob.schedulable?).to be_truthy
       end
     end
     context "when ENV['OPENDATA_ENABLED'] != 'enabled'" do
-      it 'is not schedulable' do
+      it 'is schedulable' do
         ENV['OPENDATA_ENABLED'] = nil
         expect(Cron::Datagouv::ExportAndPublishDemarchesPubliquesJob.schedulable?).to be_falsy
       end

--- a/spec/views/administrateurs/procedures/edit.html.haml_spec.rb
+++ b/spec/views/administrateurs/procedures/edit.html.haml_spec.rb
@@ -10,4 +10,24 @@ describe 'administrateurs/procedures/edit.html.haml' do
       expect(rendered).to have_selector('.procedure-logos')
     end
   end
+
+  context 'when opendata is enabled' do
+    it 'asks for opendata' do
+      Rails.application.config.ds_opendata_enabled = true
+      assign(:procedure, procedure)
+      render
+
+      expect(rendered).to have_content('Open data')
+    end
+  end
+
+  context 'when opendata is disabled' do
+    it 'asks for opendata' do
+      Rails.application.config.ds_opendata_enabled = nil
+      assign(:procedure, procedure)
+      render
+
+      expect(rendered).not_to have_content('Open data')
+    end
+  end
 end


### PR DESCRIPTION
Cette PR : 
- rend à nouveau `schedulable`le job `ExportAndPublishDemarchesPubliquesJob`
- n'utilise plus le feature flag "opendata" et s'appuie uniquement sur la variable d'environnement `ENV['OPENDATA_ENABLED`] pour savoir si l'opendata a été activé sur l'instance.