### PR TITLE
feat(dossier): prefill siret champ

### DIFF
--- a/app/components/editable_champ/siret_component/siret_component.html.haml
+++ b/app/components/editable_champ/siret_component/siret_component.html.haml
@@ -2,7 +2,7 @@
   id: @champ.input_id,
   aria: { describedby: @champ.describedby_id },
   placeholder: t(".placeholder"),
-  data: { controller: 'turbo-input', turbo_input_url_value: champs_siret_path(@champ.id) },
+  data: { controller: 'turbo-input', turbo_input_load_on_connect_value: @champ.prefilled? && @champ.value.present? && @champ.etablissement.blank?, turbo_input_url_value: champs_siret_path(@champ.id) },
   required: @champ.required?,
   pattern: "[0-9]{14}",
   title: t(".title"),

--- a/app/controllers/champs/siret_controller.rb
+++ b/app/controllers/champs/siret_controller.rb
@@ -3,6 +3,11 @@ class Champs::SiretController < ApplicationController
 
   def show
     @champ = policy_scope(Champ).find(params[:champ_id])
-    @siret = @champ.fetch_etablissement!(read_param_value(@champ.input_name, 'value'), current_user)
+
+    if @champ.fetch_etablissement!(read_param_value(@champ.input_name, 'value'), current_user)
+      @siret = @champ.etablissement.siret
+    else
+      @siret = @champ.etablissement_fetch_error_key
+    end
   end
 end

--- a/app/controllers/champs/siret_controller.rb
+++ b/app/controllers/champs/siret_controller.rb
@@ -3,61 +3,6 @@ class Champs::SiretController < ApplicationController
 
   def show
     @champ = policy_scope(Champ).find(params[:champ_id])
-    @siret = read_param_value(@champ.input_name, 'value')
-    @etablissement = @champ.etablissement
-
-    if @siret.empty?
-      return clear_siret_and_etablissement
-    end
-
-    if !Siret.new(siret: @siret).valid?
-      # i18n-tasks-use t('errors.messages.invalid_siret')
-      return siret_error(:invalid)
-    end
-
-    begin
-      etablissement = find_etablissement_with_siret
-    rescue => error
-      if error.try(:network_error?) && !APIEntrepriseService.api_up?
-        # TODO: notify ops
-        etablissement = APIEntrepriseService.create_etablissement_as_degraded_mode(@champ, @siret, current_user.id)
-
-        if !@champ.nil?
-          @champ.update!(value: etablissement.siret, etablissement: etablissement)
-        end
-
-        @siret = :api_entreprise_down
-        return
-      else
-        Sentry.capture_exception(error, extra: { dossier_id: @champ.dossier_id, siret: @siret })
-        # i18n-tasks-use t('errors.messages.siret_network_error')
-        return siret_error(:network_error)
-      end
-    end
-    if etablissement.nil?
-      # i18n-tasks-use t('errors.messages.siret_not_found')
-      return siret_error(:not_found)
-    end
-
-    @etablissement = etablissement
-    if !@champ.nil?
-      @champ.update!(value: etablissement.siret, etablissement: etablissement)
-    end
-  end
-
-  private
-
-  def find_etablissement_with_siret
-    APIEntrepriseService.create_etablissement(@champ, @siret, current_user.id)
-  end
-
-  def clear_siret_and_etablissement
-    @champ.update!(value: '')
-    @etablissement&.destroy
-  end
-
-  def siret_error(error)
-    clear_siret_and_etablissement
-    @siret = error
+    @siret = @champ.fetch_etablissement!(read_param_value(@champ.input_name, 'value'), current_user)
   end
 end

