### PR TITLE
Crash lors d'un même path procedure ?

### DIFF
--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -273,10 +273,16 @@ module Administrateurs
           @procedure.publish_revision!
           flash.notice = "Nouvelle version de la démarche publiée"
         end
-      elsif @procedure.publish_or_reopen!(current_administrateur)
-        flash.notice = "Démarche publiée"
       else
-        flash.alert = @procedure.errors.full_messages
+        begin
+          if @procedure.publish_or_reopen!(current_administrateur)
+            flash.notice = "Démarche publiée"
+          else
+            flash.alert = @procedure.errors.full_messages
+          end
+        rescue StandardError => e
+          flash.alert = @procedure.errors.full_messages
+        end
       end
 
       if params[:old_procedure].present? && @procedure.errors.empty?


### PR DESCRIPTION
Bonjour,

J'ai pu observer un crash de DS lorsque on publie une démarche avec le même path qu'une procédure existante ayant comme propriétaire un autre administrateur, il n'y a pas non plus de message d'erreur pour l'utilisateur qui l'informe.
Aussi lorsqu'on est administrateur et qu'on publie une démarche avec le même path qu'une autre qui nous appartient, on a aucun message qui nous met en garde et cela remplace directement notre démarche en clôturant l'ancienne.

J'ai pu faire un rapide correctif mais j'aurais aimé savoir si c'était un problème connu ou bien si c'était un comportement connu ou que c'était fait exprès ? 
Si c'est bien un bug, je pense que je continuerais la MR pour corriger d'une autre façon (directement dans le model).