### PR TITLE
fix(email-event): apparently mail subject could be null

### DIFF
--- a/app/models/email_event.rb
+++ b/app/models/email_event.rb
@@ -24,7 +24,7 @@ class EmailEvent < ApplicationRecord
       to.each do |recipient|
         EmailEvent.create!(
           to: recipient,
-          subject: message.subject,
+          subject: message.subject || "",
           processed_at: message.date,
           method: ActionMailer::Base.delivery_methods.key(message.delivery_method.class),
           status:


### PR DESCRIPTION
Apparemment soit `Mail::Message`  a perdu le subject, soit on envoie avec un subject null.

https://sentry.io/organizations/demarches-simplifiees/issues/3868123320/?project=1429550&query=is%3Aunresolved&referrer=issue-stream