--- a/app/javascript/controllers/turbo_input_controller.tsx
+++ b/app/javascript/controllers/turbo_input_controller.tsx
@@ -4,13 +4,18 @@ import { ApplicationController } from './application_controller';
 
 export class TurboInputController extends ApplicationController {
   static values = {
-    url: String
+    url: String,
+    loadOnConnect: { type: Boolean, default: false }
   };
 
   declare readonly urlValue: string;
+  declare readonly loadOnConnectValue: boolean;
 
   connect(): void {
     this.on('input', () => this.debounce(this.load, 200));
+    if (this.loadOnConnectValue) {
+      this.load();
+    }
   }
 
   private load(): void {

--- a/app/models/champs/siret_champ.rb
+++ b/app/models/champs/siret_champ.rb
@@ -21,6 +21,8 @@
 #  type_de_champ_id               :integer
 #
 class Champs::SiretChamp < Champ
+  include SiretChampEtablissementFetchableConcern
+
   def search_terms
     etablissement.present? ? etablissement.search_terms : [value]
   end

--- a/app/models/concerns/siret_champ_etablissement_fetchable_concern.rb
+++ b/app/models/concerns/siret_champ_etablissement_fetchable_concern.rb
@@ -27,7 +27,7 @@ module SiretChampEtablissementFetchableConcern
 
   def clear(error: nil)
     etablissement_to_destroy = etablissement
-    update!(value: '', etablissement: nil)
+    update!(etablissement: nil)
     etablissement_to_destroy&.destroy
     error.presence
   end

--- a/app/models/concerns/siret_champ_etablissement_fetchable_concern.rb
+++ b/app/models/concerns/siret_champ_etablissement_fetchable_concern.rb
@@ -5,7 +5,8 @@ module SiretChampEtablissementFetchableConcern
 
   def fetch_etablissement!(siret, user)
     return clear_etablissement!(:empty) if siret.empty?
-    return clear_etablissement!(:invalid) unless Siret.new(siret: siret).valid? # i18n-tasks-use t('errors.messages.invalid_siret')
+    return clear_etablissement!(:invalid_length) if invalid_because?(siret, :length) # i18n-tasks-use t('errors.messages.invalid_siret_length')
+    return clear_etablissement!(:invalid_checksum) if invalid_because?(siret, :checksum) # i18n-tasks-use t('errors.messages.invalid_siret_checksum')
     return clear_etablissement!(:not_found) unless (etablissement = APIEntrepriseService.create_etablissement(self, siret, user&.id)) # i18n-tasks-use t('errors.messages.siret_not_found')
 
     update!(value: siret, etablissement: etablissement)
@@ -34,5 +35,12 @@ module SiretChampEtablissementFetchableConcern
     etablissement_to_destroy&.destroy
 
     false
+  end
+
+  def invalid_because?(siret, criteria)
+    validatable_siret = Siret.new(siret: siret)
+    return false if validatable_siret.valid?
+
+    validatable_siret.errors.details[:siret].any? && validatable_siret.errors.details[:siret].first[:error] == criteria
   end
 end

--- a/app/models/concerns/siret_champ_etablissement_fetchable_concern.rb
+++ b/app/models/concerns/siret_champ_etablissement_fetchable_concern.rb
@@ -1,34 +1,38 @@
 module SiretChampEtablissementFetchableConcern
   extend ActiveSupport::Concern
 
-  def fetch_etablissement!(siret, user)
-    return clear if siret.empty?
-    return clear(error: :invalid) unless Siret.new(siret: siret).valid? # i18n-tasks-use t('errors.messages.invalid_siret')
-    return clear(error: :not_found) unless (etablissement = APIEntrepriseService.create_etablissement(self, siret, user.id)) # i18n-tasks-use t('errors.messages.siret_not_found')
+  attr_reader :etablissement_fetch_error_key
 
-    return update_etablissement!(etablissement)
+  def fetch_etablissement!(siret, user)
+    return clear_etablissement!(:empty) if siret.empty?
+    return clear_etablissement!(:invalid) unless Siret.new(siret: siret).valid? # i18n-tasks-use t('errors.messages.invalid_siret')
+    return clear_etablissement!(:not_found) unless (etablissement = APIEntrepriseService.create_etablissement(self, siret, user&.id)) # i18n-tasks-use t('errors.messages.siret_not_found')
+
+    update!(value: siret, etablissement: etablissement)
   rescue => error
     if error.try(:network_error?) && !APIEntrepriseService.api_up?
       # TODO: notify ops
-      etablissement = APIEntrepriseService.create_etablissement_as_degraded_mode(self, siret, user.id)
-      return update_etablissement!(etablissement, error: :api_entreprise_down)
+      update!(
+        value: siret,
+        etablissement: APIEntrepriseService.create_etablissement_as_degraded_mode(self, siret, user.id)
+      )
+      @etablissement_fetch_error_key = :api_entreprise_down
+      false
     else
       Sentry.capture_exception(error, extra: { dossier_id: dossier_id, siret: siret })
-      return clear(error: :network_error) # i18n-tasks-use t('errors.messages.siret_network_error')
+      clear_etablissement!(:network_error) # i18n-tasks-use t('errors.messages.siret_network_error')
     end
   end
 
   private
 
-  def update_etablissement!(etablissement, error: nil)
-    update!(value: etablissement.siret, etablissement: etablissement)
-    error.presence || etablissement.siret
-  end
+  def clear_etablissement!(error_key)
+    @etablissement_fetch_error_key = error_key
 
-  def clear(error: nil)
     etablissement_to_destroy = etablissement
     update!(etablissement: nil)
     etablissement_to_destroy&.destroy
-    error.presence
+
+    false
   end
 end

--- a/app/models/concerns/siret_champ_etablissement_fetchable_concern.rb
+++ b/app/models/concerns/siret_champ_etablissement_fetchable_concern.rb
@@ -1,0 +1,34 @@
+module SiretChampEtablissementFetchableConcern
+  extend ActiveSupport::Concern
+
+  def fetch_etablissement!(siret, user)
+    return clear if siret.empty?
+    return clear(error: :invalid) unless Siret.new(siret: siret).valid? # i18n-tasks-use t('errors.messages.invalid_siret')
+    return clear(error: :not_found) unless (etablissement = APIEntrepriseService.create_etablissement(self, siret, user.id)) # i18n-tasks-use t('errors.messages.siret_not_found')
+
+    return update_etablissement!(etablissement)
+  rescue => error
+    if error.try(:network_error?) && !APIEntrepriseService.api_up?
+      # TODO: notify ops
+      etablissement = APIEntrepriseService.create_etablissement_as_degraded_mode(self, siret, user.id)
+      return update_etablissement!(etablissement, error: :api_entreprise_down)
+    else
+      Sentry.capture_exception(error, extra: { dossier_id: dossier_id, siret: siret })
+      return clear(error: :network_error) # i18n-tasks-use t('errors.messages.siret_network_error')
+    end
+  end
+
+  private
+
+  def update_etablissement!(etablissement, error: nil)
+    update!(value: etablissement.siret, etablissement: etablissement)
+    error.presence || etablissement.siret
+  end
+
+  def clear(error: nil)
+    etablissement_to_destroy = etablissement
+    update!(value: '', etablissement: nil)
+    etablissement_to_destroy&.destroy
+    error.presence
+  end
+end

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -272,7 +272,8 @@ class TypeDeChamp < ApplicationRecord
       TypeDeChamp.type_champs.fetch(:drop_down_list),
       TypeDeChamp.type_champs.fetch(:repetition),
       TypeDeChamp.type_champs.fetch(:multiple_drop_down_list),
-      TypeDeChamp.type_champs.fetch(:epci)
+      TypeDeChamp.type_champs.fetch(:epci),
+      TypeDeChamp.type_champs.fetch(:siret)
     ])
   end
 

