### PR TITLE
feat(dossier): prefill region champ

### DIFF
--- a/app/models/champs/region_champ.rb
+++ b/app/models/champs/region_champ.rb
@@ -21,6 +21,10 @@
 #  type_de_champ_id               :integer
 #
 class Champs::RegionChamp < Champs::TextChamp
+  # TODO: SEB possible values (https://geo.api.gouv.fr/regions)
+  # TODO: SEB example value
+  # TODO: SEB add validation
+
   def for_export
     [name, code]
   end

--- a/app/models/champs/region_champ.rb
+++ b/app/models/champs/region_champ.rb
@@ -21,8 +21,8 @@
 #  type_de_champ_id               :integer
 #
 class Champs::RegionChamp < Champs::TextChamp
-  validates :value, inclusion: APIGeoService.regions.pluck(:name), allow_nil: true, allow_blank: false
-  validates :external_id, inclusion: APIGeoService.regions.pluck(:code), allow_nil: true, allow_blank: false
+  validate :value_in_region_names, unless: -> { value.nil? }
+  validate :external_id_in_region_codes, unless: -> { external_id.nil? }
 
   def for_export
     [name, code]
@@ -51,5 +51,19 @@ class Champs::RegionChamp < Champs::TextChamp
       self.external_id = APIGeoService.region_code(code)
       super(code)
     end
+  end
+
+  private
+
+  def value_in_region_names
+    return if value.in?(APIGeoService.regions.pluck(:name))
+
+    errors.add(:value, :not_in_region_names)
+  end
+
+  def external_id_in_region_codes
+    return if external_id.in?(APIGeoService.regions.pluck(:code))
+
+    errors.add(:external_id, :not_in_region_codes)
   end
 end

--- a/app/models/champs/region_champ.rb
+++ b/app/models/champs/region_champ.rb
@@ -21,7 +21,8 @@
 #  type_de_champ_id               :integer
 #
 class Champs::RegionChamp < Champs::TextChamp
-  # TODO: SEB add validation
+  validates :value, inclusion: APIGeoService.regions.pluck(:name), allow_nil: true, allow_blank: false
+  validates :external_id, inclusion: APIGeoService.regions.pluck(:code), allow_nil: true, allow_blank: false
 
   def for_export
     [name, code]
@@ -46,6 +47,9 @@ class Champs::RegionChamp < Champs::TextChamp
     elsif code.blank?
       self.external_id = nil
       super(nil)
+    else
+      self.external_id = APIGeoService.region_code(code)
+      super(code)
     end
   end
 end

--- a/app/models/champs/region_champ.rb
+++ b/app/models/champs/region_champ.rb
@@ -21,8 +21,6 @@
 #  type_de_champ_id               :integer
 #
 class Champs::RegionChamp < Champs::TextChamp
-  # TODO: SEB possible values (https://geo.api.gouv.fr/regions)
-  # TODO: SEB example value
   # TODO: SEB add validation
 
   def for_export

--- a/app/models/prefill_params.rb
+++ b/app/models/prefill_params.rb
@@ -39,7 +39,8 @@ class PrefillParams
       TypeDeChamp.type_champs.fetch(:civilite),
       TypeDeChamp.type_champs.fetch(:yes_no),
       TypeDeChamp.type_champs.fetch(:checkbox),
-      TypeDeChamp.type_champs.fetch(:pays)
+      TypeDeChamp.type_champs.fetch(:pays),
+      TypeDeChamp.type_champs.fetch(:regions)
     ]
 
     attr_reader :champ, :value

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -268,7 +268,8 @@ class TypeDeChamp < ApplicationRecord
       TypeDeChamp.type_champs.fetch(:datetime),
       TypeDeChamp.type_champs.fetch(:yes_no),
       TypeDeChamp.type_champs.fetch(:checkbox),
-      TypeDeChamp.type_champs.fetch(:drop_down_list)
+      TypeDeChamp.type_champs.fetch(:drop_down_list),
+      TypeDeChamp.type_champs.fetch(:regions)
     ])
   end
 

