### PR TITLE
feat(demarche): prefilling stats

### DIFF
--- a/app/controllers/api/public/v1/base_controller.rb
+++ b/app/controllers/api/public/v1/base_controller.rb
@@ -1,7 +1,7 @@
 class API::Public::V1::BaseController < APIController
   skip_forgery_protection
 
-  before_action :check_content_type_is_json
+  before_action :check_content_type_is_json, if: -> { request.post? || request.patch? || request.put? }
 
   protected
 

--- a/app/controllers/api/public/v1/stats_controller.rb
+++ b/app/controllers/api/public/v1/stats_controller.rb
@@ -1,0 +1,20 @@
+class API::Public::V1::StatsController < API::Public::V1::BaseController
+  before_action :retrieve_procedure
+
+  def index
+    render json: {
+      funnel: @procedure.stats_dossiers_funnel.as_json,
+      done: @procedure.stats_termines_states.as_json,
+      done_by_week: @procedure.stats_termines_by_week.as_json,
+      processing_time: @procedure.stats_usual_traitement_time.as_json,
+      processing_time_by_month: @procedure.stats_usual_traitement_time_by_month_in_days.as_json
+    }
+  end
+
+  private
+
+  def retrieve_procedure
+    @procedure = Procedure.publiees_ou_brouillons.opendata.find_by(id: params[:id])
+    render_not_found("procedure", params[:id]) if @procedure.blank?
+  end
+end

--- a/app/controllers/api/public/v1/stats_controller.rb
+++ b/app/controllers/api/public/v1/stats_controller.rb
@@ -4,8 +4,8 @@ class API::Public::V1::StatsController < API::Public::V1::BaseController
   def index
     render json: {
       funnel: @procedure.stats_dossiers_funnel.as_json,
-      done: @procedure.stats_termines_states.as_json,
-      done_by_week: @procedure.stats_termines_by_week.as_json,
+      processed: @procedure.stats_termines_states.as_json,
+      processed_by_week: @procedure.stats_termines_by_week.as_json,
       processing_time: @procedure.stats_usual_traitement_time.as_json,
       processing_time_by_month: @procedure.stats_usual_traitement_time_by_month_in_days.as_json
     }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -273,6 +273,7 @@ Rails.application.routes.draw do
         resources :demarches, only: [] do
           member do
             resources :dossiers, only: :create
+            resources :stats, only: :index
           end
         end
       end

