### PR TITLE
fix(combobox): let direct upload finish before submitting form

### DIFF
--- a/app/javascript/components/shared/hooks.ts
+++ b/app/javascript/components/shared/hooks.ts
@@ -15,7 +15,15 @@ export function useDeferredSubmit(input?: HTMLInputElement): {
       const interceptFormSubmit = (event: Event) => {
         event.preventDefault();
         runCallback();
-        form.submit();
+
+        if (
+          !Array.from(form.elements).some((e) =>
+            e.hasAttribute('data-direct-upload-url')
+          )
+        ) {
+          form.submit();
+        }
+        // else: form will be submitted by diret upload once file have been uploaded
       };
       calledRef.current = false;
       form.addEventListener('submit', interceptFormSubmit);


### PR DESCRIPTION
Quand un form pour lequel on intercepte le submit via `useDeferredSubmit`  pour un combobox a un direct upload, on laisse le direct upload gérer le submit ; autrement le form est parfois soumis sans la référence au fichier (un string vide plutôt que la key), ce qui provoque des erreurs rails `InvalidSignature`.

Le fix est moche mais les combo sont de toute façon sur la sellette