### PR TITLE
hide values and examples for unprefillable champs

### DIFF
--- a/app/models/prefill_description.rb
+++ b/app/models/prefill_description.rb
@@ -15,7 +15,7 @@ class PrefillDescription < SimpleDelegator
   end
 
   def types_de_champ
-    active_revision.types_de_champ_public.fillable
+    active_revision.types_de_champ_public.fillable.partition(&:prefillable?).flatten
   end
 
   def include?(type_de_champ_id)
@@ -31,7 +31,7 @@ class PrefillDescription < SimpleDelegator
   end
 
   def prefilled_champs
-    @prefilled_champs ||= types_de_champ.where(id: selected_type_de_champ_ids)
+    @prefilled_champs ||= active_fillable_public_types_de_champ.where(id: selected_type_de_champ_ids)
   end
 
   private
@@ -46,5 +46,9 @@ class PrefillDescription < SimpleDelegator
 
   def example_value(type_de_champ)
     I18n.t("views.prefill_descriptions.edit.examples.#{type_de_champ.type_champ}")
+  end
+
+  def active_fillable_public_types_de_champ
+    active_revision.types_de_champ_public.fillable
   end
 end

--- a/app/views/prefill_descriptions/_types_de_champs.html.haml
+++ b/app/views/prefill_descriptions/_types_de_champs.html.haml
@@ -1,6 +1,8 @@
 = turbo_frame_tag "#{dom_id(@prefill_description)}_types_de_champs" do
   .fr-grid-row.fr-grid-row--gutters.fr-py-5w
     - prefill_description.types_de_champ.each do |type_de_champ|
+      - prefillable = type_de_champ.prefillable?
+
       .fr-col-md-6.fr-col-12
         .card
           .card-title.flex.justify-between.align-center
@@ -10,7 +12,7 @@
                 - (prefill_description.selected_type_de_champ_ids - [type_de_champ.id.to_s]).each do |id|
                   = f.hidden_field :selected_type_de_champ_ids, value: id, multiple: true
                 = f.submit t("views.prefill_descriptions.edit.champ_remove"), class: 'fr-btn fr-btn--secondary fr-btn--md'
-              - elsif type_de_champ.prefillable?
+              - elsif prefillable
                 - (prefill_description.selected_type_de_champ_ids + [type_de_champ.id.to_s]).each do |id|
                   = f.hidden_field :selected_type_de_champ_ids, value: id, multiple: true
                 = f.submit t("views.prefill_descriptions.edit.champ_add"), class: 'fr-btn fr-btn--md'
@@ -32,13 +34,13 @@
                   = t("views.prefill_descriptions.edit.champ_type")
                 %td
                   = t("activerecord.attributes.type_de_champ.type_champs.#{type_de_champ.type_champ}")
-              %tr
+              %tr{ class: prefillable ? "" : "fr-text-mention--grey" }
                 %th
                   = t("views.prefill_descriptions.edit.possible_values.title")
                 %td
-                  = t("views.prefill_descriptions.edit.possible_values.#{type_de_champ.type_champ}")
-              %tr
+                  = t("views.prefill_descriptions.edit.possible_values.#{type_de_champ.type_champ}") if prefillable
+              %tr{ class: prefillable ? "" : "fr-text-mention--grey" }
                 %th
                   = t("views.prefill_descriptions.edit.examples.title")
                 %td
-                  = t("views.prefill_descriptions.edit.examples.#{type_de_champ.type_champ}")
+                  = t("views.prefill_descriptions.edit.examples.#{type_de_champ.type_champ}") if prefillable

--- a/spec/models/prefill_description_spec.rb
+++ b/spec/models/prefill_description_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe PrefillDescription, type: :model do
 
   describe '#types_de_champ' do
     let(:procedure) { create(:procedure) }
-    let(:type_de_champ) { create(:type_de_champ_text, procedure: procedure) }
+    let!(:type_de_champ) { create(:type_de_champ_text, procedure: procedure) }
     let(:prefill_description) { described_class.new(procedure) }
 
     it { expect(prefill_description.types_de_champ).to match([type_de_champ]) }
@@ -32,6 +32,19 @@ RSpec.describe PrefillDescription, type: :model do
 
     it_behaves_like "filters out non fillable types de champ", :type_de_champ_header_section
     it_behaves_like "filters out non fillable types de champ", :type_de_champ_explication
+
+    context 'when the procedure contains prefillable and non prefillable types de champ' do
+      let!(:non_prefillable_type_de_champ) { create(:type_de_champ_carte, procedure: procedure) }
+      let!(:prefillable_type_de_champ) { create(:type_de_champ_decimal_number, procedure: procedure) }
+
+      it "sort types de champ by putting prefillable ones first" do
+        expect(prefill_description.types_de_champ).to eq([
+          type_de_champ,
+          prefillable_type_de_champ,
+          non_prefillable_type_de_champ
+        ])
+      end
+    end
   end
 
   describe '#include?' do


### PR DESCRIPTION
On masque les valeurs disponibles et les examples pour les champs qu'on ne peut pas préremplir.

# Avant

![image](https://user-images.githubusercontent.com/1193334/208650708-89c5e3fb-42e2-4c7f-8222-31774429adca.png)

# Après

![image](https://user-images.githubusercontent.com/1193334/208650775-7129d072-6719-4b36-aeeb-8887184034ba.png)
