### PR TITLE
Us/poc multiple - 2 dernières actions de l'onglet suivi

### DIFF
--- a/app/components/dossiers/batch_alert_component/batch_alert_component.en.yml
+++ b/app/components/dossiers/batch_alert_component/batch_alert_component.en.yml
@@ -35,6 +35,15 @@ en:
       text_success:
         one: 1/1 is being followed
         other: "%{progress_count}/%{count} files have been followed"
+  repasser_en_construction:
+    finish:
+      text_success:
+        one: 1/1 file has been changed to in progress
+        other: "%{success_count}/%{count} files have been changed to in progress"
+    in_progress:
+      text_success:
+        one: 1/1 is being changed to in progress
+        other: "%{progress_count}/%{count} files have been changed to in progress"
   title:
     finish: The bulk action is finished
     in_progress:  A bulk action is processing

--- a/app/components/dossiers/batch_alert_component/batch_alert_component.en.yml
+++ b/app/components/dossiers/batch_alert_component/batch_alert_component.en.yml
@@ -35,6 +35,15 @@ en:
       text_success:
         one: 1/1 is being followed
         other: "%{progress_count}/%{count} files have been followed"
+  unfollow:
+    finish:
+      text_success:
+        one: 1/1 file has been unfollowed
+        other: "%{success_count}/%{count} files have been unfollowed"
+    in_progress:
+      text_success:
+        one: 1/1 is being unfollowed
+        other: "%{progress_count}/%{count} files have been unfollowed"
   repasser_en_construction:
     finish:
       text_success:

--- a/app/components/dossiers/batch_alert_component/batch_alert_component.fr.yml
+++ b/app/components/dossiers/batch_alert_component/batch_alert_component.fr.yml
@@ -35,6 +35,15 @@ fr:
       text_success:
         one: 1 dossier sera suivi
         other: "%{progress_count}/%{count} dossiers ont été suivis"
+  repasser_en_construction:
+    finish:
+      text_success:
+        one: 1 dossier a été repassé en construction
+        other: "%{success_count}/%{count} dossiers ont été repassés en construction"
+    in_progress:
+      text_success:
+        one: 1 dossier sera repassé en construction
+        other: "%{progress_count}/%{count} dossiers ont été repassés en construction"
   title:
     finish: L'action de masse est terminée
     in_progress: Une action de masse est en cours

--- a/app/components/dossiers/batch_alert_component/batch_alert_component.fr.yml
+++ b/app/components/dossiers/batch_alert_component/batch_alert_component.fr.yml
@@ -35,6 +35,15 @@ fr:
       text_success:
         one: 1 dossier sera suivi
         other: "%{progress_count}/%{count} dossiers ont été suivis"
+  unfollow:
+    finish:
+      text_success:
+        one: 1 dossier n'est plus suivi
+        other: "%{success_count}/%{count} dossiers ne sont plus suivis"
+    in_progress:
+      text_success:
+        one: 1 dossier ne sera plus suivi
+        other: "%{progress_count}/%{count} dossiers ne sont plus suivis"
   repasser_en_construction:
     finish:
       text_success:

--- a/app/components/dossiers/batch_operation_component.rb
+++ b/app/components/dossiers/batch_operation_component.rb
@@ -13,9 +13,9 @@ class Dossiers::BatchOperationComponent < ApplicationComponent
   def operations_for_dossier(dossier)
     case dossier.state
     when Dossier.states.fetch(:en_construction)
-      [BatchOperation.operations.fetch(:passer_en_instruction), BatchOperation.operations.fetch(:follow)]
+      [BatchOperation.operations.fetch(:passer_en_instruction), BatchOperation.operations.fetch(:follow), BatchOperation.operations.fetch(:unfollow)]
     when Dossier.states.fetch(:en_instruction)
-      [BatchOperation.operations.fetch(:accepter), BatchOperation.operations.fetch(:repasser_en_construction)]
+      [BatchOperation.operations.fetch(:accepter), BatchOperation.operations.fetch(:repasser_en_construction), BatchOperation.operations.fetch(:follow), BatchOperation.operations.fetch(:unfollow)]
     when Dossier.states.fetch(:accepte), Dossier.states.fetch(:refuse), Dossier.states.fetch(:sans_suite)
       [BatchOperation.operations.fetch(:archiver)]
     else
