### PR TITLE
Support des images distantes à la génération des PDF

### DIFF
--- a/app/views/dossiers/dossier_vide.pdf.prawn
+++ b/app/views/dossiers/dossier_vide.pdf.prawn
@@ -1,3 +1,4 @@
+require "open-uri"
 require 'prawn/measurement_extensions'
 
 # Render text in a box that expands vertically, then move the cursor down to the end of the rendered text
@@ -199,6 +200,10 @@ def add_champs(pdf, champs)
   end
 end
 
+def maybe_open(src)
+  URI(src).scheme.nil? ? src : URI.parse(src).open
+end
+
 prawn_document(page_size: "A4") do |pdf|
   pdf.font_families.update('marianne' => {
     normal: Rails.root.join('lib/prawn/fonts/marianne/marianne-regular.ttf'),
@@ -206,7 +211,7 @@ prawn_document(page_size: "A4") do |pdf|
     italic: Rails.root.join('lib/prawn/fonts/marianne/marianne-thin.ttf')
   })
   pdf.font 'marianne'
-  pdf.image DOSSIER_PDF_EXPORT_LOGO_SRC, width: 300, position: :center
+  pdf.image maybe_open(DOSSIER_PDF_EXPORT_LOGO_SRC), width: 300, position: :center
   pdf.move_down(40)
 
   render_in_2_columns(pdf, 'Démarche', @dossier.procedure.libelle)

--- a/app/views/dossiers/show.pdf.prawn
+++ b/app/views/dossiers/show.pdf.prawn
@@ -1,3 +1,4 @@
+require "open-uri"
 require 'prawn/measurement_extensions'
 
 def default_margin
@@ -214,6 +215,10 @@ def add_etats_dossier(pdf, dossier)
   end
 end
 
+def maybe_open(src)
+  URI(src).scheme.nil? ? src : URI.parse(src).open
+end
+
 prawn_document(page_size: "A4") do |pdf|
   pdf.font_families.update('marianne' => {
     normal: Rails.root.join('lib/prawn/fonts/marianne/marianne-regular.ttf'),
@@ -222,7 +227,7 @@ prawn_document(page_size: "A4") do |pdf|
   pdf.font 'marianne'
 
   pdf.pad_bottom(40) do
-    pdf.image DOSSIER_PDF_EXPORT_LOGO_SRC, width: 300, position: :center
+    pdf.image maybe_open(DOSSIER_PDF_EXPORT_LOGO_SRC), width: 300, position: :center
   end
 
   format_in_2_columns(pdf, 'Dossier Nº', @dossier.id.to_s)

--- a/app/views/users/dossiers/papertrail.pdf.prawn
+++ b/app/views/users/dossiers/papertrail.pdf.prawn
@@ -1,4 +1,9 @@
+require "open-uri"
 require 'prawn/measurement_extensions'
+
+def maybe_open(src)
+  URI(src).scheme.nil? ? src : URI.parse(src).open
+end
 
 #----- A4 page size
 page_size = 'A4'
@@ -25,7 +30,7 @@ prawn_document(margin: [top_margin, right_margin, bottom_margin, left_margin], p
   black = '333333'
 
   pdf.pad_bottom(30) do
-    pdf.image DOSSIER_PDF_EXPORT_LOGO_SRC, width: 300, position: :center
+    pdf.image maybe_open(DOSSIER_PDF_EXPORT_LOGO_SRC), width: 300, position: :center
 
     pdf.pad_top(15) do
       pdf.fill_color grey

--- a/spec/fixtures/cassettes/dossiers/dossier_vide.yml
+++ b/spec/fixtures/cassettes/dossiers/dossier_vide.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://example.org/images/logo.png
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - openresty/1.15.8.1
+      Date:
+      - Thu, 12 Jan 2023 08:50:07 GMT
+      Content-Type:
+      - image/png
+      Content-Length:
+      - '114'
+      Connection:
+      - keep-alive
+      Last-Modified:
+      - Tue, 10 Jan 2023 21:37:12 GMT
+      Etag:
+      - '"63bdda88-c52"'
+      Cache-Control:
+      - max-age=31536000
+      - public
+      Accept-Ranges:
+      - bytes
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVQYV2NgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII=
+  recorded_at: Thu, 12 Jan 2023 08:50:07 GMT
+recorded_with: VCR 6.1.0

--- a/spec/views/dossiers/dossier_vide.pdf.prawn_spec.rb
+++ b/spec/views/dossiers/dossier_vide.pdf.prawn_spec.rb
@@ -9,8 +9,28 @@ describe 'dossiers/dossier_vide.pdf.prawn', type: :view do
 
   subject { render }
 
-  it 'renders a PDF document with empty fields' do
-    subject
-    expect(rendered).to be_present
+  describe "with local images" do
+    before do
+      stub_const("DOSSIER_PDF_EXPORT_LOGO_SRC", "app/assets/images/header/logo-ds-wide.png")
+    end
+
+    it 'renders a PDF document with empty fields' do
+      subject
+      expect(rendered).to be_present
+    end
+  end
+
+  describe "with remote images" do
+    before do
+      stub_const("DOSSIER_PDF_EXPORT_LOGO_SRC", "https://example.org/images/logo.png")
+    end
+
+    it 'renders a PDF document with empty fields' do
+      VCR.use_cassette("dossiers/dossier_vide") do
+        subject
+      end
+
+      expect(rendered).to be_present
+    end
   end
 end


### PR DESCRIPTION
# Résumé

<!-- décrire en quelques phrases la problématique adressée -->

Il peut arriver que la variable d'env `DOSSIER_PDF_EXPORT_LOGO_SRC` fasse référence à une image distante, si tel est le cas, Prawn nécessite l'appel à `URI.open`. Ce correctif propose de gérer ce cas de figure.

voir: https://prawnpdf.org/docs/0.11.1/Prawn/Images.html

mots-clés : image, pdf, prawn, remote, uri

fixes à référencer / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`