### PR TITLE
Définition d'une raison par défaut lors de la purge des dossiers expirés lorsque celle-ci est manquante

### DIFF
--- a/app/models/deleted_dossier.rb
+++ b/app/models/deleted_dossier.rb
@@ -27,10 +27,11 @@ class DeletedDossier < ApplicationRecord
     user_removed:      'user_removed',
     procedure_removed: 'procedure_removed',
     expired:           'expired',
-    instructeur_request: 'instructeur_request'
+    instructeur_request: 'instructeur_request',
+    unknown: 'unknown'
   }
 
-  def self.create_from_dossier(dossier, reason)
+  def self.create_from_dossier(dossier, reason = :unknown)
     return if !dossier.log_operations?
 
     # We have some bad data because of partially deleted dossiers in the past.


### PR DESCRIPTION
# Résumé

<!-- décrire en quelques phrases la problématique adressée -->

Cette PR vise à définir une raison par défaut lors de la purge des dossiers expirés lorsque celle-ci est manquante. En effet, il est arrivé que le job `Cron::DiscardedDossiersDeletionJob` retourne cette erreur :

```
--- !ruby/object:ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper
    job_data:
      job_class: Cron::DiscardedDossiersDeletionJob
      job_id: 9bbaca6d-38ea-4c6d-8327-761b5747325a
      provider_job_id: 
      queue_name: cron
      priority: 
      arguments: []
      executions: 0
      exception_executions: {}
      locale: fr
      timezone: Paris
      enqueued_at: '2022-02-10T10:09:51Z'

Last Error
    Toggle full message

    key not found: nil
    /usr/local/bundle/ruby/3.1.0/gems/activesupport-6.1.7/lib/active_support/hash_with_indifferent_access.rb:192:in `fetch'
    /usr/local/bundle/ruby/3.1.0/gems/activesupport-6.1.7/lib/active_support/hash_with_indifferent_access.rb:192:in `fetch'
    /app/app/models/deleted_dossier.rb:39:in `create_from_dossier'
    /app/app/models/dossier.rb:1188:in `block in purge_discarded'
	/app/app/models/dossier.rb:1187:in `purge_discarded'
	/app/app/models/dossier.rb:1197:in `purge_discarded'
	/app/app/jobs/cron/discarded_dossiers_deletion_job.rb:5:in `perform'
```

mots-clés : cron, default, dossier, expire, job, reason

fixes à référencer / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`