### PR TITLE
Email: améliore le wording des emails de dossiers arrivant à expiration et de suppression automatique

### DIFF
--- a/app/views/dossier_mailer/notify_automatic_deletion_to_user.html.haml
+++ b/app/views/dossier_mailer/notify_automatic_deletion_to_user.html.haml
@@ -6,7 +6,10 @@
   = t('.header', count: @deleted_dossiers.size)
   %ul
     - @deleted_dossiers.each do |d|
-      %li n° #{d.dossier_id} (#{d.procedure.libelle})
+      %li N° #{d.dossier_id} (#{d.procedure.libelle})
+
+%p
+  %strong= t('.account_active', count: @deleted_dossiers.size)
 
 - if @state == Dossier.states.fetch(:en_construction)
   %p= t('.footer_en_construction', count: @deleted_dossiers.size)

--- a/app/views/dossier_mailer/notify_near_deletion_to_administration.html.haml
+++ b/app/views/dossier_mailer/notify_near_deletion_to_administration.html.haml
@@ -10,7 +10,7 @@
   %ul
     - @dossiers.each do |d|
       %li
-        #{link_to("n° #{d.id} (#{d.procedure.libelle})", dossier_url(d))}. Retrouvez le dossier au format #{link_to("PDF", instructeur_dossier_url(d.procedure, d, format: :pdf))}
+        #{link_to("N° #{d.id} (#{d.procedure.libelle})", dossier_url(d))}. Retrouvez le dossier au format #{link_to("PDF", instructeur_dossier_url(d.procedure, d, format: :pdf))}
 
 %p
   - if @state == Dossier.states.fetch(:en_construction)

--- a/app/views/dossier_mailer/notify_near_deletion_to_user.html.haml
+++ b/app/views/dossier_mailer/notify_near_deletion_to_user.html.haml
@@ -10,12 +10,15 @@
   %ul
     - @dossiers.each do |d|
       %li
-        #{link_to("n° #{d.id} (#{d.procedure.libelle})", dossier_url(d))}. Retrouvez le dossier au format #{link_to("PDF", dossier_url(d, format: :pdf))}
+        #{link_to("N° #{d.id} (#{d.procedure.libelle})", dossier_url(d))}
 
 %p
-  = sanitize(t('.footer', count: @dossiers.size))
+  %strong= t('.account_active', count: @dossiers.size)
+
 %p
   - if @state == Dossier.states.fetch(:en_construction)
     = sanitize(t('.footer_en_construction', count: @dossiers.size))
+  - else
+    = sanitize(t('.footer_termine', count: @dossiers.size, dossiers_url: dossiers_url))
 
 = render partial: "layouts/mailers/signature"

--- a/app/views/instructeurs/dossiers/_expiration_banner.html.haml
+++ b/app/views/instructeurs/dossiers/_expiration_banner.html.haml
@@ -6,23 +6,22 @@
       = t("shared.dossiers.header.expires_at.#{dossier.state}", date: safe_expiration_date(dossier), duree_conservation_totale: dossier.duree_totale_conservation_in_months)
       - if dossier.conservation_extension.positive?
         = t('instructeurs.dossiers.header.banner.expiration_date_extended')
-  -# big banner warning
+
   - if dossier.close_to_expiration?
-    .card.warning.mb-3
-      .card-title= t('instructeurs.dossiers.header.banner.title')
-      %p
-      - if dossier.brouillon?
-        = t('instructeurs.dossiers.header.banner.states.brouillon')
-      - elsif dossier.en_construction?
-        = t('instructeurs.dossiers.header.banner.states.en_construction')
-      - elsif dossier.termine?
-        = t('instructeurs.dossiers.header.banner.states.termine')
+    = render Dsfr::CalloutComponent.new(title: t('instructeurs.dossiers.header.banner.title'), theme: :warning) do |c|
+      - c.with_body do
+        - if dossier.brouillon?
+          = t('instructeurs.dossiers.header.banner.states.brouillon')
+        - elsif dossier.en_construction?
+          = t('instructeurs.dossiers.header.banner.states.en_construction', nominal_duration_months: dossier.procedure.duree_conservation_dossiers_dans_ds)
+        - elsif dossier.termine?
+          = t('instructeurs.dossiers.header.banner.states.termine')
 
       - if dossier.expiration_can_be_extended?
