### PR TITLE
feat(dossier): prefill rna champ

### DIFF
--- a/app/components/editable_champ/rna_component/rna_component.html.haml
+++ b/app/components/editable_champ/rna_component/rna_component.html.haml
@@ -2,7 +2,7 @@
   id: @champ.input_id,
   aria: { describedby: @champ.describedby_id },
   placeholder: t(".placeholder"),
-  data: { controller: 'turbo-input', turbo_input_url_value: champs_rna_path(@champ.id) },
+  data: { controller: 'turbo-input', turbo_input_load_on_connect_value: @champ.prefilled? && @champ.value.present? && @champ.data.blank?, turbo_input_url_value: champs_rna_path(@champ.id) },
   required: @champ.required?,
   pattern: "W[0-9]{9}",
   title: t(".title"),

--- a/app/components/editable_champ/rna_component/rna_component.html.haml
+++ b/app/components/editable_champ/rna_component/rna_component.html.haml
@@ -9,4 +9,4 @@
   class: "width-33-desktop",
   maxlength: 10
 .rna-info{ id: dom_id(@champ, :rna_info) }
-  = render 'shared/champs/rna/association', champ: @champ, network_error: false, rna: @champ.value
+  = render 'shared/champs/rna/association', champ: @champ, error: nil

--- a/app/controllers/champs/rna_controller.rb
+++ b/app/controllers/champs/rna_controller.rb
@@ -4,13 +4,6 @@ class Champs::RNAController < ApplicationController
   def show
     @champ = policy_scope(Champ).find(params[:champ_id])
     @rna = read_param_value(@champ.input_name, 'value')
-    @network_error = false
-    begin
-      data = APIEntreprise::RNAAdapter.new(@rna, @champ.procedure_id).to_params
-      @champ.update!(data: data, value: @rna)
-    rescue APIEntreprise::API::Error, ActiveRecord::RecordInvalid => error
-      @network_error = true if error.try(:network_error?) && !APIEntrepriseService.api_up?
-      @champ.update(data: nil, value: nil)
-    end
+    @network_error = @champ.fetch_association!(@rna).present?
   end
 end

--- a/app/controllers/champs/rna_controller.rb
+++ b/app/controllers/champs/rna_controller.rb
@@ -3,7 +3,6 @@ class Champs::RNAController < ApplicationController
 
   def show
     @champ = policy_scope(Champ).find(params[:champ_id])
-    @rna = read_param_value(@champ.input_name, 'value')
-    @network_error = @champ.fetch_association!(@rna).present?
+    @error = @champ.association_fetch_error_key unless @champ.fetch_association!(read_param_value(@champ.input_name, 'value'))
   end
 end

--- a/app/controllers/champs/rna_controller.rb
+++ b/app/controllers/champs/rna_controller.rb
@@ -3,6 +3,10 @@ class Champs::RNAController < ApplicationController
 
   def show
     @champ = policy_scope(Champ).find(params[:champ_id])
-    @error = @champ.association_fetch_error_key unless @champ.fetch_association!(read_param_value(@champ.input_name, 'value'))
+    rna = read_param_value(@champ.input_name, 'value')
+
+    unless @champ.fetch_association!(rna)
+      @error = @champ.association_fetch_error_key
+    end
   end
 end

--- a/app/models/champs/rna_champ.rb
+++ b/app/models/champs/rna_champ.rb
@@ -21,6 +21,8 @@
 #  row_id                         :string
 #
 class Champs::RNAChamp < Champ
+  include RNAChampAssociationFetchableConcern
+
   validates :value, allow_blank: true, format: {
     with: /\AW[0-9]{9}\z/, message: I18n.t(:not_a_rna, scope: 'activerecord.errors.messages')
   }, if: -> { validation_context != :brouillon }

