### PR TITLE
correctif(administrateur/commencer#dossier_vide): lorsqu'il deux procedures avec le même path (l'une etant fermée), on renvoie la premiere qui remonte sur les formulaires pdf

### DIFF
--- a/app/controllers/users/commencer_controller.rb
+++ b/app/controllers/users/commencer_controller.rb
@@ -75,7 +75,7 @@ module Users
     end
 
     def retrieve_procedure_with_closed
-      Procedure.publiees.or(Procedure.brouillons).or(Procedure.closes).find_by(path: params[:path])
+      Procedure.find(params[:procedure_id])
     end
 
     def retrieve_prefilled_dossier

--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -30,7 +30,7 @@ module DossierHelper
   end
 
   def commencer_dossier_vide_for_revision_path(revision)
-    revision.draft? ? commencer_dossier_vide_test_path(path: revision.procedure.path) : commencer_dossier_vide_path(path: revision.procedure.path)
+    revision.draft? ? commencer_dossier_vide_test_path(procedure_id: revision.procedure.id) : commencer_dossier_vide_path(procedure_id: revision.procedure.id)
   end
 
   def dossier_submission_is_closed?(dossier)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -285,10 +285,10 @@ Rails.application.routes.draw do
     end
 
     namespace :commencer do
-      get '/test/:path/dossier_vide', action: :dossier_vide_pdf_test, as: :dossier_vide_test
+      get '/test/:procedure_id/dossier_vide', action: :dossier_vide_pdf_test, as: :dossier_vide_test
       get '/test/:path', action: 'commencer_test', as: :test
       get '/:path', action: 'commencer'
-      get '/:path/dossier_vide', action: 'dossier_vide_pdf', as: :dossier_vide
+      get '/:procedure_id/dossier_vide', action: 'dossier_vide_pdf', as: :dossier_vide
       get '/:path/sign_in', action: 'sign_in', as: :sign_in
       get '/:path/sign_up', action: 'sign_up', as: :sign_up
       get '/:path/france_connect', action: 'france_connect', as: :france_connect

--- a/spec/controllers/users/commencer_controller_spec.rb
+++ b/spec/controllers/users/commencer_controller_spec.rb
@@ -350,7 +350,7 @@ describe Users::CommencerController, type: :controller do
 
   describe '#dossier_vide_test_pdf' do
     render_views
-    before { get :dossier_vide_pdf_test, params: { path: procedure.path }, format: :pdf }
+    before { get :dossier_vide_pdf_test, params: { procedure_id: procedure.id }, format: :pdf }
 
     context 'not published procedure with service' do
       let(:procedure) { create(:procedure, :with_service, :with_path) }


### PR DESCRIPTION
hs: https://secure.helpscout.net/conversation/2082078068/#thread-6194227613

je me suis permis de mettre l'id a la place du path sur ces liens, pas l'impression que se soit problèmatique