### PR TITLE
a11y : contact standardize links

### DIFF
--- a/app/assets/stylesheets/contact.scss
+++ b/app/assets/stylesheets/contact.scss
@@ -9,6 +9,14 @@ $contact-padding: $default-space * 2;
     padding-bottom: $contact-padding;
   }
 
+  .recommandations {
+    p {
+      font-size: 1.5rem;
+      font-weight: bold;
+      line-height: 1.5rem;
+    }
+  }
+
   ul {
     margin-bottom: $default-space;
   }

--- a/app/views/support/index.html.haml
+++ b/app/views/support/index.html.haml
@@ -11,7 +11,7 @@
 
       .description
         .recommandations
-          %h2 
+          %h2
             = t('.intro_html')
         %p.mandatory-explanation= t('asterisk_html', scope: [:utils])
 

--- a/app/views/support/index.html.haml
+++ b/app/views/support/index.html.haml
@@ -9,9 +9,10 @@
 
     = form_tag contact_path, method: :post, multipart: true, class: 'fr-form-group', data: {controller: :support } do
 
-      .description 
+      .description
         .recommandations
-          = t('.intro_html')
+          %h2 
+            = t('.intro_html')
         %p.mandatory-explanation= t('asterisk_html', scope: [:utils])
 
       - if !user_signed_in?

--- a/app/views/support/index.html.haml
+++ b/app/views/support/index.html.haml
@@ -9,9 +9,9 @@
 
     = form_tag contact_path, method: :post, multipart: true, class: 'fr-form-group', data: {controller: :support } do
 
-      .description
-        %h2= t('.intro_html')
-        %br
+      .description 
+        .recommandations
+          = t('.intro_html')
         %p.mandatory-explanation= t('asterisk_html', scope: [:utils])
 
       - if !user_signed_in?

--- a/config/locales/views/support/en.yml
+++ b/config/locales/views/support/en.yml
@@ -3,7 +3,7 @@ en:
     index:
       contact: Contact
       intro_html: "<p>Contact us via this form and we will answer you as quickly as possible.</p>
-      <p>Make sure you provide all the required information so we can help you in the best way.</p>"
+        <p>Make sure you provide all the required information so we can help you in the best way.</p>"
       your_question: Your question
       our_answer: 👉 Our answer
       notice_pj_product: A screenshot can help us identify the element to improve.
@@ -11,31 +11,28 @@ en:
       procedure_info:
         question: I've encountered a problem while completing my application
         answer_html: "<p>Are you sure that all the mandatory fields (<span class= mandatory> * </span>) are properly filled?
-              <p>If you have questions about the information requested, <a href=%{link_procedure_info}>contact the service in charge of the procedure (FAQ)</a>.</p>"
+              <p>If you have questions about the information requested, <a href=\"%{link_procedure_info}\">contact the service in charge of the procedure (FAQ)</a>.</p>"
       instruction_info:
         question: I have a question about the instruction of my application
-        answer_html: "<p>Si vous avez des questions sur l’instruction de votre dossier (par exemple sur les délais), nous vous invitons à <a href=%{link_instruction_info}>contacter directement les services qui instruisent votre dossier par votre messagerie (FAQ)</a>.</p>
-        <p>Si vous souhaitez poser une question pour un problème technique sur le site, utilisez le formulaire ci-dessous. Nous ne pourrons pas vous renseigner sur l’instruction de votre dossier.</p>"
-        answer_html: "<p>If you have questions about the instruction of your application (response delay for example), <a href=%{link_instruction_info}>contact directly the instructor via our mail system (FAQ)</a>.</p>
-              <p>If you are facing technical issues on the website, use the form below. We will not be able to inform you about the instruction of your application.</p>"
+        answer_html: "<p>If you have questions about the instruction of your application (response delay for example), <a href=\"%{link_instruction_info}\">contact directly the instructor via our mail system (FAQ)</a>.</p>
+          <p>If you are facing technical issues on the website, use the form below. We will not be able to inform you about the instruction of your application.</p>"
       product:
         question: I have an idea to improve the website
