### PR TITLE
fix(autosave): submit before debounced autosave

### DIFF
--- a/app/javascript/controllers/autosave_controller.ts
+++ b/app/javascript/controllers/autosave_controller.ts
@@ -100,6 +100,8 @@ export class AutosaveController extends ApplicationController {
       target.getAttribute('role') != 'combobox' &&
       isTextInputElement(target)
     ) {
+      // File submit have to know a request will be enqueued and it should wait for it.
+      this.willEnqueue();
       this.debounce(this.enqueueAutosaveRequest, AUTOSAVE_DEBOUNCE_DELAY);
     }
   }
@@ -112,6 +114,10 @@ export class AutosaveController extends ApplicationController {
     if (this.#needsRetry) {
       this.enqueueAutosaveRequest();
     }
+  }
+
+  private willEnqueue() {
+    this.globalDispatch('autosave:enqueue');
   }
 
   private didEnqueue() {

--- a/app/javascript/controllers/autosave_controller.ts
+++ b/app/javascript/controllers/autosave_controller.ts
@@ -80,8 +80,7 @@ export class AutosaveController extends ApplicationController {
         }
       } else if (target.type == 'hidden') {
         // In React comboboxes we dispatch a "change" event on hidden inputs to trigger autosave.
-        // We want to debounce them.
-        this.debounce(this.enqueueAutosaveRequest, AUTOSAVE_DEBOUNCE_DELAY);
+        this.enqueueAutosaveRequest();
       } else if (
         isSelectElement(target) ||
         isCheckboxOrRadioInputElement(target) ||


### PR DESCRIPTION
Tentative de fix quand on clique très vite sur "déposer un dossier" pour prendre en compte le dernier champ modifié du dossier, c'est à dire attendre attendre l'exécution du debounce.

- champ texte, alors qu'une requête d'autosave est dans le buffer du debounce : => on rend inopérant le submit, l'utilisateur devra recliquer dessus pour déposer le dossier mais c'est un cas très limite donc à mon avis pas un comportement génant
- lorsqu'un combobox search vient d'être validé (champ hidden mis à jour) et attendait le debounce. Je ne vois pas le cas d'usage qui nécessite d'avoir un debounce donc je l'ai enlevé, mais alternativement on pourrait faire comme ci-dessus

Ce sont des cas assez improbables pour un vrai utilisateur, mais peut-être que sur un appareil lent, si le debounce a du de retard ça résout certains problèmes ?

Closes #8311 