--- a/app/services/api_entreprise_service.rb
+++ b/app/services/api_entreprise_service.rb
@@ -15,6 +15,9 @@ class APIEntrepriseService
       etablissement_params = APIEntreprise::EtablissementAdapter.new(siret, procedure_id).to_params
       return nil if etablissement_params.empty?
 
+      entreprise_params = APIEntreprise::EntrepriseAdapter.new(siret, procedure_id).to_params
+      etablissement_params.merge!(entreprise_params) if entreprise_params.any?
+
       etablissement = dossier_or_champ.build_etablissement(etablissement_params)
       etablissement.save!
 

--- a/app/views/champs/siret/show.turbo_stream.haml
+++ b/app/views/champs/siret/show.turbo_stream.haml
@@ -1,1 +1,1 @@
-= turbo_stream.update dom_id(@champ, :siret_info), partial: 'shared/champs/siret/etablissement', locals: { siret: @siret, etablissement: @etablissement }
+= turbo_stream.update dom_id(@champ, :siret_info), partial: 'shared/champs/siret/etablissement', locals: { siret: @siret, etablissement: @champ.etablissement }

--- a/app/views/shared/champs/siret/_etablissement.html.haml
+++ b/app/views/shared/champs/siret/_etablissement.html.haml
@@ -1,6 +1,9 @@
 - case siret
-- when :invalid
-  Le numéro de SIRET doit comporter exactement 14 chiffres.
+- when :invalid_length
+  = t('errors.messages.invalid_siret_length')
+
+- when :invalid_checksum
+  = t('errors.messages.invalid_siret_checksum')
 
 - when :not_found
   Nous n’avons pas trouvé d’établissement correspondant à ce numéro de SIRET.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -136,6 +136,7 @@ en:
           date_html: ISO8601 date
           datetime_html: ISO8601 datetime
           drop_down_list_other_html: Any value
+          siret_html: A SIRET number
           repetition_html: A array of hashes with possible values for each field of the repetition.
           epci_html: An array of the department code and the <a href="https://geo.api.gouv.fr/epcis" target="_blank" rel="noopener noreferrer">EPCI one</a>.
         examples:
@@ -154,6 +155,7 @@ en:
           date: "2023-02-01"
           datetime: "2023-02-01T10:30"
           checkbox: "true"
+          siret: 828212345600023
         prefill_link_title: Prefill link (GET)
         prefill_link_info: Use the button to copy the link, then remplace the values with your data.
         prefill_link_too_long: Warning, the prefill link is too long and may not work on all browsers.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -155,7 +155,7 @@ en:
           date: "2023-02-01"
           datetime: "2023-02-01T10:30"
           checkbox: "true"
-          siret: 828212345600023
+          siret: 13002526500013
         prefill_link_title: Prefill link (GET)
         prefill_link_info: Use the button to copy the link, then remplace the values with your data.
         prefill_link_too_long: Warning, the prefill link is too long and may not work on all browsers.
@@ -511,7 +511,8 @@ en:
       dossier_not_found: "The file does not exist or you do not have access to it."
       # # dossier_map_not_activated: "The file does not have access to the map."
       targeted_user_link_expired: "This invitation link or the file is no longer available."
-      invalid_siret: "The SIRET is incorrect"
+      invalid_siret_length: "The SIRET number must contain exactly 14 numbers."
+      invalid_siret_checksum: "The SIRET number is invalid."
       procedure_not_found: "The procedure does not exist"
       siret_unknown: 'Sorry, we did not find any establishment registered under this SIRET number.'
       siret_network_error: 'Désolé, la récupération des informations SIRET est temporairement indisponible. Veuillez réessayer dans quelques instants.'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -147,7 +147,7 @@ fr:
           date: "2023-02-01"
           datetime: "2023-02-01T10:30"
           checkbox: "true"
-          siret: 82812345600023
+          siret: 13002526500013
         prefill_link_title: Lien de préremplissage (GET)
         prefill_link_info: Copiez le lien grâce au bouton ci-dessous et remplacez les valeurs par les données dont vous disposez.
         prefill_link_too_long: Attention, ce lien de préremplissage est trop long et risque de ne pas fonctionner sur certains navigateurs.
@@ -507,7 +507,8 @@ fr:
       dossier_not_found: "Le dossier n’existe pas ou vous n’y avez pas accès."
       # dossier_map_not_activated: "Le dossier n’a pas accès à la cartographie."
       targeted_user_link_expired: "Ce lien d’invitation n’est plus valable ou le dossier n’est plus accessible."
-      invalid_siret: "Le siret est incorrect"
+      invalid_siret_length: "Le numéro de SIRET doit comporter exactement 14 chiffres."
+      invalid_siret_checksum: "Le format du numéro de SIRET est invalide."
       procedure_not_found: "La démarche n’existe pas"
       siret_unknown: 'Désolé, nous n’avons pas trouvé d’établissement enregistré correspondant à ce numéro SIRET.'
       siret_network_error: 'Désolé, la récupération des informations SIRET est temporairement indisponible. Veuillez réessayer dans quelques instants.'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -127,6 +127,7 @@ fr:
           datetime_html: Datetime au format ISO8601
           date_html: Date au format ISO8601
           drop_down_list_other_html: Toute valeur
+          siret_html: Un numéro de SIRET
           repetition_html: Un tableau de dictionnaires avec les valeurs possibles pour chaque champ de la répétition.
           epci_html: Un tableau contenant le code de département et <a href="https://geo.api.gouv.fr/epcis" target="_blank" rel="noopener noreferrer">celui de l'EPCI</a>.
         examples:
@@ -146,6 +147,7 @@ fr:
           date: "2023-02-01"
           datetime: "2023-02-01T10:30"
           checkbox: "true"
