### PR TITLE
Propose uniquement des tags sur les démarches publiées

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -825,7 +825,7 @@ class Procedure < ApplicationRecord
 
   def self.tags
     unnest = Arel::Nodes::NamedFunction.new('UNNEST', [self.arel_table[:tags]])
-    query = self.select(unnest.as('tags')).publiees_ou_closes.distinct.order('tags')
+    query = self.select(unnest.as('tags')).publiees.distinct.order('tags')
     self.connection.query(query.to_sql).flatten
   end
 


### PR DESCRIPTION
@tchak En fait dans la page "toutes les démarches" il n'y a que des démarches publiées. Il reste encore des cas incohérents : lorsqu'on selectionne un tag, aucune démarche (car close).

Or, je ne pense pas que cela soit le comportement voulu sur la page. Proposer uniquement des tags qui sont sur des démraches publiées me semble plus cohérent et pertinent pour les admins.