### PR TITLE
perf: gros gain sur les pages dossier des instructeurs

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -1184,7 +1184,7 @@ class Dossier < ApplicationRecord
   end
 
   def geo_data?
-    geo_areas.present?
+    GeoArea.exists?(champ_id: champs_public.ids + champs_private.ids)
   end
 
   def to_feature_collection


### PR DESCRIPTION
On faisait 1 requête par champ sur chaque page instructeur d'un dossier  juste pour savoir s'il faut afficher le bouton d'export GeoJSON dans le header

Sur les grosses démarches on gagne plusieurs centaines de ms par page.

