### PR TITLE
Email events: premières briques pour un monitoring — emails dispatchés par ActionMailer

### DIFF
--- a/app/controllers/manager/application_controller.rb
+++ b/app/controllers/manager/application_controller.rb
@@ -4,7 +4,7 @@ module Manager
     before_action :default_params
 
     def default_params
-      params[resource_name] ||= {
+      request.query_parameters[resource_name] ||= {
         order: "created_at",
         direction: "desc"
       }

--- a/app/controllers/manager/email_events_controller.rb
+++ b/app/controllers/manager/email_events_controller.rb
@@ -1,0 +1,4 @@
+module Manager
+  class EmailEventsController < Manager::ApplicationController
+  end
+end

--- a/app/dashboards/email_event_dashboard.rb
+++ b/app/dashboards/email_event_dashboard.rb
@@ -11,8 +11,14 @@ class EmailEventDashboard < Administrate::BaseDashboard
   }
   COLLECTION_ATTRIBUTES = [:id, :to, :subject, :method, :status, :processed_at].freeze
   SHOW_PAGE_ATTRIBUTES = [:id, :to, :subject, :method, :status, :processed_at].freeze
+
+  METHODS_FILTERS =
+    ActionMailer::Base.delivery_methods.keys.index_with do |method|
+      -> (resources) { resources.where(method: method) }
+    end
+
   COLLECTION_FILTERS = {
     dispatched: -> (resources) { resources.dispatched },
     dispatch_error: -> (resources) { resources.dispatch_error }
-  }.freeze
+  }.merge(METHODS_FILTERS).freeze
 end

--- a/app/dashboards/email_event_dashboard.rb
+++ b/app/dashboards/email_event_dashboard.rb
@@ -1,0 +1,18 @@
+require "administrate/base_dashboard"
+
+class EmailEventDashboard < Administrate::BaseDashboard
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    to: Field::String,
+    subject: Field::String,
+    method: Field::Enum,
+    status: Field::Enum,
+    processed_at: Field::DateTime.with_options(format: "%F %T")
+  }
+  COLLECTION_ATTRIBUTES = [:id, :to, :subject, :method, :status, :processed_at].freeze
+  SHOW_PAGE_ATTRIBUTES = [:id, :to, :subject, :method, :status, :processed_at].freeze
+  COLLECTION_FILTERS = {
+    dispatched: -> (resources) { resources.dispatched },
+    dispatch_error: -> (resources) { resources.dispatch_error }
+  }.freeze
+end

--- a/app/lib/mailjet/api.rb
+++ b/app/lib/mailjet/api.rb
@@ -1,6 +1,6 @@
 class Mailjet::API
   def properly_configured?
-    [Mailjet.config.api_key, Mailjet.config.secret_key].all?(&:present?)
+    Mailjet.respond_to?(:config) && [Mailjet.config.api_key, Mailjet.config.secret_key].all?(&:present?)
   end
 
   # Get messages sent to a user through SendInBlue.

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,5 @@
 class ApplicationMailer < ActionMailer::Base
-  include MailerErrorConcern
+  include MailerMonitoringConcern
 
   helper :application # gives access to all helpers defined within `application_helper`.
   default from: "#{APPLICATION_NAME} <#{CONTACT_EMAIL}>"
@@ -19,13 +19,5 @@ class ApplicationMailer < ActionMailer::Base
     # A problem occured when reading logo, maybe the logo is missing and we should clean the procedure to remove logo reference ?
     Sentry.capture_exception(e, extra: { procedure_id: procedure.id })
     nil
-  end
-
-  # mandatory for dolist
-  # used for tracking in Dolist UI
-  # the delivery_method is yet unknown (:balancer)
-  # so we add the dolist header for everyone
-  def add_dolist_header
-    headers['X-Dolist-Message-Name'] = action_name
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,24 +1,11 @@
 class ApplicationMailer < ActionMailer::Base
+  include MailerErrorConcern
+
   helper :application # gives access to all helpers defined within `application_helper`.
   default from: "#{APPLICATION_NAME} <#{CONTACT_EMAIL}>"
   layout 'mailer'
 
   before_action :add_dolist_header
