### PR TITLE
a11y : update html tags card-title

### DIFF
--- a/app/views/support/index.html.haml
+++ b/app/views/support/index.html.haml
@@ -34,7 +34,7 @@
 
               - if link.present?
                 .support.card.featured.mb-4.ml-4.hidden{ id: "card-#{question_type}", "aria-hidden": true , data: { "support-target": "content" } }
-                  .card-title
+                  %p.card-title
                     = t('.our_answer')
                   .card-content
                     -# i18n-tasks-use t("support.index.#{question_type}.answer_html")


### PR DESCRIPTION
Remplacement des balises html `<div>` par des balises `<p>` pour le texte "Notre réponse" : 

<img width="434" alt="Capture d’écran 2023-01-26 à 14 29 53" src="https://user-images.githubusercontent.com/49035942/214848469-7f19c857-8e5f-488d-b9f8-982073c018aa.png">
<img width="1137" alt="Capture d’écran 2023-01-26 à 14 30 03" src="https://user-images.githubusercontent.com/49035942/214848484-9edbb88e-1637-4d35-8dd8-fd51c520337f.png">
