### PR TITLE
Substitution de la variable FAQ_URL par des locales

### DIFF
--- a/app/lib/helpscout/form_adapter.rb
+++ b/app/lib/helpscout/form_adapter.rb
@@ -3,9 +3,9 @@ class Helpscout::FormAdapter
 
   def self.options
     [
-      [I18n.t(:question, scope: [:support, :index, TYPE_INFO]), TYPE_INFO, FAQ_CONTACTER_SERVICE_EN_CHARGE_URL],
+      [I18n.t(:question, scope: [:support, :index, TYPE_INFO]), TYPE_INFO, I18n.t("links.common.faq.contacter_service_en_charge_url")],
       [I18n.t(:question, scope: [:support, :index, TYPE_PERDU]), TYPE_PERDU, LISTE_DES_DEMARCHES_URL],
-      [I18n.t(:question, scope: [:support, :index, TYPE_INSTRUCTION]), TYPE_INSTRUCTION, FAQ_OU_EN_EST_MON_DOSSIER_URL],
+      [I18n.t(:question, scope: [:support, :index, TYPE_INSTRUCTION]), TYPE_INSTRUCTION, I18n.t("links.common.faq.ou_en_est_mon_dossier_url")],
       [I18n.t(:question, scope: [:support, :index, TYPE_AMELIORATION]), TYPE_AMELIORATION, FEATURE_UPVOTE_URL],
       [I18n.t(:question, scope: [:support, :index, TYPE_AUTRE]), TYPE_AUTRE]
     ]

--- a/app/views/layouts/_header.haml
+++ b/app/views/layouts/_header.haml
@@ -51,7 +51,7 @@
                   = render partial: 'shared/help/help_dropdown_instructeur'
                 - else
                   // NB: on mobile in order to have links correctly aligned, we need a left icon
-                  = link_to t('help'), FAQ_URL, class: 'fr-btn fr-icon-questionnaire-line fr-btn--icon-left', title: new_tab_suffix(t('help')), **external_link_attributes
+                  = link_to t('help'), t("links.footer.faq.url"), class: 'fr-btn fr-icon-questionnaire-line fr-btn--icon-left', title: new_tab_suffix(t('help')), **external_link_attributes
 
 
 

--- a/app/views/layouts/_header.haml
+++ b/app/views/layouts/_header.haml
@@ -51,7 +51,7 @@
                   = render partial: 'shared/help/help_dropdown_instructeur'
                 - else
                   // NB: on mobile in order to have links correctly aligned, we need a left icon
-                  = link_to t('help'), t("links.footer.faq.url"), class: 'fr-btn fr-icon-questionnaire-line fr-btn--icon-left', title: new_tab_suffix(t('help')), **external_link_attributes
+                  = link_to t('help'), t("links.common.faq.url"), class: 'fr-btn fr-icon-questionnaire-line fr-btn--icon-left', title: new_tab_suffix(t('help')), **external_link_attributes
 
 
 

--- a/app/views/layouts/commencer/_no_procedure.html.haml
+++ b/app/views/layouts/commencer/_no_procedure.html.haml
@@ -12,4 +12,4 @@
       %span.small-simple= t('.are_you_new', app_name: APPLICATION_NAME.gsub("-","&#8209;")).html_safe
       %br
       %br
-      = link_to t('views.users.sessions.new.find_procedure'), COMMENT_TROUVER_MA_DEMARCHE_URL, title: new_tab_suffix(t('views.users.sessions.new.find_procedure')), class: "fr-btn fr-btn--secondary", **external_link_attributes
+      = link_to t('views.users.sessions.new.find_procedure'), t("links.common.faq.comment_trouver_ma_demarche_url"), title: new_tab_suffix(t('views.users.sessions.new.find_procedure')), class: "fr-btn fr-btn--secondary", **external_link_attributes

--- a/app/views/root/_footer.html.haml
+++ b/app/views/root/_footer.html.haml
@@ -28,7 +28,7 @@
             %li.fr-footer__top-link
               = link_to t("links.footer.api_doc.label"), t("links.footer.api_doc.url"), title: t("links.footer.api_doc.title"), class: "fr-footer__top-link", rel: "noopener noreferrer"
             %li.fr-footer__top-link