-        answer_html: "<p>Got an idea? <a href=%{link_product}>Please check our enhancement dashboard</a> :</p>
+        answer_html: "<p>Got an idea? <a href=\"%{link_product}\" rel=\"noopener noreferrer\" target=\"_blank\" title=\"Open features dashboard - New tab\">Please check our enhancement dashboard</a> :</p>
               <ul><li>Vote for your priority improvements</li>
               <li>Share your own ideas</li></ul>"
       lost_user:
         question: I am having trouble finding the procedure I am looking for
         answer_html: "<p>We invite you to contact the administration in charge of the procedure so they can provide you the link.
-              It should look like this: %{base_url}/commencer/NOM_DE_LA_DEMARCHE.</p>
-              <p>You can <a href=%{link_lost_user}>find here the most popular procedures (licence, detr, etc.)</a>.</p>"
+              It should look like this: <code>%{base_url}/commencer/NOM_DE_LA_DEMARCHE</code>.</p>
+              <p>You can <a href=\"%{link_lost_user}\">find here the most popular procedures (licence, detr, etc.)</a>.</p>"
       other:
         question: Other topic
     admin:
       your_question: Your question
       admin_intro_html: "<p>As an administration, you can contact us through this form. We'll answer you as quickly as possibly by e-mail or phone.</p>
-      <br>
-      <p><strong>Caution, this form is dedicated to public bodies only.</strong>
-      It does not concern individuals, companies nor associations (except those recognised of public utility). If you belong to one of these categories, contact us <a href=%{contact_path}>here</a>.</p>"
+        <p><strong>Caution, this form is dedicated to public bodies only.</strong>
+        It does not concern individuals, companies nor associations (except those recognised of public utility). If you belong to one of these categories, contact us <a href=\"%{contact_path}\">here</a>.</p>"
       contact_team: Contact our team
       pro_phone_number: Professional phone number (direct line)
       pro_mail: Professional email address

--- a/config/locales/views/support/en.yml
+++ b/config/locales/views/support/en.yml
@@ -2,7 +2,8 @@ en:
   support:
     index:
       contact: Contact
-      intro_html: Contact us via this form and we will answer you as quickly as possible.<br>Make sure you provide all the required information so we can help you in the best way.
+      intro_html: "<p>Contact us via this form and we will answer you as quickly as possible.</p>
+      <p>Make sure you provide all the required information so we can help you in the best way.</p>"
       your_question: Your question
       our_answer: 👉 Our answer
       notice_pj_product: A screenshot can help us identify the element to improve.
@@ -10,27 +11,23 @@ en:
       procedure_info:
         question: I've encountered a problem while completing my application
         answer_html: "<p>Are you sure that all the mandatory fields (<span class= mandatory> * </span>) are properly filled?
-              <p>If you have questions about the information requested, contact the service in charge of the procedure.</p>
-              <p><a href=%{link_procedure_info}>Find more information</a></p>"
+              <p>If you have questions about the information requested, <a href=%{link_procedure_info}>contact the service in charge of the procedure (FAQ)</a>.</p>"
       instruction_info:
         question: I have a question about the instruction of my application
-        answer_html: "<p>If you have questions about the instruction of your application (response delay for example), contact directly the instructor via our mail system.</p>
-              <p><a href=%{link_instruction_info}>Find more information</a></p>
-              <br>
+        answer_html: "<p>Si vous avez des questions sur l’instruction de votre dossier (par exemple sur les délais), nous vous invitons à <a href=%{link_instruction_info}>contacter directement les services qui instruisent votre dossier par votre messagerie (FAQ)</a>.</p>
+        <p>Si vous souhaitez poser une question pour un problème technique sur le site, utilisez le formulaire ci-dessous. Nous ne pourrons pas vous renseigner sur l’instruction de votre dossier.</p>"
+        answer_html: "<p>If you have questions about the instruction of your application (response delay for example), <a href=%{link_instruction_info}>contact directly the instructor via our mail system (FAQ)</a>.</p>
               <p>If you are facing technical issues on the website, use the form below. We will not be able to inform you about the instruction of your application.</p>"
       product:
         question: I have an idea to improve the website
