### PR TITLE
Manager: permet de masquer l'estimation de durée de remplissage à la demande

### DIFF
--- a/app/components/types_de_champ_editor/estimated_fill_duration_component.rb
+++ b/app/components/types_de_champ_editor/estimated_fill_duration_component.rb
@@ -10,6 +10,10 @@ class TypesDeChampEditor::EstimatedFillDurationComponent < ApplicationComponent
     @is_annotation
   end
 
+  def render?
+    @revision.procedure.estimated_duration_visible?
+  end
+
   def show?
     !annotations? && @revision.types_de_champ_public.present?
   end

--- a/app/dashboards/procedure_dashboard.rb
+++ b/app/dashboards/procedure_dashboard.rb
@@ -38,6 +38,7 @@ class ProcedureDashboard < Administrate::BaseDashboard
     procedure_expires_when_termine_enabled: Field::Boolean,
     duree_conservation_dossiers_dans_ds: Field::Number,
     max_duree_conservation_dossiers_dans_ds: Field::Number,
+    estimated_duration_visible: Field::Boolean,
     tags: Field::Text
   }.freeze
 
@@ -88,7 +89,8 @@ class ProcedureDashboard < Administrate::BaseDashboard
     :attestation_template,
     :procedure_expires_when_termine_enabled,
     :duree_conservation_dossiers_dans_ds,
-    :max_duree_conservation_dossiers_dans_ds
+    :max_duree_conservation_dossiers_dans_ds,
+    :estimated_duration_visible
   ].freeze
 
   # FORM_ATTRIBUTES
@@ -97,7 +99,8 @@ class ProcedureDashboard < Administrate::BaseDashboard
   FORM_ATTRIBUTES = [
     :procedure_expires_when_termine_enabled,
     :duree_conservation_dossiers_dans_ds,
-    :max_duree_conservation_dossiers_dans_ds
+    :max_duree_conservation_dossiers_dans_ds,
+    :estimated_duration_visible
   ].freeze
 
   # Overwrite this method to customize how procedures are displayed

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -18,6 +18,7 @@
 #  duree_conservation_dossiers_dans_ds       :integer
 #  duree_conservation_etendue_par_ds         :boolean          default(FALSE)
 #  encrypted_api_particulier_token           :string
+#  estimated_duration_visible                :boolean          default(TRUE), not null
 #  euro_flag                                 :boolean          default(FALSE)
 #  experts_require_administrateur_invitation :boolean          default(FALSE)
 #  for_individual                            :boolean          default(FALSE)

--- a/app/views/shared/_procedure_description.html.haml
+++ b/app/views/shared/_procedure_description.html.haml
@@ -8,7 +8,7 @@
 %h1.procedure-title
   = procedure.libelle
 
-- if procedure.persisted?
+- if procedure.persisted? && procedure.estimated_duration_visible?
   %p.procedure-configuration.procedure-configuration--fill-duration
     %span.icon.clock
     = t('shared.procedure_description.estimated_fill_duration', estimated_minutes: estimated_fill_duration_minutes(procedure))

--- a/db/migrate/20230131172119_add_estimated_duration_visible_to_procedures.rb
+++ b/db/migrate/20230131172119_add_estimated_duration_visible_to_procedures.rb
@@ -1,0 +1,5 @@
+class AddEstimatedDurationVisibleToProcedures < ActiveRecord::Migration[6.1]
+  def change
+    add_column :procedures, :estimated_duration_visible, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_26_145329) do
+ActiveRecord::Schema.define(version: 2023_01_31_172119) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -707,6 +707,7 @@ ActiveRecord::Schema.define(version: 2023_01_26_145329) do
     t.boolean "duree_conservation_etendue_par_ds", default: false
     t.boolean "durees_conservation_required", default: true
     t.string "encrypted_api_particulier_token"
+    t.boolean "estimated_duration_visible", default: true, null: false
     t.boolean "euro_flag", default: false
     t.boolean "experts_require_administrateur_invitation", default: false
     t.boolean "for_individual", default: false

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     published_at { nil }
     duree_conservation_dossiers_dans_ds { 3 }
     max_duree_conservation_dossiers_dans_ds { Procedure::OLD_MAX_DUREE_CONSERVATION }
