### PR TITLE
a11y : add label textarea message

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -30,7 +30,6 @@
     color: $dark-red;
   }
 
-  label,
   legend.form-label {
     font-size: 18px;
     margin-bottom: $default-padding;
@@ -198,9 +197,6 @@
   input[type=tel],
   textarea,
   select {
-    border-radius: 4px;
-    border: solid 1px $border-grey;
-    padding: $default-padding;
 
     &.small {
       padding: $default-spacer;
@@ -218,7 +214,7 @@
     }
 
     // Hide the browser default invalidity indicator until the field is touched
-    &:invalid:not(:focus) {
+    &:invalid:not(:focus):not(.fr-input) {
       box-shadow: none;
     }
 

--- a/app/views/shared/dossiers/messages/_form.html.haml
+++ b/app/views/shared/dossiers/messages/_form.html.haml
@@ -3,12 +3,17 @@
   - placeholder = t('views.shared.dossiers.messages.form.write_message_to_administration_placeholder')
   - if instructeur_signed_in? || administrateur_signed_in? || expert_signed_in?
     - placeholder = t('views.shared.dossiers.messages.form.write_message_placeholder')
-  = f.text_area :body, rows: 5, placeholder: placeholder, title: placeholder, required: true, class: 'message-textarea'
+  %p.mandatory-explanation= t('asterisk_html', scope: [:utils])
+  .fr-input-group
+    = label_tag :commentaire_body, class: 'fr-label' do
+      = t('message', scope: [:utils])
+      %span.mandatory *
+    = f.text_area :body, rows: 5, placeholder: placeholder, title: placeholder, required: true, class: 'fr-input message-textarea'
   .flex.justify-between.wrap
     - disable_piece_jointe = defined?(disable_piece_jointe) ? disable_piece_jointe : false
     %div
       - if !disable_piece_jointe
         = render Attachment::EditComponent.new(attached_file: commentaire.piece_jointe)
 
-    %div
-      = f.submit t('views.shared.dossiers.messages.form.send_message'), class: 'button primary send', data: { disable: true }
+    .send-wrapper.fr-my-3w
+      = f.submit t('views.shared.dossiers.messages.form.send_message'), class: 'fr-btn send', data: { disable: true }

--- a/app/views/users/dossiers/show/_print_dossier.html.haml
+++ b/app/views/users/dossiers/show/_print_dossier.html.haml
@@ -1,4 +1,4 @@
-%span.dropdown.print-menu-opener{ data: { controller: 'menu-button' } }
+.dropdown.print-menu-opener{ data: { controller: 'menu-button' } }
   %button.button.dropdown-button.icon-only{ title: t('views.users.dossiers.show.header.print'), 'aria-label': 'imprimer', data: { menu_button_target: 'button' } }
     %span.icon.printer
   %ul#print-menu.print-menu.dropdown-content{ data: { menu_button_target: 'menu' } }


### PR DESCRIPTION
Voici les corrections apportées :

- Ajout d'une légende pour les champs obligatoires
- Ajout d'une étiquette au champ
- Harmonisation des styles avec le DSFR
<img width="1181" alt="Capture d’écran 2023-01-24 à 16 20 23" src="https://user-images.githubusercontent.com/49035942/214333987-b1b18a0e-9c57-4b90-bc0c-f67dc2a246bf.png">


- J'en ai profité pour corriger la structure HTML du bouton d'impression : 
(Remplacement de la balise `<span>` par une balise `<div>` pour encadrer la balise `<button>`)

<img width="124" alt="Capture d’écran 2023-01-19 à 12 30 26" src="https://user-images.githubusercontent.com/49035942/213431436-8eb0e9fd-b087-4cd4-a9aa-68b2f1896435.png">

- Pour l'envoi de pièces jointes, j'ai voulu reprendre la structure de la page Contact afin d'ajouter un étiquette au champ et des informations sur le format de pièces jointes téléchargeables :  

<img width="493" alt="Capture d’écran 2023-01-19 à 12 30 55" src="https://user-images.githubusercontent.com/49035942/213431669-253b175e-723f-41e6-94c7-f150d4238e56.png">

La structure HTML et les attributs utilisés sont très différents et je n'ai pas voulu bloquer certaines fonctionnalités.
Afin d'harmoniser l'ensemble des pages du site, ces informations sont importantes pour l'utilisateur.