### PR TITLE
a11y : update style link dsfr

### DIFF
--- a/app/views/users/dossiers/show/_status_overview.html.haml
+++ b/app/views/users/dossiers/show/_status_overview.html.haml
@@ -65,7 +65,7 @@
 
         = render partial: 'users/dossiers/show/download_justificatif', locals: { dossier: dossier }
         .action
-          = link_to t('views.users.dossiers.show.status_overview.refuse_reply'), messagerie_dossier_url(dossier, anchor: 'new_commentaire'), class: 'button'
+          = link_to t('views.users.dossiers.show.status_overview.refuse_reply'), messagerie_dossier_url(dossier, anchor: 'new_commentaire'), class: 'fr-link'
 
     - elsif dossier.sans_suite?
       .sans-suite


### PR DESCRIPTION
Voici la correction apportée : 

Application du style DSFR pour le lien "[Envoyer un message à l’administration](https://www.demarches-simplifiees.fr/dossiers/10659723/messagerie#new_commentaire)"

<img width="1102" alt="Capture d’écran 2023-01-24 à 14 58 21" src="https://user-images.githubusercontent.com/49035942/214314464-b48b72c8-6dbc-4b03-ba27-cf7971c9a6ba.png">