--- a/app/models/types_de_champ/prefill_region_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_region_type_de_champ.rb
@@ -1,0 +1,15 @@
+class TypesDeChamp::PrefillRegionTypeDeChamp < TypesDeChamp::PrefillTypeDeChamp
+  def possible_values
+    regions.map { |region| "#{region[:code]} (#{region[:name]})" }
+  end
+
+  def example_value
+    regions.pick(:code)
+  end
+
+  private
+
+  def regions
+    @regions ||= APIGeoService.regions.sort_by { |region| region[:code] }
+  end
+end

--- a/app/models/types_de_champ/prefill_region_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_region_type_de_champ.rb
@@ -3,10 +3,6 @@ class TypesDeChamp::PrefillRegionTypeDeChamp < TypesDeChamp::PrefillTypeDeChamp
     regions.map { |region| "#{region[:code]} (#{region[:name]})" }
   end
 
-  def example_value
-    regions.pick(:code)
-  end
-
   private
 
   def regions

--- a/app/models/types_de_champ/prefill_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_type_de_champ.rb
@@ -7,6 +7,8 @@ class TypesDeChamp::PrefillTypeDeChamp < SimpleDelegator
       TypesDeChamp::PrefillDropDownListTypeDeChamp.new(type_de_champ)
     when TypeDeChamp.type_champs.fetch(:pays)
       TypesDeChamp::PrefillPaysTypeDeChamp.new(type_de_champ)
+    when TypeDeChamp.type_champs.fetch(:regions)
+      TypesDeChamp::PrefillRegionTypeDeChamp.new(type_de_champ)
     else
       new(type_de_champ)
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -450,6 +450,12 @@ en:
           attributes:
             value:
               not_in_options: "must be in the given options"
+        "champs/region_champ":
+          attributes:
+            value:
+              not_in_region_names: "must be a valid region name"
+            external_id:
+              not_in_region_codes: "must be a valid region code"
   errors:
     format: "Field « %{attribute} » %{message}"
     messages:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -139,6 +139,7 @@ en:
           iban: FR7611315000011234567890138
           yes_no: "true"
           pays: "FR"
+          regions: "53"
           date: "2023-02-01"
           datetime: "2023-02-01T10:30"
           checkbox: "true"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -124,6 +124,7 @@ en:
           yes_no_html: '"true" for Yes, "false" pour No'
           checkbox_html: '"true" to check, "false" to uncheck'
           pays_html: An <a href="https://en.wikipedia.org/wiki/ISO_3166-2" target="_blank">ISO 3166-2 country code</a>
+          regions_html: An <a href="https://fr.wikipedia.org/wiki/R%C3%A9gion_fran%C3%A7aise" target="_blank">INSEE region code</a>
           date_html: ISO8601 date
           datetime_html: ISO8601 datetime
           drop_down_list_other_html: Any value

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -131,6 +131,7 @@ fr:
           yes_no: "true"
           civilite: "M."
           pays: "FR"
+          regions: "53"
           date: "2023-02-01"
           datetime: "2023-02-01T10:30"
           checkbox: "true"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -115,6 +115,7 @@ fr:
           yes_no_html: '"true" pour Oui, "false" pour Non'
           checkbox_html: '"true" pour coché, "false" pour décoché'
           pays_html: Un <a href="https://en.wikipedia.org/wiki/ISO_3166-2" target="_blank">code pays ISO 3166-2</a>
+          regions_html: Un <a href="https://fr.wikipedia.org/wiki/R%C3%A9gion_fran%C3%A7aise" target="_blank">code INSEE de région</a>
           datetime_html: Datetime au format ISO8601
           date_html: Date au format ISO8601
           drop_down_list_other_html: Toute valeur

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -445,6 +445,12 @@ fr:
           attributes:
             value:
               not_in_options: "doit être dans les options proposées"
+        "champs/region_champ":
+          attributes:
+            value:
+              not_in_region_names: "doit être un nom de région valide"
+            external_id:
+              not_in_region_codes: "doit être un code de région valide"
   errors:
     format: "Le champ « %{attribute} » %{message}"
     messages:

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -9,6 +9,8 @@ describe API::V2::GraphqlController do
   let(:dossiers) { [dossier] }
   let(:instructeur) { create(:instructeur, followed_dossiers: dossiers) }
 