@@ -63,6 +63,11 @@ class Dossiers::BatchOperationComponent < ApplicationComponent
             },
 
             {
+              label: t(".operations.unfollow"),
+              operation: BatchOperation.operations.fetch(:unfollow)
+            },
+
+            {
               label: t(".operations.repasser_en_construction"),
               operation: BatchOperation.operations.fetch(:repasser_en_construction)
             }
@@ -81,7 +86,8 @@ class Dossiers::BatchOperationComponent < ApplicationComponent
       archiver: 'fr-icon-folder-2-line',
       follow: 'fr-icon-star-line',
       passer_en_instruction: 'fr-icon-edit-line',
-      repasser_en_construction: 'fr-icon-draft-line'
+      repasser_en_construction: 'fr-icon-draft-line',
+      unfollow: 'fr-icon-star-fill'
     }
   end
 end

--- a/app/components/dossiers/batch_operation_component.rb
+++ b/app/components/dossiers/batch_operation_component.rb
@@ -13,14 +13,14 @@ class Dossiers::BatchOperationComponent < ApplicationComponent
   def operations_for_dossier(dossier)
     case dossier.state
     when Dossier.states.fetch(:en_construction)
-      [BatchOperation.operations.fetch(:passer_en_instruction), BatchOperation.operations.fetch(:follow), BatchOperation.operations.fetch(:unfollow)]
+      [BatchOperation.operations.fetch(:passer_en_instruction)]
     when Dossier.states.fetch(:en_instruction)
-      [BatchOperation.operations.fetch(:accepter), BatchOperation.operations.fetch(:repasser_en_construction), BatchOperation.operations.fetch(:follow), BatchOperation.operations.fetch(:unfollow)]
+      [BatchOperation.operations.fetch(:accepter), BatchOperation.operations.fetch(:repasser_en_construction)]
     when Dossier.states.fetch(:accepte), Dossier.states.fetch(:refuse), Dossier.states.fetch(:sans_suite)
       [BatchOperation.operations.fetch(:archiver)]
     else
       []
-    end
+    end.append(BatchOperation.operations.fetch(:follow), BatchOperation.operations.fetch(:unfollow))
   end
 
   private

--- a/app/components/dossiers/batch_operation_component.rb
+++ b/app/components/dossiers/batch_operation_component.rb
@@ -15,7 +15,7 @@ class Dossiers::BatchOperationComponent < ApplicationComponent
     when Dossier.states.fetch(:en_construction)
       [BatchOperation.operations.fetch(:passer_en_instruction), BatchOperation.operations.fetch(:follow)]
     when Dossier.states.fetch(:en_instruction)
-      [BatchOperation.operations.fetch(:accepter)]
+      [BatchOperation.operations.fetch(:accepter), BatchOperation.operations.fetch(:repasser_en_construction)]
     when Dossier.states.fetch(:accepte), Dossier.states.fetch(:refuse), Dossier.states.fetch(:sans_suite)
       [BatchOperation.operations.fetch(:archiver)]
     else
@@ -60,6 +60,11 @@ class Dossiers::BatchOperationComponent < ApplicationComponent
             {
               label: t(".operations.accepter"),
               operation: BatchOperation.operations.fetch(:accepter)
+            },
+
+            {
+              label: t(".operations.repasser_en_construction"),
+              operation: BatchOperation.operations.fetch(:repasser_en_construction)
             }
           ]
       }
@@ -75,7 +80,8 @@ class Dossiers::BatchOperationComponent < ApplicationComponent
       accepter: 'fr-icon-success-line',
       archiver: 'fr-icon-folder-2-line',
       follow: 'fr-icon-star-line',
-      passer_en_instruction: 'fr-icon-edit-line'
+      passer_en_instruction: 'fr-icon-edit-line',
+      repasser_en_construction: 'fr-icon-draft-line'
     }
   end
 end