-              = link_to t("links.footer.faq.label"), t("links.footer.faq.url"), title: t("links.footer.faq.title"), class: "fr-footer__top-link", rel: "noopener noreferrer"
+              = link_to t("links.common.faq.label"), t("links.common.faq.url"), title: t("links.common.faq.title"), class: "fr-footer__top-link", rel: "noopener noreferrer"
             %li.fr-footer__top-link
               = link_to t("links.footer.code.label"), t("links.footer.code.url"), title: t("links.footer.code.title"), class: "fr-footer__top-link", rel: "noopener noreferrer"
         .fr-col-12.fr-col-sm-3.fr-col-md-3

--- a/app/views/root/administration.html.haml
+++ b/app/views/root/administration.html.haml
@@ -120,4 +120,4 @@
           %h1.cta-panel-title Une question, un problème ?
           %p.cta-panel-explanation Consultez notre FAQ
         %div
-          = link_to "Voir la FAQ", t("links.footer.faq.url"), class: "fr-btn fr-btn--lg", **external_link_attributes
+          = link_to "Voir la FAQ", t("links.common.faq.url"), class: "fr-btn fr-btn--lg", **external_link_attributes

--- a/app/views/root/administration.html.haml
+++ b/app/views/root/administration.html.haml
@@ -120,4 +120,4 @@
           %h1.cta-panel-title Une question, un problème ?
           %p.cta-panel-explanation Consultez notre FAQ
         %div
-          = link_to "Voir la FAQ", FAQ_URL, class: "fr-btn fr-btn--lg", **external_link_attributes
+          = link_to "Voir la FAQ", t("links.footer.faq.url"), class: "fr-btn fr-btn--lg", **external_link_attributes

--- a/app/views/root/landing.html.haml
+++ b/app/views/root/landing.html.haml
@@ -51,7 +51,7 @@
           %h2.cta-panel-title= t(".question")
           %p.cta-panel-explanation= t(".answer_in_faq")
         %div
-          = link_to t(".online_help"), FAQ_URL, class: "fr-btn fr-btn--lg", title: new_tab_suffix(t(".online_help")), **external_link_attributes
+          = link_to t(".online_help"), t("links.footer.faq.url"), class: "fr-btn fr-btn--lg", title: new_tab_suffix(t(".online_help")), **external_link_attributes
         -#   We temporarily disable the link to the contact page on the homepage
         -#   %p.cta-panel-explanation Notre équipe est disponible pour vous renseigner et vous aider
         -# %div

--- a/app/views/root/landing.html.haml
+++ b/app/views/root/landing.html.haml
@@ -23,7 +23,7 @@
           %h2= t(".have_a_procedure")
           %p.fr-h5= t(".fill_procedure")
 
-          = link_to t(".how_to_find_procedure"), COMMENT_TROUVER_MA_DEMARCHE_URL, class: "fr-btn fr-btn--lg fr-mr-1w fr-mb-2w", title: new_tab_suffix(t(".how_to_find_procedure")), **external_link_attributes
+          = link_to t(".how_to_find_procedure"), t("links.common.faq.comment_trouver_ma_demarche_url"), class: "fr-btn fr-btn--lg fr-mr-1w fr-mb-2w", title: new_tab_suffix(t(".how_to_find_procedure")), **external_link_attributes
           = link_to t("views.users.sessions.new.connection"), new_user_session_path, class: "fr-btn fr-btn--secondary fr-btn--lg"
 
   - cache [I18n.locale, "numbers-panel"], expires_in: 3.hours do

--- a/app/views/root/landing.html.haml
+++ b/app/views/root/landing.html.haml
@@ -51,7 +51,7 @@
           %h2.cta-panel-title= t(".question")
           %p.cta-panel-explanation= t(".answer_in_faq")
         %div
-          = link_to t(".online_help"), t("links.footer.faq.url"), class: "fr-btn fr-btn--lg", title: new_tab_suffix(t(".online_help")), **external_link_attributes
+          = link_to t(".online_help"), t("links.common.faq.url"), class: "fr-btn fr-btn--lg", title: new_tab_suffix(t(".online_help")), **external_link_attributes
         -#   We temporarily disable the link to the contact page on the homepage
         -#   %p.cta-panel-explanation Notre équipe est disponible pour vous renseigner et vous aider
         -# %div

--- a/app/views/shared/champs/siret/_etablissement.html.haml
+++ b/app/views/shared/champs/siret/_etablissement.html.haml
@@ -4,7 +4,7 @@
 
 - when :not_found
   Nous n’avons pas trouvé d’établissement correspondant à ce numéro de SIRET.