+  let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+
   def compute_checksum_in_chunks(io)
     Digest::MD5.new.tap do |checksum|
       while (chunk = io.read(5.megabytes))
@@ -37,6 +39,9 @@ describe API::V2::GraphqlController do
   end
 
   before do
+    allow(Rails).to receive(:cache).and_return(memory_store)
+    Rails.cache.clear
+
     allow(APIGeoService).to receive(:departement_name).with('01').and_return('Ain')
     instructeur.assign_to_procedure(procedure)
   end
@@ -392,7 +397,7 @@ describe API::V2::GraphqlController do
         dossier
       end
 
-      context "for individual" do
+      context "for individual", vcr: { cassette_name: 'api_geo_regions' } do
         let(:procedure) { create(:procedure, :published, :for_individual, :with_service, :with_all_champs, :with_all_annotations, administrateurs: [admin]) }
         let(:query) do
           "{

--- a/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
@@ -11,12 +11,7 @@ describe API::V2::GraphqlController do
   let(:instructeur) { create(:instructeur, followed_dossiers: dossiers) }
   let(:authorization_header) { ActionController::HttpAuthentication::Token.encode_credentials(token) }
 
-  let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
-
   before do
-    allow(Rails).to receive(:cache).and_return(memory_store)
-    Rails.cache.clear
-
     instructeur.assign_to_procedure(procedure)
   end
 

--- a/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
@@ -11,7 +11,12 @@ describe API::V2::GraphqlController do
   let(:instructeur) { create(:instructeur, followed_dossiers: dossiers) }
   let(:authorization_header) { ActionController::HttpAuthentication::Token.encode_credentials(token) }
 
+  let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+
   before do
+    allow(Rails).to receive(:cache).and_return(memory_store)
+    Rails.cache.clear
+
     instructeur.assign_to_procedure(procedure)
   end
 

--- a/spec/lib/tasks/deployment/20220705164551_remove_unused_champs_spec.rb
+++ b/spec/lib/tasks/deployment/20220705164551_remove_unused_champs_spec.rb
@@ -1,4 +1,6 @@
 describe '20220705164551_remove_unused_champs' do
+  let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+
   let(:rake_task) { Rake::Task['after_party:remove_unused_champs'] }
   let(:procedure) { create(:procedure, :with_all_champs) }
   let(:dossier) { create(:dossier, :with_populated_champs, procedure: procedure) }
@@ -10,12 +12,14 @@ describe '20220705164551_remove_unused_champs' do
   end
 
   before do
-    allow(APIGeoService).to receive(:departement_name).with('01').and_return('Ain')
+    allow(Rails).to receive(:cache).and_return(memory_store)
+    Rails.cache.clear
+
     champ_repetition.champs.first.update(type_de_champ: create(:type_de_champ))
   end
   after { rake_task.reenable }
 
-  describe 'remove_unused_champs' do
+  describe 'remove_unused_champs', vcr: { cassette_name: 'api_geo_all' } do
     it "with bad champs" do
       expect(Champ.where(dossier: dossier).count).to eq(38)
       run_task

--- a/spec/models/champ_spec.rb
+++ b/spec/models/champ_spec.rb
@@ -155,11 +155,18 @@ describe Champ do
     end
   end
 
-  describe 'for_export' do
+  describe 'for_export', vcr: { cassette_name: 'api_geo_all' } do
     let(:type_de_champ) { create(:type_de_champ) }
     let(:champ) { type_de_champ.champ.build(value: value) }
 
-    before { champ.save }
+    let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+
+    before do
+      allow(Rails).to receive(:cache).and_return(memory_store)
+      Rails.cache.clear
+
+      champ.save
+    end
 
     context 'when type_de_champ is text' do
       let(:value) { '123' }
@@ -196,7 +203,7 @@ describe Champ do
       end
     end
 
-    describe '#search_terms', vcr: { cassette_name: 'api_geo_all' } do
+    describe '#search_terms' do
       let(:champ) { type_de_champ.champ.build(value: value) }
       subject { champ.search_terms }
 

