### PR TITLE
fix(prefill): don't mark the dossier as prefilled when it's not

### DIFF
--- a/app/models/concerns/dossier_prefillable_concern.rb
+++ b/app/models/concerns/dossier_prefillable_concern.rb
@@ -4,8 +4,10 @@ module DossierPrefillableConcern
   extend ActiveSupport::Concern
 
   def prefill!(champs_public_attributes)
+    return unless champs_public_attributes.any?
+
     attr = { prefilled: true }
-    attr[:champs_public_attributes] = champs_public_attributes.map { |h| h.merge(prefilled: true) } if champs_public_attributes.any?
+    attr[:champs_public_attributes] = champs_public_attributes.map { |h| h.merge(prefilled: true) }
 
     assign_attributes(attr)
     save(validate: false)

--- a/spec/models/concern/dossier_prefillable_concern_spec.rb
+++ b/spec/models/concern/dossier_prefillable_concern_spec.rb
@@ -17,7 +17,9 @@ RSpec.describe DossierPrefillableConcern do
     context 'when champs_public_attributes is empty' do
       let(:values) { [] }
 
-      it_behaves_like 'a dossier marked as prefilled'
+      it "doesn't mark the dossier as prefilled" do
+        expect { fill }.not_to change { dossier.reload.prefilled }.from(nil)
+      end
 
       it "doesn't change champs_public" do
         expect { fill }.not_to change { dossier.champs_public.to_a }


### PR DESCRIPTION
Quand il n'y a pas de paramètres pour le préremplissage, on ne devrait pas indiquer que le dossier est prérempli. En effet, ça revient à n'avoir QUE des dossiers marqués avec `prefilled: true`, qu'ils aient été effectivement préremplis ou non.