-        answer_html: "<p>Got an idea? Please check our <strong>enhancement dashboard</strong></p>
+        answer_html: "<p>Got an idea? <a href=%{link_product}>Please check our enhancement dashboard</a> :</p>
               <ul><li>Vote for your priority improvements</li>
-              <li>Share your own ideas</li></ul>
-              <p><strong><a href=%{link_product}>➡ Access the enhancement dashboard</a></strong></p>"
+              <li>Share your own ideas</li></ul>"
       lost_user:
         question: I am having trouble finding the procedure I am looking for
         answer_html: "<p>We invite you to contact the administration in charge of the procedure so they can provide you the link.
               It should look like this: %{base_url}/commencer/NOM_DE_LA_DEMARCHE.</p>
-              <br>
-              <p>You can find here the most popular procedures (licence, detr, etc.) :</p>
-              <p><a href=%{link_lost_user}>%{link_lost_user}</a></p>"
+              <p>You can <a href=%{link_lost_user}>find here the most popular procedures (licence, detr, etc.)</a>.</p>"
       other:
         question: Other topic
     admin:

--- a/config/locales/views/support/fr.yml
+++ b/config/locales/views/support/fr.yml
@@ -2,7 +2,8 @@ fr:
   support:
     index:
       contact: Contact
-      intro_html: Contactez-nous via ce formulaire et nous vous répondrons dans les plus brefs délais.<br>Pensez bien à nous donner le plus d’informations possible pour que nous puissions vous aider au mieux.
+      intro_html: "<p>Contactez-nous via ce formulaire et nous vous répondrons dans les plus brefs délais.</p>
+      <p>Pensez bien à nous donner le plus d’informations possible pour que nous puissions vous aider au mieux.</p>"
       your_question: Votre question
       our_answer: 👉 Notre réponse
       notice_pj_product: Une capture d’écran peut nous aider à identifier plus facilement l’endroit à améliorer.
@@ -10,32 +11,25 @@ fr:
       procedure_info:
         question: J’ai un problème lors du remplissage de mon dossier
         answer_html: "<p>Avez-vous bien vérifié que tous les champs obligatoires (<span class= mandatory> * </span>) sont remplis ?
-        <p>Si vous avez des questions sur les informations à saisir, contactez les services en charge de la démarche.</p>
-        <p><a href=%{link_procedure_info}>En savoir plus</a></p>"
+        <p>Si vous avez des questions sur les informations à saisir, <a href=%{link_procedure_info}>contactez les services en charge de la démarche (FAQ)</a>.</p>"
       instruction_info:
         question: J’ai une question sur l’instruction de mon dossier
-        answer_html: "<p>Si vous avez des questions sur l’instruction de votre dossier (par exemple sur les délais), nous vous invitons à contacter directement les services qui instruisent votre dossier par votre messagerie.</p>
-        <p><a href=%{link_instruction_info}>En savoir plus</a></p>
-        <br>
+        answer_html: "<p>Si vous avez des questions sur l’instruction de votre dossier (par exemple sur les délais), nous vous invitons à <a href=%{link_instruction_info}>contacter directement les services qui instruisent votre dossier par votre messagerie (FAQ)</a>.</p>
         <p>Si vous souhaitez poser une question pour un problème technique sur le site, utilisez le formulaire ci-dessous. Nous ne pourrons pas vous renseigner sur l’instruction de votre dossier.</p>"
       product:
         question: J’ai une idée d’amélioration pour votre site