-        %br
-        = button_to repousser_expiration_instructeur_dossier_path(dossier.procedure, dossier), class: 'button mt-2', id: 'test-instructeur-repousser-expiration' do
-          %span.icon.standby
-          = t('instructeurs.dossiers.header.banner.button_delay_expiration')
+        - c.with_bottom do
+          = button_to repousser_expiration_instructeur_dossier_path(dossier.procedure, dossier), class: 'fr-btn', id: 'test-instructeur-repousser-expiration' do
+            = t('instructeurs.dossiers.header.banner.button_delay_expiration', count: dossier.procedure.duree_conservation_dossiers_dans_ds)
+
 - elsif dossier.en_instruction? && dossier.procedure.procedure_expires_when_termine_enabled
   %p.expires_at_en_instruction
     %small= t("shared.dossiers.header.expires_at.en_instruction")

--- a/app/views/users/dossiers/_expiration_banner.html.haml
+++ b/app/views/users/dossiers/_expiration_banner.html.haml
@@ -2,23 +2,22 @@
 - if dossier.expirable?
   %p.expires_at.mb-2
     %small= t("shared.dossiers.header.expires_at.#{dossier.state}", date: safe_expiration_date(dossier), duree_conservation_totale: dossier.duree_totale_conservation_in_months)
-  -# big banner warning
+
   - if dossier.close_to_expiration?
-    .card.warning.mb-3
-      .card-title= t('users.dossiers.header.banner.title')
-      %p
-      - if dossier.brouillon?
-        = t('users.dossiers.header.banner.states.brouillon')
-      - elsif dossier.en_construction?
-        = t('users.dossiers.header.banner.states.en_construction')
-      - elsif dossier.termine?
-        = t('users.dossiers.header.banner.states.termine')
+    = render Dsfr::CalloutComponent.new(title: t('users.dossiers.header.banner.title'), theme: :warning) do |c|
+      - c.with_body do
+        - if dossier.brouillon?
+          = t('users.dossiers.header.banner.states.brouillon')
+        - elsif dossier.en_construction?
+          = t('users.dossiers.header.banner.states.en_construction', nominal_duration_months: dossier.procedure.duree_conservation_dossiers_dans_ds)
+        - elsif dossier.termine?
+          = t('users.dossiers.header.banner.states.termine')
 
       - if dossier.expiration_can_be_extended?
-        %br
-        = button_to users_dossier_repousser_expiration_path(dossier), class: 'button mt-2', id: 'test-user-repousser-expiration' do
-          %span.icon.standby
-          = t('users.dossiers.header.banner.button_delay_expiration', count: dossier.procedure.duree_conservation_dossiers_dans_ds)
+        - c.with_bottom do
+          = button_to users_dossier_repousser_expiration_path(dossier), class: 'fr-btn', id: 'test-user-repousser-expiration' do
+            = t('users.dossiers.header.banner.button_delay_expiration', count: dossier.procedure.duree_conservation_dossiers_dans_ds)
+
 - elsif dossier.en_instruction? && dossier.procedure.procedure_expires_when_termine_enabled
   %p.expires_at_en_instruction
     %small= t("shared.dossiers.header.expires_at.en_instruction")

--- a/app/views/users/dossiers/_expiration_banner.html.haml
+++ b/app/views/users/dossiers/_expiration_banner.html.haml
@@ -18,7 +18,7 @@
         %br
         = button_to users_dossier_repousser_expiration_path(dossier), class: 'button mt-2', id: 'test-user-repousser-expiration' do
           %span.icon.standby