+          siret: 82812345600023
         prefill_link_title: Lien de préremplissage (GET)
         prefill_link_info: Copiez le lien grâce au bouton ci-dessous et remplacez les valeurs par les données dont vous disposez.
         prefill_link_too_long: Attention, ce lien de préremplissage est trop long et risque de ne pas fonctionner sur certains navigateurs.

--- a/spec/controllers/champs/siret_controller_spec.rb
+++ b/spec/controllers/champs/siret_controller_spec.rb
@@ -48,7 +48,7 @@ describe Champs::SiretController, type: :controller do
         end
       end
 
-      context 'when the SIRET is invalid' do
+      context "when the SIRET is invalid because of it's length" do
         let(:siret) { '1234' }
 
         subject! { get :show, params: params, format: :turbo_stream }
@@ -59,6 +59,20 @@ describe Champs::SiretController, type: :controller do
 
         it 'displays a “SIRET is invalid” error message' do
           expect(response.body).to include('Le numéro de SIRET doit comporter exactement 14 chiffres.')
+        end
+      end
+
+      context "when the SIRET is invalid because of it's checksum" do
+        let(:siret) { '82812345600023' }
+
+        subject! { get :show, params: params, format: :turbo_stream }
+
+        it 'clears the etablissement on the model' do
+          expect(champ.reload.etablissement).to be_nil
+        end
+
+        it 'displays a “SIRET is invalid” error message' do
+          expect(response.body).to include('Le format du numéro de SIRET est invalide.')
         end
       end
 

--- a/spec/controllers/champs/siret_controller_spec.rb
+++ b/spec/controllers/champs/siret_controller_spec.rb
@@ -39,10 +39,8 @@ describe Champs::SiretController, type: :controller do
       context 'when the SIRET is empty' do
         subject! { get :show, params: params, format: :turbo_stream }
 
-        it 'clears the etablissement and SIRET on the model' do
-          champ.reload
-          expect(champ.etablissement).to be_nil
-          expect(champ.value).to be_empty
+        it 'clears the etablissement on the model' do
+          expect(champ.reload.etablissement).to be_nil
         end
 
         it 'clears any information or error message' do
@@ -55,10 +53,8 @@ describe Champs::SiretController, type: :controller do
 
         subject! { get :show, params: params, format: :turbo_stream }
 
-        it 'clears the etablissement and SIRET on the model' do
-          champ.reload
-          expect(champ.etablissement).to be_nil
-          expect(champ.value).to be_empty
+        it 'clears the etablissement on the model' do
+          expect(champ.reload.etablissement).to be_nil
         end
 
         it 'displays a “SIRET is invalid” error message' do
@@ -76,10 +72,8 @@ describe Champs::SiretController, type: :controller do
 
         subject! { get :show, params: params, format: :turbo_stream }
 
-        it 'clears the etablissement and SIRET on the model' do
-          champ.reload
-          expect(champ.etablissement).to be_nil
-          expect(champ.value).to be_empty
+        it 'clears the etablissement on the model' do
+          expect(champ.reload.etablissement).to be_nil
         end
 
         it 'displays a “API is unavailable” error message' do
@@ -115,10 +109,8 @@ describe Champs::SiretController, type: :controller do
 
         subject! { get :show, params: params, format: :turbo_stream }
 
-        it 'clears the etablissement and SIRET on the model' do
-          champ.reload
-          expect(champ.etablissement).to be_nil
-          expect(champ.value).to be_empty
+        it 'clears the etablissement on the model' do
+          expect(champ.reload.etablissement).to be_nil
         end
 
         it 'displays a “SIRET not found” error message' do

--- a/spec/controllers/champs/siret_controller_spec.rb
+++ b/spec/controllers/champs/siret_controller_spec.rb
@@ -31,6 +31,8 @@ describe Champs::SiretController, type: :controller do
         sign_in user
         stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/etablissements\/#{siret}/)
           .to_return(status: api_etablissement_status, body: api_etablissement_body)
+        stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/entreprises\/#{siret[0..8]}/)
+          .to_return(status: 200, body: File.read('spec/fixtures/files/api_entreprise/entreprises.json'))
         allow_any_instance_of(APIEntrepriseToken).to receive(:roles)
           .and_return(["attestations_fiscales", "attestations_sociales", "bilans_entreprise_bdf"])
         allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(token_expired)

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -196,6 +196,8 @@ describe Users::DossiersController, type: :controller do
       sign_in(user)
       stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/etablissements\/#{siret}/)
         .to_return(status: api_etablissement_status, body: api_etablissement_body)
+      stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/entreprises\/#{siren}/)
+        .to_return(body: File.read('spec/fixtures/files/api_entreprise/entreprises.json'), status: 200)
       allow_any_instance_of(APIEntrepriseToken).to receive(:roles)
         .and_return(["attestations_fiscales", "attestations_sociales", "bilans_entreprise_bdf"])
       allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(token_expired)

--- a/spec/models/concern/dossier_prefillable_concern_spec.rb
+++ b/spec/models/concern/dossier_prefillable_concern_spec.rb
@@ -6,7 +6,10 @@ RSpec.describe DossierPrefillableConcern do
     let(:dossier) { create(:dossier, :brouillon, procedure: procedure) }
     let(:types_de_champ_public) { [] }
 
-    subject(:fill) { dossier.prefill!(values); dossier.reload }
+    subject(:fill) do
+      dossier.prefill!(values)
+      dossier.reload
+    end
 
     shared_examples 'a dossier marked as prefilled' do
       it 'marks the dossier as prefilled' do