--- a/app/components/dossiers/batch_operation_component/batch_operation_component.en.yml
+++ b/app/components/dossiers/batch_operation_component/batch_operation_component.en.yml
@@ -4,3 +4,4 @@ fr:
     passer_en_instruction: 'Change selected files to instructing'
     accepter: 'Accept seleted files'
     follow: 'Follow seleted files'
+    repasser_en_construction: 'Change selected files to in progress'

--- a/app/components/dossiers/batch_operation_component/batch_operation_component.en.yml
+++ b/app/components/dossiers/batch_operation_component/batch_operation_component.en.yml
@@ -4,4 +4,5 @@ fr:
     passer_en_instruction: 'Change selected files to instructing'
     accepter: 'Accept seleted files'
     follow: 'Follow seleted files'
+    unfollow: 'Unfollow seleted files'
     repasser_en_construction: 'Change selected files to in progress'

--- a/app/components/dossiers/batch_operation_component/batch_operation_component.fr.yml
+++ b/app/components/dossiers/batch_operation_component/batch_operation_component.fr.yml
@@ -4,4 +4,5 @@ fr:
     passer_en_instruction: 'Passer les dossiers en instruction'
     accepter: 'Accepter les dossiers'
     follow: 'Suivre les dossiers'
+    unfollow: 'Ne plus suivre les dossiers'
     repasser_en_construction: 'Repasser les dossiers en construction'

--- a/app/components/dossiers/batch_operation_component/batch_operation_component.fr.yml
+++ b/app/components/dossiers/batch_operation_component/batch_operation_component.fr.yml
@@ -1,6 +1,7 @@
 fr:
   operations:
     archiver: 'Archiver les dossiers'
-    passer_en_instruction: 'Passer en instruction les dossiers'
+    passer_en_instruction: 'Passer les dossiers en instruction'
     accepter: 'Accepter les dossiers'
     follow: 'Suivre les dossiers'
+    repasser_en_construction: 'Repasser les dossiers en construction'

--- a/app/components/dossiers/batch_operation_component/batch_operation_component.html.haml
+++ b/app/components/dossiers/batch_operation_component/batch_operation_component.html.haml
@@ -11,7 +11,7 @@
 
       .dropdown{ data: { controller: 'menu-button', popover: 'true' } }
         -# Dropdown button title
-        %button.fr-btn.fr-btn--sm.fr-ml-1w.dropdown-button{ disabled: true, data: { menu_button_target: 'button', batch_operation_target: 'menu' } }
+        %button.fr-btn.fr-btn--sm.fr-btn--secondary.fr-ml-1w.dropdown-button{ disabled: true, data: { menu_button_target: 'button', batch_operation_target: 'menu' } }
           Autres actions multiples
 
         #state-menu.dropdown-content.fade-in-down{ data: { menu_button_target: 'menu' } }

--- a/app/components/dossiers/export_component.rb
+++ b/app/components/dossiers/export_component.rb
@@ -1,9 +1,10 @@
 class Dossiers::ExportComponent < ApplicationComponent
-  def initialize(procedure:, exports:, statut: nil, count: nil, export_url: nil)
+  def initialize(procedure:, exports:, statut: nil, count: nil, class_btn: nil, export_url: nil)
     @procedure = procedure
     @exports = exports
     @statut = statut
     @count = count
+    @class_btn = class_btn
     @export_url = export_url
   end
 

--- a/app/components/dossiers/export_component/export_component.html.haml
+++ b/app/components/dossiers/export_component/export_component.html.haml
@@ -1,5 +1,5 @@
 %span.dropdown{ data: { controller: 'menu-button' } }
-  %button.fr-btn.fr-btn--secondary.fr-btn--sm.dropdown-button{ data: { menu_button_target: 'button' } }
+  %button.fr-btn.fr-btn--sm.dropdown-button{ data: { menu_button_target: 'button' }, class: @class_btn.present? ? @class_btn : 'fr-btn--secondary' }
     - if @count.nil?
       = t(".download_all")
     - else