--- a/app/models/concerns/rna_champ_association_fetchable_concern.rb
+++ b/app/models/concerns/rna_champ_association_fetchable_concern.rb
@@ -1,0 +1,16 @@
+module RNAChampAssociationFetchableConcern
+  extend ActiveSupport::Concern
+
+  def fetch_association!(rna)
+    data = APIEntreprise::RNAAdapter.new(rna, procedure_id).to_params
+    update!(data: data, value: rna)
+    nil
+  rescue APIEntreprise::API::Error, ActiveRecord::RecordInvalid => error
+    update(data: nil, value: nil)
+    if error.try(:network_error?) && !APIEntrepriseService.api_up?
+      :network_error
+    else
+      nil
+    end
+  end
+end

--- a/app/models/concerns/rna_champ_association_fetchable_concern.rb
+++ b/app/models/concerns/rna_champ_association_fetchable_concern.rb
@@ -1,18 +1,27 @@
 module RNAChampAssociationFetchableConcern
   extend ActiveSupport::Concern
 
+  attr_reader :association_fetch_error_key
+
   def fetch_association!(rna)
-    data = APIEntreprise::RNAAdapter.new(rna, procedure_id).to_params
-    update!(data: data, value: rna)
-    nil
-  rescue APIEntreprise::API::Error, ActiveRecord::RecordInvalid => error
-    self.data = nil
     self.value = rna
-    save(validate: false)
-    if error.try(:network_error?) && !APIEntrepriseService.api_up?
-      :network_error
-    else
-      nil
-    end
+
+    return clear_association!(:empty) if rna.empty?
+    return clear_association!(:invalid) unless valid?
+    return clear_association!(:not_found) if (data = APIEntreprise::RNAAdapter.new(rna, procedure_id).to_params).blank?
+
+    update!(data: data)
+  rescue APIEntreprise::API::Error => error
+    error_key = :network_error if error.try(:network_error?) && !APIEntrepriseService.api_up?
+    clear_association!(error_key)
+  end
+
+  private
+
+  def clear_association!(error)
+    @association_fetch_error_key = error
+    self.data = nil
+    save!(context: :brouillon)
+    false
   end
 end

--- a/app/models/concerns/rna_champ_association_fetchable_concern.rb
+++ b/app/models/concerns/rna_champ_association_fetchable_concern.rb
@@ -6,7 +6,9 @@ module RNAChampAssociationFetchableConcern
     update!(data: data, value: rna)
     nil
   rescue APIEntreprise::API::Error, ActiveRecord::RecordInvalid => error
-    update(data: nil, value: nil)
+    self.data = nil
+    self.value = rna
+    save(validate: false)
     if error.try(:network_error?) && !APIEntrepriseService.api_up?
       :network_error
     else

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -273,7 +273,8 @@ class TypeDeChamp < ApplicationRecord
       TypeDeChamp.type_champs.fetch(:repetition),
       TypeDeChamp.type_champs.fetch(:multiple_drop_down_list),
       TypeDeChamp.type_champs.fetch(:epci),
-      TypeDeChamp.type_champs.fetch(:siret)
+      TypeDeChamp.type_champs.fetch(:siret),
+      TypeDeChamp.type_champs.fetch(:rna)
     ])
   end
 

--- a/app/views/champs/rna/show.turbo_stream.haml
+++ b/app/views/champs/rna/show.turbo_stream.haml
@@ -1,1 +1,1 @@
-= turbo_stream.update dom_id(@champ, :rna_info), partial: 'shared/champs/rna/association', locals: { champ: @champ, network_error: @network_error, rna: @rna }
+= turbo_stream.update dom_id(@champ, :rna_info), partial: 'shared/champs/rna/association', locals: { champ: @champ, error: @error }

--- a/app/views/shared/champs/rna/_association.html.haml
+++ b/app/views/shared/champs/rna/_association.html.haml
@@ -1,6 +1,11 @@
-- if network_error
-  %p.pt-1= t('.network_error')
-- elsif @rna.present? && champ.data.blank?
+- case error
+- when :invalid
+  %p.pt-1
+    Le numéro RNA doit commencer par un W majuscule suivi de 9 chiffres
+- when :not_found
   %p.pt-1= t('.not_found')
