### PR TITLE
[Intégration vue instructeur] Réorganisation des boutons (filtres, telechargement…) au dessus du tableau

### DIFF
--- a/app/assets/stylesheets/procedure_show.scss
+++ b/app/assets/stylesheets/procedure_show.scss
@@ -52,11 +52,6 @@
     display: inline-block;
   }
 
-  .explication-onglet {
-    margin-bottom: 3 * $default-spacer;
-    text-align: center;
-  }
-
   [data-react-component-value^="ComboMultiple"] {
     margin-bottom: $default-fields-spacer;
 

--- a/app/components/dossiers/batch_operation_component/batch_operation_component.html.haml
+++ b/app/components/dossiers/batch_operation_component/batch_operation_component.html.haml
@@ -1,17 +1,17 @@
 - if available_operations[:options].count == 1
   - opt = available_operations[:options].dig(0)
-  = form_for(BatchOperation.new, url: instructeur_batch_operations_path(procedure_id: procedure.id), method: :post, html: { class: 'flex justify-end', id: "#{dom_id(BatchOperation.new)}" }, data: { "batch-operation-target" => "form"}) do |form|
+  = form_for(BatchOperation.new, url: instructeur_batch_operations_path(procedure_id: procedure.id), method: :post, html: { class: 'fr-ml-auto', id: "#{dom_id(BatchOperation.new)}" }, data: { "batch-operation-target" => "form"}) do |form|
     = form.button opt[:label], class: ['fr-btn fr-btn--icon-left', icons[opt[:operation].to_sym]], disabled: :disabled, name: "#{form.object_name}[operation]", data: { "batch-operation-target" => "submit", "submitter-operation" => opt[:operation] }
 
 - else
-  .flex.justify-end
+  .fr-ml-auto
     .dropdown{ data: { controller: 'menu-button', popover: 'true' } }
       -# Dropdown button title
       %button.fr-btn.dropdown-button{ id: 'batch_operation_dropdown', disabled: :disabled, data: { menu_button_target: 'button'} }
         Actions multiples
 
       #state-menu.dropdown-content.fade-in-down{ data: { menu_button_target: 'menu' } }
-        = form_for(BatchOperation.new, url: instructeur_batch_operations_path(procedure_id: procedure.id), method: :post, html: { class: 'flex justify-end form', id: "#{dom_id(BatchOperation.new)}" }, data: { "batch-operation-target" => "form"}) do |form|
+        = form_for(BatchOperation.new, url: instructeur_batch_operations_path(procedure_id: procedure.id), method: :post, html: { class: 'form', id: "#{dom_id(BatchOperation.new)}" }, data: { "batch-operation-target" => "form"}) do |form|
           %ul.dropdown-items
             - available_operations[:options].each do |opt|
               %li{ 'data-turbo': 'true' }

--- a/app/components/dossiers/notified_toggle_component/notified_toggle_component.html.haml
+++ b/app/components/dossiers/notified_toggle_component/notified_toggle_component.html.haml
@@ -1,7 +1,5 @@
 = form_tag update_sort_instructeur_procedure_path(procedure_id: @procedure.id, table: 'notifications', column: 'notifications', order: opposite_order), method: 'GET', data: {controller: 'checkbox'} do
-  .fr-form-group
-    .fr-fieldset__content
-      .fr-checkbox-group.fix-dsfr-notified-toggle-component
-        = check_box_tag :order, opposite_order, active?, data: {action: 'change->checkbox#onChange'}
-        = label_tag :order, t('.show_notified_first'), class: 'fr-label'
-        = submit_tag t('.show_notified_first'), data: {"checkbox-target": 'submit' }, class: 'visually-hidden'
+  .fr-toggle
+    = check_box_tag :order, opposite_order, active?, data: {action: 'change->checkbox#onChange'}, class: 'fr-toggle__input'
+    = label_tag :order, t('.show_notified_first'), class: 'fr-toggle__label fr-pl-1w'
+    = submit_tag t('.show_notified_first'), data: {"checkbox-target": 'submit' }, class: 'visually-hidden'

--- a/app/javascript/entrypoints/main.css
+++ b/app/javascript/entrypoints/main.css
@@ -9,6 +9,7 @@
 /* Verify README of each component to insert them in the expected order. */
 @import '@gouvfr/dsfr/dist/component/alert/alert.css';
 @import '@gouvfr/dsfr/dist/component/radio/radio.css';
+@import '@gouvfr/dsfr/dist/component/toggle/toggle.css';
 @import '@gouvfr/dsfr/dist/component/badge/badge.css';
 @import '@gouvfr/dsfr/dist/component/breadcrumb/breadcrumb.css';
 @import '@gouvfr/dsfr/dist/component/callout/callout.css';

--- a/app/views/instructeurs/procedures/_dossiers_filter.html.haml
+++ b/app/views/instructeurs/procedures/_dossiers_filter.html.haml
@@ -4,12 +4,12 @@
   #filter-menu.dropdown-content.left-aligned.fade-in-down{ data: { menu_button_target: 'menu' } }
     = render Dossiers::FilterComponent.new(procedure: procedure, procedure_presentation: @procedure_presentation, statut: statut)
 
-- current_filters.group_by { |filter| filter['table'] }.each_with_index do |(table, filters), i|
-  - if i > 0
-    = " et "
-  - filters.each_with_index do |filter, i|
+  - current_filters.group_by { |filter| filter['table'] }.each_with_index do |(table, filters), i|
     - if i > 0
-      = " ou "
-    = link_to remove_filter_instructeur_procedure_path(procedure, { statut: statut, field: "#{filter['table']}/#{filter['column']}", value: filter['value'] }),
-      class: "fr-tag fr-tag--dismiss fr-mb-1w", aria: { label: "Retirer le filtre #{filter['column']}" } do
-      = "#{filter['label'].truncate(50)} : #{procedure_presentation.human_value_for_filter(filter)}"
+      = " et "
+    - filters.each_with_index do |filter, i|
+      - if i > 0
+        = " ou "
+      = link_to remove_filter_instructeur_procedure_path(procedure, { statut: statut, field: "#{filter['table']}/#{filter['column']}", value: filter['value'] }),
+        class: "fr-tag fr-tag--dismiss fr-mb-1w", aria: { label: "Retirer le filtre #{filter['column']}" } do
+        = "#{filter['label'].truncate(50)} : #{procedure_presentation.human_value_for_filter(filter)}"

--- a/app/views/instructeurs/procedures/deleted_dossiers.html.haml
+++ b/app/views/instructeurs/procedures/deleted_dossiers.html.haml
@@ -27,7 +27,7 @@
 
   .container
     %h1.titre-dossiers Dossiers supprimés
-    %details.explication-onglet
+    %details
       %summary Les dossiers ont été supprimés. Vous ne pouvez plus les récupérer depuis Démarches Simplifiées.
       Ceci s'explique pour les raisons suivantes :
       %ul

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -25,36 +25,36 @@
         has_en_cours_notifications: @has_en_cours_notifications,
         has_termine_notifications: @has_termine_notifications }
 