-          = t('users.dossiers.header.banner.button_delay_expiration', duree_conservation_dossiers_dans_ds: dossier.procedure.duree_conservation_dossiers_dans_ds)
+          = t('users.dossiers.header.banner.button_delay_expiration', count: dossier.procedure.duree_conservation_dossiers_dans_ds)
 - elsif dossier.en_instruction? && dossier.procedure.procedure_expires_when_termine_enabled
   %p.expires_at_en_instruction
     %small= t("shared.dossiers.header.expires_at.en_instruction")

--- a/app/views/users/dossiers/index.html.haml
+++ b/app/views/users/dossiers/index.html.haml
@@ -22,6 +22,7 @@
               active: @statut == 'en-cours',
               badge: number_with_html_delimiter(@user_dossiers.count))
           - if @dossiers_traites.present?
+            // TODO: when renaming this tab in "Terminé", update notify_near_deletion_to_user email wording accordingly.
             = tab_item(t('pluralize.traites', count: @dossiers_traites.count),
               dossiers_path(statut: 'traites'),
               active: @statut == 'traites',

--- a/config/locales/views/dossier_mailer/notify_automatic_deletion_to_user/fr.yml
+++ b/config/locales/views/dossier_mailer/notify_automatic_deletion_to_user/fr.yml
@@ -2,11 +2,14 @@ fr:
   dossier_mailer:
     notify_automatic_deletion_to_user:
       subject:
-        one: "Un dossier a été supprimé automatiquement"
-        other: "Des dossiers ont été supprimés automatiquement"
+        one: "Un dossier a été supprimé automatiquement de votre compte"
+        other: "Des dossiers ont été supprimés automatiquement de votre compte"
       header:
-        one: "Le délai maximum de conservation du dossier suivant a été atteint, il a donc été supprimé :"
-        other: "Le délai maximum de conservation des dossiers suivants a été atteint, ils ont donc été supprimés :"
+        one: "Le délai maximum pour la conservation du dossier suivant a été atteint.\nLe dossier suivant a été automatiquement supprimé :"
+        other: "Le délai maximum pour la conservation des dossiers suivants a été atteint.\nLes dossiers suivants ont été automatiquement supprimés :"
+      account_active:
+        one: Votre compte reste activé sur Démarches Simplifiées, seul le dossier est supprimé.
+        other: Votre compte reste activé sur Démarches Simplifiées, seuls les dossiers ont été supprimés.
       footer_en_construction:
         one: "Le dossier ne sera pas traité, nous nous excusons de la gène occasionnée."
         other: "Les dossiers ne seront pas traités, nous nous excusons de la gène occasionnée."

--- a/config/locales/views/dossier_mailer/notify_near_deletion_to_user/fr.yml
+++ b/config/locales/views/dossier_mailer/notify_near_deletion_to_user/fr.yml
@@ -8,14 +8,17 @@ fr:
         one: Un dossier dont le traitement est terminé va bientôt être supprimé
         other: Des dossiers dont le traitement est terminé vont bientôt être supprimés
       header_en_construction:
-        one: "Afin de limiter la conservation de vos données personnelles, le dossier en construction suivant sera bientôt automatiquement supprimé :"
-        other: "Afin de limiter la conservation de vos données personnelles, les dossiers en construction suivant seront bientôt automatiquement supprimés :"
+        one: "Afin de respecter la durée de conservation de vos données personnelles, le dossier en construction suivant sera supprimé automatiquement dans deux semaines :"
+        other: "Afin de respecter la durée de conservation de vos données personnelles, les dossiers en construction suivants seront supprimés automatiquement dans deux semaines :"
       header_termine:
-        one: "Afin de limiter la conservation de vos données personnelles, le dossier suivant dont le traitement est terminé sera bientôt automatiquement supprimé :"
-        other: "Afin de limiter la conservation de vos données personnelles, les dossiers suivant dont le traitement est terminé seront bientôt automatiquement supprimés :"
-      footer:
-        one: "Vous pouvez retrouver votre dossier pendant encore <b>deux semaines</b>. Vous n’avez rien à faire."
-        other: "Vous pouvez retrouver vos dossiers pendant encore <b>deux semaines</b>. Vous n’avez rien à faire."
+        one: "Afin de respecter la durée de conservation de vos données personnelles, le dossier suivant dont le traitement est terminé sera supprimé automatiquement dans deux semaines :"
+        other: "Afin de respecter la durée de conservation de vos données personnelles, les dossiers suivants dont le traitement est terminé seront supprimés automatiquement dans deux semaines :"
+      account_active:
+        one: Votre compte reste activé sur Démarches Simplifiées, seul le dossier sera supprimé.
+        other: Votre compte reste activé sur Démarches Simplifiées, seuls les dossiers seront supprimés.
+      footer_termine:
+        one: "Vous pouvez télécharger votre dossier au format PDF depuis l’onglet « Expirant » sur la page <a href=\"%{dossiers_url}\">Mes dossiers</a>."
+        other: "Vous pouvez télécharger vos dossiers au format PDF depuis l’onglet « Expirant » sur la page <a href=\"%{dossiers_url}\">Mes dossiers</a>."
       footer_en_construction:
         one: "Si vous souhaitez conserver votre dossier plus longtemps, vous pouvez <b>prolonger sa durée de conservation</b> dans l’interface."
         other: "Si vous souhaitez conserver vos dossiers plus longtemps, vous pouvez <b>prolonger leur durée de conservation</b> au cas par cas dans l’interface."

--- a/config/locales/views/layouts/_account_dropdown.en.yml
+++ b/config/locales/views/layouts/_account_dropdown.en.yml
@@ -1,7 +1,7 @@
 en:
   layouts:
     header:
-      files: Files
+      files: My files
     menu_aria_label: 'Menu my profile'
     go_superadmin: "Switch to super-admin"
     go_user: "Switch to user"

--- a/config/locales/views/layouts/_account_dropdown.fr.yml
+++ b/config/locales/views/layouts/_account_dropdown.fr.yml
@@ -1,7 +1,7 @@
 fr:
   layouts:
     header:
-      files: Dossiers
+      files: Mes dossiers
     menu_aria_label: 'Menu mon profil'
     go_superadmin: "Passer en super-admin"
     go_user: "Passer en usager"

--- a/config/locales/views/users/header/en.yml
+++ b/config/locales/views/users/header/en.yml
@@ -16,4 +16,6 @@ en:
             brouillon: Your file is still in draft and will soon expire. So it will be deleted soon without being instructed. If you want to pursue your procedure you can submit it now. Otherwise you are able to delay its expiration by clicking on the underneath button.
             en_construction: Your file is pending for instruction. The maximum delay is 6 months, but you can extend the duration by a month by clicking on the underneath button.
             termine: Your file had been processed and will soon expire. So it will be deleted soon. If you want to keep it, you can dowload a PDF file of it.
-          button_delay_expiration: "Keep for %{duree_conservation_dossiers_dans_ds} more months"
+          button_delay_expiration:
+            one: "Keep for %{count} more month"
+            other: "Keep for %{count} more months"

--- a/config/locales/views/users/header/en.yml
+++ b/config/locales/views/users/header/en.yml
@@ -14,7 +14,7 @@ en:
           contact_service: For more information, please contact the service %{service_name}, available at  %{service_phone_number} or by email %{service_email}
           states:
             brouillon: Your file is still in draft and will soon expire. So it will be deleted soon without being instructed. If you want to pursue your procedure you can submit it now. Otherwise you are able to delay its expiration by clicking on the underneath button.
-            en_construction: Your file is pending for instruction. The maximum delay is 6 months, but you can extend the duration by a month by clicking on the underneath button.
+            en_construction: Your file is pending for instruction. The maximum delay is %{nominal_duration_months} months, but you can extend the duration by clicking on the underneath button.
             termine: Your file had been processed and will soon expire. So it will be deleted soon. If you want to keep it, you can dowload a PDF file of it.
           button_delay_expiration:
             one: "Keep for %{count} more month"

--- a/config/locales/views/users/header/fr.yml
+++ b/config/locales/views/users/header/fr.yml
@@ -16,4 +16,6 @@ fr:
             brouillon: Votre dossier est en brouillon, mais va bientôt expirer. Cela signifie qu’il va bientôt être supprimé sans avoir été déposé. Si vous souhaitez le conserver afin de poursuivre la démarche, vous pouvez le conserver un mois de plus en cliquant sur le bouton ci-dessous.
             en_construction: Votre dossier est en attente de prise en charge par l’administration. Le delais de prise en charge maximale est de 6 mois. Vous pouvez toutefois étendre cette durée d’un mois en cliquant sur le bouton suivant.
             termine: Le traitement de votre dossier est terminé, mais il va bientôt expirer. Cela signifie qu’il va bientôt être supprimé. Si vous souhaitez conserver une trace, vous pouvez le télécharger au format PDF.
-          button_delay_expiration: "Conserver %{duree_conservation_dossiers_dans_ds} mois supplémentaires "
+          button_delay_expiration:
+            one: "Conserver %{count} mois supplémentaire"
+            other: "Conserver %{count} mois supplémentaires"

--- a/config/locales/views/users/header/fr.yml
+++ b/config/locales/views/users/header/fr.yml
@@ -13,8 +13,8 @@ fr:
           contact_service: Pour plus d’informations, veuillez vous rapprocher du service %{service_name}, disponible au %{service_phone_number} ou par email %{service_email}
           title: Votre dossier va expirer
           states:
-            brouillon: Votre dossier est en brouillon, mais va bientôt expirer. Cela signifie qu’il va bientôt être supprimé sans avoir été déposé. Si vous souhaitez le conserver afin de poursuivre la démarche, vous pouvez le conserver un mois de plus en cliquant sur le bouton ci-dessous.
-            en_construction: Votre dossier est en attente de prise en charge par l’administration. Le delais de prise en charge maximale est de 6 mois. Vous pouvez toutefois étendre cette durée d’un mois en cliquant sur le bouton suivant.
+            brouillon: Votre dossier est en brouillon, mais va bientôt expirer. Cela signifie qu’il va bientôt être supprimé sans avoir été déposé. Si vous souhaitez le conserver afin de poursuivre la démarche, vous pouvez étendre la durée de conversation en cliquant sur le bouton ci-dessous.
+            en_construction: Votre dossier est en attente de prise en charge par l’administration. Le délai de prise en charge maximale est de %{nominal_duration_months} mois. Vous pouvez toutefois étendre cette durée en cliquant sur le bouton ci-dessous.
             termine: Le traitement de votre dossier est terminé, mais il va bientôt expirer. Cela signifie qu’il va bientôt être supprimé. Si vous souhaitez conserver une trace, vous pouvez le télécharger au format PDF.
           button_delay_expiration:
             one: "Conserver %{count} mois supplémentaire"

--- a/spec/mailers/dossier_mailer_spec.rb
+++ b/spec/mailers/dossier_mailer_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe DossierMailer, type: :mailer do
       subject { described_class.notify_near_deletion_to_administration([dossier], dossier.user.email) }
 
       it { expect(subject.subject).to eq("Un dossier en construction va bientôt être supprimé") }
-      it { expect(subject.body).to include("n° #{dossier.id} ") }
+      it { expect(subject.body).to include("N° #{dossier.id} ") }
       it { expect(subject.body).to include(dossier.procedure.libelle) }
       it { expect(subject.body).to include("PDF") }
       it { expect(subject.body).to include("Vous avez <b>deux semaines</b> pour commencer l’instruction du dossier.") }
@@ -173,10 +173,8 @@ RSpec.describe DossierMailer, type: :mailer do
       subject { described_class.notify_near_deletion_to_administration([dossier], dossier.user.email) }
 
       it { expect(subject.subject).to eq("Un dossier dont le traitement est terminé va bientôt être supprimé") }
-      it { expect(subject.body).to include("n° #{dossier.id} ") }
+      it { expect(subject.body).to include("N° #{dossier.id} ") }
       it { expect(subject.body).to include(dossier.procedure.libelle) }
-      it { expect(subject.body).to include("PDF") }
-      it { expect(subject.body).to include("Vous avez <b>deux semaines</b> pour archiver le dossier.") }
     end
   end
 
@@ -188,10 +186,9 @@ RSpec.describe DossierMailer, type: :mailer do
 
       it { expect(subject.to).to eq([dossier.user.email]) }
       it { expect(subject.subject).to eq("Un dossier en construction va bientôt être supprimé") }
-      it { expect(subject.body).to include("n° #{dossier.id} ") }
+      it { expect(subject.body).to include("N° #{dossier.id} ") }
       it { expect(subject.body).to include(dossier.procedure.libelle) }
-      it { expect(subject.body).to include("PDF") }
-      it { expect(subject.body).to include("Vous pouvez retrouver votre dossier pendant encore <b>deux semaines</b>. Vous n’avez rien à faire.") }
+      it { expect(subject.body).to include("Votre compte reste activé") }
       it { expect(subject.body).to include("Si vous souhaitez conserver votre dossier plus longtemps, vous pouvez <b>prolonger sa durée de conservation</b> dans l’interface.") }
     end
 
@@ -202,10 +199,21 @@ RSpec.describe DossierMailer, type: :mailer do
 
       it { expect(subject.to).to eq([dossier.user.email]) }
       it { expect(subject.subject).to eq("Un dossier dont le traitement est terminé va bientôt être supprimé") }
-      it { expect(subject.body).to include("n° #{dossier.id} ") }
+      it { expect(subject.body).to include("N° #{dossier.id} ") }
       it { expect(subject.body).to include(dossier.procedure.libelle) }
+      it { expect(subject.body).to include("Votre compte reste activé") }
       it { expect(subject.body).to include("PDF") }
-      it { expect(subject.body).to include("Vous pouvez retrouver votre dossier pendant encore <b>deux semaines</b>. Vous n’avez rien à faire.") }
+    end
+
+    describe 'multiple termines' do
+      let(:dossiers) { create_list(:dossier, 3, :accepte) }
+
+      subject { described_class.notify_near_deletion_to_user(dossiers, dossiers[0].user.email) }
+
+      it { expect(subject.subject).to eq("Des dossiers dont le traitement est terminé vont bientôt être supprimés") }
+      it { expect(subject.body).to include("N° #{dossiers[0].id} ") }
+      it { expect(subject.body).to include("N° #{dossiers[1].id} ") }
+      it { expect(subject.body).to include("N° #{dossiers[2].id} ") }
     end
   end
 

--- a/spec/mailers/dossier_mailer_spec.rb
+++ b/spec/mailers/dossier_mailer_spec.rb
@@ -125,8 +125,8 @@ RSpec.describe DossierMailer, type: :mailer do
       subject { described_class.notify_automatic_deletion_to_user([deleted_dossier], dossier.user.email) }
 
       it { expect(subject.to).to eq([dossier.user.email]) }
-      it { expect(subject.subject).to eq("Un dossier a été supprimé automatiquement") }
-      it { expect(subject.body).to include("n° #{dossier.id} ") }
+      it { expect(subject.subject).to eq("Un dossier a été supprimé automatiquement de votre compte") }
+      it { expect(subject.body).to include("N° #{dossier.id} ") }
       it { expect(subject.body).to include(dossier.procedure.libelle) }
       it { expect(subject.body).to include("nous nous excusons de la gène occasionnée") }
     end
@@ -137,8 +137,8 @@ RSpec.describe DossierMailer, type: :mailer do
       subject { described_class.notify_automatic_deletion_to_user([deleted_dossier], dossier.user.email) }
 
       it { expect(subject.to).to eq([dossier.user.email]) }
-      it { expect(subject.subject).to eq("Un dossier a été supprimé automatiquement") }
-      it { expect(subject.body).to include("n° #{dossier.id} ") }
+      it { expect(subject.subject).to eq("Un dossier a été supprimé automatiquement de votre compte") }
+      it { expect(subject.body).to include("N° #{dossier.id} ") }
       it { expect(subject.body).to include(dossier.procedure.libelle) }
       it { expect(subject.body).not_to include("nous nous excusons de la gène occasionnée") }
     end

--- a/spec/mailers/previews/dossier_mailer_preview.rb
+++ b/spec/mailers/previews/dossier_mailer_preview.rb
@@ -32,6 +32,10 @@ class DossierMailerPreview < ActionMailer::Preview
     DossierMailer.notify_near_deletion_to_user([dossier_accepte], usager_email)
   end
 
+  def notify_termine_near_deletion_to_user_multiple
+    DossierMailer.notify_near_deletion_to_user([dossier_accepte, dossier_accepte], usager_email)
+  end
+
   def notify_termine_near_deletion_to_administration
     DossierMailer.notify_near_deletion_to_administration([dossier_accepte, dossier_accepte], administration_email)
   end

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -166,13 +166,13 @@ describe 'The user' do
     login_as(user, scope: :user)
     visit brouillon_dossier_path(user_old_dossier)
 
-    expect(page).to have_css('.card-title', text: 'Votre dossier va expirer', visible: true)
+    expect(page).to have_css('.fr-callout__title', text: 'Votre dossier va expirer', visible: true)
     find('#test-user-repousser-expiration').click
     expect(page).to have_no_selector('#test-user-repousser-expiration')
 
     Timecop.freeze(simple_procedure.duree_conservation_dossiers_dans_ds.month.from_now) do
       visit brouillon_dossier_path(user_old_dossier)
-      expect(page).to have_css('.card-title', text: 'Votre dossier va expirer', visible: true)
+      expect(page).to have_css('.fr-callout__title', text: 'Votre dossier va expirer', visible: true)
       find('#test-user-repousser-expiration').click
       expect(page).to have_no_selector('#test-user-repousser-expiration')
     end

--- a/spec/views/layouts/_header_spec.rb
+++ b/spec/views/layouts/_header_spec.rb
@@ -44,7 +44,7 @@ describe 'layouts/_header.html.haml', type: :view do
     let(:profile) { :user }
 
     it { is_expected.to have_css(".fr-header__logo") }
-    it { is_expected.to have_link("Dossiers", href: dossiers_path) }
+    it { is_expected.to have_link("Mes dossiers", href: dossiers_path) }
     it { is_expected.to have_selector(:button, user.email, class: "account-btn") }
 
     it 'displays the Help button' do


### PR DESCRIPTION
- Utilise le nouveau wording qui avait été validé pour ces emails & variantes
- Met à jour quelques éléments d'interface en conséquence, notamment l'onglet _Dossiers_ => _Mes dossiers_ et les durées réelle d'expiration maintenant qu'elle sont dynamiques
- J'en profite pour passer au DSFR le bannière d'expiration (validé par @Olivier-Marcellin )

---

- Arrivant à expiration : 
![Capture d’écran 2023-01-04 à 13 11 51](https://user-images.githubusercontent.com/150279/210552672-19b377a7-9141-4c72-bf0f-72c9537e41ce.png)


- Supprimés automatiquement : 
![Capture d’écran 2023-01-03 à 18 50 22](https://user-images.githubusercontent.com/150279/210413329-90a1a69d-5237-4613-ab87-8ceced6c8fa7.png)



Bannière côté utilisateur : 
![Capture d’écran 2023-01-03 à 17 16 03](https://user-images.githubusercontent.com/150279/210397038-56e147c8-5078-46ce-a687-59bdc172de65.png)

Bannière côté instructeur (durée d'extension figée à 1 mois) : 

![Capture d’écran 2023-01-03 à 17 01 18](https://user-images.githubusercontent.com/150279/210397052-10622ba1-103f-4515-8568-6cc42da882f2.png)

---

J'ai aussi bien avancé sur stripo.email sur la création d'un template d'email transactionnel tel que designé dans les maquettes. Mais on attend la confirmation que le DSFR n'a pas dans ses plans de faire le leur à moyen terme avant de terminer cette intégration.

Closes #7688