+    estimated_duration_visible { true }
     ask_birthday { false }
     lien_site_web { "https://mon-site.gouv" }
     path { SecureRandom.uuid }

--- a/spec/system/administrateurs/types_de_champ_spec.rb
+++ b/spec/system/administrateurs/types_de_champ_spec.rb
@@ -1,6 +1,7 @@
 describe 'As an administrateur I can edit types de champ', js: true do
   let(:administrateur) { procedure.administrateurs.first }
-  let(:procedure) { create(:procedure) }
+  let(:estimated_duration_visible) { true }
+  let(:procedure) { create(:procedure, estimated_duration_visible:) }
 
   before do
     login_as administrateur.user, scope: :user
@@ -156,23 +157,39 @@ describe 'As an administrateur I can edit types de champ', js: true do
     expect(page).to have_content('Un menu')
   end
 
-  scenario "displaying the estimated fill duration" do
-    # It doesn't display anything when there are no champs
-    expect(page).not_to have_content('Durée de remplissage estimée')
+  context "estimated duration visible" do
+    scenario "displaying the estimated fill duration" do
+      # It doesn't display anything when there are no champs
+      expect(page).not_to have_content('Durée de remplissage estimée')
 
-    # It displays the estimate when adding a new champ
-    add_champ
-    select('Pièce justificative', from: 'Type de champ')
-    expect(page).to have_content('Durée de remplissage estimée : 2 min')
+      # It displays the estimate when adding a new champ
+      add_champ
+      select('Pièce justificative', from: 'Type de champ')
+      expect(page).to have_content('Durée de remplissage estimée : 2 min')
 
-    # It updates the estimate when updating the champ
-    check 'Champ obligatoire'
-    expect(page).to have_content('Durée de remplissage estimée : 3 min')
+      # It updates the estimate when updating the champ
+      check 'Champ obligatoire'
+      expect(page).to have_content('Durée de remplissage estimée : 3 min')
 
-    # It updates the estimate when removing the champ
-    page.accept_alert do
-      click_on 'Supprimer'
+      # It updates the estimate when removing the champ
+      page.accept_alert do
+        click_on 'Supprimer'
+      end
+      expect(page).not_to have_content('Durée de remplissage estimée')
     end
-    expect(page).not_to have_content('Durée de remplissage estimée')
+  end
+
+  context "estimated duration not visible" do
+    let(:estimated_duration_visible) { false }
+
+    scenario "hide the estimated fill duration" do
+      # It doesn't display anything when there are no champs
+      expect(page).not_to have_content('Durée de remplissage estimée')
+
+      # It displays the estimate when adding a new champ
+      add_champ
+      select('Pièce justificative', from: 'Type de champ')
+      expect(page).not_to have_content('Durée de remplissage estimée')
+    end
   end
 end

--- a/spec/views/shared/_procedure_description.html.haml_spec.rb
+++ b/spec/views/shared/_procedure_description.html.haml_spec.rb
@@ -1,5 +1,6 @@
 describe 'shared/_procedure_description.html.haml', type: :view do
-  let(:procedure) { create(:procedure, :published, :with_service) }
+  let(:estimated_duration_visible) { true }
+  let(:procedure) { create(:procedure, :published, :with_service, estimated_duration_visible:) }
 
   subject { render partial: 'shared/procedure_description', locals: { procedure: procedure } }
 
@@ -9,6 +10,14 @@ describe 'shared/_procedure_description.html.haml', type: :view do
     expect(rendered).to have_text(procedure.libelle)
     expect(rendered).to have_text(procedure.description)
     expect(rendered).to have_text('Temps de remplissage estimé')
+  end
+
+  context 'procedure with estimated duration not visible' do
+    let(:estimated_duration_visible) { false }
+    it 'hides the estimated duration' do
+      subject
+      expect(rendered).not_to have_text('Temps de remplissage estimé')
+    end
   end
 
   it 'does not show empty date limite' do


### PR DESCRIPTION
Masque la durée

- sur la page "commencer" de l'usager
- dans l'éditeur de type de champ

Closes #8466 