### PR TITLE
S3 storage support

### DIFF
--- a/config/env.example
+++ b/config/env.example
@@ -37,6 +37,12 @@ BASIC_AUTH_PASSWORD=""
 # (See config/storage.yml for the configuration of each service.)
 ACTIVE_STORAGE_SERVICE="local"
 
+# Configuration for the S3 storage service (if enabled)
+S3_ACCESS_KEY_ID=""
+S3_SECRET_ACCESS_KEY=""
+S3_REGION=""
+S3_BUCKET=""
+
 # Configuration for the OpenStack storage service (if enabled)
 FOG_OPENSTACK_API_KEY=""
 FOG_OPENSTACK_USERNAME=""

--- a/config/env.example
+++ b/config/env.example
@@ -37,12 +37,6 @@ BASIC_AUTH_PASSWORD=""
 # (See config/storage.yml for the configuration of each service.)
 ACTIVE_STORAGE_SERVICE="local"
 
-# Configuration for the S3 storage service (if enabled)
-S3_ACCESS_KEY_ID=""
-S3_SECRET_ACCESS_KEY=""
-S3_REGION=""
-S3_BUCKET=""
-
 # Configuration for the OpenStack storage service (if enabled)
 FOG_OPENSTACK_API_KEY=""
 FOG_OPENSTACK_USERNAME=""

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -146,6 +146,11 @@ DATAGOUV_DESCRIPTIF_DEMARCHES_RESOURCE="resourceid"
 # Zonage
 ZONAGE_ENABLED='enabled' # zonage disabled by default if `ZONAGE_ENABLED` not set
 
+# Configuration for the S3 storage service (if enabled)
+S3_ACCESS_KEY_ID=""
+S3_SECRET_ACCESS_KEY=""
+S3_REGION=""
+S3_BUCKET=""
 
 # SAML
 SAML_IDP_CERTIFICATE="idpcertificate"

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -22,6 +22,7 @@ Rails.application.config.content_security_policy do |policy|
 
   connect_whitelist = ["wss://*.crisp.chat", "*.crisp.chat", "app.franceconnect.gouv.fr", "openmaptiles.geo.data.gouv.fr", "openmaptiles.github.io", "tiles.geo.api.gouv.fr", "wxs.ign.fr"]
   connect_whitelist << ENV.fetch('APP_HOST')
+  connect_whitelist << "*.amazonaws.com" if Rails.configuration.active_storage.service == :amazon
   connect_whitelist += [URI(ENV["SENTRY_DSN_JS"]).host, URI(ENV["SENTRY_DSN_RAILS"]).host].compact.uniq
   connect_whitelist << URI(DS_PROXY_URL).host if DS_PROXY_URL.present?
   connect_whitelist << URI(API_ADRESSE_URL).host if API_ADRESSE_URL.present?

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -13,3 +13,9 @@ openstack:
     openstack_username: "<%= ENV['FOG_OPENSTACK_USERNAME'] %>"
     openstack_region: "<%= ENV['FOG_OPENSTACK_REGION'] %>"
     openstack_temp_url_key: "<%= ENV['FOG_OPENSTACK_TEMP_URL_KEY'] %>"
+amazon:
+  service: S3
+  access_key_id: <%= ENV.fetch("S3_ACCESS_KEY_ID", "") %>
+  secret_access_key: <%= ENV.fetch("S3_SECRET_ACCESS_KEY", "") %>
+  region: <%= ENV.fetch("S3_REGION", "") %>
+  bucket: <%= ENV.fetch("S3_BUCKET", "") %>


### PR DESCRIPTION
# Résumé

<!-- décrire en quelques phrases la problématique adressée -->

Ajout du support S3 chez Amazon pour ActiveStorage. Cela été déjà mentionné en commentaire, mais pas effectivement supporté.

mots-clés : activestorage, amazon, aws, s3

fixes à référencer / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`