### PR TITLE
ETQ admin, je peux voir le nb de dossiers par démarche dans la liste de toutes les démarches

### DIFF
--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -418,7 +418,7 @@ module Administrateurs
       procedures_result = procedures_result.where('unaccent(libelle) ILIKE unaccent(?)', "%#{filter.libelle}%") if filter.libelle.present?
       procedures_sql = procedures_result.to_sql
 
-      sql = "select id, libelle, published_at, aasm_state, count(administrateurs_procedures.administrateur_id) as admin_count from administrateurs_procedures inner join procedures on procedures.id = administrateurs_procedures.procedure_id where procedures.id in (#{procedures_sql}) group by procedures.id order by published_at desc"
+      sql = "select id, libelle, published_at, aasm_state, estimated_dossiers_count, count(administrateurs_procedures.administrateur_id) as admin_count from administrateurs_procedures inner join procedures on procedures.id = administrateurs_procedures.procedure_id where procedures.id in (#{procedures_sql}) group by procedures.id order by published_at desc"
       ActiveRecord::Base.connection.execute(sql)
     end
 

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -874,6 +874,7 @@ class Dossier < ApplicationRecord
       .passer_en_construction
       .processed_at
     save!
+    procedure.compute_dossiers_count
   end
 
   def after_passer_en_instruction(h)

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -15,10 +15,12 @@
 #  closed_at                                 :datetime
 #  declarative_with_state                    :string
 #  description                               :string
+#  dossiers_count_computed_at                :datetime
 #  duree_conservation_dossiers_dans_ds       :integer
 #  duree_conservation_etendue_par_ds         :boolean          default(FALSE)
 #  encrypted_api_particulier_token           :string
 #  estimated_duration_visible                :boolean          default(TRUE), not null
+#  estimated_dossiers_count                  :integer
 #  euro_flag                                 :boolean          default(FALSE)
 #  experts_require_administrateur_invitation :boolean          default(FALSE)
 #  for_individual                            :boolean          default(FALSE)
@@ -70,6 +72,8 @@ class Procedure < ApplicationRecord
   NEW_MAX_DUREE_CONSERVATION = ENV.fetch('NEW_MAX_DUREE_CONSERVATION') { 12 }.to_i
 
   MIN_WEIGHT = 350000
+
+  DOSSIERS_COUNT_EXPIRING = 1.hour
 
   attr_encrypted :api_particulier_token
 
@@ -836,7 +840,13 @@ class Procedure < ApplicationRecord
     self.connection.query(query.to_sql).flatten
   end
 
-  private
+  def compute_dossiers_count
+    now = Time.zone.now
+    if now > (self.dossiers_count_computed_at || self.created_at) + DOSSIERS_COUNT_EXPIRING
+      self.update(estimated_dossiers_count: self.dossiers.visible_by_administration.count,
+                dossiers_count_computed_at: now)
+    end
+  end
 
   def move_new_children_to_new_parent_coordinate(new_draft)
     children = new_draft.revision_types_de_champ

--- a/app/views/administrateurs/procedures/_detail.html.haml
+++ b/app/views/administrateurs/procedures/_detail.html.haml
@@ -8,6 +8,7 @@
 
   %td= procedure.libelle
   %td= procedure.id
+  %td= procedure.estimated_dossiers_count
   %td= procedure.administrateurs.count
   %td= t procedure.aasm_state, scope: 'activerecord.attributes.procedure.aasm_state'
   %td= l(procedure.published_at, format: :message_date_without_time)
@@ -16,7 +17,7 @@
 
 - if show_detail
   %tr.procedure{ id: "procedure_detail_#{procedure.id}" }
-    %td.fr-highlight--beige-gris-galet{ colspan: '7' }
+    %td.fr-highlight--beige-gris-galet{ colspan: '8' }
       .fr-container
         .fr-grid-row
           .fr-col-6

--- a/app/views/administrateurs/procedures/all.html.haml
+++ b/app/views/administrateurs/procedures/all.html.haml
@@ -41,6 +41,7 @@
           %th{ scope: 'col' }
           %th{ scope: 'col' } Démarche
           %th{ scope: 'col' } №
+          %th{ scope: 'col' } Dossiers
           %th{ scope: 'col' } Administrateurs
           %th{ scope: 'col' } Statut
           %th{ scope: 'col' } Date

--- a/db/migrate/20230217094119_add_estimated_dossiers_count_and_dossiers_count_computed_at_to_procedures.rb
+++ b/db/migrate/20230217094119_add_estimated_dossiers_count_and_dossiers_count_computed_at_to_procedures.rb
@@ -1,0 +1,6 @@
+class AddEstimatedDossiersCountAndDossiersCountComputedAtToProcedures < ActiveRecord::Migration[6.1]
+  def change
+    add_column :procedures, :estimated_dossiers_count, :integer
+    add_column :procedures, :dossiers_count_computed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_16_141558) do
+ActiveRecord::Schema.define(version: 2023_02_17_094119) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -703,12 +703,14 @@ ActiveRecord::Schema.define(version: 2023_02_16_141558) do
     t.string "declarative_with_state"
     t.string "description"
     t.string "direction"
+    t.datetime "dossiers_count_computed_at"
     t.bigint "draft_revision_id"
     t.integer "duree_conservation_dossiers_dans_ds"
     t.boolean "duree_conservation_etendue_par_ds", default: false
     t.boolean "durees_conservation_required", default: true
     t.string "encrypted_api_particulier_token"
     t.boolean "estimated_duration_visible", default: true, null: false
+    t.integer "estimated_dossiers_count"
     t.boolean "euro_flag", default: false
     t.boolean "experts_require_administrateur_invitation", default: false
     t.boolean "for_individual", default: false

--- a/lib/tasks/deployment/20230223103427_update_procedure_dossiers_count.rake
+++ b/lib/tasks/deployment/20230223103427_update_procedure_dossiers_count.rake
@@ -1,0 +1,20 @@
+namespace :after_party do
+  desc 'Deployment task: update_procedure_dossiers_count'
+  task update_procedure_dossiers_count: :environment do
+    puts "Running deploy task 'update_procedure_dossiers_count'"
+    progress = ProgressReport.new(Procedure.count)
+
+    Procedure.find_each do |p|
+      progress.inc
+      begin
+        p.update_columns(estimated_dossiers_count: p.dossiers.visible_by_administration.count, dossiers_count_computed_at: Time.zone.now)
+      rescue => e
+        Sentry.capture_exception(e, extra: { procedure_id: p.id })
+      end
+    end
+    progress.finish
+
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -2080,6 +2080,15 @@ describe Dossier do
     end
   end
 
+  describe 'update procedure dossiers count' do
+    let(:dossier) { create(:dossier, :brouillon, :with_individual) }
+
+    it 'update procedure dossiers count when passing to construction' do
+      expect(dossier.procedure).to receive(:compute_dossiers_count)
+      dossier.passer_en_construction!
+    end
+  end
+
   private
 
   def count_for_month(processed_by_month, month)


### PR DESCRIPTION
Cette PR permet d'afficher le nb de dossiers par démarche dans la liste de toutes les démarches.

Il s'agit du nb de dossiers, tous dossiers confondus (y compris les brouillons)
Le nombre de dossiers est mis en cache dans le champ `Procedure#estimated_dossiers_count`
Ce cache est rafraichi lors de la création d'un nouveau dossier pour une démarche donnée si la dernière mise à jour du cache a eu lieu il y a plus d'une heure.

close #8354 