### PR TITLE
chore(sentry): more traces

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -29,7 +29,7 @@ Sentry.init do |config|
       # Don't trace on all attempts
       [0, 2, 5, 10, 20, max_attempts].include?(attempts)
     else # rails requests
-      0.001
+      0.01
     end
   end
 


### PR DESCRIPTION
Dans sentry on a des erreurs pour lesquelles on a pas les traces complètes. D'après la doc ça pourrait être lié à un sampling trop bas, donc c'est une tentative d'améliorer ça.