### PR TITLE
Fix: prévient l'instructeur lorsqu'un dossier n'est pas terminable à cause de champ SIRET incomplet

### DIFF
--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -315,7 +315,7 @@ module Instructeurs
     def aasm_error_message(exception, target_state:)
       if exception.originating_state == target_state
         "Le dossier est déjà #{dossier_display_state(target_state, lower: true)}."
-      elsif exception.failures.include?(:can_terminer?)
+      elsif exception.failures.include?(:can_terminer?) && dossier.any_etablissement_as_degraded_mode?
         "Les données relatives au SIRET de ce dossier n’ont pas pu encore être vérifiées : il n’est pas possible de le passer #{dossier_display_state(target_state, lower: true)}."
       else
         "Le dossier est en ce moment #{dossier_display_state(exception.originating_state, lower: true)} : il n’est pas possible de le passer #{dossier_display_state(target_state, lower: true)}."

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -540,7 +540,7 @@ class Dossier < ApplicationRecord
   end
 
   def can_terminer?
-    return false if etablissement&.as_degraded_mode?
+    return false if any_etablissement_as_degraded_mode?
 
     true
   end
@@ -567,6 +567,13 @@ class Dossier < ApplicationRecord
 
   def can_be_deleted_by_administration?(reason)
     termine? || reason == :procedure_removed
+  end
+
+  def any_etablissement_as_degraded_mode?
+    return true if etablissement&.as_degraded_mode?
+    return true if champs_public_all.any? { _1.etablissement&.as_degraded_mode? }
+
+    false
   end
 
   def messagerie_available?

--- a/app/services/serializer_service.rb
+++ b/app/services/serializer_service.rb
@@ -1,12 +1,20 @@
 class SerializerService
   def self.dossier(dossier)
-    data = execute_query('serializeDossier', { number: dossier.id })
-    data && data['dossier']
+    Sentry.with_scope do |scope|
+      scope.set_tags(dossier_id: dossier.id)
+
+      data = execute_query('serializeDossier', { number: dossier.id })
+      data && data['dossier']
+    end
   end
 
   def self.dossiers(procedure)
-    data = execute_query('serializeDossiers', { number: procedure.id })
-    data && data['demarche']['dossiers']
+    Sentry.with_scope do |scope|
+      scope.set_tags(procedure_id: procedure.id)
+
+      data = execute_query('serializeDossiers', { number: procedure.id })
+      data && data['demarche']['dossiers']
+    end
   end
 
   def self.demarches_publiques(after: nil)
@@ -20,12 +28,16 @@ class SerializerService
   end
 
   def self.champ(champ)
-    if champ.private?
-      data = execute_query('serializeAnnotation', { number: champ.dossier_id, id: champ.to_typed_id })
-      data && data['dossier']['annotations'].first
-    else
-      data = execute_query('serializeChamp', { number: champ.dossier_id, id: champ.to_typed_id })
-      data && data['dossier']['champs'].first
+    Sentry.with_scope do |scope|
+      scope.set_tags(champ_id: champ.id)
+
+      if champ.private?
+        data = execute_query('serializeAnnotation', { number: champ.dossier_id, id: champ.to_typed_id })
+        data && data['dossier']['annotations'].first
+      else
+        data = execute_query('serializeChamp', { number: champ.dossier_id, id: champ.to_typed_id })
+        data && data['dossier']['champs'].first
+      end
     end
   end
 

--- a/app/views/shared/dossiers/_identite_entreprise.html.haml
+++ b/app/views/shared/dossiers/_identite_entreprise.html.haml
@@ -2,7 +2,16 @@
   %table.table.vertical.dossier-champs{ role: :presentation }
     %tbody
       %tr
-        %td.libelle{ colspan: 2 } ⚠ LʼINSEE est indisponible, les informations sur lʼentreprise arriveront dʼici quelques heures.
+        %td{ colspan: 2 }
+          .fr-alert.fr-alert--warning.fr-alert--sm
+            %p
+              LʼINSEE est indisponible, les informations sur lʼentreprise arriveront dʼici quelques heures.
+              - if profile == "instructeur"
+                %br
+                Il nʼest pas possible dʼaccepter ou de refuser un dossier sans cette étape.
+
+
+
       %tr
         %td.libelle SIRET :
         %td= etablissement.siret

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1192,6 +1192,21 @@ describe Dossier do
         expect(dossier_ok.accepter_automatiquement(instructeur:, motivation:)).to be_truthy
       end
     end
+
+    context "when a SIRET champ has etablissement in degraded mode" do
+      let(:dossier_incomplete) { create(:dossier, :en_instruction) }
+      let(:dossier_ok) { create(:dossier, :en_instruction) }
+
+      before do
+        dossier_incomplete.champs_public << create(:champ_siret, dossier: dossier_incomplete, etablissement: Etablissement.new(siret: build(:etablissement).siret))
+        dossier_ok.champs_public << create(:champ_siret, dossier: dossier_ok)
+      end
+
+      it "can't accepter" do
+        expect(dossier_incomplete.may_accepter?(instructeur:, motivation:)).to be_falsey
+        expect(dossier_ok.may_accepter?(instructeur:, motivation:)).to be_truthy
+      end
+    end
   end
 
   describe "#check_mandatory_and_visible_champs" do


### PR DESCRIPTION
Quand l'API INSEE est down, on a des champs siret ayant des établissements incomplets. Ça provoque des erreurs lorsqu'on créé les operations logs.

https://sentry.io/organizations/demarches-simplifiees/issues/2839832517/?project=1429550

Cette PR empêche les transitions en amont, et prévient les instructeurs en s'appuyant sur ce qui avait été déjà fait pour l'établissement du demandeur.

A priori ça provoque pas de query supplémentaire

![Capture d’écran 2023-01-18 à 18 36 08](https://user-images.githubusercontent.com/150279/213253928-34df8ba1-5ab5-46cb-b7e5-6a4a464e14ac.png)



Closes #8449 



J'ai aussi rajouté un peu de contexte pour sentry quand l'erreur pop de graphql, on a presque rien et c'est assez laborieux. Mais c'est verbeux, je peux retirer 