-
-  # Don’t retry to send a message if the server rejects the recipient address
-  rescue_from Net::SMTPSyntaxError do |_exception|
-    message.perform_deliveries = false
-  end
-
-  rescue_from Net::SMTPServerBusy do |exception|
-    if /unexpected recipients/.match?(exception.message)
-      message.perform_deliveries = false
-    else
-      log_smtp_error(exception)
-    end
-  end
-
-  rescue_from Net::SMTPError, with: :log_smtp_error
 
   # Attach the procedure logo to the email (if any).
   # Returns the attachment url.
@@ -28,7 +15,6 @@ class ApplicationMailer < ActionMailer::Base
       attachments.inline[logo_filename] = procedure.logo.download
       attachments[logo_filename].url
     end
-
   rescue StandardError => e
     # A problem occured when reading logo, maybe the logo is missing and we should clean the procedure to remove logo reference ?
     Sentry.capture_exception(e, extra: { procedure_id: procedure.id })
@@ -41,15 +27,5 @@ class ApplicationMailer < ActionMailer::Base
   # so we add the dolist header for everyone
   def add_dolist_header
     headers['X-Dolist-Message-Name'] = action_name
-  end
-
-  def log_smtp_error(exception)
-    if defined?(message) && message.to.present?
-      EmailEvent.create_from_message!(message, status: "dispatch_error")
-    end
-
-    Sentry.capture_exception(exception, extra: { to: message&.to, subject: message&.subject })
-
-    # TODO find a way to re attempt the job
   end
 end

--- a/app/mailers/concerns/mailer_error_concern.rb
+++ b/app/mailers/concerns/mailer_error_concern.rb
@@ -20,12 +20,8 @@ module MailerErrorConcern
     protected
 
     def log_delivery_error(exception)
-      if defined?(message) && message.to.present?
-        EmailEvent.create_from_message!(message, status: "dispatch_error")
-        Sentry.capture_exception(exception, extra: { to: message&.to, subject: message&.subject })
-      else
-        Sentry.capture_exception(exception)
-      end
+      EmailEvent.create_from_message!(message, status: "dispatch_error")
+      Sentry.capture_exception(exception, extra: { to: message.to, subject: message.subject })
 
       # TODO find a way to re attempt the job
     end

--- a/app/mailers/concerns/mailer_error_concern.rb
+++ b/app/mailers/concerns/mailer_error_concern.rb
@@ -1,0 +1,33 @@
+module MailerErrorConcern
+  extend ActiveSupport::Concern
+
+  included do
+    # Don’t retry to send a message if the server rejects the recipient address
+    rescue_from Net::SMTPSyntaxError do |_exception|
+      message.perform_deliveries = false
+    end
+
+    rescue_from Net::SMTPServerBusy do |exception|
+      if /unexpected recipients/.match?(exception.message)
+        message.perform_deliveries = false
+      else
+        log_delivery_error(exception)
+      end
+    end
+
+    rescue_from StandardError, with: :log_delivery_error
+
+    protected
+
+    def log_delivery_error(exception)
+      if defined?(message) && message.to.present?
+        EmailEvent.create_from_message!(message, status: "dispatch_error")
+        Sentry.capture_exception(exception, extra: { to: message&.to, subject: message&.subject })
+      else
+        Sentry.capture_exception(exception)
+      end
+
+      # TODO find a way to re attempt the job
+    end
+  end
+end

--- a/app/mailers/concerns/mailer_monitoring_concern.rb
+++ b/app/mailers/concerns/mailer_monitoring_concern.rb
@@ -1,4 +1,4 @@
-module MailerErrorConcern
+module MailerMonitoringConcern
   extend ActiveSupport::Concern
 
   included do
@@ -16,6 +16,14 @@ module MailerErrorConcern
     end
 
     rescue_from StandardError, with: :log_delivery_error
+
+    # mandatory for dolist
+    # used for tracking in Dolist UI
+    # the delivery_method is yet unknown (:balancer)
+    # so we add the dolist header for everyone
+    def add_dolist_header
+      headers['X-Dolist-Message-Name'] = action_name
+    end
 
     protected
 