-        answer_html: "<p>Une idée ? Pensez à consulter notre <strong>tableau de bord des améliorations</strong></p>
-        <ul><li>Votez pour vos améliorations prioritaires;</li>
-        <li>Proposez votre propre idée.</li></ul>
-        <p><strong><a href=%{link_product}>➡ Accéder au tableau des améliorations</a></strong></p>"
+        answer_html: "<p>Une idée ? Pensez à <a href=%{link_product}>consulter notre tableau de bord des améliorations</a> :</p>
+        <ul><li>Votez pour vos améliorations prioritaires,</li>
+        <li>Proposez votre propre idée.</li></ul>"
       lost_user:
         question: Je ne trouve pas la démarche que je veux faire
         answer_html: "<p>Nous vous invitons à contacter l’administration en charge de votre démarche pour qu’elle vous indique le lien à suivre. Celui-ci devrait ressembler à cela : %{base_url}/commencer/NOM_DE_LA_DEMARCHE.</p>
-        <br>
-        <p>Vous pouvez aussi consulter ici la liste de nos démarches les plus frequentes (permis, detr etc) :</p>
-        <p><a href=%{link_lost_user}>%{link_lost_user}</a></p>"
+        <p>Vous pouvez aussi <a href=%{link_lost_user}>consulter ici la liste de nos démarches les plus fréquentes (permis, detr etc)</a>.</p>"
       other:
         question: Autre sujet
     admin:
       your_question: Votre question
       admin_intro_html: "<p>En tant qu’administration, vous pouvez nous contactez via ce formulaire. Nous vous répondrons dans les plus brefs délais, par email ou par téléphone.</p>
-      <br>
       <p><strong>Attention, ce formulaire est réservé uniquement aux organismes publics.</strong>
       Il ne concerne ni les particuliers, ni les entreprises, ni les associations (sauf celles reconnues d’utilité publique). Si c'est votre cas, rendez-vous sur notre
       <a href=%{contact_path}>formulaire de contact public</a>.</p>"

--- a/config/locales/views/support/fr.yml
+++ b/config/locales/views/support/fr.yml
@@ -3,7 +3,7 @@ fr:
     index:
       contact: Contact
       intro_html: "<p>Contactez-nous via ce formulaire et nous vous répondrons dans les plus brefs délais.</p>
-      <p>Pensez bien à nous donner le plus d’informations possible pour que nous puissions vous aider au mieux.</p>"
+        <p>Pensez bien à nous donner le plus d’informations possible pour que nous puissions vous aider au mieux.</p>"
       your_question: Votre question
       our_answer: 👉 Notre réponse
       notice_pj_product: Une capture d’écran peut nous aider à identifier plus facilement l’endroit à améliorer.
@@ -11,28 +11,28 @@ fr:
       procedure_info:
         question: J’ai un problème lors du remplissage de mon dossier
         answer_html: "<p>Avez-vous bien vérifié que tous les champs obligatoires (<span class= mandatory> * </span>) sont remplis ?
-        <p>Si vous avez des questions sur les informations à saisir, <a href=%{link_procedure_info}>contactez les services en charge de la démarche (FAQ)</a>.</p>"
+          <p>Si vous avez des questions sur les informations à saisir, <a href=\"%{link_procedure_info}\">contactez les services en charge de la démarche (FAQ)</a>.</p>"
       instruction_info:
         question: J’ai une question sur l’instruction de mon dossier
-        answer_html: "<p>Si vous avez des questions sur l’instruction de votre dossier (par exemple sur les délais), nous vous invitons à <a href=%{link_instruction_info}>contacter directement les services qui instruisent votre dossier par votre messagerie (FAQ)</a>.</p>
-        <p>Si vous souhaitez poser une question pour un problème technique sur le site, utilisez le formulaire ci-dessous. Nous ne pourrons pas vous renseigner sur l’instruction de votre dossier.</p>"
+        answer_html: "<p>Si vous avez des questions sur l’instruction de votre dossier (par exemple sur les délais), nous vous invitons à <a href=\"%{link_instruction_info}\">contacter directement les services qui instruisent votre dossier par votre messagerie (FAQ)</a>.</p>
+          <p>Si vous souhaitez poser une question pour un problème technique sur le site, utilisez le formulaire ci-dessous. Nous ne pourrons pas vous renseigner sur l’instruction de votre dossier.</p>"
       product:
         question: J’ai une idée d’amélioration pour votre site
