### PR TITLE
Fix : flash.now pour groupe instructeurs

### DIFF
--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -31,13 +31,11 @@ module Administrateurs
         .groupe_instructeurs
         .new({ instructeurs: [current_administrateur.instructeur] }.merge(groupe_instructeur_params))
 
-      begin
-        @groupe_instructeur.save!
+      if @groupe_instructeur.save
         routing_notice = " et le routage a été activé" if procedure.groupe_instructeurs.active.size == 2
         redirect_to admin_procedure_groupe_instructeur_path(procedure, @groupe_instructeur),
         notice: "Le groupe d’instructeurs « #{@groupe_instructeur.label} » a été créé#{routing_notice}."
-      rescue StandardError => e
-        Rails.logger.error e.message
+      else
         @procedure = procedure
         @instructeurs = paginated_instructeurs
         @groupes_instructeurs = paginated_groupe_instructeurs
@@ -50,12 +48,10 @@ module Administrateurs
     def update
       @groupe_instructeur = groupe_instructeur
 
-      begin
-        @groupe_instructeur.update!(groupe_instructeur_params)
+      if @groupe_instructeur.update(groupe_instructeur_params)
         redirect_to admin_procedure_groupe_instructeur_path(procedure, groupe_instructeur),
         notice: "Le nom est à présent « #{@groupe_instructeur.label} »."
-      rescue StandardError => e
-        Rails.logger.error e.message
+      else
         @procedure = procedure
         @instructeurs = paginated_instructeurs
         @available_instructeur_emails = available_instructeur_emails
@@ -69,9 +65,9 @@ module Administrateurs
       @groupe_instructeur = groupe_instructeur
 
       if @groupe_instructeur.dossiers.present?
-        flash[:alert] = "Impossible de supprimer un groupe avec des dossiers. Il faut le réaffecter avant"
+        flash.now[:alert] = "Impossible de supprimer un groupe avec des dossiers. Il faut le réaffecter avant"
       elsif procedure.groupe_instructeurs.one?
-        flash[:alert] = "Suppression impossible : il doit y avoir au moins un groupe instructeur sur chaque procédure"
+        flash.now[:alert] = "Suppression impossible : il doit y avoir au moins un groupe instructeur sur chaque procédure"
       else
         begin
           @groupe_instructeur.destroy!
@@ -79,7 +75,7 @@ module Administrateurs
             procedure.update!(routing_enabled: false)
             routing_notice = " et le routage a été désactivé"
           end
-          flash[:notice] = "le groupe « #{@groupe_instructeur.label} » a été supprimé#{routing_notice}."
+          flash.now[:notice] = "le groupe « #{@groupe_instructeur.label} » a été supprimé#{routing_notice}."
         rescue StandardError => e
           Rails.logger.error e.message
         end

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -32,11 +32,10 @@ module Administrateurs
         .new({ instructeurs: [current_administrateur.instructeur] }.merge(groupe_instructeur_params))
 
       begin
-        if @groupe_instructeur.save!
-          routing_notice = " et le routage a été activé" if procedure.groupe_instructeurs.active.size == 2
-          redirect_to admin_procedure_groupe_instructeur_path(procedure, @groupe_instructeur),
-          notice: "Le groupe d’instructeurs « #{@groupe_instructeur.label} » a été créé#{routing_notice}."
-        end
+        @groupe_instructeur.save!
+        routing_notice = " et le routage a été activé" if procedure.groupe_instructeurs.active.size == 2
+        redirect_to admin_procedure_groupe_instructeur_path(procedure, @groupe_instructeur),
+        notice: "Le groupe d’instructeurs « #{@groupe_instructeur.label} » a été créé#{routing_notice}."
       rescue StandardError => e
         Rails.logger.error e.message
         @procedure = procedure
@@ -52,10 +51,9 @@ module Administrateurs
       @groupe_instructeur = groupe_instructeur
 
       begin
-        if @groupe_instructeur.update!(groupe_instructeur_params)
-          redirect_to admin_procedure_groupe_instructeur_path(procedure, groupe_instructeur),
-          notice: "Le nom est à présent « #{@groupe_instructeur.label} »."
-        end
+        @groupe_instructeur.update!(groupe_instructeur_params)
+        redirect_to admin_procedure_groupe_instructeur_path(procedure, groupe_instructeur),
+        notice: "Le nom est à présent « #{@groupe_instructeur.label} »."
       rescue StandardError => e
         Rails.logger.error e.message
         @procedure = procedure

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -69,13 +69,12 @@ module Administrateurs
       elsif procedure.groupe_instructeurs.one?
         flash.now[:alert] = "Suppression impossible : il doit y avoir au moins un groupe instructeur sur chaque procédure"
       else
