### PR TITLE
correctif(instructeurs/dossier#telecharger_pjs): ne pas inclure les bills et horodatage quand on telecharge un dossier unitairement

### DIFF
--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -230,7 +230,7 @@ module Instructeurs
     end
 
     def telecharger_pjs
-      files = ActiveStorage::DownloadableFile.create_list_from_dossiers(Dossier.where(id: dossier.id))
+      files = ActiveStorage::DownloadableFile.create_list_from_dossiers(Dossier.where(id: dossier.id), true)
       cleaned_files = ActiveStorage::DownloadableFile.cleanup_list_from_dossier(files)
 
       zipline(cleaned_files, "dossier-#{dossier.id}.zip")

--- a/spec/system/instructeurs/instruction_spec.rb
+++ b/spec/system/instructeurs/instruction_spec.rb
@@ -224,11 +224,10 @@ describe 'Instructing a dossier:', js: true do
       files = ZipTricks::FileReader.read_zip_structure(io: File.open(DownloadHelpers.download))
 
       expect(DownloadHelpers.download).to include "dossier-#{dossier.id}.zip"
-      expect(files.size).to be 3
+      expect(files.size).to be 2
       expect(files[0].filename.include?('export')).to be_truthy
       expect(files[1].filename.include?('piece_justificative_0')).to be_truthy
       expect(files[1].uncompressed_size).to be File.size(path)
-      expect(files[2].filename.include?('horodatage/operation')).to be_truthy
     end
 
     scenario 'A instructeur can download an archive containing several identical attachments' do
@@ -244,14 +243,13 @@ describe 'Instructing a dossier:', js: true do
       files = ZipTricks::FileReader.read_zip_structure(io: File.open(DownloadHelpers.download))
 
       expect(DownloadHelpers.download).to include "dossier-#{dossier.id}.zip"
-      expect(files.size).to be 4
+      expect(files.size).to be 3
       expect(files[0].filename.include?('export')).to be_truthy
       expect(files[1].filename.include?('piece_justificative_0')).to be_truthy
       expect(files[2].filename.include?('piece_justificative_0')).to be_truthy
       expect(files[1].filename).not_to eq files[2].filename
       expect(files[1].uncompressed_size).to be File.size(path)
       expect(files[2].uncompressed_size).to be File.size(path)
-      expect(files[3].filename.include?('horodatage/operation')).to be_truthy
     end
 
     before { DownloadHelpers.clear_downloads }


### PR DESCRIPTION
voir: https://secure.helpscout.net/conversation/2092564687/2007498/