-- elsif champ.value.present?
-  %p.pt-1= t('.data_fetched', title: champ.title)
+- when :network_error
+  %p.pt-1= t('.network_error')
+- else
+  - if champ.value.present?
+    %p.pt-1= t('.data_fetched', title: champ.title)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -137,6 +137,7 @@ en:
           datetime_html: ISO8601 datetime
           drop_down_list_other_html: Any value
           siret_html: A SIRET number
+          rna_html: A RNA number
           repetition_html: A array of hashes with possible values for each field of the repetition.
           epci_html: An array of the department code and the <a href="https://geo.api.gouv.fr/epcis" target="_blank" rel="noopener noreferrer">EPCI one</a>.
         examples:
@@ -155,7 +156,8 @@ en:
           date: "2023-02-01"
           datetime: "2023-02-01T10:30"
           checkbox: "true"
-          siret: 13002526500013
+          rna: "W503726238"
+          siret: "13002526500013"
         prefill_link_title: Prefill link (GET)
         prefill_link_info: Use the button to copy the link, then remplace the values with your data.
         prefill_link_too_long: Warning, the prefill link is too long and may not work on all browsers.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -127,6 +127,7 @@ fr:
           datetime_html: Datetime au format ISO8601
           date_html: Date au format ISO8601
           drop_down_list_other_html: Toute valeur
+          rna_html: Un numéro RNA
           siret_html: Un numéro de SIRET
           repetition_html: Un tableau de dictionnaires avec les valeurs possibles pour chaque champ de la répétition.
           epci_html: Un tableau contenant le code de département et <a href="https://geo.api.gouv.fr/epcis" target="_blank" rel="noopener noreferrer">celui de l'EPCI</a>.
@@ -147,7 +148,8 @@ fr:
           date: "2023-02-01"
           datetime: "2023-02-01T10:30"
           checkbox: "true"
-          siret: 13002526500013
+          rna: "W503726238"
+          siret: "13002526500013"
         prefill_link_title: Lien de préremplissage (GET)
         prefill_link_info: Copiez le lien grâce au bouton ci-dessous et remplacez les valeurs par les données dont vous disposez.
         prefill_link_too_long: Attention, ce lien de préremplissage est trop long et risque de ne pas fonctionner sur certains navigateurs.

--- a/spec/controllers/champs/rna_controller_spec.rb
+++ b/spec/controllers/champs/rna_controller_spec.rb
@@ -37,10 +37,8 @@ describe Champs::RNAController, type: :controller do
 
         subject! { get :show, params: params, format: :turbo_stream }
 
-        it 'clears the data and value on the model' do
-          champ.reload
-          expect(champ.data).to eq({})
-          expect(champ.value).to eq("")
+        it 'clears the data on the model' do
+          expect(champ.reload.data).to eq({})
         end
 
         it 'clears any information or error message' do
@@ -55,10 +53,8 @@ describe Champs::RNAController, type: :controller do
 
         subject! { get :show, params: params, format: :turbo_stream }
 
-        it 'clears the data and value on the model' do
-          champ.reload
-          expect(champ.data).to be_nil
-          expect(champ.value).to be_nil
+        it 'clears the data on the model' do
+          expect(champ.reload.data).to be_nil
         end
 
         it 'displays a “RNA is invalid” error message' do
@@ -94,10 +90,8 @@ describe Champs::RNAController, type: :controller do
 
         subject! { get :show, params: params, format: :turbo_stream }
 
-        it 'clears the data and value on the model' do
-          champ.reload
-          expect(champ.data).to be_nil
-          expect(champ.value).to be_nil
+        it 'clears the data on the model' do
+          expect(champ.reload.data).to be_nil
         end
 
         it 'displays a “API is unavailable” error message' do

--- a/spec/controllers/champs/rna_controller_spec.rb
+++ b/spec/controllers/champs/rna_controller_spec.rb
@@ -38,7 +38,7 @@ describe Champs::RNAController, type: :controller do
         subject! { get :show, params: params, format: :turbo_stream }
 
         it 'clears the data on the model' do