--- a/spec/models/concern/siret_champ_etablissement_fetchable_concern_spec.rb
+++ b/spec/models/concern/siret_champ_etablissement_fetchable_concern_spec.rb
@@ -1,0 +1,94 @@
+RSpec.describe SiretChampEtablissementFetchableConcern do
+  describe '.fetch_etablissement!' do
+    let(:api_etablissement_status) { 200 }
+    let(:api_etablissement_body) { File.read('spec/fixtures/files/api_entreprise/etablissements.json') }
+    let(:token_expired) { false }
+    let!(:champ) { create(:champ_siret) }
+
+    before do
+      stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/etablissements\/#{siret}/)
+        .to_return(status: api_etablissement_status, body: api_etablissement_body)
+      allow_any_instance_of(APIEntrepriseToken).to receive(:roles)
+        .and_return(["attestations_fiscales", "attestations_sociales", "bilans_entreprise_bdf"])
+      allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(token_expired)
+    end
+
+    subject(:fetch_etablissement!) { champ.fetch_etablissement!(siret, build_stubbed(:user)) }
+
+    shared_examples 'an error occured' do |error|
+      it { expect { fetch_etablissement! }.to change { champ.reload.value }.to('') }
+
+      it { expect { fetch_etablissement! }.to change { champ.reload.etablissement }.to(nil) }
+
+      it { expect { fetch_etablissement! }.to change { Etablissement.count }.by(-1) }
+
+      it { expect(fetch_etablissement!).to eq(error) }
+    end
+
+    context 'when the SIRET is empty' do
+      let(:siret) { '' }
+
+      it_behaves_like 'an error occured', nil
+    end
+
+    context 'when the SIRET is invalid' do
+      let(:siret) { '1234' }
+
+      it_behaves_like 'an error occured', :invalid
+    end
+
+    context 'when the API is unavailable due to network error' do
+      let(:siret) { '82161143100015' }
+      let(:api_etablissement_status) { 503 }
+
+      before { expect(APIEntrepriseService).to receive(:api_up?).and_return(true) }
+
+      it_behaves_like 'an error occured', :network_error
+
+      it 'sends the error to Sentry' do
+        expect(Sentry).to receive(:capture_exception)
+        fetch_etablissement!
+      end
+    end
+
+    context 'when the API is unavailable due to an api maintenance or pb' do
+      let(:siret) { '82161143100015' }
+      let(:api_etablissement_status) { 502 }
+
+      before { expect(APIEntrepriseService).to receive(:api_up?).and_return(false) }
+
+      it { expect { fetch_etablissement! }.to change { champ.reload.value }.to(siret) }
+
+      it { expect { fetch_etablissement! }.to change { champ.reload.etablissement } }
+
+      it { expect { fetch_etablissement! }.to change { champ.reload.etablissement.as_degraded_mode? }.to(true) }
+
+      it { expect { fetch_etablissement! }.to change { Etablissement.count }.by(1) }
+
+      it { expect(fetch_etablissement!).to eq(:api_entreprise_down) }
+    end
+
+    context 'when the SIRET is valid but unknown' do
+      let(:siret) { '00000000000000' }
+      let(:api_etablissement_status) { 404 }
+
+      it_behaves_like 'an error occured', :not_found
+    end
+
+    context 'when the SIRET informations are retrieved successfully' do
+      let(:siret) { '41816609600051' }
+      let(:api_etablissement_status) { 200 }
+      let(:api_etablissement_body) { File.read('spec/fixtures/files/api_entreprise/etablissements.json') }
+
+      it { expect { fetch_etablissement! }.to change { champ.reload.value }.to(siret) }
+
+      it { expect { fetch_etablissement! }.to change { champ.reload.etablissement.siret }.to(siret) }
+
+      it { expect { fetch_etablissement! }.to change { champ.reload.etablissement.naf }.to("6202A") }
+
+      it { expect { fetch_etablissement! }.to change { Etablissement.count }.by(1) }
+
+      it { expect(fetch_etablissement!).to eq(siret) }
+    end
+  end
+end

--- a/spec/models/concern/siret_champ_etablissement_fetchable_concern_spec.rb
+++ b/spec/models/concern/siret_champ_etablissement_fetchable_concern_spec.rb
@@ -20,13 +20,18 @@ RSpec.describe SiretChampEtablissementFetchableConcern do
 
       it { expect { fetch_etablissement! }.to change { Etablissement.count }.by(-1) }
 
-      it { expect(fetch_etablissement!).to eq(error) }
+      it { expect(fetch_etablissement!).to eq(false) }
+
+      it 'populates the etablissement_fetch_error_key' do
+        fetch_etablissement!
+        expect(champ.etablissement_fetch_error_key).to eq(error)
+      end
     end
 
     context 'when the SIRET is empty' do
       let(:siret) { '' }
 
-      it_behaves_like 'an error occured', nil
+      it_behaves_like 'an error occured', :empty
     end
 
     context 'when the SIRET is invalid' do
@@ -63,7 +68,12 @@ RSpec.describe SiretChampEtablissementFetchableConcern do
 
       it { expect { fetch_etablissement! }.to change { Etablissement.count }.by(1) }
 
-      it { expect(fetch_etablissement!).to eq(:api_entreprise_down) }
+      it { expect(fetch_etablissement!).to eq(false) }
+
+      it 'populates the etablissement_fetch_error_key' do
+        fetch_etablissement!
+        expect(champ.etablissement_fetch_error_key).to eq(:api_entreprise_down)
+      end
     end
 
     context 'when the SIRET is valid but unknown' do
@@ -86,7 +96,7 @@ RSpec.describe SiretChampEtablissementFetchableConcern do
 
       it { expect { fetch_etablissement! }.to change { Etablissement.count }.by(1) }
 
-      it { expect(fetch_etablissement!).to eq(siret) }
+      it { expect(fetch_etablissement!).to eq(true) }
     end
   end
 end

