### PR TITLE
correct(champs::date): renforce la validation d'un champs de type date

### DIFF
--- a/app/models/champs/date_champ.rb
+++ b/app/models/champs/date_champ.rb
@@ -39,7 +39,7 @@ class Champs::DateChamp < Champ
   private
 
   def convert_to_iso8601
-    return if valid_iso8601?
+    return if likely_iso8601_format? && parsable_iso8601?
 
     self.value = if /^\d{2}\/\d{2}\/\d{4}$/.match?(value)
       Date.parse(value).iso8601
@@ -49,12 +49,20 @@ class Champs::DateChamp < Champ
   end
 
   def iso_8601
-    return if valid_iso8601? || value.blank?
+    return if parsable_iso8601? || value.blank?
     # i18n-tasks-use t('errors.messages.not_a_date')
     errors.add :date, errors.generate_message(:value, :not_a_date)
   end
 
-  def valid_iso8601?
+  def likely_iso8601_format?
     /^\d{4}-\d{2}-\d{2}$/.match?(value)
+  end
+
+  def parsable_iso8601?
+    Date.parse(value)
+    true
+  rescue ArgumentError, # case 2023-27-02, out of range
+         TypeError # nil
+    false
   end
 end

--- a/spec/models/champs/date_champ_spec.rb
+++ b/spec/models/champs/date_champ_spec.rb
@@ -39,6 +39,14 @@ describe Champs::DateChamp do
     end
   end
 
+  describe 'validate :iso_8601' do
+    it 'works' do
+      date_champ.value = '2023-27-02'
+      date_champ.send(:iso_8601)
+      expect(date_champ.valid?).to eq(false)
+      expect(date_champ.to_s).not_to raise_error
+    end
+  end
   def champ_with_value(number)
     date_champ.tap { |c| c.value = number }
   end

--- a/spec/models/champs/date_champ_spec.rb
+++ b/spec/models/champs/date_champ_spec.rb
@@ -1,5 +1,5 @@
 describe Champs::DateChamp do
-  let(:date_champ) { build(:champ_date) }
+  let(:date_champ) { create(:champ_date) }
 
   describe '#convert_to_iso8601' do
     it 'preserves nil' do
@@ -37,16 +37,14 @@ describe Champs::DateChamp do
       champ.save
       expect(champ.reload.value).to eq("2023-12-21")
     end
-  end
 
-  describe 'validate :iso_8601' do
-    it 'works' do
-      date_champ.value = '2023-27-02'
-      date_champ.send(:iso_8601)
-      expect(date_champ.valid?).to eq(false)
-      expect(date_champ.to_s).not_to raise_error
+    it 'converts to nil if false iso' do
+      champ = champ_with_value("2023-27-02")
+      champ.save
+      expect(champ.reload.value).to eq(nil)
     end
   end
+
   def champ_with_value(number)
     date_champ.tap { |c| c.value = number }
   end


### PR DESCRIPTION
issue: #8324 8324
hs: https://secure.helpscout.net/conversation/2134446466/2012327?folderId=1653799
sentry: 3889604976 /3891411025

on a une date en base 2023-27-02 ; qui n'est pas une date iso (yyyy-mm-dd. pas 27eme mois dans notre calendrier).

une PR pour fixer la donnée en prod suivra