-          expect(champ.reload.data).to eq({})
+          expect(champ.reload.data).to be_nil
         end
 
         it 'clears any information or error message' do
@@ -58,7 +58,7 @@ describe Champs::RNAController, type: :controller do
         end
 
         it 'displays a “RNA is invalid” error message' do
-          expect(response.body).to include("Aucun établissement trouvé")
+          expect(response.body).to include("Le numéro RNA doit commencer par un W majuscule suivi de 9 chiffres")
         end
       end
 
@@ -71,7 +71,7 @@ describe Champs::RNAController, type: :controller do
 
         it 'clears the data on the model' do
           champ.reload
-          expect(champ.data).to eq({})
+          expect(champ.data).to be_nil
         end
 
         it 'displays a “RNA is invalid” error message' do

--- a/spec/models/concern/rna_champ_association_fetchable_concern_spec.rb
+++ b/spec/models/concern/rna_champ_association_fetchable_concern_spec.rb
@@ -1,0 +1,90 @@
+RSpec.describe RNAChampAssociationFetchableConcern do
+  describe '.fetch_association!' do
+    let!(:champ) { create(:champ_rna, data: "not nil data") }
+
+    before do
+      stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/associations\//)
+        .to_return(body: body, status: status)
+      allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
+    end
+
+    subject(:fetch_association!) { champ.fetch_association!(rna) }
+
+    shared_examples "an association fetcher" do |expected_result, expected_value, expected_data|
+      it { expect(fetch_association!).to eq(expected_result) }
+
+      it { expect { fetch_association! }.to change { champ.reload.value }.to(expected_value) }
+
+      it { expect { fetch_association! }.to change { champ.reload.data }.to(expected_data) }
+    end
+
+    context 'when the RNA is empty' do
+      let(:rna) { '' }
+      let(:status) { 422 }
+      let(:body) { '' }
+
+      it_behaves_like "an association fetcher", nil, '', {}
+    end
+
+    context 'when the RNA is invalid' do
+      let(:rna) { '1234' }
+      let(:status) { 422 }
+      let(:body) { '' }
+
+      it_behaves_like "an association fetcher", nil, nil, nil
+    end
+
+    context 'when the RNA is unknow' do
+      let(:rna) { 'W111111111' }
+      let(:status) { 404 }
+      let(:body) { '' }
+
+      it_behaves_like "an association fetcher", nil, 'W111111111', {}
+    end
+
+    context 'when the API is unavailable due to network error' do
+      let(:rna) { 'W595001988' }
+      let(:status) { 503 }
+      let(:body) { File.read('spec/fixtures/files/api_entreprise/associations.json') }
+
+      before { expect(APIEntrepriseService).to receive(:api_up?).and_return(false) }
+
+      it_behaves_like "an association fetcher", :network_error, nil, nil
+    end
+
+    context 'when the RNA informations are retrieved successfully' do
+      let(:rna) { 'W595001988' }
+      let(:status) { 200 }
+      let(:body) { File.read('spec/fixtures/files/api_entreprise/associations.json') }
+
+      it_behaves_like "an association fetcher", nil, 'W595001988', {
+        "association_id" => "W595001988",
+        "association_titre" => "UN SUR QUATRE",
+        "association_objet" => "valoriser, transmettre et partager auprès des publics les plus larges possibles, les bienfaits de l'immigration, la richesse de la diversité et la curiosité de l'autre autrement",
+        "association_siret" => nil,
+        "association_date_creation" => "2014-01-23",
+        "association_date_declaration" => "2014-01-24",
+        "association_date_publication" => "2014-02-08",
+        "association_date_dissolution" => "0001-01-01",
+        "association_adresse_siege" => {
+          "complement" => "",
+          "numero_voie" => "61",
+          "type_voie" => "RUE",
+          "libelle_voie" => "des Noyers",
+          "distribution" => "_",
+          "code_insee" => "93063",
+          "code_postal" => "93230",
+          "commune" => "Romainville"
+        },
+        "association_code_civilite_dirigeant" => "PM",
+        "association_civilite_dirigeant" => "Monsieur le Président",
+        "association_code_etat" => "A",
+        "association_etat" => "Active",
+        "association_code_groupement" => "S",
+        "association_groupement" => "simple",
+        "association_mise_a_jour" => 1392295833,
+        "association_rna" => "W595001988"
+      }
+    end
+  end
+end

