### PR TITLE
a11y : sign in remove tags used only for presentation

### DIFF
--- a/app/assets/stylesheets/auth.scss
+++ b/app/assets/stylesheets/auth.scss
@@ -11,7 +11,6 @@
   // The procedure description can still be read from the /commencer
   // pages.
   @media (max-width: $two-columns-breakpoint) {
-    .procedure-preview,
     .agent-intro {
       display: none;
     }

--- a/app/assets/stylesheets/procedure_context.scss
+++ b/app/assets/stylesheets/procedure_context.scss
@@ -145,7 +145,7 @@ $procedure-description-line-height: 22px;
 }
 
 .no-procedure-presentation {
-  margin-bottom:1.6rem;
+  margin-bottom: 1.6rem;
 
   p {
     margin: 0;

--- a/app/assets/stylesheets/procedure_context.scss
+++ b/app/assets/stylesheets/procedure_context.scss
@@ -17,7 +17,8 @@ $procedure-description-line-height: 22px;
   }
 
   .simple {
-    font-size: 24px;
+    margin-bottom: 0.2rem;
+    font-size: 1.5rem;
     color: $blue-france-500;
     font-weight: bold;
   }
@@ -140,6 +141,14 @@ $procedure-description-line-height: 22px;
         max-height: 130px;
       }
     }
+  }
+}
+
+.no-procedure-presentation {
+  margin-bottom:1.6rem;
+
+  p {
+    margin: 0;
   }
 }
 

--- a/app/views/layouts/commencer/_no_procedure.html.haml
+++ b/app/views/layouts/commencer/_no_procedure.html.haml
@@ -1,15 +1,10 @@
 .no-procedure
   = image_tag "landing/hero/dematerialiser.svg", class: "paperless-logo", alt: ""
   .baseline.center
-    %p
-      %span.simple= t('.line1')
-      %br
-      = t('.line2')
-      %br
-      = t('.line3')
+    .no-procedure-presentation
+      %p.simple= t('.line1')
+      %p= t('.line2')
+      %p= t('.line3')
     %hr
-    %p
-      %span.small-simple= t('.are_you_new', app_name: APPLICATION_NAME.gsub("-","&#8209;")).html_safe
-      %br
-      %br
-      = link_to t('views.users.sessions.new.find_procedure'), t("links.common.faq.comment_trouver_ma_demarche_url"), title: new_tab_suffix(t('views.users.sessions.new.find_procedure')), class: "fr-btn fr-btn--secondary", **external_link_attributes
+    %p.small-simple= t('.are_you_new', app_name: APPLICATION_NAME.gsub("-","&#8209;")).html_safe
+    = link_to t('views.users.sessions.new.find_procedure'), t("links.common.faq.comment_trouver_ma_demarche_url"), title: new_tab_suffix(t('views.users.sessions.new.find_procedure')), class: "fr-btn fr-btn--secondary", **external_link_attributes


### PR DESCRIPTION
Voici les corrections apportées : 

- Suppression des balises `<br>` utilisées pour la présentation
- Affichage des mêmes fonctionnalités sur mobile et desktop : 
<img width="487" alt="Capture d’écran 2023-01-26 à 15 13 59" src="https://user-images.githubusercontent.com/49035942/214858978-0789dd0d-007d-421f-b36f-256219255802.png">
<img width="583" alt="Capture d’écran 2023-01-26 à 15 14 26" src="https://user-images.githubusercontent.com/49035942/214858996-02bdd67c-d988-43de-b103-6fee5382b934.png">