-  .fr-container--fluid.fr-mx-4w.overflow-y-visible
-    .container.fr-highlight
-      - if @statut == 'a-suivre'
-        %p
-          = t('views.instructeurs.dossiers.tab_explainations.a_suivre')
-      - if @statut == 'suivis'
-        %p
-          = t('views.instructeurs.dossiers.tab_explainations.suivis')
-      - if @statut == 'traites'
-        %p
-          = t('views.instructeurs.dossiers.tab_explainations.traites_html', archives_path: instructeur_archives_path(@procedure))
-      - if @statut == 'tous'
-        %p
-          = t('views.instructeurs.dossiers.tab_explainations.tous')
-      - if @statut == 'supprimes_recemment'
-        %p
-          = t('views.instructeurs.dossiers.tab_explainations.supprimes_recemment')
-      - if @statut == 'archives'
-        %p
-          = t('views.instructeurs.dossiers.tab_explainations.archives')
-          %br
-          Ces dossiers seront supprimés lorsque leur délai de conservation dans Démarches-simplifiées
-          - if @procedure.duree_conservation_dossiers_dans_ds
-            = "(#{@procedure.duree_conservation_dossiers_dans_ds} mois)"
-          sera expiré.
-          = link_to 'En savoir plus', ARCHIVAGE_DOC_URL
-      - if @statut == 'expirant'
-        %p
-          = t('views.instructeurs.dossiers.tab_explainations.expirant')
+  .container.fr-highlight
+    - if @statut == 'a-suivre'
+      %p
+        = t('views.instructeurs.dossiers.tab_explainations.a_suivre')
+    - if @statut == 'suivis'
+      %p
+        = t('views.instructeurs.dossiers.tab_explainations.suivis')
+    - if @statut == 'traites'
+      %p
+        = t('views.instructeurs.dossiers.tab_explainations.traites_html', archives_path: instructeur_archives_path(@procedure))
+    - if @statut == 'tous'
+      %p
+        = t('views.instructeurs.dossiers.tab_explainations.tous')
+    - if @statut == 'supprimes_recemment'
+      %p
+        = t('views.instructeurs.dossiers.tab_explainations.supprimes_recemment')
+    - if @statut == 'archives'
+      %p
+        = t('views.instructeurs.dossiers.tab_explainations.archives')
+        %br
+        Ces dossiers seront supprimés lorsque leur délai de conservation dans Démarches-simplifiées
+        - if @procedure.duree_conservation_dossiers_dans_ds
+          = "(#{@procedure.duree_conservation_dossiers_dans_ds} mois)"
+        sera expiré.
+        = link_to 'En savoir plus', ARCHIVAGE_DOC_URL
+    - if @statut == 'expirant'
+      %p
+        = t('views.instructeurs.dossiers.tab_explainations.expirant')
 