--- a/app/mailers/devise_user_mailer.rb
+++ b/app/mailers/devise_user_mailer.rb
@@ -3,7 +3,7 @@ class DeviseUserMailer < Devise::Mailer
   helper :application # gives access to all helpers defined within `application_helper`.
   helper MailerHelper
   include Devise::Controllers::UrlHelpers # Optional. eg. `confirmation_url`
-  include MailerErrorConcern
+  include MailerMonitoringConcern
   layout 'mailers/layout'
 
   def template_paths

--- a/app/mailers/devise_user_mailer.rb
+++ b/app/mailers/devise_user_mailer.rb
@@ -3,18 +3,8 @@ class DeviseUserMailer < Devise::Mailer
   helper :application # gives access to all helpers defined within `application_helper`.
   helper MailerHelper
   include Devise::Controllers::UrlHelpers # Optional. eg. `confirmation_url`
+  include MailerErrorConcern
   layout 'mailers/layout'
-
-  # Don’t retry to send a message if the server rejects the recipient address
-  rescue_from Net::SMTPSyntaxError do |_error|
-    message.perform_deliveries = false
-  end
-
-  rescue_from Net::SMTPServerBusy do |error|
-    if /unexpected recipients/.match?(error.message)
-      message.perform_deliveries = false
-    end
-  end
 
   def template_paths
     ['devise_mailer']

--- a/app/models/email_event.rb
+++ b/app/models/email_event.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: email_events
+#
+#  id           :bigint           not null, primary key
+#  method       :string           not null
+#  processed_at :datetime
+#  status       :string           not null
+#  subject      :string           not null
+#  to           :string           not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+class EmailEvent < ApplicationRecord
+  enum status: {
+    dispatched: 'dispatched'
+  }
+end

