### PR TITLE
amelioration(modele_attestation): re-tente a génération de l'attestation dans le cas ou notre objectstorage est en bagotage

### DIFF
--- a/app/views/administrateurs/attestation_templates/show.pdf.prawn
+++ b/app/views/administrateurs/attestation_templates/show.pdf.prawn
@@ -31,6 +31,22 @@ created_at = @attestation.fetch(:created_at)
 logo = @attestation[:logo]
 signature = @attestation[:signature]
 
+def download_file_and_retry(file_or_attached_one, max_attempts = 3)
+  if file_or_attached_one.is_a?(ActiveStorage::Attached::One)
+    file_or_attached_one.download
+  else
+    file_or_attached_one.rewind && file_or_attached_one.read
+  end
+rescue Fog::OpenStack::Storage::NotFound => e
+  if max_attempts > 0
+    max_attempts = max_attempts - 1
+    sleep 1
+    retry
+  else
+    raise e
+  end
+end
+
 prawn_document(margin: [top_margin, right_margin, bottom_margin, left_margin], page_size: page_size) do |pdf|
   pdf.font_families.update('marianne' => { normal: Rails.root.join('lib/prawn/fonts/marianne/marianne-regular.ttf') })
   pdf.font 'marianne'


### PR DESCRIPTION
see: https://secure.helpscout.net/conversation/2130856854/2011688?folderId=5175185

détail d'implem. ca peut paraitre bizarre de retry dans la vue. mais le contexte de vue rewrap l'erreur dans un Template::Error. Alors c'est un raccourcis pas tres joli.