-  = link_to('Plus d’informations', FAQ_ERREUR_SIRET_URL, target: '_blank', rel: 'noopener')
+  = link_to('Plus d’informations', t("links.common.faq.erreur_siret_url"), **external_link_attributes)
 
 - when :network_error
   = t('errors.messages.siret_network_error')

--- a/app/views/shared/dossiers/_autosave.html.haml
+++ b/app/views/shared/dossiers/_autosave.html.haml
@@ -5,7 +5,7 @@
         = t('views.users.dossiers.autosave.draft_explanation')
       - else
         = t('views.users.dossiers.autosave.explanation')
-    = link_to t('views.users.dossiers.autosave.more_information'), FAQ_AUTOSAVE_URL, target: '_blank', rel: 'noopener', class: 'autosave-more-infos fr-link fr-link--sm'
+    = link_to t('views.users.dossiers.autosave.more_information'), t("links.common.faq.autosave_url"), class: 'autosave-more-infos fr-link fr-link--sm', **external_link_attributes
 
   %p.autosave-status.succeeded
     %span.autosave-icon.icon.accept
@@ -14,7 +14,7 @@
         = t('views.users.dossiers.autosave.draft_confirmation')
       - else
         = t('views.users.dossiers.autosave.confirmation')
-    = link_to t('views.users.dossiers.autosave.more_information'), FAQ_AUTOSAVE_URL, target: '_blank', rel: 'noopener', class: 'autosave-more-infos fr-link fr-link--sm'
+    = link_to t('views.users.dossiers.autosave.more_information'), t("links.common.faq.autosave_url"), class: 'autosave-more-infos fr-link fr-link--sm', **external_link_attributes
 
   %p.autosave-status.failed
     %span.autosave-icon ⚠️

--- a/app/views/shared/help/dropdown_items/_faq_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_faq_item.html.haml
@@ -1,5 +1,5 @@
 %li
-  = link_to t("links.footer.faq.url"), title: new_tab_suffix(t('help_dropdown.general_title')), **external_link_attributes do
+  = link_to t("links.common.faq.url"), title: new_tab_suffix(t('help_dropdown.general_title')), **external_link_attributes do
     %span.icon.help
     .dropdown-description
       %span.help-dropdown-title

--- a/app/views/shared/help/dropdown_items/_faq_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_faq_item.html.haml
@@ -1,5 +1,5 @@
 %li
-  = link_to FAQ_URL, title: new_tab_suffix(t('help_dropdown.general_title')), **external_link_attributes do
+  = link_to t("links.footer.faq.url"), title: new_tab_suffix(t('help_dropdown.general_title')), **external_link_attributes do
     %span.icon.help
     .dropdown-description
       %span.help-dropdown-title

--- a/app/views/users/confirmations/new.html.haml
+++ b/app/views/users/confirmations/new.html.haml
@@ -34,5 +34,5 @@
 
       %p
         Vous pouvez également consulter notre
-        = link_to('FAQ', FAQ_EMAIL_NON_RECU_URL, title: new_tab_suffix('FAQ'), **external_link_attributes)
+        = link_to(t("links.common.faq.label"), t("links.common.faq.email_non_recu_url"), title: new_tab_suffix(t("links.common.faq.title")), **external_link_attributes)
         \.

--- a/app/views/users/sessions/link_sent.html.haml
+++ b/app/views/users/sessions/link_sent.html.haml
@@ -15,6 +15,6 @@
 
   %section.link-sent-help
     %p
-      Si vous voyez cette page trop souvent, consultez notre aide : #{link_to FAQ_CONFIRMER_COMPTE_CHAQUE_CONNEXION_URL, FAQ_CONFIRMER_COMPTE_CHAQUE_CONNEXION_URL, target: '_blank', rel: 'noopener' }
+      Si vous voyez cette page trop souvent, consultez notre aide : #{link_to t("links.common.faq.confirmer_compte_chaque_connexion_url"), **external_link_attributes}
     %p
       = t('views.users.shared.contact_us_if_any_trouble_html', href: contact_admin_url)

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -39,9 +39,6 @@ DS_ENV="staging"
 # Instance customization: URL of the documentation website
 # DOC_URL="https://doc.demarches-simplifiees.fr"
 
-# Instance customization: URL of the documentation support website
-# FAQ_URL="https://faq.demarches-simplifiees.fr"
-
 # Instance customization: URL of the accessibility statement
 # ACCESSIBILITE_URL=""
 