--- a/spec/models/champs/region_champ_spec.rb
+++ b/spec/models/champs/region_champ_spec.rb
@@ -6,9 +6,69 @@ describe Champs::RegionChamp, type: :model do
     Rails.cache.clear
   end
 
-  let(:champ) { described_class.new }
+  describe 'validations' do
+    describe 'external link' do
+      subject { build(:champ_regions, external_id: external_id) }
+
+      context 'when nil' do
+        let(:external_id) { nil }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'when blank' do
+        let(:external_id) { '' }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context 'when included in the region codes' do
+        let(:external_id) { "01" }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'when not included in the region codes' do
+        let(:external_id) { "totoro" }
+
+        it { is_expected.not_to be_valid }
+      end
+    end
+
+    describe 'value' do
+      subject { create(:champ_regions) }
+
+      before { subject.update_columns(value: value) }
+
+      context 'when nil' do
+        let(:value) { nil }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'when blank' do
+        let(:value) { '' }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context 'when included in the region names' do
+        let(:value) { "Guyane" }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'when not included in the region names' do
+        let(:value) { "totoro" }
+
+        it { is_expected.not_to be_valid }
+      end
+    end
+  end
 
   describe 'value', vcr: { cassette_name: 'api_geo_regions' } do
+    let(:champ) { described_class.new }
+
     it 'with code' do
       champ.value = '01'
       expect(champ.external_id).to eq('01')

--- a/spec/models/champs/region_champ_spec.rb
+++ b/spec/models/champs/region_champ_spec.rb
@@ -6,7 +6,7 @@ describe Champs::RegionChamp, type: :model do
     Rails.cache.clear
   end
 
-  describe 'validations' do
+  describe 'validations', vcr: { cassette_name: 'api_geo_regions' } do
     describe 'external link' do
       subject { build(:champ_regions, external_id: external_id) }
 

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1697,8 +1697,14 @@ describe Dossier do
     end
   end
 
-  describe "#destroy" do
-    before { allow(APIGeoService).to receive(:departement_name).with('01').and_return('Ain') }
+  describe "#destroy", vcr: { cassette_name: 'api_geo_all' } do
+    let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+
+    before do
+      allow(Rails).to receive(:cache).and_return(memory_store)
+      Rails.cache.clear
+    end
+
     let(:procedure) { create(:procedure, :with_all_champs, :with_all_annotations) }
     let(:transfer) { create(:dossier_transfer) }
     let(:dossier) { create(:dossier, :with_populated_champs, :with_populated_annotations, transfer: transfer, procedure: procedure) }

--- a/spec/models/prefill_params_spec.rb
+++ b/spec/models/prefill_params_spec.rb
@@ -1,11 +1,18 @@
 RSpec.describe PrefillParams do
-  describe "#to_a" do
+  describe "#to_a", vcr: { cassette_name: 'api_geo_regions' } do
+    let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+
     let(:procedure) { create(:procedure, :published, types_de_champ_public:, types_de_champ_private:) }
     let(:dossier) { create(:dossier, :brouillon, procedure: procedure) }
     let(:types_de_champ_public) { [] }
     let(:types_de_champ_private) { [] }
 
     subject(:prefill_params_array) { described_class.new(dossier, params).to_a }
+
+    before do
+      allow(Rails).to receive(:cache).and_return(memory_store)
+      Rails.cache.clear
+    end
 
     context "when the stable ids match the TypeDeChamp of the corresponding procedure" do
       let(:types_de_champ_public) { [{ type: :text }, { type: :textarea }] }
@@ -161,7 +168,7 @@ RSpec.describe PrefillParams do
     it_behaves_like "a champ public value that is unauthorized", :carte, "value"
     it_behaves_like "a champ public value that is unauthorized", :address, "value"
     it_behaves_like "a champ public value that is unauthorized", :pays, "value"
-    # TODO: SEB it_behaves_like "a champ public value that is unauthorized", :regions, "value"
+    it_behaves_like "a champ public value that is unauthorized", :regions, "value"
     it_behaves_like "a champ public value that is unauthorized", :departements, "value"
     it_behaves_like "a champ public value that is unauthorized", :siret, "value"
     it_behaves_like "a champ public value that is unauthorized", :rna, "value"

