### PR TITLE
feat(dossier): add dossier id to prefill response

### DIFF
--- a/app/controllers/api/public/v1/dossiers_controller.rb
+++ b/app/controllers/api/public/v1/dossiers_controller.rb
@@ -13,7 +13,8 @@ class API::Public::V1::DossiersController < API::Public::V1::BaseController
       dossier.prefill!(PrefillParams.new(dossier, params.to_unsafe_h).to_a)
       render json: {
         dossier_url: commencer_url(@procedure.path, prefill_token: dossier.prefill_token),
-        dossier_id: dossier.to_typed_id
+        dossier_id: dossier.to_typed_id,
+        dossier_number: dossier.id
       }, status: :created
     else
       render_bad_request(dossier.errors.full_messages.to_sentence)

--- a/app/controllers/api/public/v1/dossiers_controller.rb
+++ b/app/controllers/api/public/v1/dossiers_controller.rb
@@ -11,7 +11,10 @@ class API::Public::V1::DossiersController < API::Public::V1::BaseController
     dossier.build_default_individual
     if dossier.save
       dossier.prefill!(PrefillParams.new(dossier, params.to_unsafe_h).to_a)
-      render json: { dossier_url: commencer_url(@procedure.path, prefill_token: dossier.prefill_token) }, status: :created
+      render json: {
+        dossier_url: commencer_url(@procedure.path, prefill_token: dossier.prefill_token),
+        dossier_id: dossier.id
+      }, status: :created
     else
       render_bad_request(dossier.errors.full_messages.to_sentence)
     end

--- a/app/controllers/api/public/v1/dossiers_controller.rb
+++ b/app/controllers/api/public/v1/dossiers_controller.rb
@@ -13,7 +13,7 @@ class API::Public::V1::DossiersController < API::Public::V1::BaseController
       dossier.prefill!(PrefillParams.new(dossier, params.to_unsafe_h).to_a)
       render json: {
         dossier_url: commencer_url(@procedure.path, prefill_token: dossier.prefill_token),
-        dossier_id: dossier.id
+        dossier_id: dossier.to_typed_id
       }, status: :created
     else
       render_bad_request(dossier.errors.full_messages.to_sentence)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -139,7 +139,7 @@ en:
         prefill_link_copy: Copy prefill link
         prefill_query_title: Prefill query (POST)
         prefill_query_info: Use the button to copy the query, then remplace the values with your data.
-        prefill_query_response_html: '# Response:<br># {"dossier_url":"%{url}"}'
+        prefill_query_response_html: '# Response:<br># {<br>#    "dossier_url": "%{url}",<br>#    "dossier_id": 42<br># }'
         prefill_query_copy: Copy prefill query
     registrations:
       new:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -139,7 +139,7 @@ en:
         prefill_link_copy: Copy prefill link
         prefill_query_title: Prefill query (POST)
         prefill_query_info: Use the button to copy the query, then remplace the values with your data.
-        prefill_query_response_html: '# Response:<br># {<br>#    "dossier_url": "%{url}",<br>#    "dossier_id": "aBase64Id=="<br># }'
+        prefill_query_response_html: '# Response:<br># {<br>#    "dossier_url": "%{url}",<br>#    "dossier_id": "aBase64Id==",<br>#    "dossier_number": 42<br># }'
         prefill_query_copy: Copy prefill query
     registrations:
       new:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -139,7 +139,7 @@ en:
         prefill_link_copy: Copy prefill link
         prefill_query_title: Prefill query (POST)
         prefill_query_info: Use the button to copy the query, then remplace the values with your data.
-        prefill_query_response_html: '# Response:<br># {<br>#    "dossier_url": "%{url}",<br>#    "dossier_id": 42<br># }'
+        prefill_query_response_html: '# Response:<br># {<br>#    "dossier_url": "%{url}",<br>#    "dossier_id": "aBase64Id=="<br># }'
         prefill_query_copy: Copy prefill query
     registrations:
       new:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -132,7 +132,7 @@ fr:
         prefill_link_copy: Copier le lien de préremplissage
         prefill_query_title: Requête de préremplissage (POST)
         prefill_query_info: Copiez la requête grâce au bouton ci-dessous et remplacez les valeurs par les données dont vous disposez.
