### PR TITLE
Upload: prévient qu'une erreur d'envoi peut être causée par un pare-feu bloquant l'envoi de fichiers

### DIFF
--- a/app/javascript/shared/activestorage/auto-upload.ts
+++ b/app/javascript/shared/activestorage/auto-upload.ts
@@ -83,7 +83,8 @@ export class AutoUpload {
     if (error.failureReason == FAILURE_CONNECTIVITY) {
       return {
         title:
-          'Le fichier n’a pas pu être envoyé. Vérifiez votre connexion à Internet, puis ré-essayez.',
+          'Le fichier n’a pas pu être envoyé. Vérifiez votre connexion à Internet, puis ré-essayez. Vérifiez aussi que le pare-feu de votre appareil ou votre réseau autorise l’envoi de fichier vers ' +
+          window.location.host,
         retry: true
       };
     } else if (error.code == ERROR_CODE_READ) {


### PR DESCRIPTION
Des utilisateurs remontent qu'ils ne peuvent pas envoye de fichiers alors que leur connexion est OK. On a déjà vu que dans certains cas ça provient de firewalls. 

NB: pour les instances l'hostname n'est pas hardcodé mais dérivé de la page

![Capture d’écran 2023-01-31 à 16 13 17](https://user-images.githubusercontent.com/150279/215799464-05d845ad-ef52-4163-aac0-7179c392b903.png)
