### PR TITLE
a11y : update structure search engine

### DIFF
--- a/app/views/layouts/_search_dossiers_form.html.haml
+++ b/app/views/layouts/_search_dossiers_form.html.haml
@@ -1,11 +1,9 @@
 #search-modal.fr-header__search.fr-modal
   .fr-container.fr-container-lg--fluid
     %button.fr-btn--close.fr-btn{ "aria-controls" => "search-modal", :title => t('close_modal', scope: [:layouts, :header]) }= t('close_modal', scope: [:layouts, :header])
-    #search-473.fr-search-bar{ :role => "search" }
-      = form_tag "#{search_endpoint}", method: :get, class: "flex width-100" do
+    #search-473.fr-search-bar
+      = form_tag "#{search_endpoint}", method: :get, :role => "search", class: "flex width-100" do
         = label_tag "q", t('views.users.dossiers.search.search_file'), class: 'fr-label'
-        = text_field_tag "q", "#{@search_terms if @search_terms.present?}", placeholder: t('views.users.dossiers.search.search_file'), aria: { label: t('views.users.dossiers.search.search_file') }, class: "fr-input"
+        = text_field_tag "q", "#{@search_terms if @search_terms.present?}", placeholder: t('views.users.dossiers.search.placeholder'), class: "fr-input"
         %button.fr-btn{ title: t('views.users.dossiers.search.search_file') }
-          = image_tag "icons/search-blue.svg", alt: t('views.users.dossiers.search.search_file'), 'aria-hidden':'true', width: 24, height: 24, loading: 'lazy'
-
-
+          = t('views.users.dossiers.search.search_file')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -313,7 +313,8 @@ en:
         demande:
           edit_dossier: "Edit file"
         search:
-          search_file: Search a file
+          placeholder: Search a file
+          search_file: Search
         index:
           dossiers: "Files"
         dossiers_list:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -309,7 +309,8 @@ fr:
         demande:
           edit_dossier: "Modifier le dossier"
         search:
-          search_file: Rechercher un dossier
+          placeholder: Rechercher un dossier
+          search_file: Rechercher
         index:
           dossiers: "Dossiers"
         dossiers_list:


### PR DESCRIPTION
Le moteur de recherche principal du header a été optimisé pour l'accessibilité en version française et anglaise : 

- Affichage mobile :

<img width="426" alt="Capture d’écran 2023-01-26 à 13 53 36" src="https://user-images.githubusercontent.com/49035942/214841729-180fecef-0d02-445e-aef8-7a36c464c556.png">
<img width="509" alt="Capture d’écran 2023-01-26 à 13 53 08" src="https://user-images.githubusercontent.com/49035942/214841735-ff27a234-1760-4280-87d8-c02bceb1f5c5.png">

- Affichage bureau :

<img width="484" alt="Capture d’écran 2023-01-26 à 13 52 58" src="https://user-images.githubusercontent.com/49035942/214841733-d3d4277a-80f8-4b16-b06c-25ebc1faf46d.png">

<img width="493" alt="Capture d’écran 2023-01-26 à 13 53 26" src="https://user-images.githubusercontent.com/49035942/214841738-35efa5f2-45e2-4de1-9c56-799cd54ec8cb.png">