--- a/app/models/batch_operation.rb
+++ b/app/models/batch_operation.rb
@@ -21,7 +21,8 @@ class BatchOperation < ApplicationRecord
     archiver: 'archiver',
     follow: 'follow',
     passer_en_instruction: 'passer_en_instruction',
-    repasser_en_construction: 'repasser_en_construction'
+    repasser_en_construction: 'repasser_en_construction',
+    unfollow: 'unfollow'
   }
 
   has_many :dossiers, dependent: :nullify
@@ -64,6 +65,8 @@ class BatchOperation < ApplicationRecord
       query.without_followers.en_cours
     when BatchOperation.operations.fetch(:repasser_en_construction) then
       query.state_en_instruction
+    when BatchOperation.operations.fetch(:unfollow) then
+      query.with_followers.en_cours
     end
   end
 
@@ -84,6 +87,8 @@ class BatchOperation < ApplicationRecord
       instructeur.follow(dossier)
     when BatchOperation.operations.fetch(:repasser_en_construction)
       dossier.repasser_en_construction!(instructeur: instructeur)
+    when BatchOperation.operations.fetch(:unfollow)
+      instructeur.unfollow(dossier)
     end
   end
 

--- a/app/models/batch_operation.rb
+++ b/app/models/batch_operation.rb
@@ -20,7 +20,8 @@ class BatchOperation < ApplicationRecord
     accepter: 'accepter',
     archiver: 'archiver',
     follow: 'follow',
-    passer_en_instruction: 'passer_en_instruction'
+    passer_en_instruction: 'passer_en_instruction',
+    repasser_en_construction: 'repasser_en_construction'
   }
 
   has_many :dossiers, dependent: :nullify
@@ -61,6 +62,8 @@ class BatchOperation < ApplicationRecord
       query.state_en_instruction
     when BatchOperation.operations.fetch(:follow) then
       query.without_followers.en_cours
+    when BatchOperation.operations.fetch(:repasser_en_construction) then
+      query.state_en_instruction
     end
   end
 
@@ -79,6 +82,8 @@ class BatchOperation < ApplicationRecord
       dossier.accepter(instructeur: instructeur, motivation: motivation, justificatif: justificatif_motivation)
     when BatchOperation.operations.fetch(:follow)
       instructeur.follow(dossier)
+    when BatchOperation.operations.fetch(:repasser_en_construction)
+      dossier.repasser_en_construction!(instructeur: instructeur)
     end
   end
 

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -275,6 +275,7 @@ class Dossier < ApplicationRecord
   }
   scope :en_cours,                    -> { not_archived.state_en_construction_ou_instruction }
   scope :without_followers,           -> { left_outer_joins(:follows).where(follows: { id: nil }) }