-        prefill_query_response_html: '# Response:<br># {"dossier_url":"%{url}"}'
+        prefill_query_response_html: '# Response:<br># {<br>#    "dossier_url": "%{url}",<br>#    "dossier_id": 42<br># }'
         prefill_query_copy: Copier la requête de préremplissage
     registrations:
       new:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -132,7 +132,7 @@ fr:
         prefill_link_copy: Copier le lien de préremplissage
         prefill_query_title: Requête de préremplissage (POST)
         prefill_query_info: Copiez la requête grâce au bouton ci-dessous et remplacez les valeurs par les données dont vous disposez.
-        prefill_query_response_html: '# Response:<br># {<br>#    "dossier_url": "%{url}",<br>#    "dossier_id": "aBase64Id=="<br># }'
+        prefill_query_response_html: '# Response:<br># {<br>#    "dossier_url": "%{url}",<br>#    "dossier_id": "aBase64Id==",<br>#    "dossier_number": 42<br># }'
         prefill_query_copy: Copier la requête de préremplissage
     registrations:
       new:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -132,7 +132,7 @@ fr:
         prefill_link_copy: Copier le lien de préremplissage
         prefill_query_title: Requête de préremplissage (POST)
         prefill_query_info: Copiez la requête grâce au bouton ci-dessous et remplacez les valeurs par les données dont vous disposez.
-        prefill_query_response_html: '# Response:<br># {<br>#    "dossier_url": "%{url}",<br>#    "dossier_id": 42<br># }'
+        prefill_query_response_html: '# Response:<br># {<br>#    "dossier_url": "%{url}",<br>#    "dossier_id": "aBase64Id=="<br># }'
         prefill_query_copy: Copier la requête de préremplissage
     registrations:
       new:

--- a/spec/controllers/api/public/v1/dossiers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/dossiers_controller_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe API::Public::V1::DossiersController, type: :controller do
             dossier_url = "http://test.host#{commencer_path(procedure.path, prefill_token: dossier.prefill_token)}"
             expect(JSON.parse(response.body)["dossier_url"]).to eq(dossier_url)
             expect(JSON.parse(response.body)["dossier_id"]).to eq(dossier.to_typed_id)
+            expect(JSON.parse(response.body)["dossier_number"]).to eq(dossier.id)
           end
 
           context 'when prefill values are given' do

--- a/spec/controllers/api/public/v1/dossiers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/dossiers_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe API::Public::V1::DossiersController, type: :controller do
             dossier = Dossier.last
             dossier_url = "http://test.host#{commencer_path(procedure.path, prefill_token: dossier.prefill_token)}"
             expect(JSON.parse(response.body)["dossier_url"]).to eq(dossier_url)
-            expect(JSON.parse(response.body)["dossier_id"]).to eq(dossier.id)
+            expect(JSON.parse(response.body)["dossier_id"]).to eq(dossier.to_typed_id)
           end
 
           context 'when prefill values are given' do

--- a/spec/controllers/api/public/v1/dossiers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/dossiers_controller_spec.rb
@@ -30,11 +30,13 @@ RSpec.describe API::Public::V1::DossiersController, type: :controller do
             expect(Dossier.last.user).to eq(nil)
           end
 
-          it "responds with the brouillon dossier path" do
+          it "responds with the brouillon dossier url and id" do
             create_request
-            expect(JSON.parse(response.body)["dossier_url"]).to eq(
-              "http://test.host#{commencer_path(procedure.path, prefill_token: Dossier.last.prefill_token)}"
-            )
+
+            dossier = Dossier.last
+            dossier_url = "http://test.host#{commencer_path(procedure.path, prefill_token: dossier.prefill_token)}"
+            expect(JSON.parse(response.body)["dossier_url"]).to eq(dossier_url)
+            expect(JSON.parse(response.body)["dossier_id"]).to eq(dossier.id)
           end
 
           context 'when prefill values are given' do


### PR DESCRIPTION
Besoin évoqué sur Mattermost : CNFS a besoin de récupérer l'ID du dossier prérempli.

Ici, on ajoute l'ID du dossier dans la réponse lorsque le dossier est prérempli en POST.

![image](https://user-images.githubusercontent.com/1193334/211001566-5817fa6c-6af0-467a-b1a8-c172b11438e0.png)

![image](https://user-images.githubusercontent.com/1193334/211001584-44139c2c-d7a1-4b8f-9a2f-0acb0eb87cc2.png)