--- a/spec/models/prefill_params_spec.rb
+++ b/spec/models/prefill_params_spec.rb
@@ -118,6 +118,7 @@ RSpec.describe PrefillParams do
     it_behaves_like "a champ public value that is authorized", :checkbox, "true"
     it_behaves_like "a champ public value that is authorized", :checkbox, "false"
     it_behaves_like "a champ public value that is authorized", :drop_down_list, "value"
+    it_behaves_like "a champ public value that is authorized", :regions, "03"
 
     it_behaves_like "a champ private value that is authorized", :text, "value"
     it_behaves_like "a champ private value that is authorized", :textarea, "value"
@@ -135,6 +136,7 @@ RSpec.describe PrefillParams do
     it_behaves_like "a champ private value that is authorized", :checkbox, "true"
     it_behaves_like "a champ private value that is authorized", :checkbox, "false"
     it_behaves_like "a champ private value that is authorized", :drop_down_list, "value"
+    it_behaves_like "a champ private value that is authorized", :regions, "93"
 
     it_behaves_like "a champ public value that is unauthorized", :decimal_number, "non decimal string"
     it_behaves_like "a champ public value that is unauthorized", :integer_number, "non integer string"
@@ -159,7 +161,7 @@ RSpec.describe PrefillParams do
     it_behaves_like "a champ public value that is unauthorized", :carte, "value"
     it_behaves_like "a champ public value that is unauthorized", :address, "value"
     it_behaves_like "a champ public value that is unauthorized", :pays, "value"
-    it_behaves_like "a champ public value that is unauthorized", :regions, "value"
+    # TODO: SEB it_behaves_like "a champ public value that is unauthorized", :regions, "value"
     it_behaves_like "a champ public value that is unauthorized", :departements, "value"
     it_behaves_like "a champ public value that is unauthorized", :siret, "value"
     it_behaves_like "a champ public value that is unauthorized", :rna, "value"

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -249,6 +249,7 @@ describe TypeDeChamp do
     it_behaves_like "a prefillable type de champ", :type_de_champ_yes_no
     it_behaves_like "a prefillable type de champ", :type_de_champ_checkbox
     it_behaves_like "a prefillable type de champ", :type_de_champ_drop_down_list
+    it_behaves_like "a prefillable type de champ", :type_de_champ_regions
 
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_number
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_communes
@@ -266,7 +267,6 @@ describe TypeDeChamp do
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_mesri
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_carte
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_address
-    it_behaves_like "a non-prefillable type de champ", :type_de_champ_regions
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_departements
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_siret
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_rna

--- a/spec/models/types_de_champ/prefill_region_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_region_type_de_champ_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe TypesDeChamp::PrefillRegionTypeDeChamp, type: :model do
+  let(:type_de_champ) { build(:type_de_champ_regions) }
+  let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+
+  before do
+    allow(Rails).to receive(:cache).and_return(memory_store)
+    Rails.cache.clear
+  end
+
+  describe '#possible_values', vcr: { cassette_name: 'api_geo_regions' } do
+    let(:expected_values) { APIGeoService.regions.sort_by { |region| region[:code] }.map { |region| "#{region[:code]} (#{region[:name]})" } }
+    subject(:possible_values) { described_class.new(type_de_champ).possible_values }
+
+    it { expect(possible_values).to match(expected_values) }
+  end
+
+  describe '#example_value', vcr: { cassette_name: 'api_geo_regions' } do
+    subject(:example_value) { described_class.new(type_de_champ).example_value }
+
+    it { expect(example_value).to eq(APIGeoService.regions.sort_by { |region| region[:code] }.first[:code]) }
+  end
+end

--- a/spec/models/types_de_champ/prefill_region_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_region_type_de_champ_spec.rb
@@ -9,16 +9,16 @@ RSpec.describe TypesDeChamp::PrefillRegionTypeDeChamp, type: :model do
     Rails.cache.clear
   end
 
