### PR TITLE
prefill: open possible values in a new tab

### DIFF
--- a/app/views/prefill_descriptions/_types_de_champs.html.haml
+++ b/app/views/prefill_descriptions/_types_de_champs.html.haml
@@ -43,7 +43,7 @@
                     = t("views.prefill_descriptions.edit.possible_values.#{type_de_champ.type_champ}_html")
                     %br
                   - if type_de_champ.too_many_possible_values?
-                    = link_to "Voir toutes les valeurs possibles", prefill_type_de_champ_path(prefill_description.path, type_de_champ)
+                    = link_to "Voir toutes les valeurs possibles", prefill_type_de_champ_path(prefill_description.path, type_de_champ), target: "_blank"
                   - else
                     = type_de_champ.possible_values.to_sentence
               %tr{ class: prefillable ? "" : "fr-text-mention--grey" }


### PR DESCRIPTION
Je propose d'ouvrir le lien "Voir toutes les valeurs possibles" dans un nouvel onglet.

![image](https://user-images.githubusercontent.com/1193334/215490593-2569d0c3-fccc-4dfd-8357-7c75c70a2f49.png)


J'ai adopté cette approche parce qu'il y a peu de liens "Revenir en arrière" dans l'application. On avait envisagé ce lien sur la page des valeurs possibles, pour ramener la personne vers la page de préremplissage. Mais cette solution, qui consiste à ouvrir la page dans un nouvel onglet, me paraît plus confortable, en plus d'être plus simple (sinon il faut retoucher le header, pour avoir un lien "Revenir en arrière" qui soit bien intégré à la fois sur desktop et sur mobile).