### PR TITLE
Fix RNA Association adapter sans date_publication

### DIFF
--- a/app/schemas/association.json
+++ b/app/schemas/association.json
@@ -29,8 +29,15 @@
       "format": "date"
     },
     "association_date_publication": {
-      "type": "string",
-      "format": "date"
+      "anyOf": [
+        {
+          "type": "string",
+          "format": "date"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "association_date_dissolution": {
       "anyOf": [
@@ -236,7 +243,6 @@
   "required": [
     "association_titre",
     "association_rna",
-    "association_date_declaration",
-    "association_date_publication"
+    "association_date_declaration"
   ]
 }

--- a/spec/lib/api_entreprise/rna_adapter_spec.rb
+++ b/spec/lib/api_entreprise/rna_adapter_spec.rb
@@ -30,7 +30,6 @@ describe APIEntreprise::RNAAdapter do
       expect(subject["association_titre"]).to eq('UN SUR QUATRE')
       expect(subject["association_objet"]).to eq("valoriser, transmettre et partager auprès des publics les plus larges possibles, les bienfaits de l'immigration, la richesse de la diversité et la curiosité de l'autre autrement")
       expect(subject["association_date_declaration"]).to eq('2014-01-24')
-      expect(subject["association_date_publication"]).to eq('2014-02-08')
     end
   end
 


### PR DESCRIPTION
On a encore beaucoup d'erreurs de l'adapter avec des associations qui ne matchent pas notre schema

https://sentry.io/organizations/demarches-simplifiees/issues/3698792231/?project=1429550

J'ai rajouté du contexte sentry pour gagner du temps plus tard si on rencontre encore d'autres types d'erreurs