+  describe 'ancestors' do
+    subject { described_class.build(type_de_champ) }
+
+    it { is_expected.to be_kind_of(TypesDeChamp::PrefillTypeDeChamp) }
+  end
+
   describe '#possible_values', vcr: { cassette_name: 'api_geo_regions' } do
     let(:expected_values) { APIGeoService.regions.sort_by { |region| region[:code] }.map { |region| "#{region[:code]} (#{region[:name]})" } }
     subject(:possible_values) { described_class.new(type_de_champ).possible_values }
 
     it { expect(possible_values).to match(expected_values) }
-  end
-
-  describe '#example_value', vcr: { cassette_name: 'api_geo_regions' } do
-    subject(:example_value) { described_class.new(type_de_champ).example_value }
-
-    it { expect(example_value).to eq(APIGeoService.regions.sort_by { |region| region[:code] }.first[:code]) }
   end
 end

--- a/spec/models/types_de_champ/prefill_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_type_de_champ_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe TypesDeChamp::PrefillTypeDeChamp, type: :model do
       it { expect(built).to be_kind_of(TypesDeChamp::PrefillPaysTypeDeChamp) }
     end
 
+    context 'when the type de champ is a regions' do
+      let(:type_de_champ) { build(:type_de_champ_regions) }
+
+      it { expect(built).to be_kind_of(TypesDeChamp::PrefillRegionTypeDeChamp) }
+    end
+
     context 'when any other type de champ' do
       let(:type_de_champ) { build(:type_de_champ_date) }
 

--- a/spec/services/procedure_export_service_spec.rb
+++ b/spec/services/procedure_export_service_spec.rb
@@ -1,17 +1,17 @@
 require 'csv'
 
-describe ProcedureExportService, vcr: { cassette_name: 'api_geo_all' } do
+describe ProcedureExportService do
+  let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+
   let(:procedure) { create(:procedure, :published, :for_individual, :with_all_champs) }
   let(:service) { ProcedureExportService.new(procedure, procedure.dossiers) }
-
-  let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
 
   before do
     allow(Rails).to receive(:cache).and_return(memory_store)
     Rails.cache.clear
   end
 
-  describe 'to_xlsx' do
+  describe 'to_xlsx', vcr: { cassette_name: 'api_geo_all' } do
     subject do
       service
         .to_xlsx
@@ -463,7 +463,7 @@ describe ProcedureExportService, vcr: { cassette_name: 'api_geo_all' } do
     end
   end
 
-  describe 'to_zip' do
+  describe 'to_zip', vcr: { cassette_name: 'api_geo_all' } do
     subject { service.to_zip }
     context 'without files' do
       it 'does not raises in_batches' do
@@ -521,7 +521,7 @@ describe ProcedureExportService, vcr: { cassette_name: 'api_geo_all' } do
       create(:geo_area, :polygon, champ: champ_carte)
     end
 
-    it 'should have features' do
+    it 'should have features', vcr: { cassette_name: 'api_geo_all' } do
       expect(subject['features'].size).to eq(1)
       expect(properties['dossier_id']).to eq(dossier.id)
       expect(properties['champ_id']).to eq(champ_carte.stable_id)


### PR DESCRIPTION
On rend le champ "region" préremplissable.

Pour cela, on ajoute les valeurs possibles et une valeur en exemple (qui viennent de api.geo.gouv.fr).

On ajoute ensuite des validations sur `RegionChamp` afin de s'assurer qu'on n'écrira pas n'importe quoi dans les champs `value` et `external_id`.

Comme les validations sont chargées dès que le fichier est chargé, et non à l'exécution, j'ai rencontré des difficultés avec VCR. Impossible d'utiliser une cassette, VCR lève une exception dès le chargement de fichier. Le seul contournement que j'ai trouvé, c'est d'ajouter `c.allow_http_connections_when_no_cassette = true` dans la configuration de VCR. D'après la [documentation](https://relishapp.com/vcr/vcr/v/6-1-0/docs/configuration/allow-http-connections-when-no-cassette), ça signifie que **VCR ne lèvera pas d'erreur si on effectue une requête sans utiliser de cassette**.

Je trouve ça super dommage, mais je n'ai pas trouvé mieux. Je suis preneur si vous avez une idée.

![image](https://user-images.githubusercontent.com/1193334/213463789-ef142153-c5b4-4f79-b2e8-57e5c40a8545.png)