--- a/spec/models/concern/siret_champ_etablissement_fetchable_concern_spec.rb
+++ b/spec/models/concern/siret_champ_etablissement_fetchable_concern_spec.rb
@@ -16,8 +16,6 @@ RSpec.describe SiretChampEtablissementFetchableConcern do
     subject(:fetch_etablissement!) { champ.fetch_etablissement!(siret, build_stubbed(:user)) }
 
     shared_examples 'an error occured' do |error|
-      it { expect { fetch_etablissement! }.to change { champ.reload.value }.to('') }
-
       it { expect { fetch_etablissement! }.to change { champ.reload.etablissement }.to(nil) }
 
       it { expect { fetch_etablissement! }.to change { Etablissement.count }.by(-1) }

--- a/spec/models/concern/siret_champ_etablissement_fetchable_concern_spec.rb
+++ b/spec/models/concern/siret_champ_etablissement_fetchable_concern_spec.rb
@@ -34,10 +34,16 @@ RSpec.describe SiretChampEtablissementFetchableConcern do
       it_behaves_like 'an error occured', :empty
     end
 
-    context 'when the SIRET is invalid' do
+    context "when the SIRET is invalid because of it's length" do
       let(:siret) { '1234' }
 
-      it_behaves_like 'an error occured', :invalid
+      it_behaves_like 'an error occured', :invalid_length
+    end
+
+    context "when the SIRET is invalid because of it's checksum" do
+      let(:siret) { '82812345600023' }
+
+      it_behaves_like 'an error occured', :invalid_checksum
     end
 
     context 'when the API is unavailable due to network error' do

--- a/spec/models/concern/siret_champ_etablissement_fetchable_concern_spec.rb
+++ b/spec/models/concern/siret_champ_etablissement_fetchable_concern_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe SiretChampEtablissementFetchableConcern do
     before do
       stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/etablissements\/#{siret}/)
         .to_return(status: api_etablissement_status, body: api_etablissement_body)
+      stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/entreprises\/#{siret[0..8]}/)
+        .to_return(body: File.read('spec/fixtures/files/api_entreprise/entreprises.json'), status: 200)
       allow_any_instance_of(APIEntrepriseToken).to receive(:roles)
         .and_return(["attestations_fiscales", "attestations_sociales", "bilans_entreprise_bdf"])
       allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(token_expired)
@@ -103,6 +105,11 @@ RSpec.describe SiretChampEtablissementFetchableConcern do
       it { expect { fetch_etablissement! }.to change { Etablissement.count }.by(1) }
 
       it { expect(fetch_etablissement!).to eq(true) }
+
+      it "fetches the entreprise raison sociale" do
+        fetch_etablissement!
+        expect(champ.reload.etablissement.entreprise_raison_sociale).to eq("OCTO-TECHNOLOGY")
+      end
     end
   end
 end

--- a/spec/models/prefill_params_spec.rb
+++ b/spec/models/prefill_params_spec.rb
@@ -142,6 +142,7 @@ RSpec.describe PrefillParams do
     it_behaves_like "a champ public value that is authorized", :communes, ['01', '01457']
     it_behaves_like "a champ public value that is authorized", :multiple_drop_down_list, ["val1", "val2"]
     it_behaves_like "a champ public value that is authorized", :epci, ['01', '200042935']
+    it_behaves_like "a champ public value that is authorized", :siret, "13002526500013"
 
     context "when the public type de champ is authorized (repetition)" do
       let(:types_de_champ_public) { [{ type: :repetition, children: [{ type: :text }] }] }
@@ -175,6 +176,7 @@ RSpec.describe PrefillParams do
     it_behaves_like "a champ private value that is authorized", :checkbox, "false"
     it_behaves_like "a champ private value that is authorized", :drop_down_list, "value"
     it_behaves_like "a champ private value that is authorized", :regions, "93"
+    it_behaves_like "a champ private value that is authorized", :siret, "13002526500013"
     it_behaves_like "a champ private value that is authorized", :departements, "03"
     it_behaves_like "a champ private value that is authorized", :communes, ['01', '01457']
     it_behaves_like "a champ private value that is authorized", :multiple_drop_down_list, ["val1", "val2"]

--- a/spec/models/prefill_params_spec.rb
+++ b/spec/models/prefill_params_spec.rb
@@ -217,7 +217,6 @@ RSpec.describe PrefillParams do
     it_behaves_like "a champ public value that is unauthorized", :regions, "value"
     it_behaves_like "a champ public value that is unauthorized", :departements, "value"
     it_behaves_like "a champ public value that is unauthorized", :communes, "value"
-    it_behaves_like "a champ public value that is unauthorized", :siret, "value"
     it_behaves_like "a champ public value that is unauthorized", :rna, "value"
     it_behaves_like "a champ public value that is unauthorized", :annuaire_education, "value"
     it_behaves_like "a champ public value that is unauthorized", :multiple_drop_down_list, ["value"]

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -255,6 +255,7 @@ describe TypeDeChamp do
     it_behaves_like "a prefillable type de champ", :type_de_champ_repetition
     it_behaves_like "a prefillable type de champ", :type_de_champ_multiple_drop_down_list
     it_behaves_like "a prefillable type de champ", :type_de_champ_epci
+    it_behaves_like "a prefillable type de champ", :type_de_champ_siret
 
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_number
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_dossier_link
@@ -269,7 +270,6 @@ describe TypeDeChamp do
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_mesri
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_carte
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_address
-    it_behaves_like "a non-prefillable type de champ", :type_de_champ_siret
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_rna
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_annuaire_education
   end