-          @groupe_instructeur.destroy!
-          if procedure.groupe_instructeurs.active.one?
-            procedure.update!(routing_enabled: false)
-            routing_notice = " et le routage a été désactivé"
-          end
-          flash.now[:notice] = "le groupe « #{@groupe_instructeur.label} » a été supprimé#{routing_notice}."
+        @groupe_instructeur.destroy!
+        if procedure.groupe_instructeurs.active.one?
+          procedure.update!(routing_enabled: false)
+          routing_notice = " et le routage a été désactivé"
         end
+        flash.now[:notice] = "le groupe « #{@groupe_instructeur.label} » a été supprimé#{routing_notice}."
       end
       redirect_to admin_procedure_groupe_instructeurs_path(procedure)
     end

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -69,15 +69,12 @@ module Administrateurs
       elsif procedure.groupe_instructeurs.one?
         flash.now[:alert] = "Suppression impossible : il doit y avoir au moins un groupe instructeur sur chaque procédure"
       else
-        begin
           @groupe_instructeur.destroy!
           if procedure.groupe_instructeurs.active.one?
             procedure.update!(routing_enabled: false)
             routing_notice = " et le routage a été désactivé"
           end
           flash.now[:notice] = "le groupe « #{@groupe_instructeur.label} » a été supprimé#{routing_notice}."
-        rescue StandardError => e
-          Rails.logger.error e.message
         end
       end
       redirect_to admin_procedure_groupe_instructeurs_path(procedure)

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -65,16 +65,16 @@ module Administrateurs
       @groupe_instructeur = groupe_instructeur
 
       if @groupe_instructeur.dossiers.present?
-        flash.now[:alert] = "Impossible de supprimer un groupe avec des dossiers. Il faut le réaffecter avant"
+        flash[:alert] = "Impossible de supprimer un groupe avec des dossiers. Il faut le réaffecter avant"
       elsif procedure.groupe_instructeurs.one?
-        flash.now[:alert] = "Suppression impossible : il doit y avoir au moins un groupe instructeur sur chaque procédure"
+        flash[:alert] = "Suppression impossible : il doit y avoir au moins un groupe instructeur sur chaque procédure"
       else
         @groupe_instructeur.destroy!
         if procedure.groupe_instructeurs.active.one?
           procedure.update!(routing_enabled: false)
           routing_notice = " et le routage a été désactivé"
         end
-        flash.now[:notice] = "le groupe « #{@groupe_instructeur.label} » a été supprimé#{routing_notice}."
+        flash[:notice] = "le groupe « #{@groupe_instructeur.label} » a été supprimé#{routing_notice}."
       end
       redirect_to admin_procedure_groupe_instructeurs_path(procedure)
     end

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -34,7 +34,7 @@ module Administrateurs
       if @groupe_instructeur.save
         routing_notice = " et le routage a été activé" if procedure.groupe_instructeurs.active.size == 2
         redirect_to admin_procedure_groupe_instructeur_path(procedure, @groupe_instructeur),
-        notice: "Le groupe d’instructeurs « #{@groupe_instructeur.label} » a été créé#{routing_notice}."
+          notice: "Le groupe d’instructeurs « #{@groupe_instructeur.label} » a été créé#{routing_notice}."
       else
         @procedure = procedure
         @instructeurs = paginated_instructeurs
@@ -50,7 +50,7 @@ module Administrateurs
 
       if @groupe_instructeur.update(groupe_instructeur_params)
         redirect_to admin_procedure_groupe_instructeur_path(procedure, groupe_instructeur),
-        notice: "Le nom est à présent « #{@groupe_instructeur.label} »."
+          notice: "Le nom est à présent « #{@groupe_instructeur.label} »."
       else
         @procedure = procedure
         @instructeurs = paginated_instructeurs

--- a/app/controllers/administrateurs/services_controller.rb
+++ b/app/controllers/administrateurs/services_controller.rb
@@ -15,12 +15,10 @@ module Administrateurs
       @service.administrateur = current_administrateur
 
       begin
