### PR TITLE
fix(mailers): observers for balancer and balanced delivery methods

### DIFF
--- a/config/initializers/mail_observers.rb
+++ b/config/initializers/mail_observers.rb
@@ -1,3 +1,6 @@
-Rails.application.configure do
-  config.action_mailer.observers = ['EmailDeliveryObserver']
+# Must be registered *before* loading custom delivery methods
+# otherwise the observer won't be invoked.
+#
+ActiveSupport.on_load(:action_mailer) do |mailer|
+  mailer.register_observer EmailDeliveryObserver
 end

--- a/spec/lib/balancer_delivery_method_spec.rb
+++ b/spec/lib/balancer_delivery_method_spec.rb
@@ -83,6 +83,24 @@ RSpec.describe BalancerDeliveryMethod do
     end
   end
 
+  context 'when observers are configured' do
+    let(:observer) { double("Observer") }
+
+    before do
+      allow(observer).to receive(:delivered_email)
+      ActionMailer::Base.register_observer(observer)
+    end
+
+    after do
+      ActionMailer::Base.unregister_observer(observer)
+    end
+
+    it 'invoke the observer exactly once' do
+      mail = ExampleMailer.greet('Joshua').deliver_now
+      expect(observer).to have_received(:delivered_email).with(mail).once
+    end
+  end
+
   # Helpers
 
   def have_been_delivered_using(delivery_class)


### PR DESCRIPTION
Suite de https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/8389 qui corrige le fait qu'en prod, notre `BalancerDeliveryMethod` ignore les observers qui permettent le suivi des emails et qui font qu'on a aucun event pour le moment.

- Les observers doivent être déclarés *avant* le chargement de nos delivery methods (Balancer, Sendinblue & Dolist), sinon ils seront ignorés par ces derniers

- dans le balancer, on ne peut pas appeler `.deliver` sur le message une seconde fois, sinon les observers (et interceptors, mais aussi des instrumenters et loggers du mailer) sont invoqués deux fois. En fait du point de vue du mailer, le mail doit être délivré par le balancer ; le fait que le balancer s'appuie sur un autre système de délivrance est un détail d'implémentation.


Testé en local en reprenant une config similaire à la prod.

---

Alternativement, si on voulait conserver un appel à `mail.deliver` dans le balancer , on pourrait rendre NOOP l'invocation des observers autour du deliver comme ceci, mais c'est nettement plus lourd

```ruby
mail.instance_eval "alias_method :inform_observers, :inform_observers_original"
def mail.inform_observers; end

mail.deliver

mail.instance_eval "alias_method :inform_observers_original, :inform_observers"

mail
```

La troisième option serait de rendre l'observer idempotent, par exemple en loggant le message id dans l'event, ce qui permettrait de faire un genre de `find_or_initialize` sur les events. On pourra peut-être aller vers là plus tard.