### PR TITLE
amelioration(no-reply): l'administration est joignable 🤝 

### DIFF
--- a/app/lib/dolist/api.rb
+++ b/app/lib/dolist/api.rb
@@ -67,7 +67,7 @@ class Dolist::API
 
   def to_sent_mail(email_address, contact_id, dolist_message)
     SentMail.new(
-      from: ENV['DOLIST_NO_REPLY_EMAIL'],
+      from: CONTACT_EMAIL,
       to: email_address,
       subject: dolist_message['SendingName'],
       delivered_at: Time.zone.parse(dolist_message['SendDate']),

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -2,7 +2,6 @@ class ApplicationMailer < ActionMailer::Base
   include MailerMonitoringConcern
 
   helper :application # gives access to all helpers defined within `application_helper`.
-  default from: "#{APPLICATION_NAME} <#{CONTACT_EMAIL}>"
   layout 'mailer'
 
   # Attach the procedure logo to the email (if any).

--- a/app/mailers/concerns/mailer_monitoring_concern.rb
+++ b/app/mailers/concerns/mailer_monitoring_concern.rb
@@ -4,6 +4,10 @@ module MailerMonitoringConcern
   included do
     before_action :add_dolist_header
 
+    # a same sender for all mailers
+    # just in case their is issues with no-reply/ne-pas-repondre subject
+    default from: "#{APPLICATION_NAME} <#{CONTACT_EMAIL}>"
+
     # Don’t retry to send a message if the server rejects the recipient address
     rescue_from Net::SMTPSyntaxError do |_exception|
       message.perform_deliveries = false

--- a/app/mailers/devise_user_mailer.rb
+++ b/app/mailers/devise_user_mailer.rb
@@ -12,7 +12,6 @@ class DeviseUserMailer < Devise::Mailer
   end
 
   def confirmation_instructions(record, token, opts = {})
-    opts[:from] = NO_REPLY_EMAIL
     @procedure = opts[:procedure_after_confirmation] || nil
     @prefill_token = opts[:prefill_token]
     super

--- a/app/mailers/dossier_mailer.rb
+++ b/app/mailers/dossier_mailer.rb
@@ -5,7 +5,7 @@ class DossierMailer < ApplicationMailer
   helper ProcedureHelper
 
   layout 'mailers/layout'
-  default from: NO_REPLY_EMAIL
+  default from: CONTACT_EMAIL
   after_action :prevent_perform_deliveries, only: [:notify_new_draft, :notify_new_answer]
 
   def notify_new_draft

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -15,7 +15,7 @@ class NotificationMailer < ApplicationMailer
   helper MailerHelper
 
   layout 'mailers/notifications_layout'
-  default from: NO_REPLY_EMAIL
+  default from: CONTACT_EMAIL
 
   def send_notification
     @service = @dossier.procedure.service

--- a/config/initializers/contacts.rb
+++ b/config/initializers/contacts.rb
@@ -4,7 +4,6 @@ if !defined?(CONTACT_EMAIL)
   CONTACT_EMAIL = ENV.fetch("CONTACT_EMAIL", "contact@demarches-simplifiees.fr")
   EQUIPE_EMAIL = ENV.fetch("EQUIPE_EMAIL", "equipe@demarches-simplifiees.fr")
   TECH_EMAIL = ENV.fetch("TECH_EMAIL", "tech@demarches-simplifiees.fr")
-  NO_REPLY_EMAIL = ENV.fetch("NO_REPLY_EMAIL", "Ne pas répondre <ne-pas-repondre@demarches-simplifiees.fr>")
   CONTACT_PHONE = ENV.fetch("CONTACT_PHONE", "01 76 42 02 87")
 
   OLD_CONTACT_EMAIL = ENV.fetch("OLD_CONTACT_EMAIL", "contact@tps.apientreprise.fr")

--- a/config/initializers/dolist.rb
+++ b/config/initializers/dolist.rb
@@ -2,8 +2,8 @@ ActiveSupport.on_load(:action_mailer) do
   module Dolist
     class SMTP < ::Mail::SMTP
       def deliver!(mail)
-        mail.from(ENV['DOLIST_NO_REPLY_EMAIL'])
-        mail.sender(ENV['DOLIST_NO_REPLY_EMAIL'])
+        mail.from(CONTACT_EMAIL)
+        mail.sender(CONTACT_EMAIL)
         mail['X-ACCOUNT-ID'] = Rails.application.secrets.dolist[:account_id]
 
         mail['X-Dolist-Sending-Type'] = 'TransactionalService' # send even if the target is not active

--- a/spec/mailers/dossier_mailer_spec.rb
+++ b/spec/mailers/dossier_mailer_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe DossierMailer, type: :mailer do
 
   shared_examples 'a dossier notification' do
     it 'is sent from a no-reply address' do
-      expect(subject.from.first).to eq(Mail::Address.new(NO_REPLY_EMAIL).address)
+      expect(subject.from.first).to eq(Mail::Address.new(CONTACT_EMAIL).address)
     end
 
     it 'includes the contact informations in the footer' do

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe NotificationMailer, type: :mailer do
     end
 
     it 'sends the mail from a no-reply address' do
-      expect(subject.from.first).to eq(Mail::Address.new(NO_REPLY_EMAIL).address)
+      expect(subject.from.first).to eq(Mail::Address.new(CONTACT_EMAIL).address)
     end
   end
 


### PR DESCRIPTION
partant du sujet de deliverabilité, je propose de "simplifier" l'adresse des sender (PAS de reply-to/ne-pas-repondre). On opère un service a l'écoute des usagers. le no-reply/ne-pas-répondre.... c'est moyen non ? 

en bonus: 
* certains disent que le no-reply aide pas a la deliverabilité ex: https://www.mailpoet.com/blog/never-use-no-reply-email-address/
* on n'a pas a configurer `x` senders chez les fournisseurs
* et pourquoi les utilisateurs ne devraient t'il pas pouvoir répondre aux mail ? si ils répondent, p-e qu'il y aun prob de wording, de comprehension, ou autre...

