### PR TITLE
Supprime le feature flag administrateurs Tags

### DIFF
--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -66,7 +66,6 @@ module Administrateurs
 
     def new
       @procedure ||= Procedure.new(for_individual: true)
-      @existing_tags = Procedure.tags
     end
 
     SIGNIFICANT_DOSSIERS_THRESHOLD = 30

--- a/app/views/administrateurs/procedures/_informations.html.haml
+++ b/app/views/administrateurs/procedures/_informations.html.haml
@@ -99,19 +99,19 @@
 
   %p.explication
     Si votre démarche s’adresse indifféremment à une personne morale ou un particulier, choisissez l'option « Particuliers ». Vous pourrez ajouter un champ SIRET directement dans le formulaire.
-  - if feature_enabled?(:administrateur_add_tags)
-    %h3.header-subsection Ajouter des tags
-    %p.explication Les tags sont des mots ou des expressions que vous attribuez aux démarches pour décrire leur contenu et pour les retrouver. Les tags sont partagés avec la communauté, ce qui vous permet de voir les tags attribués aux démarches créées par les autres administrateurs.
-    = hidden_field_tag  'procedure[tags]', nil
-    = react_component("ComboMultiple",
-      options: @existing_tags,
-      selected: @procedure.tags,
-      disabled: [],
-      label: 'Tags',
-      group: '.procedure-form__column--form',
-      name: 'tags',
-      describedby: 'procedure-tags',
-      acceptNewValues: true)
+
+  %h3.header-subsection Ajouter des tags
+  %p.explication Les tags sont des mots ou des expressions que vous attribuez aux démarches pour décrire leur contenu et pour les retrouver. Les tags sont partagés avec la communauté, ce qui vous permet de voir les tags attribués aux démarches créées par les autres administrateurs.
+  = hidden_field_tag  'procedure[tags]', nil
+  = react_component("ComboMultiple",
+    options: Procedure.tags,
+    selected: @procedure.tags,
+    disabled: [],
+    label: 'Tags',
+    group: '.procedure-form__column--form',
+    name: 'tags',
+    describedby: 'procedure-tags',
+    acceptNewValues: true)
 
 %details.procedure-form__options-details
   %summary.procedure-form__options-summary


### PR DESCRIPTION
Supprime le feature flag pour que tous les administrateurs puissent ajouter des tags sur leur démarches.