### PR TITLE
fix(dossier): schedule a rebase to all pending dossiers

### DIFF
--- a/lib/tasks/deployment/20221221090151_schedule_rebase_for_all_dossiers.rake
+++ b/lib/tasks/deployment/20221221090151_schedule_rebase_for_all_dossiers.rake
@@ -1,0 +1,24 @@
+namespace :after_party do
+  desc 'Deployment task: schedule_rebase_for_all_dossiers'
+  task schedule_rebase_for_all_dossiers: :environment do
+    puts "Running deploy task 'schedule_rebase_for_all_dossiers'"
+
+    dossiers = Dossier.joins(:procedure)
+      .state_not_termine
+      .state_not_brouillon
+      .where('revision_id != procedures.published_revision_id')
+
+    progress = ProgressReport.new(dossiers.count)
+
+    dossiers.find_each do |dossier|
+      dossier.rebase_later
+      progress.inc
+    end
+    progress.finish
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
Nous avons relaxé les règles de rebase récemment. Pour les nouveaux dossiers, on autorise le rebase dans beaucoup plus de cas. Mais beaucoup de vieux dossiers sont restés coincés sur de vieilles revisions. Cette tache va mettre dans la queue un rebase pour tous les dossiers pas à jour. Sur mon extrait local, c'est ~80 000 dossiers.