### PR TITLE
remove useless DOSSIER_DEPOSIT_RECEIPT_LOGO_SRC env var

### DIFF
--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -68,9 +68,6 @@ DS_ENV="staging"
 # Instance customization: Procedure default logo  ---> to be put in "app/assets/images"
 # PROCEDURE_DEFAULT_LOGO_SRC="republique-francaise-logo.svg"
 
-# Instance customization: Deposit receipt logo  ---> to be put in "app/assets/images"
-# DOSSIER_DEPOSIT_RECEIPT_LOGO_SRC="app/assets/images/republique-francaise-logo.svg"
-
 # Instance customization: PDF export logo ---> to be put in "app/assets/images"
 # DOSSIER_PDF_EXPORT_LOGO_SRC="app/assets/images/header/logo-ds-wide.png"
 

--- a/config/initializers/images.rb
+++ b/config/initializers/images.rb
@@ -16,8 +16,5 @@ MAILER_FOOTER_LOGO_SRC = ENV.fetch("MAILER_FOOTER_LOGO_SRC", "mailer/instructeur
 # Default logo of a procedure
 PROCEDURE_DEFAULT_LOGO_SRC = ENV.fetch("PROCEDURE_DEFAULT_LOGO_SRC", "republique-francaise-logo.svg")
 
-# Deposit receipt logo
-DOSSIER_DEPOSIT_RECEIPT_LOGO_SRC = ENV.fetch("DOSSIER_DEPOSIT_RECEIPT_LOGO_SRC", "app/assets/images/republique-francaise-logo.svg")
-
 # Logo in PDF export of a "Dossier"
 DOSSIER_PDF_EXPORT_LOGO_SRC = ENV.fetch("DOSSIER_PDF_EXPORT_LOGO_SRC", "app/assets/images/header/logo-ds-wide.png")


### PR DESCRIPTION
# Résumé

<!-- décrire en quelques phrases la problématique adressée -->

La variable d'environnement `DOSSIER_DEPOSIT_RECEIPT_LOGO_SRC` est mentionnée dans le fichier `config/env.example.optional` et sert à déclarer une constante dans `config/initializers/images.rb`, mais cette dernière n'est utilisée nullepart.

mots-clés : env, var

fixes #8332 / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`