### PR TITLE
Add migrated champ routage to dossiers, procedures and procedure_revisions

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -27,6 +27,7 @@
 #  last_champ_private_updated_at                      :datetime
 #  last_champ_updated_at                              :datetime
 #  last_commentaire_updated_at                        :datetime
+#  migrated_champ_routage                             :boolean
 #  motivation                                         :text
 #  prefill_token                                      :string
 #  prefilled                                          :boolean

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -30,6 +30,7 @@
 #  lien_notice                               :string
 #  lien_site_web                             :string
 #  max_duree_conservation_dossiers_dans_ds   :integer          default(12)
+#  migrated_champ_routage                    :boolean
 #  monavis_embed                             :text
 #  opendata                                  :boolean          default(TRUE)
 #  organisation                              :string

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -3,6 +3,7 @@
 # Table name: procedure_revisions
 #
 #  id                           :bigint           not null, primary key
+#  migrated_champ_routage       :boolean
 #  published_at                 :datetime
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null

--- a/db/migrate/20230111094621_add_migrated_champ_routage_to_dossiers.rb
+++ b/db/migrate/20230111094621_add_migrated_champ_routage_to_dossiers.rb
@@ -1,0 +1,7 @@
+class AddMigratedChampRoutageToDossiers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :dossiers, :migrated_champ_routage, :boolean, default: false, null: false
+    add_column :procedures, :migrated_champ_routage, :boolean, default: false, null: false
+    add_column :procedure_revisions, :migrated_champ_routage, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20230111094621_add_migrated_champ_routage_to_dossiers.rb
+++ b/db/migrate/20230111094621_add_migrated_champ_routage_to_dossiers.rb
@@ -1,7 +1,7 @@
 class AddMigratedChampRoutageToDossiers < ActiveRecord::Migration[6.1]
   def change
-    add_column :dossiers, :migrated_champ_routage, :boolean, default: false, null: false
-    add_column :procedures, :migrated_champ_routage, :boolean, default: false, null: false
-    add_column :procedure_revisions, :migrated_champ_routage, :boolean, default: false, null: false
+    add_column :dossiers, :migrated_champ_routage, :boolean
+    add_column :procedures, :migrated_champ_routage, :boolean
+    add_column :procedure_revisions, :migrated_champ_routage, :boolean
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_10_181426) do
+ActiveRecord::Schema.define(version: 2023_01_11_094621) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -376,6 +376,7 @@ ActiveRecord::Schema.define(version: 2023_01_10_181426) do
     t.datetime "last_champ_private_updated_at"
     t.datetime "last_champ_updated_at"
     t.datetime "last_commentaire_updated_at"
+    t.boolean "migrated_champ_routage"
     t.text "motivation"
     t.bigint "parent_dossier_id"
     t.string "prefill_token"
@@ -678,6 +679,7 @@ ActiveRecord::Schema.define(version: 2023_01_10_181426) do
     t.bigint "attestation_template_id"
     t.datetime "created_at", null: false
     t.bigint "dossier_submitted_message_id"
+    t.boolean "migrated_champ_routage"
     t.bigint "procedure_id", null: false
     t.datetime "published_at"
     t.datetime "updated_at", null: false
@@ -720,6 +722,7 @@ ActiveRecord::Schema.define(version: 2023_01_10_181426) do
     t.string "lien_notice"
     t.string "lien_site_web"
     t.integer "max_duree_conservation_dossiers_dans_ds", default: 12
+    t.boolean "migrated_champ_routage"
     t.text "monavis_embed"
     t.boolean "opendata", default: true
     t.string "organisation"


### PR DESCRIPTION
Dans le cadre de la transformation du routage en type de champ, on fait cette migration avant pour éviter des bugs lors du déploiement