### PR TITLE
Fix: affichage du nombre d'admins d'une démarche sur la page "toutes les démarches"

### DIFF
--- a/app/models/procedure_detail.rb
+++ b/app/models/procedure_detail.rb
@@ -8,7 +8,7 @@ class ProcedureDetail < OpenStruct
   end
 
   def administrateurs
-    Administrateurs.new(count: admin_count)
+    Administrateurs.new(admin_count)
   end
 
   Administrateurs = Struct.new(:count)


### PR DESCRIPTION
Comme ça on affiche plus `{:count => 2}` ;)