--- a/spec/models/concern/rna_champ_association_fetchable_concern_spec.rb
+++ b/spec/models/concern/rna_champ_association_fetchable_concern_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe RNAChampAssociationFetchableConcern do
 
     subject(:fetch_association!) { champ.fetch_association!(rna) }
 
-    shared_examples "an association fetcher" do |expected_result, expected_value, expected_data|
+    shared_examples "an association fetcher" do |expected_result, _expected_value, expected_data|
       it { expect(fetch_association!).to eq(expected_result) }
 
-      it { expect { fetch_association! }.to change { champ.reload.value }.to(expected_value) }
+      it { expect { fetch_association! }.to change { champ.reload.value }.to(rna) }
 
       it { expect { fetch_association! }.to change { champ.reload.data }.to(expected_data) }
     end
@@ -31,7 +31,7 @@ RSpec.describe RNAChampAssociationFetchableConcern do
       let(:status) { 422 }
       let(:body) { '' }
 
-      it_behaves_like "an association fetcher", nil, nil, nil
+      it_behaves_like "an association fetcher", nil, '1234', nil
     end
 
     context 'when the RNA is unknow' do
@@ -49,7 +49,7 @@ RSpec.describe RNAChampAssociationFetchableConcern do
 
       before { expect(APIEntrepriseService).to receive(:api_up?).and_return(false) }
 
-      it_behaves_like "an association fetcher", :network_error, nil, nil
+      it_behaves_like "an association fetcher", :network_error, 'W595001988', nil
     end
 
     context 'when the RNA informations are retrieved successfully' do

--- a/spec/models/prefill_params_spec.rb
+++ b/spec/models/prefill_params_spec.rb
@@ -143,6 +143,7 @@ RSpec.describe PrefillParams do
     it_behaves_like "a champ public value that is authorized", :multiple_drop_down_list, ["val1", "val2"]
     it_behaves_like "a champ public value that is authorized", :epci, ['01', '200042935']
     it_behaves_like "a champ public value that is authorized", :siret, "13002526500013"
+    it_behaves_like "a champ public value that is authorized", :rna, "value"
 
     context "when the public type de champ is authorized (repetition)" do
       let(:types_de_champ_public) { [{ type: :repetition, children: [{ type: :text }] }] }
@@ -176,6 +177,7 @@ RSpec.describe PrefillParams do
     it_behaves_like "a champ private value that is authorized", :checkbox, "false"
     it_behaves_like "a champ private value that is authorized", :drop_down_list, "value"
     it_behaves_like "a champ private value that is authorized", :regions, "93"
+    it_behaves_like "a champ private value that is authorized", :rna, "value"
     it_behaves_like "a champ private value that is authorized", :siret, "13002526500013"
     it_behaves_like "a champ private value that is authorized", :departements, "03"
     it_behaves_like "a champ private value that is authorized", :communes, ['01', '01457']
@@ -219,7 +221,6 @@ RSpec.describe PrefillParams do
     it_behaves_like "a champ public value that is unauthorized", :regions, "value"
     it_behaves_like "a champ public value that is unauthorized", :departements, "value"
     it_behaves_like "a champ public value that is unauthorized", :communes, "value"