+  .fr-container--fluid.fr-mx-4w.overflow-y-visible
     %hr
     .flex.fr-mb-2w
       - if @filtered_sorted_paginated_ids.present? || @current_filters.count > 0

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -26,60 +26,79 @@
         has_termine_notifications: @has_termine_notifications }
 
   .fr-container--fluid.fr-mx-4w.overflow-y-visible
-    - if @statut == 'a-suivre'
-      %p.explication-onglet
-        = t('views.instructeurs.dossiers.tab_explainations.a_suivre')
-    - if @statut == 'suivis'
-      %p.explication-onglet
-        = t('views.instructeurs.dossiers.tab_explainations.suivis')
-    - if @statut == 'traites'
-      %p.explication-onglet
-        = t('views.instructeurs.dossiers.tab_explainations.traites_html', archives_path: instructeur_archives_path(@procedure))
-    - if @statut == 'tous'
-      %p.explication-onglet
-        = t('views.instructeurs.dossiers.tab_explainations.tous')
-    - if @statut == 'supprimes_recemment'
-      %p.explication-onglet
-        = t('views.instructeurs.dossiers.tab_explainations.supprimes_recemment')
-    - if @statut == 'archives'
-      %p.explication-onglet
-        = t('views.instructeurs.dossiers.tab_explainations.archives')
-        %br
-        Ces dossiers seront supprimés lorsque leur délai de conservation dans Démarches-simplifiées
-        - if @procedure.duree_conservation_dossiers_dans_ds
-          = "(#{@procedure.duree_conservation_dossiers_dans_ds} mois)"
-        sera expiré.
-        = link_to 'En savoir plus', ARCHIVAGE_DOC_URL
-    - if @statut == 'expirant'
-      %p.explication-onglet
-        = t('views.instructeurs.dossiers.tab_explainations.expirant')
+    .container.fr-highlight
+      - if @statut == 'a-suivre'
+        %p
+          = t('views.instructeurs.dossiers.tab_explainations.a_suivre')
+      - if @statut == 'suivis'
+        %p
+          = t('views.instructeurs.dossiers.tab_explainations.suivis')
+      - if @statut == 'traites'
+        %p
+          = t('views.instructeurs.dossiers.tab_explainations.traites_html', archives_path: instructeur_archives_path(@procedure))
+      - if @statut == 'tous'
+        %p
+          = t('views.instructeurs.dossiers.tab_explainations.tous')
+      - if @statut == 'supprimes_recemment'
+        %p
+          = t('views.instructeurs.dossiers.tab_explainations.supprimes_recemment')
+      - if @statut == 'archives'
+        %p
+          = t('views.instructeurs.dossiers.tab_explainations.archives')
+          %br
+          Ces dossiers seront supprimés lorsque leur délai de conservation dans Démarches-simplifiées
+          - if @procedure.duree_conservation_dossiers_dans_ds
+            = "(#{@procedure.duree_conservation_dossiers_dans_ds} mois)"
+          sera expiré.
+          = link_to 'En savoir plus', ARCHIVAGE_DOC_URL
+      - if @statut == 'expirant'
+        %p
+          = t('views.instructeurs.dossiers.tab_explainations.expirant')
 
-    .flex
+    %hr
+    .flex.fr-mb-2w
       - if @filtered_sorted_paginated_ids.present? || @current_filters.count > 0