-        answer_html: "<p>Une idée ? Pensez à <a href=%{link_product}>consulter notre tableau de bord des améliorations</a> :</p>
-        <ul><li>Votez pour vos améliorations prioritaires,</li>
-        <li>Proposez votre propre idée.</li></ul>"
+        answer_html: "<p>Une idée ? Pensez à <a href=\"%{link_product}\" rel=\"noopener noreferrer\" target=\"_blank\" title=\"Ouvrir le tableau des évolutions - Nouvel onglet\">consulter notre tableau de bord des améliorations</a> :</p>
+          <ul><li>Votez pour vos améliorations prioritaires,</li>
+          <li>Proposez votre propre idée.</li></ul>"
       lost_user:
         question: Je ne trouve pas la démarche que je veux faire
-        answer_html: "<p>Nous vous invitons à contacter l’administration en charge de votre démarche pour qu’elle vous indique le lien à suivre. Celui-ci devrait ressembler à cela : %{base_url}/commencer/NOM_DE_LA_DEMARCHE.</p>
-        <p>Vous pouvez aussi <a href=%{link_lost_user}>consulter ici la liste de nos démarches les plus fréquentes (permis, detr etc)</a>.</p>"
+        answer_html: "<p>Nous vous invitons à contacter l’administration en charge de votre démarche pour qu’elle vous indique le lien à suivre. Celui-ci devrait ressembler à cela : <code>%{base_url}/commencer/NOM_DE_LA_DEMARCHE</code>.</p>
+          <p>Vous pouvez aussi <a href=\"%{link_lost_user}\">consulter ici la liste de nos démarches les plus fréquentes (permis, detr etc)</a>.</p>"
       other:
         question: Autre sujet
     admin:
       your_question: Votre question
       admin_intro_html: "<p>En tant qu’administration, vous pouvez nous contactez via ce formulaire. Nous vous répondrons dans les plus brefs délais, par email ou par téléphone.</p>
-      <p><strong>Attention, ce formulaire est réservé uniquement aux organismes publics.</strong>
-      Il ne concerne ni les particuliers, ni les entreprises, ni les associations (sauf celles reconnues d’utilité publique). Si c'est votre cas, rendez-vous sur notre
-      <a href=%{contact_path}>formulaire de contact public</a>.</p>"
+        <p><strong>Attention, ce formulaire est réservé uniquement aux organismes publics.</strong>
+        Il ne concerne ni les particuliers, ni les entreprises, ni les associations (sauf celles reconnues d’utilité publique). Si c'est votre cas, rendez-vous sur notre
+        <a href=\"%{contact_path}\">formulaire de contact public</a>.</p>"
       contact_team: Contactez notre équipe
       pro_phone_number: Numéro de téléphone professionnel (ligne directe)
       pro_mail: Adresse e-mail professionnelle


### PR DESCRIPTION
Voici les corrections apportées :

- Uniformisation de l'apparence des liens
- Intitulés plus explicites
- Suppression des balises `<br>` de la page

Version française : 
<img width="787" alt="Capture d’écran 2023-01-25 à 17 04 29" src="https://user-images.githubusercontent.com/49035942/214626574-cf354e96-c320-4fe7-a2e2-7102eb39903c.png">

Version anglaise : 
<img width="655" alt="Capture d’écran 2023-01-25 à 17 47 46" src="https://user-images.githubusercontent.com/49035942/214626650-fbd07c48-0f3d-4ac4-9fcb-90b2e95b31ac.png">
 
