### PR TITLE
Clean URL prefill link

### DIFF
--- a/app/controllers/concerns/query_params_store_concern.rb
+++ b/app/controllers/concerns/query_params_store_concern.rb
@@ -6,7 +6,7 @@ module QueryParamsStoreConcern
     # lost previously stored params
     return if session[:stored_params].present? || request.query_parameters.empty?
 
-    session[:stored_params] = request.query_parameters.to_json
+    session[:stored_params] = request.query_parameters.transform_values { |v| v[/[^=].*/] }.to_json
   end
 
   def retrieve_and_delete_stored_query_params

--- a/app/models/prefill_description.rb
+++ b/app/models/prefill_description.rb
@@ -27,7 +27,7 @@ class PrefillDescription < SimpleDelegator
   end
 
   def prefill_link
-    @prefill_link ||= commencer_url({ path: path }.merge(prefilled_champs_for_link))
+    @prefill_link ||= URI.decode_www_form_component(commencer_url({ path: path }.merge(prefilled_champs_for_link)))
   end
 
   def prefilled_champs
@@ -37,7 +37,7 @@ class PrefillDescription < SimpleDelegator
   private
 
   def prefilled_champs_for_link
-    prefilled_champs.map { |type_de_champ| ["champ_#{type_de_champ.to_typed_id}", type_de_champ.libelle] }.to_h
+    prefilled_champs.map { |type_de_champ| ["champ_#{type_de_champ.to_typed_id}", type_de_champ.libelle.tr(" ", "+")] }.to_h
   end
 
   def prefilled_champs_for_query

--- a/spec/models/prefill_description_spec.rb
+++ b/spec/models/prefill_description_spec.rb
@@ -68,12 +68,7 @@ RSpec.describe PrefillDescription, type: :model do
     before { prefill_description.update(selected_type_de_champ_ids: [type_de_champ.id]) }
 
     it "builds the URL to create a new prefilled dossier" do
-      expect(prefill_description.prefill_link).to eq(
-        commencer_url(
-          path: procedure.path,
-          "champ_#{type_de_champ.to_typed_id}" => type_de_champ.libelle
-        )
-      )
+      expect(prefill_description.prefill_link).to eq("http://localhost:3000/commencer/#{procedure.path}?champ_#{type_de_champ.to_typed_id}=#{type_de_champ.libelle.tr(" ", "+")}")
     end
   end
 end


### PR DESCRIPTION
@sebastiencarceles Une proposition pour clarifier l'URL des prefill_link qui ne me semblent pas toujours facilement "lisibles". Je ne sais pas si c'est nécessaire vu que ça nécessitera un travail d'intégration quoi qu'il arrive.

On passe par exemple de ça: http://localhost:3000/commencer/test-complet?champ_Q2hhbXAtMTY%3D=T%C3%A9l%C3%A9phone
à ca: http://localhost:3000/commencer/test-complet?champ_Q2hhbXAtMTY==Téléphone