### PR TITLE
Correction d'une typo sur le message flash des archives

### DIFF
--- a/app/controllers/administrateurs/archives_controller.rb
+++ b/app/controllers/administrateurs/archives_controller.rb
@@ -17,7 +17,7 @@ module Administrateurs
       archive = Archive.find_or_create_archive(type, year_month, all_groupe_instructeurs)
       if archive.pending?
         ArchiveCreationJob.perform_later(@procedure, archive, current_administrateur)
-        flash[:notice] = "Votre demande a été prise en compte. Selon le nombre de dossiers, cela peut prendre de quelques minutes a plusieurs heures. Vous recevrez un courriel lorsque le fichier sera disponible."
+        flash[:notice] = "Votre demande a été prise en compte. Selon le nombre de dossiers, cela peut prendre de quelques minutes à plusieurs heures. Vous recevrez un courriel lorsque le fichier sera disponible."
       else
         flash[:notice] = "Cette archive a déjà été générée."
       end

--- a/app/controllers/instructeurs/archives_controller.rb
+++ b/app/controllers/instructeurs/archives_controller.rb
@@ -16,7 +16,7 @@ module Instructeurs
       archive = Archive.find_or_create_archive(type, year_month, groupe_instructeurs)
       if archive.pending?
         ArchiveCreationJob.perform_later(@procedure, archive, current_instructeur)
-        flash[:notice] = "Votre demande a été prise en compte. Selon le nombre de dossiers, cela peut prendre de quelques minutes a plusieurs heures. Vous recevrez un courriel lorsque le fichier sera disponible."
+        flash[:notice] = "Votre demande a été prise en compte. Selon le nombre de dossiers, cela peut prendre de quelques minutes à plusieurs heures. Vous recevrez un courriel lorsque le fichier sera disponible."
       else
         flash[:notice] = "Cette archive a déjà été générée."
       end

--- a/spec/system/administrateurs/procedure_archive_and_export_spec.rb
+++ b/spec/system/administrateurs/procedure_archive_and_export_spec.rb
@@ -31,7 +31,7 @@ describe 'Creating a new procedure', js: true do
     expect {
       page.first(".archive-table .button").click
     }.to have_enqueued_job(ArchiveCreationJob).with(procedure, an_instance_of(Archive), administrateur)
-    expect(page).to have_content("Votre demande a été prise en compte. Selon le nombre de dossiers, cela peut prendre de quelques minutes a plusieurs heures. Vous recevrez un courriel lorsque le fichier sera disponible.")
+    expect(page).to have_content("Votre demande a été prise en compte. Selon le nombre de dossiers, cela peut prendre de quelques minutes à plusieurs heures. Vous recevrez un courriel lorsque le fichier sera disponible.")
     expect(Archive.first.month).not_to be_nil
 
     # check exports


### PR DESCRIPTION
# Résumé

<!-- décrire en quelques phrases la problématique adressée -->

Correction d'une typo sur le message flash des archives.

mots-clés : archive, flash, message

fixes à référencer / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`