-        %div
-          = render partial: "dossiers_filter", locals: { procedure: @procedure, procedure_presentation: @procedure_presentation, current_filters: @current_filters, statut: @statut, filterable_fields_for_select: @filterable_fields_for_select }
+
+        = render partial: "dossiers_filter", locals: { procedure: @procedure, procedure_presentation: @procedure_presentation, current_filters: @current_filters, statut: @statut, filterable_fields_for_select: @filterable_fields_for_select }
+        .fr-ml-auto
+          %span.dropdown{ data: { controller: 'menu-button', popover: 'true' } }
+            %button.fr-btn.fr-btn--sm.fr-btn--secondary.dropdown-button.fr-ml-1w{ data: { menu_button_target: 'button' } }
+              = t('views.instructeurs.dossiers.personalize')
+            #custom-menu.dropdown-content.fade-in-down{ data: { menu_button_target: 'menu' } }
+              = form_tag update_displayed_fields_instructeur_procedure_path(@procedure), method: :patch, class: 'dropdown-form large columns-form' do
+                = hidden_field_tag :values, nil
+                = react_component("ComboMultiple",
+                  options: @displayable_fields_for_select,
+                  selected: @displayable_fields_selected,
+                  disabled: [],
+                  label: 'Colonne à afficher',
+                  group: '.columns-form',
+                  name: 'values')
+
+                = submit_tag t('views.instructeurs.dossiers.save'), class: 'fr-btn fr-btn--secondary'
+
         .fr-ml-2w
-          = render Dossiers::NotifiedToggleComponent.new(procedure: @procedure, procedure_presentation: @procedure_presentation)
+          - if @statut == 'archives'
+            = link_to deleted_dossiers_instructeur_procedure_path(@procedure), class: "fr-link fr-icon-delete-line fr-link--icon-left fr-mr-2w" do
+              = t('views.instructeurs.dossiers.show_deleted_dossiers')
 
-      .flex-grow.text-right
-        - if @statut == 'archives'
-          = link_to deleted_dossiers_instructeur_procedure_path(@procedure), class: "fr-link fr-icon-delete-line fr-link--icon-left fr-mr-2w" do
-            = t('views.instructeurs.dossiers.show_deleted_dossiers')
-
-        - if @dossiers_count > 0
-          %span.dossiers-export
-            = render Dossiers::ExportComponent.new(procedure: @procedure, exports: @exports, statut: @statut, count: @dossiers_count, export_url: method(:download_export_instructeur_procedure_path))
-      %hr.fr-mt-5v
+          - if @dossiers_count > 0
+            %span.dossiers-export
+              = render Dossiers::ExportComponent.new(procedure: @procedure, exports: @exports, statut: @statut, count: @dossiers_count, export_url: method(:download_export_instructeur_procedure_path))
 
     - if @filtered_sorted_paginated_ids.present? || @current_filters.count > 0
       - batch_operation_component = Dossiers::BatchOperationComponent.new(statut: @statut, procedure: @procedure)
+
+      - if @batch_operations.present?
+        - @batch_operations.each do |batch_operation|
+          = render Dossiers::BatchAlertComponent.new(batch: batch_operation, procedure: @procedure)
+
       %div{ data: batch_operation_component.render? ? { controller: 'batch-operation' } : {} }
-
-        - if @batch_operations.present?
-          - @batch_operations.each do |batch_operation|
-            = render Dossiers::BatchAlertComponent.new(batch: batch_operation, procedure: @procedure)
-
-        = render batch_operation_component
+        .flex.align-center
+          %span.fr-h6.fr-mb-0.fr-mr-2w
+            = t('views.instructeurs.dossiers.dossiers_count', count: @dossiers_count)
+          = render Dossiers::NotifiedToggleComponent.new(procedure: @procedure, procedure_presentation: @procedure_presentation)
+          = render batch_operation_component
         .fr-table.fr-table--bordered
           %table.table.dossiers-table.hoverable
             %thead
@@ -97,23 +116,7 @@
                   = render partial: "header_field", locals: { field: field, classname: field['classname'] }
 
                 %th.action-col.follow-col
-                  %span.dropdown{ data: { controller: 'menu-button', popover: 'true' } }
-                    %button.fr-btn.fr-btn--sm.fr-btn--secondary.dropdown-button{ data: { menu_button_target: 'button' } }
-                      = t('views.instructeurs.dossiers.personalize')
-                    #custom-menu.dropdown-content.fade-in-down{ data: { menu_button_target: 'menu' } }
-                      = form_tag update_displayed_fields_instructeur_procedure_path(@procedure), method: :patch, class: 'dropdown-form large columns-form' do
-                        = hidden_field_tag :values, nil
-                        = react_component("ComboMultiple",
-                          options: @displayable_fields_for_select,
-                          selected: @displayable_fields_selected,
-                          disabled: [],
-                          label: 'Colonne à afficher',
-                          group: '.columns-form',
-                          name: 'values')
-
-                        = submit_tag t('views.instructeurs.dossiers.save'), class: 'fr-btn fr-btn--secondary'
-
-
+                  Actions
               %tr
 
             %tbody

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -215,12 +215,15 @@ en:
         deleted_by_administration: "File deleted by administration"
         restore: "Restore"
         filters:
-          title: Filter
+          title: Select a filter
         select_all: Select all
         batch_operation:
           enabled: "Add this file to the selection for the bulk operation"
           disabled: "Impossible to add this file to the selection because it is already in a bulk operation"
-        personalize: Personalize
+        dossiers_count:
+          one: 1 file
+          other: "%{count} files"
+        personalize: Personalize the table
         show_deleted_dossiers: Show deleted files
         follow_file: Follow-up the file
         save: Save

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -211,13 +211,16 @@ fr:
         deleted_by_administration: "Dossier supprimé par l’administration"
         restore: "Restaurer"
         filters:
-          title: Filtrer
+          title: Sélectionner un filtre
         select_all: Tout selectionner
         batch_operation:
           enabled: "Ajouter ce dossier à la selection pour un traitement de masse"
           disabled: "Impossible d'ajouter ce dossier à la selection car il est déjà dans un traitement de masse"
+        dossiers_count:
+          one: 1 dossier
+          other: "%{count} dossiers"
         show_deleted_dossiers: Afficher les dossiers supprimés
-        personalize: Personnaliser
+        personalize: Personnaliser le tableau
         download: Télécharger un dossier
         follow_file: Suivre le dossier
         stop_follow: Ne plus suivre

--- a/spec/system/instructeurs/procedure_filters_spec.rb
+++ b/spec/system/instructeurs/procedure_filters_spec.rb
@@ -79,14 +79,14 @@ describe "procedure filters" do
 
   scenario "should be able to user custom fiters", js: true do
     # use date filter
-    click_on 'Filtrer'
+    click_on 'Sélectionner un filtre'
     select "En construction le", from: "Colonne"
     find("input#value[type=date]", visible: true)
     fill_in "Valeur", with: "10/10/2010"
     click_button "Ajouter le filtre"
 
     # use enum filter
-    click_on 'Filtrer'
+    click_on 'Sélectionner un filtre'
     select "Statut", from: "Colonne"
     find("select#value", visible: false)
     select 'En construction', from: "Valeur"
@@ -130,7 +130,7 @@ describe "procedure filters" do
   end
 
   def add_filter(column_name, filter_value)
-    click_on 'Filtrer'
+    click_on 'Sélectionner un filtre'
     select column_name, from: "Colonne"
     fill_in "Valeur", with: filter_value
     click_button "Ajouter le filtre"


### PR DESCRIPTION
Avec l'arrivée récente du bouton des actions multiples ça semblait le bon moment pour 
- réorganiser les différents boutons de filtres / telechargement etc…
- faire apparaitre le nombre de dossiers au dessus du tableau

**Remarques**
- Je me suis permise de remplacer la checkbox par un toggle switch qui ressemble plus à une fonctionnalité de filtres : actif / pas actif
- J'ai isolé le bouton "sélectionner un filtre" à gauche, car lorsqu'on sélectionne un filtre il vient se positionner à droite, ça me semblait donc plus pertinent 

**Maquettes**
Ce nouveau design s'appuie / s'inpire des maquettes d' @Olivier-Marcellin 
<img width="683" alt="Capture d’écran 2023-01-05 à 11 08 46" src="https://user-images.githubusercontent.com/6756627/210754979-f47c0c25-1ab8-49ee-983b-0cc9de9274d9.png">

**Rendu intégration**
<img width="1411" alt="Capture d’écran 2023-01-05 à 10 42 51" src="https://user-images.githubusercontent.com/6756627/210755115-6c0e2a7b-a9ee-4e53-a30d-00f119f0ee6d.png">

<img width="1420" alt="Capture d’écran 2023-01-05 à 10 43 14" src="https://user-images.githubusercontent.com/6756627/210755145-04cb8eb5-e684-475b-81ac-0419ad423a7c.png">

**Rendu avant la nouvelle inté**
<img width="1413" alt="Capture d’écran 2023-01-05 à 11 11 30" src="https://user-images.githubusercontent.com/6756627/210755653-1c0e5202-790c-4fa3-9a32-8d31768deea0.png">
