### PR TITLE
a11y : footer remove br tags

### DIFF
--- a/app/assets/stylesheets/new_footer.scss
+++ b/app/assets/stylesheets/new_footer.scss
@@ -18,3 +18,9 @@
     width: 9rem;
   }
 }
+
+.fr-footer__top-link p {
+  margin-bottom: 0;
+  font-size: 0.75rem;
+  line-height: 1.25rem;
+}

--- a/app/views/layouts/mailers/_service_footer.html.haml
+++ b/app/views/layouts/mailers/_service_footer.html.haml
@@ -12,11 +12,8 @@
         %p
           %strong
             = t('.procedure_management')
-          %br
           = service.nom
-          %br
           = service.organisme
-          %br
           = service.adresse
       %td{ width: "50%", valign: "top" }
         %p

--- a/app/views/users/_procedure_footer.html.haml
+++ b/app/views/users/_procedure_footer.html.haml
@@ -15,9 +15,10 @@
               %li
                 - horaires = "#{I18n.t('users.procedure_footer.contact.schedule.prefix')}#{formatted_horaires(service.horaires)}"
                 = link_to service.telephone_url, class: 'fr-footer__top-link' do
-                  = I18n.t('users.procedure_footer.contact.phone.link', service_telephone: service.telephone)
-                  %br
-                  = horaires
+                  %p
+                    = I18n.t('users.procedure_footer.contact.phone.link', service_telephone: service.telephone)
+                  %p
+                    = horaires
               %li
                 = link_to I18n.t('users.procedure_footer.contact.stats.link'), statistiques_path(procedure.path), class: 'fr-footer__top-link', rel: 'noopener'
 


### PR DESCRIPTION
Voici les corrections apportées : 
Suppression des balises `<br>` dans les zones du footer : 
-  "Poser une question sur votre dossier" : 
<img width="400" alt="Capture d’écran 2023-01-25 à 15 40 08" src="https://user-images.githubusercontent.com/49035942/214593720-9af67ded-0464-4b3c-be57-443fa9346f4f.png">

- "Cette démarche est gérée par" : 

<img width="737" alt="Capture d’écran 2023-01-25 à 15 40 21" src="https://user-images.githubusercontent.com/49035942/214593724-123150f4-1c99-4872-bef0-c6683d1e1b68.png">