-    it_behaves_like "a champ public value that is unauthorized", :rna, "value"
     it_behaves_like "a champ public value that is unauthorized", :annuaire_education, "value"
     it_behaves_like "a champ public value that is unauthorized", :multiple_drop_down_list, ["value"]
 

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -256,6 +256,7 @@ describe TypeDeChamp do
     it_behaves_like "a prefillable type de champ", :type_de_champ_multiple_drop_down_list
     it_behaves_like "a prefillable type de champ", :type_de_champ_epci
     it_behaves_like "a prefillable type de champ", :type_de_champ_siret
+    it_behaves_like "a prefillable type de champ", :type_de_champ_rna
 
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_number
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_dossier_link
@@ -270,7 +271,6 @@ describe TypeDeChamp do
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_mesri
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_carte
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_address
-    it_behaves_like "a non-prefillable type de champ", :type_de_champ_rna
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_annuaire_education
   end
 end

--- a/spec/support/shared_examples_for_prefilled_dossier.rb
+++ b/spec/support/shared_examples_for_prefilled_dossier.rb
@@ -14,6 +14,7 @@ shared_examples "the user has got a prefilled dossier, owned by themselves" do
     expect(page).to have_field(type_de_champ_text.libelle, with: text_value)
     expect(page).to have_field(type_de_champ_phone.libelle, with: phone_value)
     expect(page).to have_css('label', text: type_de_champ_phone.libelle)
+    expect(page).to have_field(type_de_champ_rna.libelle, with: rna_value)
     expect(page).to have_field(type_de_champ_siret.libelle, with: siret_value)
     expect(page).to have_css('h3', text: type_de_champ_repetition.libelle)
     expect(page).to have_field(text_repetition_libelle, with: text_repetition_value)

--- a/spec/system/users/dossier_prefill_get_spec.rb
+++ b/spec/system/users/dossier_prefill_get_spec.rb
@@ -8,6 +8,7 @@ describe 'Prefilling a dossier (with a GET request):', js: true do
 
   let(:type_de_champ_text) { create(:type_de_champ_text, procedure: procedure) }
   let(:type_de_champ_phone) { create(:type_de_champ_phone, procedure: procedure) }
+  let(:type_de_champ_rna) { create(:type_de_champ_rna, procedure: procedure) }
   let(:type_de_champ_siret) { create(:type_de_champ_siret, procedure: procedure) }
   let(:type_de_champ_datetime) { create(:type_de_champ_datetime, procedure: procedure) }
   let(:type_de_champ_multiple_drop_down_list) { create(:type_de_champ_multiple_drop_down_list, procedure: procedure) }
@@ -17,6 +18,7 @@ describe 'Prefilling a dossier (with a GET request):', js: true do
 
   let(:text_value) { "My Neighbor Totoro is the best movie ever" }
   let(:phone_value) { "invalid phone value" }
