### PR TITLE
fix(prefill): code pays display

### DIFF
--- a/app/models/types_de_champ/prefill_pays_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_pays_type_de_champ.rb
@@ -1,0 +1,15 @@
+class TypesDeChamp::PrefillPaysTypeDeChamp < TypesDeChamp::PrefillTypeDeChamp
+  def possible_values
+    countries.map { |country| "#{country[:code]} (#{country[:name]})" }
+  end
+
+  def example_value
+    countries.pick(:code)
+  end
+
+  private
+
+  def countries
+    @countries ||= APIGeoService.countries.sort_by { |country| country[:code] }
+  end
+end

--- a/app/models/types_de_champ/prefill_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_type_de_champ.rb
@@ -5,6 +5,8 @@ class TypesDeChamp::PrefillTypeDeChamp < SimpleDelegator
     case type_de_champ.type_champ
     when TypeDeChamp.type_champs.fetch(:drop_down_list)
       TypesDeChamp::PrefillDropDownListTypeDeChamp.new(type_de_champ)
+    when TypeDeChamp.type_champs.fetch(:pays)
+      TypesDeChamp::PrefillPaysTypeDeChamp.new(type_de_champ)
     else
       new(type_de_champ)
     end

--- a/app/models/types_de_champ/prefill_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_type_de_champ.rb
@@ -29,8 +29,4 @@ class TypesDeChamp::PrefillTypeDeChamp < SimpleDelegator
   def too_many_possible_values?
     possible_values.count > POSSIBLE_VALUES_THRESHOLD
   end
-
-  def possible_values_sample
-    possible_values.first(POSSIBLE_VALUES_THRESHOLD)
-  end
 end

--- a/app/models/types_de_champ/prefill_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_type_de_champ.rb
@@ -15,9 +15,7 @@ class TypesDeChamp::PrefillTypeDeChamp < SimpleDelegator
   end
 
   def possible_values
-    return [] unless prefillable?
-
-    [I18n.t("views.prefill_descriptions.edit.possible_values.#{type_champ}_html")]
+    []
   end
 
   def example_value

--- a/app/models/types_de_champ/prefill_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_type_de_champ.rb
@@ -1,5 +1,5 @@
 class TypesDeChamp::PrefillTypeDeChamp < SimpleDelegator
-  POSSIBLE_VALUES_THRESHOLD = 10
+  POSSIBLE_VALUES_THRESHOLD = 5
 
   def self.build(type_de_champ)
     case type_de_champ.type_champ

--- a/app/views/prefill_descriptions/_types_de_champs.html.haml
+++ b/app/views/prefill_descriptions/_types_de_champs.html.haml
@@ -43,8 +43,6 @@
                     = t("views.prefill_descriptions.edit.possible_values.#{type_de_champ.type_champ}_html")
                     %br
                   - if type_de_champ.too_many_possible_values?
-                    = "#{type_de_champ.possible_values_sample.join(", ")}..."
-                    %br
                     = link_to "Voir toutes les valeurs possibles", prefill_type_de_champ_path(prefill_description.path, type_de_champ)
                   - else
                     = type_de_champ.possible_values.to_sentence

--- a/app/views/prefill_descriptions/_types_de_champs.html.haml
+++ b/app/views/prefill_descriptions/_types_de_champs.html.haml
@@ -39,6 +39,9 @@
                 %th
                   = t("views.prefill_descriptions.edit.possible_values.title")
                 %td
+                  - if I18n.exists?("views.prefill_descriptions.edit.possible_values.#{type_de_champ.type_champ}_html")
+                    = t("views.prefill_descriptions.edit.possible_values.#{type_de_champ.type_champ}_html")
+                    %br
                   - if type_de_champ.too_many_possible_values?
                     = "#{type_de_champ.possible_values_sample.join(", ")}..."
                     %br

--- a/spec/models/types_de_champ/prefill_pays_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_pays_type_de_champ_spec.rb
@@ -1,0 +1,17 @@
+
+RSpec.describe TypesDeChamp::PrefillPaysTypeDeChamp, type: :model do
+  let(:type_de_champ) { build(:type_de_champ_pays) }
+
+  describe '#possible_values' do
+    let(:expected_values) { APIGeoService.countries.sort_by { |country| country[:code] }.map { |country| "#{country[:code]} (#{country[:name]})" } }
+    subject(:possible_values) { described_class.new(type_de_champ).possible_values }
+
+    it { expect(possible_values).to match(expected_values) }
+  end
+
+  describe '#example_value' do
+    subject(:example_value) { described_class.new(type_de_champ).example_value }
+
+    it { expect(example_value).to eq(APIGeoService.countries.sort_by { |country| country[:code] }.first[:code]) }
+  end
+end

--- a/spec/models/types_de_champ/prefill_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_type_de_champ_spec.rb
@@ -10,6 +10,12 @@ RSpec.describe TypesDeChamp::PrefillTypeDeChamp, type: :model do
       it { expect(built).to be_kind_of(TypesDeChamp::PrefillDropDownListTypeDeChamp) }
     end
 
+    context 'when the type de champ is a pays' do
+      let(:type_de_champ) { build(:type_de_champ_pays) }
+
+      it { expect(built).to be_kind_of(TypesDeChamp::PrefillPaysTypeDeChamp) }
+    end
+
     context 'when any other type de champ' do
       let(:type_de_champ) { build(:type_de_champ_date) }
 

--- a/spec/models/types_de_champ/prefill_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_type_de_champ_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe TypesDeChamp::PrefillTypeDeChamp, type: :model do
     context 'when the type de champ is prefillable' do
       let(:type_de_champ) { build(:type_de_champ_email) }
 
-      it { expect(possible_values).to match([I18n.t("views.prefill_descriptions.edit.possible_values.#{type_de_champ.type_champ}_html")]) }
+      it { expect(possible_values).to match([]) }
     end
   end
 

--- a/spec/models/types_de_champ/prefill_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_type_de_champ_spec.rb
@@ -80,12 +80,4 @@ RSpec.describe TypesDeChamp::PrefillTypeDeChamp, type: :model do
       it { expect(too_many_possible_values).to eq(false) }
     end
   end
-
-  describe '#possible_values_sample' do
-    let(:drop_down_options) { (1..described_class::POSSIBLE_VALUES_THRESHOLD + 1).map(&:to_s) }
-    let(:type_de_champ) { build(:type_de_champ_drop_down_list, drop_down_options: drop_down_options) }
-    subject(:possible_values_sample) { described_class.build(type_de_champ).possible_values_sample }
-
-    it { expect(possible_values_sample).to match(drop_down_options.first(described_class::POSSIBLE_VALUES_THRESHOLD)) }
-  end
 end


### PR DESCRIPTION
On corrige l'affichage du lien pour les pays.

Par ailleurs, lorsqu'on a à la fois une traduction et des valeurs possibles, on fait en sorte d'afficher les deux (notamment grâce au lien "Voir toutes les valeurs possibles").

# Avant

![image](https://user-images.githubusercontent.com/1193334/214023977-9cec9fe1-05f5-4542-a325-e8fa0c6bf950.png)

# Après

![image](https://user-images.githubusercontent.com/1193334/214024074-983e7184-c350-479a-a5c8-f8c2c3e8f278.png)