--- a/app/models/email_event.rb
+++ b/app/models/email_event.rb
@@ -23,7 +23,7 @@ class EmailEvent < ApplicationRecord
 
       to.each do |recipient|
         EmailEvent.create!(
-          to: pseudonymize_email(recipient),
+          to: recipient,
           subject: message.subject,
           processed_at: message.date,
           method: ActionMailer::Base.delivery_methods.key(message.delivery_method.class),
@@ -32,18 +32,6 @@ class EmailEvent < ApplicationRecord
       rescue StandardError => error
         Sentry.capture_exception(error, extra: { subject: message.subject, status: })
       end
-    end
-
-    def pseudonymize_email(email)
-      username, domain_name = email.split("@")
-
-      username_masked = if username.length > 3
-        username[0..1] + "*" * (username.length - 3) + username[-1]
-      else
-        "*" * username.length
-      end
-
-      "#{username_masked}@#{domain_name}"
     end
   end
 end

--- a/app/models/email_event.rb
+++ b/app/models/email_event.rb
@@ -15,4 +15,31 @@ class EmailEvent < ApplicationRecord
   enum status: {
     dispatched: 'dispatched'
   }
+  class << self
+    def create_from_message!(message, status:)
+      message.to.each do |recipient|
+        EmailEvent.create!(
+          to: pseudonymize_email(recipient),
+          subject: message.subject,
+          processed_at: message.date,
+          method: ActionMailer::Base.delivery_methods.key(message.delivery_method.class),
+          status:
+        )
+      rescue StandardError => error
+        Sentry.capture_exception(error, extra: { subject: message.subject, status: })
+      end
+    end
+
+    def pseudonymize_email(email)
+      username, domain_name = email.split("@")
+
+      username_masked = if username.length > 3
+        username[0..1] + "*" * (username.length - 3) + username[-1]
+      else
+        "*" * username.length
+      end
+
+      "#{username_masked}@#{domain_name}"
+    end
+  end
 end

--- a/app/models/email_event.rb
+++ b/app/models/email_event.rb
@@ -19,7 +19,9 @@ class EmailEvent < ApplicationRecord
 
   class << self
     def create_from_message!(message, status:)
-      message.to.each do |recipient|
+      to = message.to || ["unset"] # no recipients when error occurs *before* setting to: in the mailer
+
+      to.each do |recipient|
         EmailEvent.create!(
           to: pseudonymize_email(recipient),
           subject: message.subject,

--- a/app/models/email_event.rb
+++ b/app/models/email_event.rb
@@ -13,8 +13,10 @@
 #
 class EmailEvent < ApplicationRecord
   enum status: {
-    dispatched: 'dispatched'
+    dispatched: 'dispatched',
+    dispatch_error: 'dispatch_error'
   }
+
   class << self
     def create_from_message!(message, status:)
       message.to.each do |recipient|

--- a/app/services/email_delivery_observer.rb
+++ b/app/services/email_delivery_observer.rb
@@ -1,0 +1,7 @@
+class EmailDeliveryObserver
+  def self.delivered_email(message)
+    return if message.to.nil?
+
+    EmailEvent.create_from_message!(message, status: "dispatched")
+  end
+end

--- a/app/services/email_delivery_observer.rb
+++ b/app/services/email_delivery_observer.rb
@@ -1,7 +1,5 @@
 class EmailDeliveryObserver
   def self.delivered_email(message)
-    return if message.to.nil?
-
     EmailEvent.create_from_message!(message, status: "dispatched")
   end
 end

--- a/app/views/manager/users/emails.html.erb
+++ b/app/views/manager/users/emails.html.erb
@@ -77,6 +77,8 @@
   </p>
 <% end %>
 
+<%= link_to "Voir aussi les événements d'email", manager_email_events_path("search" =>  EmailEvent.pseudonymize_email(@user.email)) %>
+
   <h2 style="font-size: 1.3em; margin: 24px 0 8px 0">Problèmes potentiel</h2>
 
   <% if @user.confirmed? %>

--- a/app/views/manager/users/emails.html.erb
+++ b/app/views/manager/users/emails.html.erb
@@ -77,7 +77,7 @@
   </p>
 <% end %>
 
-<%= link_to "Voir aussi les événements d'email", manager_email_events_path("search" =>  EmailEvent.pseudonymize_email(@user.email)) %>
+<%= link_to "Voir aussi les événements d'email", manager_email_events_path("search" => @user.email) %>
 
   <h2 style="font-size: 1.3em; margin: 24px 0 8px 0">Problèmes potentiel</h2>
 

--- a/config/initializers/mail_observers.rb
+++ b/config/initializers/mail_observers.rb
@@ -1,0 +1,3 @@
+Rails.application.configure do
+  config.action_mailer.observers = ['EmailDeliveryObserver']
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,8 @@ Rails.application.routes.draw do
 
     resources :team_accounts, only: [:index, :show]
 
+    resources :email_events, only: [:index, :show]
+
     resources :dubious_procedures, only: [:index]
     resources :outdated_procedures, only: [:index] do
       patch :bulk_update, on: :collection

--- a/db/migrate/20230109140138_create_email_events.rb
+++ b/db/migrate/20230109140138_create_email_events.rb
@@ -1,0 +1,13 @@
+class CreateEmailEvents < ActiveRecord::Migration[6.1]
+  def change
+    create_table :email_events do |t|
+      t.string :to, null: false
+      t.string :method, null: false
+      t.string :status, null: false
+      t.string :subject, null: false
+      t.datetime :processed_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_27_084442) do
+ActiveRecord::Schema.define(version: 2023_01_09_140138) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -405,6 +405,16 @@ ActiveRecord::Schema.define(version: 2022_12_27_084442) do
     t.datetime "updated_at"
     t.string "value"
     t.index ["type_de_champ_id"], name: "index_drop_down_lists_on_type_de_champ_id"
+  end
+
+  create_table "email_events", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.string "method", null: false
+    t.datetime "processed_at"
+    t.string "status", null: false
+    t.string "subject", null: false
+    t.string "to", null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "etablissements", id: :serial, force: :cascade do |t|

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -28,13 +28,13 @@ RSpec.describe ApplicationMailer, type: :mailer do
 
   describe 'EmailDeliveryObserver is invoked' do
     let(:user1) { create(:user) }
-    let(:user2) { create(:user, email: "thisisyour@email.com") }
+    let(:user2) { create(:user, email: "your@email.com") }
 
     it 'creates a new EmailEvent record with the correct information' do
       expect { UserMailer.ask_for_merge(user1, user2.email).deliver_now }.to change { EmailEvent.count }.by(1)
       event = EmailEvent.last
 
-      expect(event.to).to eq("th*******r@email.com")
+      expect(event.to).to eq("your@email.com")
       expect(event.method).to eq("test")
       expect(event.subject).to eq('Fusion de compte')
       expect(event.processed_at).to be_within(1.second).of(Time.zone.now)

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe ApplicationMailer, type: :mailer do
         end
       end
 
-      context "smtp unknown error" do
-        let(:smtp_error) { Net::SMTPUnknownError.new }
+      context "generic unknown error" do
+        let(:smtp_error) { Net::OpenTimeout.new }
 
         it "creates an event" do
           expect { send_email }.to change { EmailEvent.count }.by(1)

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -25,4 +25,20 @@ RSpec.describe ApplicationMailer, type: :mailer do
       it { expect(subject.message).not_to be_an_instance_of(ActionMailer::Base::NullMail) }
     end
   end
+
+  describe 'EmailDeliveryObserver is invoked' do
+    let(:user1) { create(:user) }
+    let(:user2) { create(:user, email: "thisisyour@email.com") }
+
+    it 'creates a new EmailEvent record with the correct information' do
+      expect { UserMailer.ask_for_merge(user1, user2.email).deliver_now }.to change { EmailEvent.count }.by(1)
+      event = EmailEvent.last
+
+      expect(event.to).to eq("th*******r@email.com")
+      expect(event.method).to eq("test")
+      expect(event.subject).to eq('Fusion de compte')
+      expect(event.processed_at).to be_within(1.second).of(Time.zone.now)
+      expect(event.status).to eq('dispatched')
+    end
+  end
 end

--- a/spec/models/email_event_spec.rb
+++ b/spec/models/email_event_spec.rb
@@ -1,7 +1,2 @@
 RSpec.describe EmailEvent, type: :model do
-  describe "#pseudonymize_email" do
-    it { expect(EmailEvent.pseudonymize_email("example@rspec.com")).to eq("ex****e@rspec.com") }
-    it { expect(EmailEvent.pseudonymize_email("exa@rspec.com")).to eq("***@rspec.com") }
-    it { expect(EmailEvent.pseudonymize_email("e@rspec.com")).to eq("*@rspec.com") }
-  end
 end

--- a/spec/models/email_event_spec.rb
+++ b/spec/models/email_event_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe EmailEvent, type: :model do
+  describe "#pseudonymize_email" do
+    it { expect(EmailEvent.pseudonymize_email("example@rspec.com")).to eq("ex****e@rspec.com") }
+    it { expect(EmailEvent.pseudonymize_email("exa@rspec.com")).to eq("***@rspec.com") }
+    it { expect(EmailEvent.pseudonymize_email("e@rspec.com")).to eq("*@rspec.com") }
+  end
+end


### PR DESCRIPTION
Pour le moment c'est basique et naïf: 

- on log dans un modèle quelques infos de base des emails traités par ActionMailer, en particulier la méthode de delivery (le fournisseur)
- on intercepte les erreurs d'envoi (serveur smtp qui répond pas…)
- on fait remonter dans sentry les erreurs pour avoir les traces entières, au moins le temps de comprendre ce qu'il se passe
- dans le manager on peut visualiser les events

![Capture d’écran 2023-01-10 à 11 54 01](https://user-images.githubusercontent.com/150279/211532828-21aa156e-289f-4b1d-8dc5-41cc50975bfc.png)

On pourra enrichir progressivement les events via les API pour y ajouter l'état de traitement par les prestataires d'email. Pour Dolist ça voudra dire faire les envois par API plutôt que smtp. 



TODO:
- vu qu'on intercepte les erreurs, les jobs n'échouent plus et ne retentent pas l'envoi (c'était d'ailleurs le cas pour certaines erreurs). Il faut qu'un job puisse être relancé dans la plupart des cas
- purge des events au bout de X semaines