### PR TITLE
fix(scss): form borders & padding

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -30,6 +30,7 @@
     color: $dark-red;
   }
 
+  label,
   legend.form-label {
     font-size: 18px;
     margin-bottom: $default-padding;
@@ -202,6 +203,9 @@
   input[type=tel],
   textarea,
   select {
+    border-radius: 4px;
+    border: solid 1px $border-grey;
+    padding: $default-padding;
 
     &.small {
       padding: $default-spacer;


### PR DESCRIPTION
On revert une partie de 2d61d94a4623f171e00544c5a1b5445165acf1e0 car ça casse d'autres formulaires que la messagerie, notamment le form usager