--- a/spec/controllers/api/public/v1/stats_controller_spec.rb
+++ b/spec/controllers/api/public/v1/stats_controller_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe API::Public::V1::StatsController, type: :controller do
       it {
         expect(JSON.parse(response.body)).to match({
           funnel: procedure.stats_dossiers_funnel.as_json,
-          done: procedure.stats_termines_states.as_json,
-          done_by_week: procedure.stats_termines_by_week.as_json,
+          processed: procedure.stats_termines_states.as_json,
+          processed_by_week: procedure.stats_termines_by_week.as_json,
           processing_time: procedure.stats_usual_traitement_time.as_json,
           processing_time_by_month: procedure.stats_usual_traitement_time_by_month_in_days.as_json
         }.with_indifferent_access)

--- a/spec/controllers/api/public/v1/stats_controller_spec.rb
+++ b/spec/controllers/api/public/v1/stats_controller_spec.rb
@@ -1,0 +1,77 @@
+RSpec.describe API::Public::V1::StatsController, type: :controller do
+  describe '#index' do
+    let(:params) { { id: procedure.id } }
+    subject(:index_request) { get :index, params: params }
+
+    shared_examples 'the procedure is found' do
+      before do
+        create(:dossier, :en_instruction, procedure: procedure)
+        create(:dossier, :accepte, procedure: procedure)
+
+        index_request
+      end
+
+      it { expect(response).to be_successful }
+
+      it {
+        expect(JSON.parse(response.body)).to match({
+          funnel: procedure.stats_dossiers_funnel.as_json,
+          done: procedure.stats_termines_states.as_json,
+          done_by_week: procedure.stats_termines_by_week.as_json,
+          processing_time: procedure.stats_usual_traitement_time.as_json,
+          processing_time_by_month: procedure.stats_usual_traitement_time_by_month_in_days.as_json
+        }.with_indifferent_access)
+      }
+    end
+
+    shared_examples 'the procedure is not found' do
+      before { index_request }
+
+      it { expect(response).to have_http_status(:not_found) }
+
+      it { expect(response).to have_failed_with("procedure #{procedure.id} is not found") }
+    end
+
+    context 'when the procedure is found' do
+      context 'when the procedure is publiee' do
+        context 'when the procedure is opendata' do
+          it_behaves_like 'the procedure is found' do
+            let(:procedure) { create(:procedure, :published, opendata: true) }
+          end
+        end
+
+        context 'when the procedure is not opendata' do
+          it_behaves_like 'the procedure is not found' do
+            let(:procedure) { create(:procedure, :published, opendata: false) }
+          end
+        end
+      end
+
+      context 'when the procedure is brouillon' do
+        context 'when the procedure is opendata' do
+          it_behaves_like 'the procedure is found' do
+            let(:procedure) { create(:procedure, :draft, opendata: true) }
+          end
+        end
+
+        context 'when the procedure is not opendata' do
+          it_behaves_like 'the procedure is not found' do
+            let(:procedure) { create(:procedure, :draft, opendata: false) }
+          end
+        end
+      end
+
+      context 'when the procedure is not publiee and not brouillon' do
+        it_behaves_like 'the procedure is not found' do
+          let(:procedure) { create(:procedure, :closed) }
+        end
+      end
+    end
+
+    context 'when the procedure is not found' do
+      it_behaves_like 'the procedure is not found' do
+        let(:procedure) { double(Procedure, id: -1) }
+      end
+    end
+  end
+end

--- a/spec/models/concern/procedure_stats_concern_spec.rb
+++ b/spec/models/concern/procedure_stats_concern_spec.rb
@@ -1,4 +1,26 @@
 describe ProcedureStatsConcern do
+  describe '#stats_dossiers_funnel' do
+    let(:procedure) { create(:procedure) }
+
+    subject(:stats_dossiers_funnel) { procedure.stats_dossiers_funnel }
+
+    before do
+      create_list(:dossier, 2, :brouillon, procedure: procedure)
+      create_list(:dossier, 1, :en_instruction, procedure: procedure)
+    end
+
+    it "returns the funnel stats" do
+      expect(stats_dossiers_funnel).to match(
+        [
+          ['Démarrés', procedure.dossiers.count],
+          ['Déposés', procedure.dossiers.state_not_brouillon.count],
+          ['Instruction débutée', procedure.dossiers.state_instruction_commencee.count],
+          ['Traités', procedure.dossiers.state_termine.count]
+        ]
+      )
+    end
+  end
+
   describe '#usual_traitement_time_for_recent_dossiers' do
     let(:procedure) { create(:procedure) }
 

--- a/spec/models/concern/procedure_stats_concern_spec.rb
+++ b/spec/models/concern/procedure_stats_concern_spec.rb
@@ -6,7 +6,7 @@ describe ProcedureStatsConcern do
 
     before do
       create_list(:dossier, 2, :brouillon, procedure: procedure)
-      create_list(:dossier, 1, :en_instruction, procedure: procedure)
+      create(:dossier, :en_instruction, procedure: procedure)
     end
 
     it "returns the funnel stats" do


### PR DESCRIPTION
On ajoute un endpoint à l'API publique pour donner des statistiques sur les dossiers d'une procédure (publiée ou brouillon, opendata uniquement).

`/api/public/v1/demarches/:id/stats`

![image](https://user-images.githubusercontent.com/1193334/213117674-6c9b0c64-da79-4ef7-bca6-4ccd72bfe34c.png)

Il donne les mêmes statistiques que la page `/statistiques/:path`, mais en json.

# Post prod

À faire après la mise en production : 
- [ ] mettre à jour le gitbook

