### PR TITLE
WIP - amelioration(dolist): prepare l'usage de dolist par api

### DIFF
--- a/app/models/email_event.rb
+++ b/app/models/email_event.rb
@@ -10,6 +10,7 @@
 #  to           :string           not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#  message_id   :string
 #
 class EmailEvent < ApplicationRecord
   enum status: {
@@ -30,6 +31,7 @@ class EmailEvent < ApplicationRecord
           subject: message.subject || "",
           processed_at: message.date,
           method: ActionMailer::Base.delivery_methods.key(message.delivery_method.class),
+          external_id: message.message_id,
           status:
         )
       rescue StandardError => error

--- a/app/models/email_event.rb
+++ b/app/models/email_event.rb
@@ -17,8 +17,9 @@ class EmailEvent < ApplicationRecord
     dispatched: 'dispatched',
     dispatch_error: 'dispatch_error'
   }
-
-  scope :dolist, -> { where(method: 'dolist') }
+  scope :dolist, -> { dolist_smtp.or(dolist_api) }
+  scope :dolist_smtp, -> { where(method: 'dolist_smtp') }
+  scope :dolist_api, -> { where(method: 'dolist_api') }
   scope :sendinblue, -> { where(method: 'sendinblue') }
 
   class << self

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,12 +80,13 @@ Rails.application.configure do
   else
     sendinblue_weigth = ENV.fetch('SENDINBLUE_BALANCING_VALUE') { 0 }.to_i
     dolist_weigth = ENV.fetch('DOLIST_BALANCING_VALUE') { 0 }.to_i
-
+    dolist_api_weight = ENV.fetch('DOLIST_API_BALANCING_VALUE') { 0 }.to_i
     ActionMailer::Base.add_delivery_method :balancer, BalancerDeliveryMethod
     config.action_mailer.balancer_settings = {
       sendinblue: sendinblue_weigth,
       dolist: dolist_weigth,
-      mailjet: 100 - (sendinblue_weigth + dolist_weigth)
+      dolist_api: dolist_api_weight,
+      mailjet: 100 - (sendinblue_weigth + dolist_weigth + dolist_api_weight)
     }
     config.action_mailer.delivery_method = :balancer
   end

--- a/config/initializers/dolist.rb
+++ b/config/initializers/dolist.rb
@@ -20,7 +20,7 @@ ActiveSupport.on_load(:action_mailer) do
         if response&.dig("Result")
           mail.message_id = response.dig("Result")
         else
-          Rails.logger.info "Email sent. #{mail}"
+          fail "DoList delivery error. Body: #{response}"
         end
       end
     end

--- a/config/initializers/dolist.rb
+++ b/config/initializers/dolist.rb
@@ -16,8 +16,9 @@ ActiveSupport.on_load(:action_mailer) do
 
       def deliver!(mail)
         response = Dolist::API.new.send_email(mail)
-        if !respons&.dig("Result")
-          Rails.logger.info "Email not sent. Error message: #{mail}"
+
+        if response&.dig("Result")
+          mail.message_id = response.dig("Result")
         else
           Rails.logger.info "Email sent. #{mail}"
         end

--- a/config/initializers/dolist.rb
+++ b/config/initializers/dolist.rb
@@ -5,17 +5,28 @@ ActiveSupport.on_load(:action_mailer) do
         mail.from(ENV['DOLIST_NO_REPLY_EMAIL'])
         mail.sender(ENV['DOLIST_NO_REPLY_EMAIL'])
         mail['X-ACCOUNT-ID'] = Rails.application.secrets.dolist[:account_id]
-
         mail['X-Dolist-Sending-Type'] = 'TransactionalService' # send even if the target is not active
 
         super(mail)
       end
     end
+
+    class ApiSender
+      def initialize(mail); end
+
+      def deliver!(mail)
+        response = Dolist::API.new.send_email(mail)
+        if !respons&.dig("Result")
+          Rails.logger.info "Email not sent. Error message: #{mail}"
+        else
+          Rails.logger.info "Email sent. #{mail}"
+        end
+      end
+    end
   end
 
-  ActionMailer::Base.add_delivery_method :dolist, Dolist::SMTP
-
-  ActionMailer::Base.dolist_settings = {
+  ActionMailer::Base.add_delivery_method :dolist_smtp, Dolist::SMTP
+  ActionMailer::Base.dolist_smtp_settings = {
     user_name: Rails.application.secrets.dolist[:username],
     password: Rails.application.secrets.dolist[:password],
     address: 'smtp.dolist.net',
@@ -23,4 +34,6 @@ ActiveSupport.on_load(:action_mailer) do
     authentication: 'plain',
     enable_starttls_auto: true
   }
+
+  ActionMailer::Base.add_delivery_method :dolist_api, Dolist::ApiSender
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_31_172119) do
+ActiveRecord::Schema.define(version: 2023_02_03_134127) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -407,6 +407,7 @@ ActiveRecord::Schema.define(version: 2023_01_31_172119) do
 
   create_table "email_events", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
+    t.string "message_id"
     t.string "method", null: false
     t.datetime "processed_at"
     t.string "status", null: false

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -26,6 +26,21 @@ RSpec.describe ApplicationMailer, type: :mailer do
     end
   end
 
+  describe 'dealing with Dolist API error' do
+    let(:dossier) { create(:dossier, procedure: create(:simple_procedure)) }
+    before do
+      ActionMailer::Base.delivery_method = :dolist_api
+      api_error_response = { "ResponseStatus": { "ErrorCode": "Forbidden", "Message": "Blocked non authorized request", "Errors": [] } }
+      allow_any_instance_of(Dolist::API).to receive(:send_email).and_return(api_error_response)
+    end
+    subject { DossierMailer.with(dossier:).notify_new_draft.deliver_now }
+
+    it 'raise classic error to retry' do
+      expect { subject }.to raise_error(MailDeliveryError)
+      expect(EmailEvent.dolist_api.dispatch_error.count).to eq(1)
+    end
+  end
+
   describe 'dealing with Dolist API success' do
     let(:dossier) { create(:dossier, procedure: create(:simple_procedure)) }
     let(:message_id) { "29d9b692-0374-4084-8434-d9cddbced205" }

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -26,6 +26,21 @@ RSpec.describe ApplicationMailer, type: :mailer do
     end
   end
 
+  describe 'dealing with Dolist API success' do
+    let(:dossier) { create(:dossier, procedure: create(:simple_procedure)) }
+    let(:message_id) { "29d9b692-0374-4084-8434-d9cddbced205" }
+    before do
+      ActionMailer::Base.delivery_method = :dolist_api
+      api_success_response = { "Result" => message_id }
+      allow_any_instance_of(Dolist::API).to receive(:send_email).and_return(api_success_response)
+    end
+    subject { DossierMailer.with(dossier:).notify_new_draft.deliver_now }
+
+    it 'forward message ID to observer and EmailEvent.create_from_message!' do
+      expect { subject }.to change { EmailEvent.dolist_api.dispatched.where(message_id:).count }.to eq(1)
+    end
+  end
+
   describe 'EmailDeliveryObserver is invoked' do
     let(:user1) { create(:user) }
     let(:user2) { create(:user, email: "your@email.com") }


### PR DESCRIPTION
depends_on: [amelioration(email): ajoute la delivery_method dolist_api pour envoyer les mails via l'api comme recommandé par le fournisseur](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/8533)

TODO deporté de #8533 
- [ ] remonter l'id du mail (TransactionId) dans l'email_event ?
- [ ] tests, notamment pour s'assurer qu'en cas d'erreur de l'API le mailer le reverra, et le job retryiera