-        if @service.save!
-          @service.enqueue_api_entreprise
-
-          redirect_to admin_services_path(procedure_id: params[:procedure_id]),
-            notice: "#{@service.nom} créé"
-        end
+        @service.save!
+        @service.enqueue_api_entreprise
+        redirect_to admin_services_path(procedure_id: params[:procedure_id]),
+          notice: "#{@service.nom} créé"
       rescue StandardError => e
         Rails.logger.error e.message
         @procedure = procedure
@@ -38,14 +36,12 @@ module Administrateurs
       @service = service
 
       begin
-        if @service.update!(service_params)
-          if @service.siret_previously_changed?
-            @service.enqueue_api_entreprise
-          end
-
-          redirect_to admin_services_path(procedure_id: params[:procedure_id]),
-            notice: "#{@service.nom} modifié"
+        @service.update!(service_params)
+        if @service.siret_previously_changed?
+          @service.enqueue_api_entreprise
         end
+        redirect_to admin_services_path(procedure_id: params[:procedure_id]),
+          notice: "#{@service.nom} modifié"
       rescue StandardError => e
         Rails.logger.error e.message
         @procedure = procedure

--- a/app/controllers/administrateurs/services_controller.rb
+++ b/app/controllers/administrateurs/services_controller.rb
@@ -14,13 +14,12 @@ module Administrateurs
       @service = Service.new(service_params)
       @service.administrateur = current_administrateur
 
-      begin
-        @service.save!
+      if @service.save
         @service.enqueue_api_entreprise
+
         redirect_to admin_services_path(procedure_id: params[:procedure_id]),
           notice: "#{@service.nom} créé"
-      rescue StandardError => e
-        Rails.logger.error e.message
+      else
         @procedure = procedure
         flash[:alert] = @service.errors.full_messages
         render :new

--- a/app/controllers/administrateurs/services_controller.rb
+++ b/app/controllers/administrateurs/services_controller.rb
@@ -14,12 +14,15 @@ module Administrateurs
       @service = Service.new(service_params)
       @service.administrateur = current_administrateur
 
-      if @service.save
-        @service.enqueue_api_entreprise
+      begin
+        if @service.save!
+          @service.enqueue_api_entreprise
 
-        redirect_to admin_services_path(procedure_id: params[:procedure_id]),
-          notice: "#{@service.nom} créé"
-      else
+          redirect_to admin_services_path(procedure_id: params[:procedure_id]),
+            notice: "#{@service.nom} créé"
+        end
+      rescue StandardError => e
+        Rails.logger.error e.message
         @procedure = procedure
         flash[:alert] = @service.errors.full_messages
         render :new
@@ -34,14 +37,17 @@ module Administrateurs
     def update
       @service = service
 
-      if @service.update(service_params)
-        if @service.siret_previously_changed?
-          @service.enqueue_api_entreprise
-        end
+      begin
+        if @service.update!(service_params)
+          if @service.siret_previously_changed?
+            @service.enqueue_api_entreprise
+          end
 
-        redirect_to admin_services_path(procedure_id: params[:procedure_id]),
-          notice: "#{@service.nom} modifié"
-      else
+          redirect_to admin_services_path(procedure_id: params[:procedure_id]),
+            notice: "#{@service.nom} modifié"
+        end
+      rescue StandardError => e
+        Rails.logger.error e.message
         @procedure = procedure
         flash[:alert] = @service.errors.full_messages
         render :edit

--- a/app/controllers/administrateurs/services_controller.rb
+++ b/app/controllers/administrateurs/services_controller.rb
@@ -34,15 +34,14 @@ module Administrateurs
     def update
       @service = service
 
-      begin
-        @service.update!(service_params)
+      if @service.update(service_params)
         if @service.siret_previously_changed?
           @service.enqueue_api_entreprise
         end
+
         redirect_to admin_services_path(procedure_id: params[:procedure_id]),
           notice: "#{@service.nom} modifié"
-      rescue StandardError => e
-        Rails.logger.error e.message
+      else
         @procedure = procedure
         flash[:alert] = @service.errors.full_messages
         render :edit


### PR DESCRIPTION
Ajout de messages d'erreurs dans la console (utile aussi lors des requêtes API) lorsqu'il y a une erreur lors du save pour groupe_instructeur et services.

Et une meilleur pratique avec save! Grâce à cet ajout, les futures erreurs seront détectés plus rapidement. Aujourd'hui elles pourraient se camoufler puisque l'erreur n'est affiché qu'à l'utilisateur sur l'IHM.