+  scope :with_followers,              -> { left_outer_joins(:follows).where.not(follows: { id: nil }) }
   scope :with_champs, -> {
     includes(champs_public: [
       :type_de_champ,

--- a/app/views/instructeurs/procedures/_dossiers_filter_dropdown.html.haml
+++ b/app/views/instructeurs/procedures/_dossiers_filter_dropdown.html.haml
@@ -1,5 +1,5 @@
 %span.dropdown{ data: { controller: 'menu-button', popover: 'true' } }
-  %button.fr-btn.fr-btn--secondary.fr-btn--sm.fr-mr-2w.dropdown-button{ data: { menu_button_target: 'button' } }
+  %button.fr-btn.fr-btn--tertiary.fr-btn--sm.fr-mr-2w.dropdown-button{ data: { menu_button_target: 'button' } }
     = t('views.instructeurs.dossiers.filters.title')
   #filter-menu.dropdown-content.left-aligned.fade-in-down{ data: { menu_button_target: 'menu' } }
     = render Dossiers::FilterComponent.new(procedure: procedure, procedure_presentation: @procedure_presentation, statut: statut)

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -63,7 +63,7 @@
 
         .fr-ml-auto
           %span.dropdown{ data: { controller: 'menu-button', popover: 'true' } }
-            %button.fr-btn.fr-btn--sm.fr-btn--secondary.dropdown-button.fr-ml-1w{ data: { menu_button_target: 'button' } }
+            %button.fr-btn.fr-btn--sm.fr-btn--tertiary.dropdown-button.fr-ml-1w{ data: { menu_button_target: 'button' } }
               = t('views.instructeurs.dossiers.personalize')
             #custom-menu.dropdown-content.fade-in-down{ data: { menu_button_target: 'menu' } }
               = form_tag update_displayed_fields_instructeur_procedure_path(@procedure), method: :patch, class: 'dropdown-form large columns-form' do
@@ -85,7 +85,7 @@
 
           - if @dossiers_count > 0
             %span.dossiers-export
-              = render Dossiers::ExportComponent.new(procedure: @procedure, exports: @exports, statut: @statut, count: @dossiers_count, export_url: method(:download_export_instructeur_procedure_path))
+              = render Dossiers::ExportComponent.new(procedure: @procedure, exports: @exports, statut: @statut, count: @dossiers_count, class_btn: 'fr-btn--tertiary', export_url: method(:download_export_instructeur_procedure_path))
 
     - if @filtered_sorted_paginated_ids.present? || @current_filters.count > 0
       = render partial: "dossiers_filter_tags", locals: { procedure: @procedure, procedure_presentation: @procedure_presentation, current_filters: @current_filters, statut: @statut }
@@ -97,7 +97,7 @@
           = render Dossiers::BatchAlertComponent.new(batch: batch_operation, procedure: @procedure)
 
       %div{ data: batch_operation_component.render? ? { controller: 'batch-operation' } : {} }
-        .flex.align-center
+        .flex.align-center.fr-mt-2w
           %span.fr-h6.fr-mb-0.fr-mr-2w
             = t('views.instructeurs.dossiers.dossiers_count', count: @dossiers_count)
 

--- a/spec/components/dossiers/batch_alert_component_spec.rb
+++ b/spec/components/dossiers/batch_alert_component_spec.rb
@@ -219,6 +219,60 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
     end
   end
 
+  describe 'unfollow' do
+    let(:component) do
+      described_class.new(
+        batch: batch_operation,
+        procedure: procedure
+      )
+    end
+    let!(:dossier) { create(:dossier, :en_construction, :followed, procedure: procedure) }
+    let!(:dossier_2) { create(:dossier, :en_instruction, :followed, procedure: procedure) }
+    let!(:batch_operation) { create(:batch_operation, operation: :unfollow, dossiers: [dossier, dossier_2], instructeur: instructeur) }
+
+    context 'in_progress' do
+      before {
+         batch_operation.track_processed_dossier(true, dossier)
+         batch_operation.reload
+       }
+
+      it { is_expected.to have_selector('.fr-alert--info') }
+      it { is_expected.to have_text("Une action de masse est en cours") }
+      it { is_expected.to have_text("1/2 dossiers ne sont plus suivis") }
+    end
+
+    context 'finished and success' do
+      before {
+         batch_operation.track_processed_dossier(true, dossier)
+         batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.reload
+       }
+
+      it { is_expected.to have_selector('.fr-alert--success') }
+      it { is_expected.to have_text("L'action de masse est terminée") }
+      it { is_expected.to have_text("2 dossiers ne sont plus suivis") }
+      it { expect(batch_operation.seen_at).to eq(nil) }
+    end
+
+    context 'finished and fail' do
+      before {
+        batch_operation.track_processed_dossier(false, dossier)
+        batch_operation.track_processed_dossier(true, dossier_2)
+        batch_operation.reload
+      }
+
+      it { is_expected.to have_selector('.fr-alert--warning') }
+      it { is_expected.to have_text("L'action de masse est terminée") }
+      it { is_expected.to have_text("1/2 dossiers ne sont plus suivis") }
+      it { expect(batch_operation.seen_at).to eq(nil) }
+
+      it 'on next render "seen_at" is set to avoid rendering alert' do
+        render_inline(component).to_html
+        expect(batch_operation.seen_at).not_to eq(nil)
+      end
+    end
+  end
+
   describe 'repasser en construction' do
     let(:component) do
       described_class.new(

--- a/spec/components/dossiers/batch_operation_component_spec.rb
+++ b/spec/components/dossiers/batch_operation_component_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe Dossiers::BatchOperationComponent, type: :component do
     let(:statut) { 'suivis' }
     it { is_expected.to have_button('Passer les dossiers en instruction', disabled: true) }
     it { is_expected.to have_button('Accepter les dossiers', disabled: true) }
-    it { is_expected.to have_link('Repasser les dossiers en construction', disabled: true) }
-    it { is_expected.to have_link('Ne plus suivre les dossiers', disabled: true) }
     it { is_expected.to have_button('Autres actions multiples', disabled: true) }
+    it { is_expected.to have_button('Repasser les dossiers en construction', disabled: true) }
+    it { is_expected.to have_button('Ne plus suivre les dossiers', disabled: true) }
   end
 
   context 'statut a-suivre' do

--- a/spec/components/dossiers/batch_operation_component_spec.rb
+++ b/spec/components/dossiers/batch_operation_component_spec.rb
@@ -20,8 +20,9 @@ RSpec.describe Dossiers::BatchOperationComponent, type: :component do
   subject { render_inline(component).to_html }
   context 'statut suivis' do
     let(:statut) { 'suivis' }
-    it { is_expected.to have_button('Passer en instruction les dossiers', disabled: true) }
+    it { is_expected.to have_button('Passer les dossiers en instruction', disabled: true) }
     it { is_expected.to have_button('Accepter les dossiers', disabled: true) }
+    it { is_expected.to have_button('Repasser les dossiers en construction', disabled: true) }
   end
 
   context 'statut a-suivre' do

--- a/spec/components/dossiers/batch_operation_component_spec.rb
+++ b/spec/components/dossiers/batch_operation_component_spec.rb
@@ -22,7 +22,9 @@ RSpec.describe Dossiers::BatchOperationComponent, type: :component do
     let(:statut) { 'suivis' }
     it { is_expected.to have_button('Passer les dossiers en instruction', disabled: true) }
     it { is_expected.to have_button('Accepter les dossiers', disabled: true) }
-    it { is_expected.to have_button('Repasser les dossiers en construction', disabled: true) }
+    it { is_expected.to have_link('Repasser les dossiers en construction', disabled: true) }
+    it { is_expected.to have_link('Ne plus suivre les dossiers', disabled: true) }
+    it { is_expected.to have_button('Autres actions multiples', disabled: true) }
   end
 
   context 'statut a-suivre' do

--- a/spec/factories/batch_operation.rb
+++ b/spec/factories/batch_operation.rb
@@ -56,8 +56,8 @@ FactoryBot.define do
       after(:build) do |batch_operation, evaluator|
         procedure = create(:simple_procedure, :published, instructeurs: [evaluator.invalid_instructeur.presence || batch_operation.instructeur], administrateurs: [create(:administrateur)])
         batch_operation.dossiers = [
-          create(:dossier, :with_individual, :followed, :en_instruction, procedure: procedure),
-          create(:dossier, :with_individual, :followed, :en_construction, procedure: procedure)
+          create(:dossier, :with_individual, :en_instruction, procedure: procedure, followers_instructeurs: procedure.instructeurs),
+          create(:dossier, :with_individual, :en_construction, procedure: procedure, followers_instructeurs: procedure.instructeurs)
         ]
       end
     end

--- a/spec/factories/batch_operation.rb
+++ b/spec/factories/batch_operation.rb
@@ -50,5 +50,16 @@ FactoryBot.define do
         ]
       end
     end
+
+    trait :repasser_en_construction do
+      operation { BatchOperation.operations.fetch(:repasser_en_construction) }
+      after(:build) do |batch_operation, evaluator|
+        procedure = create(:simple_procedure, :published, instructeurs: [evaluator.invalid_instructeur.presence || batch_operation.instructeur], administrateurs: [create(:administrateur)])
+        batch_operation.dossiers = [
+          create(:dossier, :with_individual, :en_instruction, procedure: procedure),
+          create(:dossier, :with_individual, :en_instruction, procedure: procedure)
+        ]
+      end
+    end
   end
 end

--- a/spec/factories/batch_operation.rb
+++ b/spec/factories/batch_operation.rb
@@ -51,6 +51,17 @@ FactoryBot.define do
       end
     end
 
+    trait :unfollow do
+      operation { BatchOperation.operations.fetch(:unfollow) }
+      after(:build) do |batch_operation, evaluator|
+        procedure = create(:simple_procedure, :published, instructeurs: [evaluator.invalid_instructeur.presence || batch_operation.instructeur], administrateurs: [create(:administrateur)])
+        batch_operation.dossiers = [
+          create(:dossier, :with_individual, :followed, :en_instruction, procedure: procedure),
+          create(:dossier, :with_individual, :followed, :en_construction, procedure: procedure)
+        ]
+      end
+    end
+
     trait :repasser_en_construction do
       operation { BatchOperation.operations.fetch(:repasser_en_construction) }
       after(:build) do |batch_operation, evaluator|

--- a/spec/jobs/batch_operation_process_one_job_spec.rb
+++ b/spec/jobs/batch_operation_process_one_job_spec.rb
@@ -60,6 +60,21 @@ describe BatchOperationProcessOneJob, type: :job do
       end
     end
 
+    context 'when operation is "unfollow"' do
+      let(:batch_operation) do
+        create(:batch_operation, :unfollow,
+                                 options.merge(instructeur: create(:instructeur)))
+      end
+
+      it 'removes a follower to the dossier' do
+        expect { subject.perform_now }
+          .to change { dossier_job.reload.follows.first.unfollowed_at }
+          .from(nil)
+          .to(anything)
+      end
+    end
+
+
     context 'when operation is "repasser en construction"' do
       let(:batch_operation) do
         create(:batch_operation, :repasser_en_construction,

--- a/spec/jobs/batch_operation_process_one_job_spec.rb
+++ b/spec/jobs/batch_operation_process_one_job_spec.rb
@@ -68,9 +68,9 @@ describe BatchOperationProcessOneJob, type: :job do
 
       it 'removes a follower to the dossier' do
         expect { subject.perform_now }
-          .to change { dossier_job.reload.follows.first.unfollowed_at }
-          .from(nil)
-          .to(anything)
+          .to change { dossier_job.reload.follows.count }
+          .from(1)
+          .to(0)
       end
     end
 

--- a/spec/jobs/batch_operation_process_one_job_spec.rb
+++ b/spec/jobs/batch_operation_process_one_job_spec.rb
@@ -74,7 +74,6 @@ describe BatchOperationProcessOneJob, type: :job do
       end
     end
 
-
     context 'when operation is "repasser en construction"' do
       let(:batch_operation) do
         create(:batch_operation, :repasser_en_construction,

--- a/spec/jobs/batch_operation_process_one_job_spec.rb
+++ b/spec/jobs/batch_operation_process_one_job_spec.rb
@@ -60,6 +60,20 @@ describe BatchOperationProcessOneJob, type: :job do
       end
     end
 
+    context 'when operation is "repasser en construction"' do
+      let(:batch_operation) do
+        create(:batch_operation, :repasser_en_construction,
+                                 options.merge(instructeur: create(:instructeur)))
+      end
+
+      it 'changed the dossier to en construction' do
+        expect { subject.perform_now }
+          .to change { dossier_job.reload.en_construction? }
+          .from(false)
+          .to(true)
+      end
+    end
+
     context 'when operation is "accepter"' do
       let(:batch_operation) do
         create(:batch_operation, :accepter,


### PR DESCRIPTION
Mise en place des 2 dernières actions de l'onglet "suivi" : "repasser en construction" et "ne plus suivre"
Voir https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/8076


<img width="1410" alt="Capture d’écran 2023-01-13 à 15 39 12" src="https://user-images.githubusercontent.com/6756627/212346324-af49ab4b-bef4-4897-ae69-ff7ffa2b1e66.png">
