### PR TITLE
feat(groupe_instructeurs): import instructeurs in unrouted procedures with a proper CSV

### DIFF
--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -120,8 +120,6 @@ module Administrateurs
       end
 
       if instructeurs.present?
-        instructeurs.each { groupe_instructeur.add(_1) }
-
         flash[:notice] = if procedure.routing_enabled?
           t('.assignment',
             count: instructeurs.size,

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -111,7 +111,7 @@ module Administrateurs
       emails = params['emails'].presence || [].to_json
       emails = JSON.parse(emails).map { EmailSanitizableConcern::EmailSanitizer.sanitize(_1) }
 
-      instructeurs, invalid_emails = Instructeur.find_or_create_instructeurs(emails:, administrateurs: procedure.administrateurs)
+      instructeurs, invalid_emails = groupe_instructeur.add_instructeurs(emails:)
 
       if invalid_emails.present?
         flash[:alert] = t('.wrong_address',

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -111,7 +111,7 @@ module Administrateurs
       emails = params['emails'].presence || [].to_json
       emails = JSON.parse(emails).map { EmailSanitizableConcern::EmailSanitizer.sanitize(_1) }
 
-      instructeurs, invalid_emails = groupe_instructeur.add_instructeurs(emails:)
+      instructeurs, invalid_emails = Instructeur.find_or_create_instructeurs(emails:, administrateurs: procedure.administrateurs)
 
       if invalid_emails.present?
         flash[:alert] = t('.wrong_address',

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -219,13 +219,8 @@ module Administrateurs
             if groupes_emails_has_keys.blank?
               flash[:alert] = "Importation impossible, veuillez importer un csv #{view_context.link_to('suivant ce modèle', "/csv/#{I18n.locale}/import-groupe-test.csv")}"
             else
-              add_instructeurs_and_get_errors = InstructeursImportService.import_groupes(procedure, groupes_emails)
-
-              if add_instructeurs_and_get_errors.blank?
-                flash[:notice] = "La liste des instructeurs a été importée avec succès"
-              else
-                flash[:alert] = "Import terminé. Cependant les emails suivants ne sont pas pris en compte: #{add_instructeurs_and_get_errors.join(', ')}"
-              end
+              result = InstructeursImportService.import_groupes(procedure, groupes_emails)
+              flash_message_for_import(result)
             end
 
           elsif params[:instructeurs_csv_file]
@@ -237,13 +232,8 @@ module Administrateurs
             if instructors_emails_has_key.blank?
               flash[:alert] = "Importation impossible, veuillez importer un csv #{view_context.link_to('suivant ce modèle', "/csv/import-instructeurs-test.csv")}"
             else
-              add_instructeurs_and_get_errors = InstructeursImportService.import_instructeurs(procedure, instructors_emails)
-
-              if add_instructeurs_and_get_errors.blank?
-                flash[:notice] = "La liste des instructeurs a été importée avec succès"
-              else
-                flash[:alert] = "Import terminé. Cependant les emails suivants ne sont pas pris en compte: #{add_instructeurs_and_get_errors.join(', ')}"
-              end
+              result = InstructeursImportService.import_instructeurs(procedure, instructors_emails)
+              flash_message_for_import(result)
             end
           end
           redirect_to admin_procedure_groupe_instructeurs_path(procedure)
@@ -333,6 +323,14 @@ module Administrateurs
 
     def routing_enabled_params
       { routing_enabled: params.require(:routing) == 'enable' }
+    end
+
+    def flash_message_for_import(result)
+      if result.blank?
+        flash[:notice] = "La liste des instructeurs a été importée avec succès"
+      else
+        flash[:alert] = "Import terminé. Cependant les emails suivants ne sont pas pris en compte: #{result.join(', ')}"
+      end
     end
   end
 end

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -200,33 +200,54 @@ module Administrateurs
 
     def import
       if procedure.publiee_or_close?
-        if !CSV_ACCEPTED_CONTENT_TYPES.include?(group_csv_file.content_type) && !CSV_ACCEPTED_CONTENT_TYPES.include?(marcel_content_type)
+        if !CSV_ACCEPTED_CONTENT_TYPES.include?(csv_file.content_type) && !CSV_ACCEPTED_CONTENT_TYPES.include?(marcel_content_type)
           flash[:alert] = "Importation impossible : veuillez importer un fichier CSV"
 
-        elsif group_csv_file.size > CSV_MAX_SIZE
+        elsif csv_file.size > CSV_MAX_SIZE
           flash[:alert] = "Importation impossible : le poids du fichier est supérieur à #{number_to_human_size(CSV_MAX_SIZE)}"
 
         else
-          file = group_csv_file.read
+          file = csv_file.read
           base_encoding = CharlockHolmes::EncodingDetector.detect(file)
-          groupes_emails = ACSV::CSV.new_for_ruby3(file.encode("UTF-8", base_encoding[:encoding], invalid: :replace, replace: ""), headers: true, header_converters: :downcase)
-            .map { |r| r.to_h.slice('groupe', 'email') }
 
-          groupes_emails_has_keys = groupes_emails.first.has_key?("groupe") && groupes_emails.first.has_key?("email")
+          if params[:group_csv_file]
+            groupes_emails = ACSV::CSV.new_for_ruby3(file.encode("UTF-8", base_encoding[:encoding], invalid: :replace, replace: ""), headers: true, header_converters: :downcase)
+              .map { |r| r.to_h.slice('groupe', 'email') }
 
-          if groupes_emails_has_keys.blank?
-            flash[:alert] = "Importation impossible, veuillez importer un csv #{view_context.link_to('suivant ce modèle', "/csv/#{I18n.locale}/import-groupe-test.csv")}"
-          else
-            add_instructeurs_and_get_errors = InstructeursImportService.import(procedure, groupes_emails)
+            groupes_emails_has_keys = groupes_emails.first.has_key?("groupe") && groupes_emails.first.has_key?("email")
 
-            if add_instructeurs_and_get_errors.empty?
-              flash[:notice] = "La liste des instructeurs a été importée avec succès"
+            if groupes_emails_has_keys.blank?
+              flash[:alert] = "Importation impossible, veuillez importer un csv #{view_context.link_to('suivant ce modèle', "/csv/#{I18n.locale}/import-groupe-test.csv")}"
             else
-              flash[:alert] = "Import terminé. Cependant les emails suivants ne sont pas pris en compte: #{add_instructeurs_and_get_errors.join(', ')}"
+              add_instructeurs_and_get_errors = InstructeursImportService.import_groupes(procedure, groupes_emails)
+
+              if add_instructeurs_and_get_errors.blank?
+                flash[:notice] = "La liste des instructeurs a été importée avec succès"
+              else
+                flash[:alert] = "Import terminé. Cependant les emails suivants ne sont pas pris en compte: #{add_instructeurs_and_get_errors.join(', ')}"
+              end
+            end
+
+          elsif params[:instructeurs_csv_file]
+            instructors_emails = ACSV::CSV.new_for_ruby3(file.encode("UTF-8", base_encoding[:encoding], invalid: :replace, replace: ""), headers: true, header_converters: :downcase)
+              .map(&:to_h)
+
+            instructors_emails_has_key = instructors_emails.first.has_key?("email") && !instructors_emails.first.keys.many?
+
+            if instructors_emails_has_key.blank?
+              flash[:alert] = "Importation impossible, veuillez importer un csv #{view_context.link_to('suivant ce modèle', "/csv/import-instructeurs-test.csv")}"
+            else
+              add_instructeurs_and_get_errors = InstructeursImportService.import_instructeurs(procedure, instructors_emails)
+
+              if add_instructeurs_and_get_errors.blank?
+                flash[:notice] = "La liste des instructeurs a été importée avec succès"
+              else
+                flash[:alert] = "Import terminé. Cependant les emails suivants ne sont pas pris en compte: #{add_instructeurs_and_get_errors.join(', ')}"
+              end
             end
           end
+          redirect_to admin_procedure_groupe_instructeurs_path(procedure)
         end
-        redirect_to admin_procedure_groupe_instructeurs_path(procedure)
       end
     end
 
@@ -298,12 +319,12 @@ module Administrateurs
       (all - assigned).sort
     end
 
-    def group_csv_file
-      params[:group_csv_file]
+    def csv_file
+      params[:group_csv_file] || params[:instructeurs_csv_file]
     end
 
     def marcel_content_type
-      Marcel::MimeType.for(group_csv_file.read, name: group_csv_file.original_filename, declared_type: group_csv_file.content_type)
+      Marcel::MimeType.for(csv_file.read, name: csv_file.original_filename, declared_type: csv_file.content_type)
     end
 
     def instructeurs_self_management_enabled_params

--- a/app/graphql/mutations/groupe_instructeur_ajouter_instructeurs.rb
+++ b/app/graphql/mutations/groupe_instructeur_ajouter_instructeurs.rb
@@ -11,7 +11,7 @@ module Mutations
 
     def resolve(groupe_instructeur:, instructeurs:)
       ids, emails = partition_instructeurs_by(instructeurs)
-      instructeurs, invalid_emails = Instructeur.find_or_create_instructeurs(ids:, emails:, administrateurs: groupe_instructeur.procedure.administrateurs)
+      instructeurs, invalid_emails = groupe_instructeur.add_instructeurs(ids:, emails:)
 
       instructeurs.each { groupe_instructeur.add(_1) }
       groupe_instructeur.reload

--- a/app/graphql/mutations/groupe_instructeur_ajouter_instructeurs.rb
+++ b/app/graphql/mutations/groupe_instructeur_ajouter_instructeurs.rb
@@ -11,7 +11,7 @@ module Mutations
 
     def resolve(groupe_instructeur:, instructeurs:)
       ids, emails = partition_instructeurs_by(instructeurs)
-      instructeurs, invalid_emails = groupe_instructeur.add_instructeurs(ids:, emails:)
+      instructeurs, invalid_emails = Instructeur.find_or_create_instructeurs(ids:, emails:, administrateurs: groupe_instructeur.procedure.administrateurs)
 
       instructeurs.each { groupe_instructeur.add(_1) }
       groupe_instructeur.reload

--- a/app/graphql/mutations/groupe_instructeur_ajouter_instructeurs.rb
+++ b/app/graphql/mutations/groupe_instructeur_ajouter_instructeurs.rb
@@ -11,9 +11,8 @@ module Mutations
 
     def resolve(groupe_instructeur:, instructeurs:)
       ids, emails = partition_instructeurs_by(instructeurs)
-      instructeurs, invalid_emails = groupe_instructeur.add_instructeurs(ids:, emails:)
+      _, invalid_emails = groupe_instructeur.add_instructeurs(ids:, emails:)
 
-      instructeurs.each { groupe_instructeur.add(_1) }
       groupe_instructeur.reload
 
       result = { groupe_instructeur: }

--- a/app/graphql/mutations/groupe_instructeur_creer.rb
+++ b/app/graphql/mutations/groupe_instructeur_creer.rb
@@ -29,9 +29,8 @@ module Mutations
         result = { groupe_instructeur: }
 
         if emails.present? || ids.present?
-          instructeurs, invalid_emails = groupe_instructeur.add_instructeurs(ids:, emails:)
+          _, invalid_emails = groupe_instructeur.add_instructeurs(ids:, emails:)
 
-          instructeurs.each { groupe_instructeur.add(_1) }
           groupe_instructeur.reload
 
           if invalid_emails.present?

--- a/app/graphql/mutations/groupe_instructeur_creer.rb
+++ b/app/graphql/mutations/groupe_instructeur_creer.rb
@@ -29,7 +29,7 @@ module Mutations
         result = { groupe_instructeur: }
 
         if emails.present? || ids.present?
-          instructeurs, invalid_emails = groupe_instructeur.add_instructeurs(ids:, emails:)
+          instructeurs, invalid_emails = Instructeur.find_or_create_instructeurs(ids:, emails:, administrateurs: procedure.administrateurs)
 
           instructeurs.each { groupe_instructeur.add(_1) }
           groupe_instructeur.reload

--- a/app/graphql/mutations/groupe_instructeur_creer.rb
+++ b/app/graphql/mutations/groupe_instructeur_creer.rb
@@ -29,7 +29,7 @@ module Mutations
         result = { groupe_instructeur: }
 
         if emails.present? || ids.present?
-          instructeurs, invalid_emails = Instructeur.find_or_create_instructeurs(ids:, emails:, administrateurs: procedure.administrateurs)
+          instructeurs, invalid_emails = groupe_instructeur.add_instructeurs(ids:, emails:)
 
           instructeurs.each { groupe_instructeur.add(_1) }
           groupe_instructeur.reload

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -51,6 +51,25 @@ class GroupeInstructeur < ApplicationRecord
       .update_all(unfollowed_at: Time.zone.now)
   end
 
+  def add_instructeurs(ids: [], emails: [])
+    instructeurs_to_add, valid_emails, invalid_emails = Instructeur.find_all_by_identifier_with_emails(ids:, emails:)
+    not_found_emails = valid_emails - instructeurs_to_add.map(&:email)
+
+    # Send invitations to users without account
+    if not_found_emails.present?
+      instructeurs_to_add += not_found_emails.map do |email|
+        user = User.create_or_promote_to_instructeur(email, SecureRandom.hex, administrateurs: procedure.administrateurs)
+        user.invite!
+        user.instructeur
+      end
+    end
+
+    # We dont't want to assign a user to a groupe_instructeur if they are already assigned to it
+    instructeurs_to_add -= instructeurs
+
+    [instructeurs_to_add, invalid_emails]
+  end
+
   def can_delete?
     dossiers.empty? && (procedure.groupe_instructeurs.active.many? || (procedure.groupe_instructeurs.active.one? && closed))
   end

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -51,25 +51,6 @@ class GroupeInstructeur < ApplicationRecord
       .update_all(unfollowed_at: Time.zone.now)
   end
 
-  def add_instructeurs(ids: [], emails: [])
-    instructeurs_to_add, valid_emails, invalid_emails = Instructeur.find_all_by_identifier_with_emails(ids:, emails:)
-    not_found_emails = valid_emails - instructeurs_to_add.map(&:email)
-
-    # Send invitations to users without account
-    if not_found_emails.present?
-      instructeurs_to_add += not_found_emails.map do |email|
-        user = User.create_or_promote_to_instructeur(email, SecureRandom.hex, administrateurs: procedure.administrateurs)
-        user.invite!
-        user.instructeur
-      end
-    end
-
-    # We dont't want to assign a user to a groupe_instructeur if they are already assigned to it
-    instructeurs_to_add -= instructeurs
-
-    [instructeurs_to_add, invalid_emails]
-  end
-
   def can_delete?
     dossiers.empty? && (procedure.groupe_instructeurs.active.many? || (procedure.groupe_instructeurs.active.one? && closed))
   end

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -66,6 +66,7 @@ class GroupeInstructeur < ApplicationRecord
 
     # We dont't want to assign a user to a groupe_instructeur if they are already assigned to it
     instructeurs_to_add -= instructeurs
+    instructeurs_to_add.each { add(_1) }
 
     [instructeurs_to_add, invalid_emails]
   end

--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -52,22 +52,6 @@ class Instructeur < ApplicationRecord
     find_by(users: { email: email })
   end
 
-  def self.find_or_create_instructeurs(ids: [], emails: [], administrateurs:)
-    instructeurs_to_add, valid_emails, invalid_emails = Instructeur.find_all_by_identifier_with_emails(ids:, emails:)
-    not_found_emails = valid_emails - instructeurs_to_add.map(&:email)
-
-    # Send invitations to users without account
-    if not_found_emails.present?
-      instructeurs_to_add += not_found_emails.map do |email|
-        user = User.create_or_promote_to_instructeur(email, SecureRandom.hex, administrateurs: administrateurs)
-        user.invite!
-        user.instructeur
-      end
-    end
-
-    [instructeurs_to_add, invalid_emails]
-  end
-
   def self.find_all_by_identifier(ids: [], emails: [])
     find_all_by_identifier_with_emails(ids:, emails:).first
   end

--- a/app/services/instructeurs_import_service.rb
+++ b/app/services/instructeurs_import_service.rb
@@ -18,11 +18,9 @@ class InstructeursImportService
 
     target_groupes = procedure.reload.groupe_instructeurs
 
-    defaut_groupe_instructeur = procedure.defaut_groupe_instructeur
-
     instructeurs_emails = groupes_emails.map { |instructeur_email| instructeur_email["email"] }.uniq
 
-    instructeurs, invalid_emails = defaut_groupe_instructeur.add_instructeurs(emails: instructeurs_emails)
+    instructeurs, invalid_emails = Instructeur.find_or_create_instructeurs(emails: instructeurs_emails, administrateurs: procedure.administrateurs)
 
     if instructeurs.present?
       groupes_emails.each do |groupe_email|
@@ -41,7 +39,7 @@ class InstructeursImportService
 
     groupe_instructeur = procedure.defaut_groupe_instructeur
 
-    instructeurs, invalid_emails = groupe_instructeur.add_instructeurs(emails: instructeurs_emails)
+    instructeurs, invalid_emails = Instructeur.find_or_create_instructeurs(emails: instructeurs_emails, administrateurs: procedure.administrateurs)
 
     instructeurs.each { groupe_instructeur.add(_1) } if instructeurs.present?
 

--- a/app/services/instructeurs_import_service.rb
+++ b/app/services/instructeurs_import_service.rb
@@ -1,5 +1,5 @@
 class InstructeursImportService
-  def self.import(procedure, groupes_emails)
+  def self.import_groupes(procedure, groupes_emails)
     created_at = Time.zone.now
     updated_at = Time.zone.now
 
@@ -20,27 +20,46 @@ class InstructeursImportService
 
     target_groupes = procedure.reload.groupe_instructeurs
 
-    target_emails = groupes_emails.map { |groupe_email| groupe_email["email"] }.uniq
-
-    existing_emails = Instructeur.where(user: { email: target_emails }).pluck(:email)
-    missing_emails = target_emails - existing_emails
-    missing_emails.each { |email| create_instructeur(admins, email) }
-
-    target_instructeurs = User.where(email: target_emails).map(&:instructeur)
+    target_instructeurs = find_or_create_instructeurs(admins, groupes_emails)
 
     groupes_emails.each do |groupe_email|
       gi = target_groupes.find { |g| g.label == groupe_email['groupe'] }
-      instructeur = target_instructeurs.find { |i| i.email == groupe_email['email'] }
+      add_instructeur_to_groupe(target_instructeurs, groupe_email, gi)
+    end
 
-      if !gi.instructeurs.include?(instructeur)
-        gi.instructeurs << instructeur
-      end
+    errors
+  end
+
+  def self.import_instructeurs(procedure, emails)
+    admins = procedure.administrateurs
+
+    instructeurs_emails, error_instructeurs_emails = emails
+      .map { |instructeur_email| { "email" => instructeur_email["email"].present? ? instructeur_email["email"].gsub(/[[:space:]]/, '').downcase : nil } }
+      .partition { |instructeur_email| Devise.email_regexp.match?(instructeur_email['email']) }
+
+    errors = error_instructeurs_emails.map { |instructeur_email| instructeur_email['email'] }
+
+    target_instructeurs = find_or_create_instructeurs(admins, instructeurs_emails)
+
+    instructeurs_emails.each do |instructeur_email|
+      gi = procedure.defaut_groupe_instructeur
+      add_instructeur_to_groupe(target_instructeurs, instructeur_email, gi)
     end
 
     errors
   end
 
   private
+
+  def self.find_or_create_instructeurs(administrateurs, instructeurs_emails)
+    target_emails = instructeurs_emails.map { |instructeur_email| instructeur_email["email"] }.uniq
+
+    existing_emails = Instructeur.where(user: { email: target_emails }).pluck(:email)
+    missing_emails = target_emails - existing_emails
+    missing_emails.each { |email| create_instructeur(administrateurs, email) }
+
+    User.where(email: target_emails).map(&:instructeur)
+  end
 
   def self.create_instructeur(administrateurs, email)
     user = User.create_or_promote_to_instructeur(
@@ -50,5 +69,13 @@ class InstructeursImportService
     )
     user.invite!
     user.instructeur
+  end
+
+  def self.add_instructeur_to_groupe(target_instructeurs, instructeur_email, gi)
+    instructeur = target_instructeurs.find { |i| i.email == instructeur_email['email'] }
+
+    if !gi.instructeurs.include?(instructeur)
+      gi.instructeurs << instructeur
+    end
   end
 end

--- a/app/services/instructeurs_import_service.rb
+++ b/app/services/instructeurs_import_service.rb
@@ -30,8 +30,7 @@ class InstructeursImportService
       .to_h
 
     target_groupes.each do |groupe_instructeur, emails|
-      instructeurs, invalid_emails = groupe_instructeur.add_instructeurs(emails:)
-      instructeurs.each { groupe_instructeur.add(_1) }
+      _, invalid_emails = groupe_instructeur.add_instructeurs(emails:)
       errors << invalid_emails
     end
 
@@ -46,9 +45,7 @@ class InstructeursImportService
 
     groupe_instructeur = procedure.defaut_groupe_instructeur
 
-    instructeurs, invalid_emails = groupe_instructeur.add_instructeurs(emails: instructeurs_emails)
-
-    instructeurs.each { groupe_instructeur.add(_1) }
+    _, invalid_emails = groupe_instructeur.add_instructeurs(emails: instructeurs_emails)
 
     invalid_emails
   end

--- a/app/views/administrateurs/groupe_instructeurs/_edit.html.haml
+++ b/app/views/administrateurs/groupe_instructeurs/_edit.html.haml
@@ -28,11 +28,13 @@
     = form_tag import_admin_procedure_groupe_instructeurs_path(procedure), method: :post, multipart: true, class: "mt-4 form" do
       = label_tag t('.csv_import.title')
       %p.notice
-        = t('.csv_import.notice_1')
+        = procedure.routing_enabled? ? t('.csv_import.routing_enabled.notice_1') : t('.csv_import.routing_disabled.notice_1')
       %p.notice
         = t('.csv_import.notice_2', csv_max_size: number_to_human_size(csv_max_size))
-      %p.mt-2.mb-2= link_to t('.csv_import.download_exemple'), "/csv/#{I18n.locale}/import-groupe-test.csv"
-      = file_field_tag :group_csv_file, required: true, accept: 'text/csv', size: "1"
+      - sample_file_path = procedure.routing_enabled? ? "/csv/#{I18n.locale}/import-groupe-test.csv" : "/csv/import-instructeurs-test.csv"
+      %p.mt-2.mb-2= link_to t('.csv_import.download_exemple'), sample_file_path
+      - csv_params = procedure.routing_enabled? ? :group_csv_file : :instructeurs_csv_file
+      = file_field_tag csv_params, required: true, accept: 'text/csv', size: "1"
       = submit_tag t('.csv_import.import_file'), class: 'button primary send', data: { disable_with: "Envoi..." }
   - else
     %p.mt-4.form.font-weight-bold.mb-2.text-lg

--- a/config/initializers/acsv.rb
+++ b/config/initializers/acsv.rb
@@ -4,7 +4,7 @@ require 'csv'
 module ACSV
   class CSV < ::CSV
     def self.new_for_ruby3(data, options = {})
-      options[:col_sep] ||= ACSV::Detect.separator(data)
+      options[:col_sep] ||= ACSV::Detect.separator(data) || :auto
       # because of the Separation of positional and keyword arguments in Ruby 3.0
       # (https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)
       # instead of

--- a/config/locales/views/administrateurs/groupe_instructeurs/en.yml
+++ b/config/locales/views/administrateurs/groupe_instructeurs/en.yml
@@ -41,7 +41,10 @@ en:
           notice: This group will be a choice from the list "%{routing_criteria_name}"
         csv_import:
           title: CSV Import
-          notice_1: The csv file must have 2 columns (Group, Email) and be separated by commas. The import does not overwrite existing groups and instructors.
+          routing_enabled:
+            notice_1: The csv file must have 2 columns (Group, Email) and be separated by commas. The import does not overwrite existing groups and instructors.
+          routing_disabled:
+            notice_1: The csv file must have 1 column with instructors emails.
           notice_2: The size of the file must be less than %{csv_max_size}.
           download_exemple: Download sample CSV file
           import_file: Import file

--- a/config/locales/views/administrateurs/groupe_instructeurs/fr.yml
+++ b/config/locales/views/administrateurs/groupe_instructeurs/fr.yml
@@ -47,8 +47,11 @@ fr:
           notice: Ce groupe sera un choix de la liste "%{routing_criteria_name}"
         csv_import:
           title: Importer par CSV
-          notice_1: Le fichier csv doit comporter 2 colonnes (Groupe, Email) et être séparé par des virgules. Si vous n'avez pas créé de groupe, entrez « défaut » dans la colonne Groupe pour chaque instructeur. L’import n’écrase pas les groupes et les instructeurs existants. La modification du fichier csv ne s’opère que pour l’ajout de nouveaux instructeurs. La suppression d’un instructeur s’opère manuellement en cliquant sur le bouton « retirer ».
-          notice_2: Le poids du fichier doit être inférieur à %{csv_max_size}
+          routing_enabled:
+            notice_1: Le fichier csv doit comporter 2 colonnes (Groupe, Email) et être séparé par des virgules.
+          routing_disabled:
+            notice_1: Le fichier csv doit comporter 1 seule colonne (Email) avec une adresse email d'instructeur par ligne.
+          notice_2: L’import n’écrase pas les groupes et les instructeurs existants. La modification du fichier csv ne s’opère que pour l’ajout de nouveaux instructeurs. La suppression d’un instructeur s’opère manuellement en cliquant sur le bouton « retirer ». Le poids du fichier doit être inférieur à %{csv_max_size}.
           download_exemple: Télécharger l’exemple de fichier CSV
           import_file: Importer le fichier
           import_file_procedure_not_published: L’import d’instructeurs par fichier CSV est disponible une fois la démarche publiée

--- a/public/csv/import-instructeurs-test.csv
+++ b/public/csv/import-instructeurs-test.csv
@@ -1,0 +1,5 @@
+Email
+camilia@gouv.fr
+kara@gouv.fr
+simon@gouv.fr
+pauline@gouv.fr

--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -405,6 +405,17 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
       it { expect(flash.alert).to eq("Import terminé. Cependant les emails suivants ne sont pas pris en compte: kara") }
     end
 
+    context 'when the csv file has only one column' do
+      let(:csv_file) { fixture_file_upload('spec/fixtures/files/valid-instructeurs-file.csv', 'text/csv') }
+
+      before { subject }
+
+      it { expect { subject }.not_to raise_error }
+      it { expect(response.status).to eq(302) }
+      it { expect(flash.alert).to be_present }
+      it { expect(flash.alert).to eq("Importation impossible, veuillez importer un csv <a href=\"/csv/#{I18n.locale}/import-groupe-test.csv\">suivant ce modèle</a>") }
+    end
+
     context 'when the file content type is application/vnd.ms-excel' do
       let(:csv_file) { fixture_file_upload('spec/fixtures/files/groupe_avec_caracteres_speciaux.csv', "application/vnd.ms-excel") }
 

--- a/spec/fixtures/files/instructeurs-file.csv
+++ b/spec/fixtures/files/instructeurs-file.csv
@@ -1,0 +1,5 @@
+Email
+kara@beta-gouv.fr
+philippe@mail.com
+lisa@gouv.fr
+eric

--- a/spec/fixtures/files/valid-instructeurs-file.csv
+++ b/spec/fixtures/files/valid-instructeurs-file.csv
@@ -1,0 +1,4 @@
+Email
+kara@beta-gouv.fr
+philippe@mail.com
+lisa@gouv.fr

--- a/spec/services/instructeurs_import_service_spec.rb
+++ b/spec/services/instructeurs_import_service_spec.rb
@@ -1,5 +1,5 @@
 describe InstructeursImportService do
-  describe '#import' do
+  describe '#import_groupes' do
     let(:procedure) { create(:procedure) }
 
     let(:procedure_groupes) do
@@ -9,7 +9,7 @@ describe InstructeursImportService do
         .to_h
     end
 
-    subject { described_class.import(procedure, lines) }
+    subject { described_class.import_groupes(procedure, lines) }
 
     context 'nominal case' do
       let(:lines) do
@@ -20,7 +20,7 @@ describe InstructeursImportService do
         ]
       end
 
-      it 'imports' do
+      it 'imports groupes' do
         errors = subject
 
         expect(procedure_groupes.keys).to contain_exactly("Auvergne Rhone-Alpes", "Occitanie", "défaut")
@@ -123,6 +123,23 @@ describe InstructeursImportService do
         expect(procedure_groupes["défaut"]).to be_empty
 
         expect(errors).to contain_exactly("ringo@starr.uk", "paul@starr.uk")
+      end
+    end
+  end
+
+  describe '#import_instructeurs' do
+    let(:procedure_non_routee) { create(:procedure) }
+
+    subject { described_class.import_instructeurs(procedure_non_routee, emails) }
+
+    context 'nominal case' do
+      let(:emails) { [{ "email" => "john@lennon.fr" }, { "email" => "paul@mccartney.uk" }, { "email" => "ringo@starr.uk" }] }
+
+      it 'imports instructeurs' do
+        errors = subject
+        expect(procedure_non_routee.defaut_groupe_instructeur.instructeurs.pluck(:email)).to contain_exactly("john@lennon.fr", "paul@mccartney.uk", "ringo@starr.uk")
+
+        expect(errors).to match_array([])
       end
     end
   end


### PR DESCRIPTION
Voir #8251 
Initialement, l'import des instructeurs était prévu uniquement pour les procédures routées : un csv avec deux colonnes (Email, Groupe).
Récemment (https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/8182/), on a modifié le texte pour expliquer comment faire un import sur une procédure non routée : mettre "défaut" à chaque ligne dans la colonne groupe, mais ça posait des problèmes : 
- pas intuitif pour l'admin
- cette solution ne marchait pas si le routage avait été activé, puis désactivé, et qu'entre les deux le nom du groupe avait été changé.

Dans cette PR : 
- Si la procédure n'est pas routée, l'import se fait avec un fichier CSV d'une seule colonne, dont l'en-tête est Email  
- Contrairement à ce qui est demandé dans le ticket, on n'ouvre pas l'import aux démarches en brouillon. Dans cette PR https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/6819, on avait restreint l'import aux démarches publiées parce que l'import en test notifiait les instructeurs. Ça me semble bien comme ça

Procédure routée : 

![image](https://user-images.githubusercontent.com/29131404/213283342-943fa2ce-28ff-4068-8d24-cdb05246e832.png)

L'exemple de fichier csv : 

![image](https://user-images.githubusercontent.com/29131404/213283490-69b5b0fc-66b4-4839-8212-614f4fcb3937.png)

Procédure non routée : 

![image](https://user-images.githubusercontent.com/29131404/213284016-36311d37-324b-49d0-b119-72296264ec22.png)

L'exemple de fichier csv : 

![image](https://user-images.githubusercontent.com/29131404/213284141-5f4fe4cc-ac48-491e-817b-e44399c52c6d.png)