--- a/spec/services/api_entreprise_service_spec.rb
+++ b/spec/services/api_entreprise_service_spec.rb
@@ -15,11 +15,16 @@ describe APIEntrepriseService do
     before do
       stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/etablissements\/#{siret}/)
         .to_return(body: etablissements_body, status: etablissements_status)
+      stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/entreprises\/#{siret[0..8]}/)
+        .to_return(body: entreprises_body, status: entreprises_status)
     end
 
     let(:siret) { '41816609600051' }
+    let(:raison_sociale) { "OCTO-TECHNOLOGY" }
     let(:etablissements_status) { 200 }
     let(:etablissements_body) { File.read('spec/fixtures/files/api_entreprise/etablissements.json') }
+    let(:entreprises_status) { 200 }
+    let(:entreprises_body) { File.read('spec/fixtures/files/api_entreprise/entreprises.json') }
     let(:valid_token) { "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c" }
     let(:procedure) { create(:procedure, api_entreprise_token: valid_token) }
     let(:dossier) { create(:dossier, procedure: procedure) }
@@ -33,6 +38,10 @@ describe APIEntrepriseService do
     context 'when service is up' do
       it 'should fetch etablissement params' do
         expect(subject[:siret]).to eq(siret)
+      end
+
+      it 'should fetch entreprise params' do
+        expect(subject[:entreprise_raison_sociale]).to eq(raison_sociale)
       end
 
       it_behaves_like 'schedule fetch of all etablissement params'

--- a/spec/support/shared_examples_for_prefilled_dossier.rb
+++ b/spec/support/shared_examples_for_prefilled_dossier.rb
@@ -1,13 +1,9 @@
 shared_examples "the user has got a prefilled dossier, owned by themselves" do
   scenario "the user has got a prefilled dossier, owned by themselves" do
-    siret = '41816609600051'
-    stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/etablissements\/#{siret}/)
-      .to_return(status: 200, body: File.read('spec/fixtures/files/api_entreprise/etablissements.json'))
-
     expect(dossier.user).to eq(user)
 
     expect(page).to have_current_path siret_dossier_path(procedure.dossiers.last)
-    fill_in 'Numéro SIRET', with: siret
+    fill_in 'Numéro SIRET', with: siret_value
     click_on 'Valider'
 
     expect(page).to have_current_path(etablissement_dossier_path(dossier))
@@ -18,6 +14,7 @@ shared_examples "the user has got a prefilled dossier, owned by themselves" do
     expect(page).to have_field(type_de_champ_text.libelle, with: text_value)
     expect(page).to have_field(type_de_champ_phone.libelle, with: phone_value)
     expect(page).to have_css('label', text: type_de_champ_phone.libelle)
+    expect(page).to have_field(type_de_champ_siret.libelle, with: siret_value)
     expect(page).to have_css('h3', text: type_de_champ_repetition.libelle)
     expect(page).to have_field(text_repetition_libelle, with: text_repetition_value)
     expect(page).to have_field(integer_repetition_libelle, with: integer_repetition_value)

--- a/spec/system/users/dossier_prefill_get_spec.rb
+++ b/spec/system/users/dossier_prefill_get_spec.rb
@@ -59,6 +59,9 @@ describe 'Prefilling a dossier (with a GET request):', js: true do
     stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/etablissements\//)
       .to_return(status: 200, body: File.read('spec/fixtures/files/api_entreprise/etablissements.json'))
 
+    stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/entreprises\/#{siret_value[0..8]}/)
+      .to_return(status: 200, body: File.read('spec/fixtures/files/api_entreprise/entreprises.json'))
+
     VCR.insert_cassette('api_geo_departements')
     VCR.insert_cassette('api_geo_communes')
     VCR.insert_cassette('api_geo_epcis')

--- a/spec/system/users/dossier_prefill_get_spec.rb
+++ b/spec/system/users/dossier_prefill_get_spec.rb
@@ -1,4 +1,4 @@
-describe 'Prefilling a dossier (with a GET request):' do
+describe 'Prefilling a dossier (with a GET request):', js: true do
   let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
 
   let(:password) { 'my-s3cure-p4ssword' }
@@ -8,13 +8,16 @@ describe 'Prefilling a dossier (with a GET request):' do
 
   let(:type_de_champ_text) { create(:type_de_champ_text, procedure: procedure) }
   let(:type_de_champ_phone) { create(:type_de_champ_phone, procedure: procedure) }
+  let(:type_de_champ_siret) { create(:type_de_champ_siret, procedure: procedure) }
   let(:type_de_champ_datetime) { create(:type_de_champ_datetime, procedure: procedure) }
   let(:type_de_champ_multiple_drop_down_list) { create(:type_de_champ_multiple_drop_down_list, procedure: procedure) }
   let(:type_de_champ_epci) { create(:type_de_champ_epci, procedure: procedure) }
   let(:type_de_champ_commune) { create(:type_de_champ_communes, procedure: procedure) }
   let(:type_de_champ_repetition) { create(:type_de_champ_repetition, :with_types_de_champ, procedure: procedure) }
+
   let(:text_value) { "My Neighbor Totoro is the best movie ever" }
   let(:phone_value) { "invalid phone value" }