+  let(:rna_value) { 'W595001988' }
   let(:siret_value) { '41816609600051' }
   let(:datetime_value) { "2023-02-01T10:32" }
   let(:multiple_drop_down_list_values) {
@@ -43,6 +45,7 @@ describe 'Prefilling a dossier (with a GET request):', js: true do
       "champ_#{type_de_champ_epci.to_typed_id_for_query}" => epci_value,
       "champ_#{type_de_champ_commune.to_typed_id_for_query}" => commune_value,
       "champ_#{type_de_champ_siret.to_typed_id_for_query}" => siret_value,
+      "champ_#{type_de_champ_rna.to_typed_id_for_query}" => rna_value,
       "champ_#{type_de_champ_repetition.to_typed_id_for_query}" => [
         {
           "champ_#{sub_type_de_champs_repetition.first.to_typed_id_for_query}": text_repetition_value,
@@ -61,6 +64,9 @@ describe 'Prefilling a dossier (with a GET request):', js: true do
 
     stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/entreprises\/#{siret_value[0..8]}/)
       .to_return(status: 200, body: File.read('spec/fixtures/files/api_entreprise/entreprises.json'))
+
+    stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/associations\//)
+      .to_return(status: 200, body: File.read('spec/fixtures/files/api_entreprise/associations.json'))
 
     VCR.insert_cassette('api_geo_departements')
     VCR.insert_cassette('api_geo_communes')

--- a/spec/system/users/dossier_prefill_post_spec.rb
+++ b/spec/system/users/dossier_prefill_post_spec.rb
@@ -8,6 +8,7 @@ describe 'Prefilling a dossier (with a POST request):', js: true do
 
   let(:type_de_champ_text) { create(:type_de_champ_text, procedure: procedure) }
   let(:type_de_champ_phone) { create(:type_de_champ_phone, procedure: procedure) }
+  let(:type_de_champ_rna) { create(:type_de_champ_rna, procedure: procedure) }
   let(:type_de_champ_siret) { create(:type_de_champ_siret, procedure: procedure) }
   let(:type_de_champ_datetime) { create(:type_de_champ_datetime, procedure: procedure) }
   let(:type_de_champ_multiple_drop_down_list) { create(:type_de_champ_multiple_drop_down_list, procedure: procedure) }
@@ -17,6 +18,7 @@ describe 'Prefilling a dossier (with a POST request):', js: true do
 
   let(:text_value) { "My Neighbor Totoro is the best movie ever" }
   let(:phone_value) { "invalid phone value" }
+  let(:rna_value) { 'W595001988' }
   let(:siret_value) { '41816609600051' }
   let(:datetime_value) { "2023-02-01T10:32" }
   let(:multiple_drop_down_list_values) {
@@ -42,6 +44,9 @@ describe 'Prefilling a dossier (with a POST request):', js: true do
 
     stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/entreprises\/#{siret_value[0..8]}/)
       .to_return(status: 200, body: File.read('spec/fixtures/files/api_entreprise/entreprises.json'))
+
+      stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/associations\//)
+      .to_return(status: 200, body: File.read('spec/fixtures/files/api_entreprise/associations.json'))
 
     VCR.insert_cassette('api_geo_departements')
     VCR.insert_cassette('api_geo_communes')
@@ -141,6 +146,7 @@ describe 'Prefilling a dossier (with a POST request):', js: true do
       params: {
         "champ_#{type_de_champ_text.to_typed_id_for_query}" => text_value,
         "champ_#{type_de_champ_phone.to_typed_id_for_query}" => phone_value,
+        "champ_#{type_de_champ_rna.to_typed_id_for_query}" => rna_value,
         "champ_#{type_de_champ_siret.to_typed_id_for_query}" => siret_value,
         "champ_#{type_de_champ_repetition.to_typed_id_for_query}" => [
           {

--- a/spec/system/users/dossier_prefill_post_spec.rb
+++ b/spec/system/users/dossier_prefill_post_spec.rb
@@ -45,7 +45,7 @@ describe 'Prefilling a dossier (with a POST request):', js: true do
     stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/entreprises\/#{siret_value[0..8]}/)
       .to_return(status: 200, body: File.read('spec/fixtures/files/api_entreprise/entreprises.json'))
 
-      stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/associations\//)
+    stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/associations\//)
       .to_return(status: 200, body: File.read('spec/fixtures/files/api_entreprise/associations.json'))
 
     VCR.insert_cassette('api_geo_departements')


### PR DESCRIPTION
L'objectif de cette PR est de permettre le préremplissage de champ de type `rna`.

Pour éviter toute duplication future, on commence par extraire la récupération de l'association dans un concern dédié.

Ça permet de récupérer l'association au moment du préremplissage. Si le job est exécuté assez vite (c'est généralement le cas), la personne arrive sur son brouillon avec le champ préremplir et l'association affichée.

Par ailleurs, on récupère aussi l'association lorsque le dossier s'affiche en brouillon (seulement si le champ est prérempli, que le RNA est renseigné et que l'association est manquante). Cela permet de faire comme si la personne venait d'éditer le champ et d'afficher les erreurs de celui-ci, le cas échéant.

![image](https://user-images.githubusercontent.com/1193334/212468498-3bcf18bc-2404-45ad-b6d0-b64ec204b2c9.png)