### PR TITLE
sentry(3830513995): champs pays peut avoir un external_id a '', test la presence d'external_id sinon on peut renvoyer du nil via Champs::PaysChamp.name

### DIFF
--- a/app/models/champs/pays_champ.rb
+++ b/app/models/champs/pays_champ.rb
@@ -55,7 +55,7 @@ class Champs::PaysChamp < Champs::TextChamp
   end
 
   def name
-    if external_id
+    if external_id.present?
       APIGeoService.country_name(external_id)
     else
       value.present? ? value.to_s : ''


### PR DESCRIPTION
see: https://secure.helpscout.net/conversation/2108493125/2009083?folderId=1653799