### PR TITLE
fix(email): ré-essai si une erreur intervient à l'envoi

### DIFF
--- a/app/lib/mail_delivery_error.rb
+++ b/app/lib/mail_delivery_error.rb
@@ -1,0 +1,6 @@
+# Inherit from `Exception` instead of `StandardError`
+# because this error is raised in a `rescue_from StandardError`,
+# so it would be shallowed otherwise.
+#
+# TODO: add a test which verify that the error will permit the job to retry
+class MailDeliveryError < Exception; end # rubocop:disable Lint/InheritException

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,5 @@
 class ApplicationMailer < ActionMailer::Base
+  include MailerDolistConcern
   include MailerMonitoringConcern
 
   helper :application # gives access to all helpers defined within `application_helper`.

--- a/app/mailers/concerns/mailer_dolist_concern.rb
+++ b/app/mailers/concerns/mailer_dolist_concern.rb
@@ -1,0 +1,15 @@
+module MailerDolistConcern
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :add_dolist_header
+
+    # mandatory for dolist
+    # used for tracking in Dolist UI
+    # the delivery_method is yet unknown (:balancer)
+    # so we add the dolist header for everyone
+    def add_dolist_header
+      headers['X-Dolist-Message-Name'] = action_name
+    end
+  end
+end

--- a/app/mailers/concerns/mailer_monitoring_concern.rb
+++ b/app/mailers/concerns/mailer_monitoring_concern.rb
@@ -2,8 +2,6 @@ module MailerMonitoringConcern
   extend ActiveSupport::Concern
 
   included do
-    before_action :add_dolist_header
-
     # Intercept & log any error, then re-raise so job will retry.
     # NOTE: rescue_from order matters, later matchers are tried first.
     rescue_from StandardError, with: :log_and_raise_delivery_error
@@ -19,14 +17,6 @@ module MailerMonitoringConcern
       else
         log_and_raise_delivery_error(exception)
       end
-    end
-
-    # mandatory for dolist
-    # used for tracking in Dolist UI
-    # the delivery_method is yet unknown (:balancer)
-    # so we add the dolist header for everyone
-    def add_dolist_header
-      headers['X-Dolist-Message-Name'] = action_name
     end
 
     def log_and_raise_delivery_error(exception)

--- a/app/mailers/devise_user_mailer.rb
+++ b/app/mailers/devise_user_mailer.rb
@@ -3,6 +3,7 @@ class DeviseUserMailer < Devise::Mailer
   helper :application # gives access to all helpers defined within `application_helper`.
   helper MailerHelper
   include Devise::Controllers::UrlHelpers # Optional. eg. `confirmation_url`
+  include MailerDolistConcern
   include MailerMonitoringConcern
   layout 'mailers/layout'
   before_action :add_delivery_method, if: :forced_delivery?

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -80,7 +80,7 @@ Rails.application.configure do
   ActionMailer::Base.add_delivery_method :balancer, BalancerDeliveryMethod
   config.action_mailer.balancer_settings = {
     helo: ENV['HELO_ENABLED'] == 'enabled' ? 100 : 0,
-      letter_opener: ENV['HELO_ENABLED'] == 'enabled' ? 0 : 100
+    letter_opener: ENV['HELO_ENABLED'] == 'enabled' ? 0 : 100
   }
   config.action_mailer.delivery_method = :balancer
 

--- a/spec/mailers/invite_mailer_spec.rb
+++ b/spec/mailers/invite_mailer_spec.rb
@@ -18,7 +18,13 @@ RSpec.describe InviteMailer, type: :mailer do
            v = send_mail_values.shift
            v == :raise ? raise("boom") : v
          end
-         mailer.body rescue nil
+
+         begin
+           mailer.body
+         rescue MailDeliveryError
+           nil
+         end
+
          mailer.body
          expect(TargetedUserLink.where(target_model: invite, user: invite.user).count).to eq(1)
        end
@@ -42,7 +48,13 @@ RSpec.describe InviteMailer, type: :mailer do
            v = send_mail_values.shift
            v == :raise ? raise("boom") : v
          end
-         mailer.body rescue nil
+
+         begin
+           mailer.body
+         rescue MailDeliveryError
+           nil
+         end
+
          mailer.body
          expect(TargetedUserLink.where(target_model: invite, user: invite.user).count).to eq(1)
        end


### PR DESCRIPTION
Comme on intercepte dorénavant chaque `StandardError` pour le monitoring des mails
en erreur, l'erreur n'était plus visible par le job, (qui de son point de vue était un succès) et les emails
étaient perdus. Ça concerne quelques dizaines d'emails sur la dernière semaine.

A la place on re-raise une autre erreur pour que le job échoue afin de
retry plus tard. Pour ne pas être "avalée" par le rescue_from,
cette erreur doit héritée d'`Exception` plutôt que `StandardError`.
J'ai passé pas mal de temps à essayer d'écrire un test qui vérifie bien ça, sans succès. À la place j'ai bien documenté.

J'en ai profité la logique `dolist` dans son propre concern.