### PR TITLE
fix(instructeurs): exports PDF avec annotations privées

### DIFF
--- a/app/controllers/experts/avis_controller.rb
+++ b/app/controllers/experts/avis_controller.rb
@@ -140,7 +140,7 @@ module Experts
     end
 
     def telecharger_pjs
-      files = ActiveStorage::DownloadableFile.create_list_from_dossiers(Dossier.where(id: @dossier.id), true)
+      files = ActiveStorage::DownloadableFile.create_list_from_dossiers(Dossier.where(id: @dossier.id))
       cleaned_files = ActiveStorage::DownloadableFile.cleanup_list_from_dossier(files)
 
       zipline(cleaned_files, "dossier-#{@dossier.id}.zip")

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -235,7 +235,7 @@ module Instructeurs
     end
 
     def telecharger_pjs
-      files = ActiveStorage::DownloadableFile.create_list_from_dossiers(Dossier.where(id: dossier.id), with_champs_private: true)
+      files = ActiveStorage::DownloadableFile.create_list_from_dossiers(Dossier.where(id: dossier.id), with_champs_private: true, include_infos_administration: true)
       cleaned_files = ActiveStorage::DownloadableFile.cleanup_list_from_dossier(files)
 
       zipline(cleaned_files, "dossier-#{dossier.id}.zip")

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -235,7 +235,7 @@ module Instructeurs
     end
 
     def telecharger_pjs
-      files = ActiveStorage::DownloadableFile.create_list_from_dossiers(Dossier.where(id: dossier.id), true)
+      files = ActiveStorage::DownloadableFile.create_list_from_dossiers(Dossier.where(id: dossier.id), with_champs_private: true)
       cleaned_files = ActiveStorage::DownloadableFile.cleanup_list_from_dossier(files)
 
       zipline(cleaned_files, "dossier-#{dossier.id}.zip")

--- a/app/lib/active_storage/downloadable_file.rb
+++ b/app/lib/active_storage/downloadable_file.rb
@@ -1,7 +1,7 @@
 class ActiveStorage::DownloadableFile
-  def self.create_list_from_dossiers(dossiers, for_expert = false)
-    PiecesJustificativesService.generate_dossier_export(dossiers, include_infos_administration: !for_expert) +
-      PiecesJustificativesService.liste_documents(dossiers, for_expert)
+  def self.create_list_from_dossiers(dossiers, with_bills: false, with_champs_private: false, include_infos_administration: false)
+    PiecesJustificativesService.generate_dossier_export(dossiers, include_infos_administration:) +
+      PiecesJustificativesService.liste_documents(dossiers, with_bills:, with_champs_private:)
   end
 
   def self.cleanup_list_from_dossier(files)

--- a/app/services/procedure_archive_service.rb
+++ b/app/services/procedure_archive_service.rb
@@ -15,7 +15,7 @@ class ProcedureArchiveService
       dossiers.processed_in_month(archive.month)
     end
 
-    attachments = ActiveStorage::DownloadableFile.create_list_from_dossiers(dossiers)
+    attachments = ActiveStorage::DownloadableFile.create_list_from_dossiers(dossiers, with_bills: true, with_champs_private: true)
 
     DownloadableFileService.download_and_zip(@procedure, attachments, zip_root_folder(archive)) do |zip_filepath|
       ArchiveUploader.new(procedure: @procedure, filename: archive.filename(@procedure), filepath: zip_filepath)

--- a/app/services/procedure_export_service.rb
+++ b/app/services/procedure_export_service.rb
@@ -35,7 +35,7 @@ class ProcedureExportService
   end
 
   def to_zip
-    attachments = ActiveStorage::DownloadableFile.create_list_from_dossiers(dossiers, true)
+    attachments = ActiveStorage::DownloadableFile.create_list_from_dossiers(dossiers, with_champs_private: true)
 
     DownloadableFileService.download_and_zip(procedure, attachments, base_filename) do |zip_filepath|
       ArchiveUploader.new(procedure: procedure, filename: filename(:zip), filepath: zip_filepath).blob

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -865,6 +865,10 @@ describe Instructeurs::DossiersController, type: :controller do
       }
     end
 
+    before do
+      allow(PiecesJustificativesService).to receive(:generate_dossier_export).with([dossier], include_infos_administration: true).and_call_original
+    end
+
     it 'includes an attachment' do
       expect(subject.headers['Content-Disposition']).to start_with('attachment; ')
     end

--- a/spec/lib/active_storage/downloadable_file_spec.rb
+++ b/spec/lib/active_storage/downloadable_file_spec.rb
@@ -1,7 +1,7 @@
 describe ActiveStorage::DownloadableFile do
   let(:dossier) { create(:dossier, :en_construction) }
 
-  subject(:list) { ActiveStorage::DownloadableFile.create_list_from_dossiers(Dossier.where(id: dossier.id)) }
+  subject(:list) { ActiveStorage::DownloadableFile.create_list_from_dossiers(Dossier.where(id: dossier.id), with_bills: true, with_champs_private: true) }
 
   describe 'create_list_from_dossiers' do
     context 'when no piece_justificative is present' do

--- a/spec/services/pieces_justificatives_service_spec.rb
+++ b/spec/services/pieces_justificatives_service_spec.rb
@@ -1,10 +1,11 @@
 describe PiecesJustificativesService do
   describe '.liste_documents' do
-    let(:for_expert) { false }
+    let(:with_champs_private) { true }
+    let(:with_bills) { true }
 
     subject do
       PiecesJustificativesService
-        .liste_documents(Dossier.where(id: dossier.id), for_expert)
+        .liste_documents(Dossier.where(id: dossier.id), with_bills:, with_champs_private:)
         .map(&:first)
     end
 
@@ -59,8 +60,8 @@ describe PiecesJustificativesService do
 
       it { expect(subject).to match_array(private_pj_champ.call(dossier).piece_justificative_file.attachments) }
 
-      context 'for expert' do
-        let(:for_expert) { true }
+      context 'without private champ' do
+        let(:with_champs_private) { false }
 
         it { expect(subject).to be_empty }
       end
@@ -171,8 +172,8 @@ describe PiecesJustificativesService do
         expect(subject).to match_array([dossier_bs.serialized.attachment, dossier_bs.signature.attachment])
       end
 
-      context 'for expert' do
-        let(:for_expert) { true }
+      context 'without bills' do
+        let(:with_bills) { false }
 
         it { expect(subject).to be_empty }
       end
@@ -192,8 +193,8 @@ describe PiecesJustificativesService do
 
       it { expect(subject).to match_array(dol.serialized.attachment) }
 
-      context 'for expert' do
-        let(:for_expert) { true }
+      context 'without bills' do
+        let(:with_bills) { false }
 
         it { expect(subject).to be_empty }
       end


### PR DESCRIPTION
Depuis que les exports des experts excluent les champs privés (https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/8455) , les instructeurs les ont perdus.

Cette PR corrige ça, en explicitant les options d'inclusion : `with_bills` , `with_champs_private` (et conserve `include_infos_adminstration` utilisé à plusieurs endroits)

Par défaut chaque option est `false`. 

J'ai pu tester manuellement les exports des PDF pour les instructeurs et PDF qui respectent les règles.

Pour les admins j'ai constaté que les archives contiennent bien les signatures, annotations privées mais pas les PJ ; ça a l'air d'être similaire sur `main`. Je ne sais pas si c'est attendu ou non ?