--- a/config/initializers/02_urls.rb
+++ b/config/initializers/02_urls.rb
@@ -37,16 +37,6 @@ ARCHIVAGE_DOC_URL = [DOC_URL, "pour-aller-plus-loin", "archivage-longue-duree-de
 DOC_INTEGRATION_MONAVIS_URL = [DOC_URL, "tutoriels", "integration-du-bouton-mon-avis"].join("/")
 DOC_PROCEDURE_EXPIRES_URL = [DOC_URL, "expiration-et-suppression-des-dossiers"].join("/")
 
-FAQ_URL = ENV.fetch("FAQ_URL", "https://faq.demarches-simplifiees.fr")
-FAQ_ADMIN_URL = [FAQ_URL, "collection", "1-administrateur-creation-dun-formulaire"].join("/")
-FAQ_AUTOSAVE_URL = [FAQ_URL, "article", "77-enregistrer-mon-formulaire-pour-le-reprendre-plus-tard?preview=5ec28ca1042863474d1aee00"].join("/")
-COMMENT_TROUVER_MA_DEMARCHE_URL = [FAQ_URL, "article", "59-comment-trouver-ma-demarche"].join("/")
-FAQ_CONFIRMER_COMPTE_CHAQUE_CONNEXION_URL = [FAQ_URL, "article", "34-je-dois-confirmer-mon-compte-a-chaque-connexion"].join("/")
-FAQ_EMAIL_NON_RECU_URL = [FAQ_URL, "article", "79-je-ne-recois-pas-demail"].join("/")
-FAQ_CONTACTER_SERVICE_EN_CHARGE_URL = [FAQ_URL, "article", "12-contacter-le-service-en-charge-de-ma-demarche"].join("/")
-FAQ_OU_EN_EST_MON_DOSSIER_URL = [FAQ_URL, "article", "11-je-veux-savoir-ou-en-est-linstruction-de-ma-demarche"].join("/")
-FAQ_ERREUR_SIRET_URL = [FAQ_URL, "article", "4-erreur-siret"].join("/")
-
 STATUS_PAGE_URL = ENV.fetch("STATUS_PAGE_URL", "https://status.demarches-simplifiees.fr")
 DEMANDE_INSCRIPTION_ADMIN_PAGE_URL = ENV.fetch("DEMANDE_INSCRIPTION_ADMIN_PAGE_URL", "https://www.demarches-simplifiees.fr/commencer/demande-d-inscription-a-demarches-simplifiees")
 MATOMO_IFRAME_URL = ENV.fetch("MATOMO_IFRAME_URL", "https://#{ENV.fetch('MATOMO_HOST', 'stats.data.gouv.fr')}/index.php?module=CoreAdminHome&action=optOut&language=fr&&fontColor=333333&fontSize=16px&fontFamily=Muli")

--- a/config/locales/links.en.yml
+++ b/config/locales/links.en.yml
@@ -4,13 +4,18 @@ en:
       provided_by: "la DINUM"
       title: "Direction Interministérielle au Numérique"
       url: "https://numerique.gouv.fr"
+    common:
+      faq:
+        label: "FAQ"
+        title: "Frequently Asked Questions"
+        url: "https://faq.demarches-simplifiees.fr"
     footer:
       top_labels:
         communication: Communication
         legals: Legal information
         resources: Resources
         diagnostic: Diagnostic
-      description_1: Démarches simplifiées is powered by 
+      description_1: Démarches simplifiées is powered by
       link_1_label: the interdepartmental direction of digital (DINUM).
       link_1_url: "https://www.numerique.gouv.fr/dinum/"
       link_2_label: The source code
@@ -40,10 +45,6 @@ en:
         label: "Documentation"
         title: "Our Documentation"
         url: "https://doc.demarches-simplifiees.fr"
-      faq:
-        label: "FAQ"
-        title: "Frequently Asked Questions"
-        url: "https://faq.demarches-simplifiees.fr"
       mentions_legales:
         label: "Legal notices"
         title: "Legal notices regarding our platform"

--- a/config/locales/links.en.yml
+++ b/config/locales/links.en.yml
@@ -9,6 +9,13 @@ en:
         label: "FAQ"
         title: "Frequently Asked Questions"
         url: "https://faq.demarches-simplifiees.fr"
+        autosave_url: "https://faq.demarches-simplifiees.fr/article/77-enregistrer-mon-formulaire-pour-le-reprendre-plus-tard?preview=5ec28ca1042863474d1aee00"
+        comment_trouver_ma_demarche_url: "https://faq.demarches-simplifiees.fr/article/59-comment-trouver-ma-demarche"
+        confirmer_compte_chaque_connexion_url: "https://faq.demarches-simplifiees.fr/article/34-je-dois-confirmer-mon-compte-a-chaque-connexion"
+        contacter_service_en_charge_url: "https://faq.demarches-simplifiees.fr/article/12-contacter-le-service-en-charge-de-ma-demarche"
+        email_non_recu_url: "https://faq.demarches-simplifiees.fr/article/79-je-ne-recois-pas-demail"
+        erreur_siret_url: "https://faq.demarches-simplifiees.fr/article/4-erreur-siret"
+        ou_en_est_mon_dossier_url: "https://faq.demarches-simplifiees.fr/article/11-je-veux-savoir-ou-en-est-linstruction-de-ma-demarche"
     footer:
       top_labels:
         communication: Communication

--- a/config/locales/links.fr.yml
+++ b/config/locales/links.fr.yml
@@ -9,6 +9,13 @@ fr:
         label: "FAQ"
         title: "Foire aux Questions"
         url: "https://faq.demarches-simplifiees.fr"
+        autosave_url: "https://faq.demarches-simplifiees.fr/article/77-enregistrer-mon-formulaire-pour-le-reprendre-plus-tard?preview=5ec28ca1042863474d1aee00"
+        comment_trouver_ma_demarche_url: "https://faq.demarches-simplifiees.fr/article/59-comment-trouver-ma-demarche"
+        confirmer_compte_chaque_connexion_url: "https://faq.demarches-simplifiees.fr/article/34-je-dois-confirmer-mon-compte-a-chaque-connexion"
+        contacter_service_en_charge_url: "https://faq.demarches-simplifiees.fr/article/12-contacter-le-service-en-charge-de-ma-demarche"
+        email_non_recu_url: "https://faq.demarches-simplifiees.fr/article/79-je-ne-recois-pas-demail"
+        erreur_siret_url: "https://faq.demarches-simplifiees.fr/article/4-erreur-siret"
+        ou_en_est_mon_dossier_url: "https://faq.demarches-simplifiees.fr/article/11-je-veux-savoir-ou-en-est-linstruction-de-ma-demarche"
     footer:
       top_labels:
         communication: Communication

--- a/config/locales/links.fr.yml
+++ b/config/locales/links.fr.yml
@@ -4,6 +4,11 @@ fr:
       provided_by: "la DINUM"
       title: "Direction Interministérielle au Numérique"
       url: "https://numerique.gouv.fr"
+    common:
+      faq:
+        label: "FAQ"
+        title: "Foire aux Questions"
+        url: "https://faq.demarches-simplifiees.fr"
     footer:
       top_labels:
         communication: Communication
@@ -43,10 +48,6 @@ fr:
         label: "Documentation"
         title: "Documentation utilisateur"
         url: "https://doc.demarches-simplifiees.fr"
-      faq:
-        label: "FAQ"
-        title: "Foire aux Questions"
-        url: "https://faq.demarches-simplifiees.fr"
       mentions_legales:
         label: "Mentions légales"
         title: "Consulter nos Mentions légales"

--- a/spec/system/help_spec.rb
+++ b/spec/system/help_spec.rb
@@ -19,7 +19,7 @@ describe 'Getting help:' do
       within('.help-dropdown') do
         expect(page).to have_content(procedure.service.email)
         expect(page).to have_content(procedure.service.telephone)
-        expect(page).to have_link(nil, href: I18n.t("links.footer.faq.url"))
+        expect(page).to have_link(nil, href: I18n.t("links.common.faq.url"))
       end
     end
   end
@@ -52,7 +52,7 @@ describe 'Getting help:' do
         within('.help-dropdown') do
           expect(page).to have_content(dossier.procedure.service.email)
           expect(page).to have_content(dossier.procedure.service.telephone)
-          expect(page).to have_link(nil, href: I18n.t("links.footer.faq.url"))
+          expect(page).to have_link(nil, href: I18n.t("links.common.faq.url"))
         end
       end
     end
@@ -69,7 +69,7 @@ describe 'Getting help:' do
 
         within('.help-dropdown') do
           expect(page).to have_link(nil, href: messagerie_dossier_path(dossier))
-          expect(page).to have_link(nil, href: I18n.t("links.footer.faq.url"))
+          expect(page).to have_link(nil, href: I18n.t("links.common.faq.url"))
         end
       end
     end
@@ -91,7 +91,7 @@ describe 'Getting help:' do
   end
 
   def have_help_button
-    have_link('Aide', href: I18n.t("links.footer.faq.url"))
+    have_link('Aide', href: I18n.t("links.common.faq.url"))
   end
 
   def have_help_menu

--- a/spec/system/help_spec.rb
+++ b/spec/system/help_spec.rb
@@ -19,7 +19,7 @@ describe 'Getting help:' do
       within('.help-dropdown') do
         expect(page).to have_content(procedure.service.email)
         expect(page).to have_content(procedure.service.telephone)
-        expect(page).to have_link(nil, href: FAQ_URL)
+        expect(page).to have_link(nil, href: I18n.t("links.footer.faq.url"))
       end
     end
   end
@@ -52,7 +52,7 @@ describe 'Getting help:' do
         within('.help-dropdown') do
           expect(page).to have_content(dossier.procedure.service.email)
           expect(page).to have_content(dossier.procedure.service.telephone)
-          expect(page).to have_link(nil, href: FAQ_URL)
+          expect(page).to have_link(nil, href: I18n.t("links.footer.faq.url"))
         end
       end
     end
@@ -69,7 +69,7 @@ describe 'Getting help:' do
 
         within('.help-dropdown') do
           expect(page).to have_link(nil, href: messagerie_dossier_path(dossier))
-          expect(page).to have_link(nil, href: FAQ_URL)
+          expect(page).to have_link(nil, href: I18n.t("links.footer.faq.url"))
         end
       end
     end
@@ -91,7 +91,7 @@ describe 'Getting help:' do
   end
 
   def have_help_button
-    have_link('Aide', href: FAQ_URL)
+    have_link('Aide', href: I18n.t("links.footer.faq.url"))
   end
 
   def have_help_menu

--- a/spec/views/layouts/_header_spec.rb
+++ b/spec/views/layouts/_header_spec.rb
@@ -23,7 +23,7 @@ describe 'layouts/_header.html.haml', type: :view do
     it { is_expected.to_not have_css(".account-btn") }
 
     it 'displays the Help link' do
-      expect(subject).to have_link('Aide', href: FAQ_URL)
+      expect(subject).to have_link('Aide', href: I18n.t("links.footer.faq.url"))
     end
 
     context 'when on a procedure page' do
@@ -48,7 +48,7 @@ describe 'layouts/_header.html.haml', type: :view do
     it { is_expected.to have_selector(:button, user.email, class: "account-btn") }
 
     it 'displays the Help button' do
-      expect(subject).to have_link("Aide", href: FAQ_URL)
+      expect(subject).to have_link("Aide", href: I18n.t("links.footer.faq.url"))
     end
   end
 

--- a/spec/views/layouts/_header_spec.rb
+++ b/spec/views/layouts/_header_spec.rb
@@ -23,7 +23,7 @@ describe 'layouts/_header.html.haml', type: :view do
     it { is_expected.to_not have_css(".account-btn") }
 
     it 'displays the Help link' do
-      expect(subject).to have_link('Aide', href: I18n.t("links.footer.faq.url"))
+      expect(subject).to have_link('Aide', href: I18n.t("links.common.faq.url"))
     end
 
     context 'when on a procedure page' do
@@ -48,7 +48,7 @@ describe 'layouts/_header.html.haml', type: :view do
     it { is_expected.to have_selector(:button, user.email, class: "account-btn") }
 
     it 'displays the Help button' do
-      expect(subject).to have_link("Aide", href: I18n.t("links.footer.faq.url"))
+      expect(subject).to have_link("Aide", href: I18n.t("links.common.faq.url"))
     end
   end
 


### PR DESCRIPTION
# Résumé

<!-- décrire en quelques phrases la problématique adressée -->

Un double usage existait avec, d'un côté, la variable d'env `FAQ_URL` utilisée directement ou pour construire d'autres URLs, et par ailleurs une locale `links.footer.faq.url` utilisée dans le pied de page et pouvant être surchargée pour une instance DS donnée (c'est par exemple le cas sur l'instance de l'Adullact).

Cette PR vise à uniformiser l'usage en faisait systématiquement appel aux locales et en supprimant définitivement toute occurrence de la variable d'env `FAQ_URL`. Ce faisant, il est à présent possible pour une instance donnée de pointer vers une page particulière de sa propre FAQ ou vers la page par défaut de l'instance officielle.

**Bonus** : grâce à l'utilisation de locales, les URLs pointant vers des pages de la FAQ peuvent être adaptées pour chaque locale.  

mots-clés : env, faq, locale, url

fixes à référencer / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`