+  let(:siret_value) { '41816609600051' }
   let(:datetime_value) { "2023-02-01T10:32" }
   let(:multiple_drop_down_list_values) {
     [
@@ -39,6 +42,7 @@ describe 'Prefilling a dossier (with a GET request):' do
       "champ_#{type_de_champ_multiple_drop_down_list.to_typed_id_for_query}" => multiple_drop_down_list_values,
       "champ_#{type_de_champ_epci.to_typed_id_for_query}" => epci_value,
       "champ_#{type_de_champ_commune.to_typed_id_for_query}" => commune_value,
+      "champ_#{type_de_champ_siret.to_typed_id_for_query}" => siret_value,
       "champ_#{type_de_champ_repetition.to_typed_id_for_query}" => [
         {
           "champ_#{sub_type_de_champs_repetition.first.to_typed_id_for_query}": text_repetition_value,
@@ -51,6 +55,9 @@ describe 'Prefilling a dossier (with a GET request):' do
   before do
     allow(Rails).to receive(:cache).and_return(memory_store)
     Rails.cache.clear
+
+    stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/etablissements\//)
+      .to_return(status: 200, body: File.read('spec/fixtures/files/api_entreprise/etablissements.json'))
 
     VCR.insert_cassette('api_geo_departements')
     VCR.insert_cassette('api_geo_communes')

--- a/spec/system/users/dossier_prefill_post_spec.rb
+++ b/spec/system/users/dossier_prefill_post_spec.rb
@@ -1,4 +1,4 @@
-describe 'Prefilling a dossier (with a POST request):' do
+describe 'Prefilling a dossier (with a POST request):', js: true do
   let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
 
   let(:password) { 'my-s3cure-p4ssword' }
@@ -8,13 +8,16 @@ describe 'Prefilling a dossier (with a POST request):' do
 
   let(:type_de_champ_text) { create(:type_de_champ_text, procedure: procedure) }
   let(:type_de_champ_phone) { create(:type_de_champ_phone, procedure: procedure) }
+  let(:type_de_champ_siret) { create(:type_de_champ_siret, procedure: procedure) }
   let(:type_de_champ_datetime) { create(:type_de_champ_datetime, procedure: procedure) }
   let(:type_de_champ_multiple_drop_down_list) { create(:type_de_champ_multiple_drop_down_list, procedure: procedure) }
   let(:type_de_champ_epci) { create(:type_de_champ_epci, procedure: procedure) }
   let(:type_de_champ_repetition) { create(:type_de_champ_repetition, :with_types_de_champ, procedure: procedure) }
   let(:type_de_champ_commune) { create(:type_de_champ_communes, procedure: procedure) }
+
   let(:text_value) { "My Neighbor Totoro is the best movie ever" }
   let(:phone_value) { "invalid phone value" }
+  let(:siret_value) { '41816609600051' }
   let(:datetime_value) { "2023-02-01T10:32" }
   let(:multiple_drop_down_list_values) {
     [
@@ -33,6 +36,9 @@ describe 'Prefilling a dossier (with a POST request):' do
   before do
     allow(Rails).to receive(:cache).and_return(memory_store)
     Rails.cache.clear
+
+    stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/etablissements\/#{siret_value}/)
+      .to_return(status: 200, body: File.read('spec/fixtures/files/api_entreprise/etablissements.json'))
 
     VCR.insert_cassette('api_geo_departements')
     VCR.insert_cassette('api_geo_communes')
@@ -132,6 +138,7 @@ describe 'Prefilling a dossier (with a POST request):' do
       params: {
         "champ_#{type_de_champ_text.to_typed_id_for_query}" => text_value,
         "champ_#{type_de_champ_phone.to_typed_id_for_query}" => phone_value,
+        "champ_#{type_de_champ_siret.to_typed_id_for_query}" => siret_value,
         "champ_#{type_de_champ_repetition.to_typed_id_for_query}" => [
           {
             "champ_#{sub_type_de_champs_repetition.first.to_typed_id_for_query}": text_repetition_value,

--- a/spec/system/users/dossier_prefill_post_spec.rb
+++ b/spec/system/users/dossier_prefill_post_spec.rb
@@ -40,6 +40,9 @@ describe 'Prefilling a dossier (with a POST request):', js: true do
     stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/etablissements\/#{siret_value}/)
       .to_return(status: 200, body: File.read('spec/fixtures/files/api_entreprise/etablissements.json'))
 
+    stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/entreprises\/#{siret_value[0..8]}/)
+      .to_return(status: 200, body: File.read('spec/fixtures/files/api_entreprise/entreprises.json'))
+
     VCR.insert_cassette('api_geo_departements')
     VCR.insert_cassette('api_geo_communes')
     VCR.insert_cassette('api_geo_epcis')


### PR DESCRIPTION
L'objectif de cette PR est de permettre le préremplissage de champ de type `siret`.

Pour éviter une duplication, on commence par refactorer l'algo de `SiretController#show`, qui consiste à créer / mettre à jour un établissement pour le champ siret, ainsi que sa valeur, et à gérer les différentes erreurs qui peuvent se produire en cours de route. On donne cette responsabilité au champ lui-même, puisque c'est son métier, mais pour "ranger", on met l'opération `fetch_etablissement!` dans un concern dédié.

Au moment où le dossier est prérempli, on se re-sert de ce `fetch_etablissement!`. Selon le temps qui s'écoule entre le moment du préremplissage, et le moment où l'usager·ère poursuit le remplissage du dossier, le job a pu finir de récupérer les données. La personne arrive alors sur son brouillon et l'établissement est correctement renseigné.

En outre, lorsqu'un champ siret a été prérempli, on fetch l'établissement dès que le dossier s'affiche, exactement comme si l'usager•ère venait d'éditer le champ. Toutefois, on le fait seulement sous certaines conditions : si le champ est prérempli, et que le siret est renseigné, et que l'établissement est manquant.

On fait ces deux opérations à dessein. Dans la plupart des cas, l'établissement est récupéré lors de la première étape (et il s'affiche dès qu'on arrive sur l'écran), et donc on ne fait pas la deuxième. Celle-ci vient plutôt en back up, au cas où on n'aurait pas pu récupérer l'établissement lors du préremplissage.


![image](https://user-images.githubusercontent.com/1193334/212282983-ab178403-31f6-4b04-acca-5b07eae91d7d.png)
