### PR TITLE
 feat(dossier): prefill epci champ

### DIFF
--- a/app/models/champs/epci_champ.rb
+++ b/app/models/champs/epci_champ.rb
@@ -24,6 +24,10 @@ class Champs::EpciChamp < Champs::TextChamp
   store_accessor :value_json, :code_departement
   before_validation :on_departement_change
 
+  validate :code_departement_in_departement_codes, unless: -> { code_departement.nil? }
+  validate :external_id_in_departement_epci_codes, unless: -> { code_departement.nil? || external_id.nil? }
+  validate :value_in_departement_epci_names, unless: -> { code_departement.nil? || external_id.nil? || value.nil? }
+
   def for_export
     [value, code, "#{code_departement} – #{departement_name}"]
   end
@@ -73,5 +77,23 @@ class Champs::EpciChamp < Champs::TextChamp
       self.external_id = nil
       self.value = nil
     end
+  end
+
+  def code_departement_in_departement_codes
+    return if code_departement.in?(APIGeoService.departements.pluck(:code))
+
+    errors.add(:code_departement, :not_in_departement_codes)
+  end
+
+  def external_id_in_departement_epci_codes
+    return if external_id.in?(APIGeoService.epcis(code_departement).pluck(:code))
+
+    errors.add(:external_id, :not_in_departement_epci_codes)
+  end
+
+  def value_in_departement_epci_names
+    return if value.in?(APIGeoService.epcis(code_departement).pluck(:name))
+
+    errors.add(:value, :not_in_departement_epci_names)
   end
 end

--- a/app/models/prefill_description.rb
+++ b/app/models/prefill_description.rb
@@ -45,15 +45,33 @@ class PrefillDescription < SimpleDelegator
 
   private
 
+  def active_fillable_public_types_de_champ
+    active_revision.types_de_champ_public.fillable
+  end
+
   def prefilled_champs_for_link
-    prefilled_champs.map { |type_de_champ| ["champ_#{type_de_champ.to_typed_id}", type_de_champ.example_value] }.to_h
+    prefilled_champs_as_params.map(&:to_a).to_h
   end
 
   def prefilled_champs_for_query
-    prefilled_champs.map { |type_de_champ| "\"champ_#{type_de_champ.to_typed_id}\": \"#{type_de_champ.example_value}\"" } .join(', ')
+    prefilled_champs_as_params.map(&:to_s).join(', ')
   end
 
-  def active_fillable_public_types_de_champ
-    active_revision.types_de_champ_public.fillable
+  def prefilled_champs_as_params
+    prefilled_champs.map { |type_de_champ| Param.new(type_de_champ.to_typed_id, type_de_champ.example_value) }
+  end
+
+  Param = Struct.new(:key, :value) do
+    def to_a
+      ["champ_#{key}", value]
+    end
+
+    def to_s
+      if value.is_a?(Array)
+        "\"champ_#{key}\": #{value}"
+      else
+        "\"champ_#{key}\": \"#{value}\""
+      end
+    end
   end
 end

--- a/app/models/prefill_params.rb
+++ b/app/models/prefill_params.rb
@@ -41,7 +41,8 @@ class PrefillParams
       TypeDeChamp.type_champs.fetch(:checkbox),
       TypeDeChamp.type_champs.fetch(:pays),
       TypeDeChamp.type_champs.fetch(:regions),
-      TypeDeChamp.type_champs.fetch(:departements)
+      TypeDeChamp.type_champs.fetch(:departements),
+      TypeDeChamp.type_champs.fetch(:epci)
     ]
 
     attr_reader :champ, :value

--- a/app/models/prefill_params.rb
+++ b/app/models/prefill_params.rb
@@ -56,10 +56,7 @@ class PrefillParams
     end
 
     def to_h
-      {
-        id: champ.id,
-        value: value
-      }
+      { id: champ.id }.merge(champ_attributes)
     end
 
     private
@@ -67,8 +64,14 @@ class PrefillParams
     def valid?
       return true unless NEED_VALIDATION_TYPES_DE_CHAMPS.include?(champ.type_champ)
 
-      champ.value = value
+      champ.assign_attributes(champ_attributes)
       champ.valid?(:prefill)
+    end
+
+    def champ_attributes
+      TypesDeChamp::PrefillTypeDeChamp
+        .build(champ.type_de_champ)
+        .transform_value_to_assignable_attributes(value)
     end
   end
 end

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -268,7 +268,8 @@ class TypeDeChamp < ApplicationRecord
       TypeDeChamp.type_champs.fetch(:checkbox),
       TypeDeChamp.type_champs.fetch(:drop_down_list),
       TypeDeChamp.type_champs.fetch(:regions),
-      TypeDeChamp.type_champs.fetch(:departements)
+      TypeDeChamp.type_champs.fetch(:departements),
+      TypeDeChamp.type_champs.fetch(:epci)
     ])
   end
 

--- a/app/models/types_de_champ/prefill_epci_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_epci_type_de_champ.rb
@@ -1,6 +1,8 @@
 class TypesDeChamp::PrefillEpciTypeDeChamp < TypesDeChamp::PrefillTypeDeChamp
   def possible_values
-    departements.map { |departement| "#{departement[:code]} (#{departement[:name]})" }
+    departements.map do |departement|
+      "#{departement[:code]} (#{departement[:name]}) : https://geo.api.gouv.fr/epcis?codeDepartement=#{departement[:code]}"
+    end
   end
 
   def example_value

--- a/app/models/types_de_champ/prefill_epci_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_epci_type_de_champ.rb
@@ -1,0 +1,23 @@
+class TypesDeChamp::PrefillEpciTypeDeChamp < TypesDeChamp::PrefillTypeDeChamp
+  def possible_values
+    departements.map { |departement| "#{departement[:code]} (#{departement[:name]})" }
+  end
+
+  def example_value
+    departement_code = departements.pick(:code)
+    epci_code = APIGeoService.epcis(departement_code).pick(:code)
+    [departement_code, epci_code]
+  end
+
+  def transform_value_to_assignable_attributes(value)
+    return { code_departement: nil, value: nil } if value.blank? || !value.is_a?(Array)
+    return { code_departement: value.first, value: nil } if value.one?
+    { code_departement: value.first, value: value.second }
+  end
+
+  private
+
+  def departements
+    @departements ||= APIGeoService.departements.sort_by { |departement| departement[:code] }
+  end
+end

--- a/app/models/types_de_champ/prefill_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_type_de_champ.rb
@@ -11,6 +11,8 @@ class TypesDeChamp::PrefillTypeDeChamp < SimpleDelegator
       TypesDeChamp::PrefillRegionTypeDeChamp.new(type_de_champ)
     when TypeDeChamp.type_champs.fetch(:departements)
       TypesDeChamp::PrefillDepartementTypeDeChamp.new(type_de_champ)
+    when TypeDeChamp.type_champs.fetch(:epci)
+      TypesDeChamp::PrefillEpciTypeDeChamp.new(type_de_champ)
     else
       new(type_de_champ)
     end
@@ -32,5 +34,9 @@ class TypesDeChamp::PrefillTypeDeChamp < SimpleDelegator
 
   def too_many_possible_values?
     possible_values.count > POSSIBLE_VALUES_THRESHOLD
+  end
+
+  def transform_value_to_assignable_attributes(value)
+    { value: value }
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -128,12 +128,13 @@ en:
           iban_html: An Iban number
           yes_no_html: '"true" for Yes, "false" pour No'
           checkbox_html: '"true" to check, "false" to uncheck'
-          pays_html: An <a href="https://en.wikipedia.org/wiki/ISO_3166-2" target="_blank">ISO 3166-2 country code</a>
+          pays_html: An <a href="https://en.wikipedia.org/wiki/ISO_3166-2" target="_blank" rel="noopener noreferrer">ISO 3166-2 country code</a>
           departements_html: A <a href="https://fr.wikipedia.org/wiki/Num%C3%A9rotation_des_d%C3%A9partements_fran%C3%A7ais" target="_blank">department number</a>
-          regions_html: An <a href="https://fr.wikipedia.org/wiki/R%C3%A9gion_fran%C3%A7aise" target="_blank">INSEE region code</a>
+          regions_html: An <a href="https://fr.wikipedia.org/wiki/R%C3%A9gion_fran%C3%A7aise" target="_blank" rel="noopener noreferrer">INSEE region code</a>
           date_html: ISO8601 date
           datetime_html: ISO8601 datetime
           drop_down_list_other_html: Any value
+          epci_html: An array of the department code and the <a href="https://geo.api.gouv.fr/epcis" target="_blank" rel="noopener noreferrer">EPCI one</a>.
         examples:
           title: Example
           text: Short text

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -483,6 +483,14 @@ en:
               not_in_departement_names: "must be a valid department name"
             external_id:
               not_in_departement_codes: "must be a valid department code"
+        "champs/epci_champ":
+          attributes:
+            code_departement:
+              not_in_departement_codes: "must be a valid department code"
+            external_id:
+              not_in_departement_epci_codes: "must be a valid EPCI code of the matching department"
+            value:
+              not_in_departement_epci_names: "must be a valid EPCI name of the matching department"
   errors:
     format: "Field « %{attribute} » %{message}"
     messages:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -119,12 +119,13 @@ fr:
           iban_html: Un numéro Iban
           yes_no_html: '"true" pour Oui, "false" pour Non'
           checkbox_html: '"true" pour coché, "false" pour décoché'
-          pays_html: Un <a href="https://en.wikipedia.org/wiki/ISO_3166-2" target="_blank">code pays ISO 3166-2</a>
+          pays_html: Un <a href="https://en.wikipedia.org/wiki/ISO_3166-2" target="_blank" rel="noopener noreferrer">code pays ISO 3166-2</a>
           departements_html: Un <a href="https://fr.wikipedia.org/wiki/Num%C3%A9rotation_des_d%C3%A9partements_fran%C3%A7ais" target="_blank">numéro de département</a>
-          regions_html: Un <a href="https://fr.wikipedia.org/wiki/R%C3%A9gion_fran%C3%A7aise" target="_blank">code INSEE de région</a>
+          regions_html: Un <a href="https://fr.wikipedia.org/wiki/R%C3%A9gion_fran%C3%A7aise" target="_blank" rel="noopener noreferrer">code INSEE de région</a>
           datetime_html: Datetime au format ISO8601
           date_html: Date au format ISO8601
           drop_down_list_other_html: Toute valeur
+          epci_html: Un tableau contenant le code de département et <a href="https://geo.api.gouv.fr/epcis" target="_blank" rel="noopener noreferrer">celui de l'EPCI</a>.
         examples:
           title: Exemple
           text: Texte court

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -478,6 +478,14 @@ fr:
               not_in_departement_names: "doit être un nom de département valide"
             external_id:
               not_in_departement_codes: "doit être un code de département valide"
+        "champs/epci_champ":
+          attributes:
+            code_departement:
+              not_in_departement_codes: "doit être un code de département valide"
+            external_id:
+              not_in_departement_epci_codes: "doit être un code d'EPCI du département correspondant"
+            value:
+              not_in_departement_epci_names: "doit être un nom d'EPCI du département correspondant"
   errors:
     format: "Le champ « %{attribute} » %{message}"
     messages:

--- a/spec/models/champs/epci_champ_spec.rb
+++ b/spec/models/champs/epci_champ_spec.rb
@@ -6,9 +6,156 @@ describe Champs::EpciChamp, type: :model do
     Rails.cache.clear
   end
 
-  let(:champ) { described_class.new }
+  describe 'validations' do
+    describe 'code_departement', vcr: { cassette_name: 'api_geo_departements' } do
+      subject { build(:champ_epci, code_departement: code_departement) }
+
+      context 'when nil' do
+        let(:code_departement) { nil }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'when empty' do
+        let(:code_departement) { '' }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context 'when included in the departement codes' do
+        let(:code_departement) { "01" }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'when not included in the departement codes' do
+        let(:code_departement) { "totoro" }
+
+        it { is_expected.not_to be_valid }
+      end
+    end
+
+    describe 'external_id' do
+      let(:champ) { build(:champ_epci, code_departement: code_departement, external_id: nil) }
+
+      subject { champ }
+
+      before do
+        VCR.insert_cassette('api_geo_departements')
+        VCR.insert_cassette('api_geo_epcis')
+
+        champ.save!
+        champ.update_columns(external_id: external_id)
+      end
+
+      after do
+        VCR.eject_cassette('api_geo_departements')
+        VCR.eject_cassette('api_geo_epcis')
+      end
+
+      context 'when code_departement is nil' do
+        let(:code_departement) { nil }
+        let(:external_id) { nil }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'when code_departement is not nil and valid' do
+        let(:code_departement) { "01" }
+
+        context 'when external_id is nil' do
+          let(:external_id) { nil }
+
+          it { is_expected.to be_valid }
+        end
+
+        context 'when external_id is empty' do
+          let(:external_id) { '' }
+
+          it { is_expected.not_to be_valid }
+        end
+
+        context 'when external_id is included in the epci codes of the departement' do
+          let(:external_id) { '200042935' }
+
+          it { is_expected.to be_valid }
+        end
+
+        context 'when external_id is not included in the epci codes of the departement' do
+          let(:external_id) { 'totoro' }
+
+          it { is_expected.not_to be_valid }
+        end
+      end
+    end
+
+    describe 'value' do
+      let(:champ) { build(:champ_epci, code_departement: code_departement, external_id: nil, value: nil) }
+
+      subject { champ }
+
+      before do
+        VCR.insert_cassette('api_geo_departements')
+        VCR.insert_cassette('api_geo_epcis')
+
+        champ.save!
+        champ.update_columns(external_id: external_id, value: value)
+      end
+
+      after do
+        VCR.eject_cassette('api_geo_departements')
+        VCR.eject_cassette('api_geo_epcis')
+      end
+
+      context 'when code_departement is nil' do
+        let(:code_departement) { nil }
+        let(:external_id) { nil }
+        let(:value) { nil }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'when external_id is nil' do
+        let(:code_departement) { '01' }
+        let(:external_id) { nil }
+        let(:value) { nil }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'when code_departement and external_id are not nil and valid' do
+        let(:code_departement) { '01' }
+        let(:external_id) { '200042935' }
+
+        context 'when value is nil' do
+          let(:value) { nil }
+
+          it { is_expected.to be_valid }
+        end
+
+        context 'when value is empty' do
+          let(:value) { '' }
+
+          it { is_expected.not_to be_valid }
+        end
+
+        context 'when value is in departement epci names' do
+          let(:value) { 'CA Haut - Bugey Agglomération' }
+
+          it { is_expected.to be_valid }
+        end
+
+        context 'when value is not in departement epci names' do
+          let(:value) { 'totoro' }
+
+          it { is_expected.not_to be_valid }
+        end
+      end
+    end
+  end
 
   describe 'value', vcr: { cassette_name: 'api_geo_epcis' } do
+    let(:champ) { described_class.new }
     it 'with departement and code' do
       champ.code_departement = '01'
       champ.value = '200042935'

--- a/spec/models/prefill_description_spec.rb
+++ b/spec/models/prefill_description_spec.rb
@@ -101,6 +101,19 @@ RSpec.describe PrefillDescription, type: :model do
         )
       )
     end
+
+    context 'when the type de champ can have multiple values' do
+      let(:type_de_champ) { create(:type_de_champ_multiple_drop_down_list, procedure: procedure) }
+
+      it 'builds the URL with array parameter' do
+        expect(prefill_description.prefill_link).to eq(
+          commencer_url(
+            path: procedure.path,
+            "champ_#{type_de_champ.to_typed_id}": TypesDeChamp::PrefillMultipleDropDownListTypeDeChamp.new(type_de_champ).example_value
+          )
+        )
+      end
+    end
   end
 
   describe '#prefill_query' do
@@ -119,6 +132,21 @@ RSpec.describe PrefillDescription, type: :model do
 
     it "builds the query to create a new prefilled dossier" do
       expect(prefill_description.prefill_query).to eq(expected_query)
+    end
+
+    context 'when the type de champ can have multiple values' do
+      let(:type_de_champ) { create(:type_de_champ_multiple_drop_down_list, procedure: procedure) }
+      let(:expected_query) do
+        <<~TEXT
+          curl --request POST '#{api_public_v1_dossiers_url(procedure)}' \\
+               --header 'Content-Type: application/json' \\
+               --data '{"champ_#{type_de_champ.to_typed_id}": #{TypesDeChamp::PrefillMultipleDropDownListTypeDeChamp.new(type_de_champ).example_value}}'
+        TEXT
+      end
+
+      it 'builds the query with array parameter' do
+        expect(prefill_description.prefill_query).to eq(expected_query)
+      end
     end
   end
 end

--- a/spec/models/prefill_params_spec.rb
+++ b/spec/models/prefill_params_spec.rb
@@ -12,6 +12,16 @@ RSpec.describe PrefillParams do
     before do
       allow(Rails).to receive(:cache).and_return(memory_store)
       Rails.cache.clear
+
+      VCR.insert_cassette('api_geo_regions')
+      VCR.insert_cassette('api_geo_departements')
+      VCR.insert_cassette('api_geo_epcis')
+    end
+
+    after do
+      VCR.eject_cassette('api_geo_regions')
+      VCR.eject_cassette('api_geo_departements')
+      VCR.eject_cassette('api_geo_epcis')
     end
 
     context "when the stable ids match the TypeDeChamp of the corresponding procedure" do

--- a/spec/models/prefill_params_spec.rb
+++ b/spec/models/prefill_params_spec.rb
@@ -72,12 +72,12 @@ RSpec.describe PrefillParams do
       context "when the type de champ is authorized (#{type_de_champ_type})" do
         let(:types_de_champ_public) { [{ type: type_de_champ_type }] }
         let(:type_de_champ) { procedure.published_revision.types_de_champ_public.first }
-        let(:champ_id) { find_champ_by_stable_id(dossier, type_de_champ.stable_id).id }
+        let(:champ) { find_champ_by_stable_id(dossier, type_de_champ.stable_id) }
 
         let(:params) { { "champ_#{type_de_champ.to_typed_id}" => value } }
 
-        it "builds an array of hash(id, value) matching the given params" do
-          expect(prefill_params_array).to match([{ id: champ_id, value: value }])
+        it "builds an array of hash matching the given params" do
+          expect(prefill_params_array).to match([{ id: champ.id }.merge(attributes(champ, value))])
         end
       end
     end
@@ -86,12 +86,12 @@ RSpec.describe PrefillParams do
       context "when the type de champ is authorized (#{type_de_champ_type})" do
         let(:types_de_champ_private) { [{ type: type_de_champ_type }] }
         let(:type_de_champ) { procedure.published_revision.types_de_champ_private.first }
-        let(:champ_id) { find_champ_by_stable_id(dossier, type_de_champ.stable_id).id }
+        let(:champ) { find_champ_by_stable_id(dossier, type_de_champ.stable_id) }
 
         let(:params) { { "champ_#{type_de_champ.to_typed_id}" => value } }
 
-        it "builds an array of hash(id, value) matching the given params" do
-          expect(prefill_params_array).to match([{ id: champ_id, value: value }])
+        it "builds an array of hash matching the given params" do
+          expect(prefill_params_array).to match([{ id: champ.id }.merge(attributes(champ, value))])
         end
       end
     end
@@ -183,5 +183,11 @@ RSpec.describe PrefillParams do
 
   def find_champ_by_stable_id(dossier, stable_id)
     dossier.champs.joins(:type_de_champ).find_by(types_de_champ: { stable_id: stable_id })
+  end
+
+  def attributes(champ, value)
+    TypesDeChamp::PrefillTypeDeChamp
+      .build(champ.type_de_champ)
+      .transform_value_to_assignable_attributes(value)
   end
 end

--- a/spec/models/prefill_params_spec.rb
+++ b/spec/models/prefill_params_spec.rb
@@ -127,6 +127,7 @@ RSpec.describe PrefillParams do
     it_behaves_like "a champ public value that is authorized", :drop_down_list, "value"
     it_behaves_like "a champ public value that is authorized", :regions, "03"
     it_behaves_like "a champ public value that is authorized", :departements, "03"
+    it_behaves_like "a champ public value that is authorized", :epci, ['01', '200042935']
 
     it_behaves_like "a champ private value that is authorized", :text, "value"
     it_behaves_like "a champ private value that is authorized", :textarea, "value"
@@ -145,7 +146,8 @@ RSpec.describe PrefillParams do
     it_behaves_like "a champ private value that is authorized", :checkbox, "false"
     it_behaves_like "a champ private value that is authorized", :drop_down_list, "value"
     it_behaves_like "a champ private value that is authorized", :regions, "93"
-    it_behaves_like "a champ public value that is authorized", :departements, "03"
+    it_behaves_like "a champ private value that is authorized", :departements, "03"
+    it_behaves_like "a champ private value that is authorized", :epci, ['01', '200042935']
 
     it_behaves_like "a champ public value that is unauthorized", :decimal_number, "non decimal string"
     it_behaves_like "a champ public value that is unauthorized", :integer_number, "non integer string"

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -251,6 +251,7 @@ describe TypeDeChamp do
     it_behaves_like "a prefillable type de champ", :type_de_champ_drop_down_list
     it_behaves_like "a prefillable type de champ", :type_de_champ_regions
     it_behaves_like "a prefillable type de champ", :type_de_champ_departements
+    it_behaves_like "a prefillable type de champ", :type_de_champ_epci
 
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_number
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_communes

--- a/spec/models/types_de_champ/prefill_epci_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_epci_type_de_champ_spec.rb
@@ -2,14 +2,55 @@
 
 RSpec.describe TypesDeChamp::PrefillEpciTypeDeChamp do
   let(:type_de_champ) { build(:type_de_champ_epci) }
+  let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+
+  before do
+    allow(Rails).to receive(:cache).and_return(memory_store)
+    Rails.cache.clear
+  end
 
   describe 'ancestors' do
     subject { described_class.new(type_de_champ) }
 
     it { is_expected.to be_kind_of(TypesDeChamp::PrefillEpciTypeDeChamp) }
   end
-  # TODO: SEB describe '#possible_values'
-  # TODO: SEB describe '#example_value'
+
+  describe '#possible_values' do
+    let(:expected_values) do
+      departements.map { |departement| "#{departement[:code]} (#{departement[:name]}) : https://geo.api.gouv.fr/epcis?codeDepartement=#{departement[:code]}" }
+    end
+    subject(:possible_values) { described_class.new(type_de_champ).possible_values }
+
+    before do
+      VCR.insert_cassette('api_geo_departements')
+      VCR.insert_cassette('api_geo_epcis')
+    end
+
+    after do
+      VCR.eject_cassette('api_geo_departements')
+      VCR.eject_cassette('api_geo_epcis')
+    end
+
+    it { expect(possible_values).to match(expected_values) }
+  end
+
+  describe '#example_value' do
+    let(:departement_code) { departements.pick(:code) }
+    let(:epci_code) { APIGeoService.epcis(departement_code).pick(:code) }
+    subject(:example_value) { described_class.new(type_de_champ).example_value }
+
+    before do
+      VCR.insert_cassette('api_geo_departements')
+      VCR.insert_cassette('api_geo_epcis')
+    end
+
+    after do
+      VCR.eject_cassette('api_geo_departements')
+      VCR.eject_cassette('api_geo_epcis')
+    end
+
+    it { is_expected.to eq([departement_code, epci_code]) }
+  end
 
   describe '#transform_value_to_assignable_attributes' do
     subject(:transform_value_to_assignable_attributes) { described_class.build(type_de_champ).transform_value_to_assignable_attributes(value) }
@@ -43,5 +84,11 @@ RSpec.describe TypesDeChamp::PrefillEpciTypeDeChamp do
       let(:value) { ['01', '200042935', 'hello'] }
       it { is_expected.to match({ code_departement: '01', value: '200042935' }) }
     end
+  end
+
+  private
+
+  def departements
+    APIGeoService.departements.sort_by { |departement| departement[:code] }
   end
 end

--- a/spec/models/types_de_champ/prefill_epci_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_epci_type_de_champ_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe TypesDeChamp::PrefillEpciTypeDeChamp do
+  let(:type_de_champ) { build(:type_de_champ_epci) }
+
+  describe 'ancestors' do
+    subject { described_class.new(type_de_champ) }
+
+    it { is_expected.to be_kind_of(TypesDeChamp::PrefillEpciTypeDeChamp) }
+  end
+  # TODO: SEB describe '#possible_values'
+  # TODO: SEB describe '#example_value'
+
+  describe '#transform_value_to_assignable_attributes' do
+    subject(:transform_value_to_assignable_attributes) { described_class.build(type_de_champ).transform_value_to_assignable_attributes(value) }
+
+    context 'when the value is nil' do
+      let(:value) { nil }
+      it { is_expected.to match({ code_departement: nil, value: nil }) }
+    end
+
+    context 'when the value is empty' do
+      let(:value) { '' }
+      it { is_expected.to match({ code_departement: nil, value: nil }) }
+    end
+
+    context 'when the value is a string' do
+      let(:value) { 'hello' }
+      it { is_expected.to match({ code_departement: nil, value: nil }) }
+    end
+
+    context 'when the value is an array of one element' do
+      let(:value) { ['01'] }
+      it { is_expected.to match({ code_departement: '01', value: nil }) }
+    end
+
+    context 'when the value is an array of two elements' do
+      let(:value) { ['01', '200042935'] }
+      it { is_expected.to match({ code_departement: '01', value: '200042935' }) }
+    end
+
+    context 'when the value is an array of three or more elements' do
+      let(:value) { ['01', '200042935', 'hello'] }
+      it { is_expected.to match({ code_departement: '01', value: '200042935' }) }
+    end
+  end
+end

--- a/spec/models/types_de_champ/prefill_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_type_de_champ_spec.rb
@@ -28,6 +28,12 @@ RSpec.describe TypesDeChamp::PrefillTypeDeChamp, type: :model do
       it { expect(built).to be_kind_of(TypesDeChamp::PrefillDepartementTypeDeChamp) }
     end
 
+    context 'when the type de champ is a epci' do
+      let(:type_de_champ) { build(:type_de_champ_epci) }
+
+      it { expect(built).to be_kind_of(TypesDeChamp::PrefillEpciTypeDeChamp) }
+    end
+
     context 'when any other type de champ' do
       let(:type_de_champ) { build(:type_de_champ_date) }
 
@@ -91,5 +97,13 @@ RSpec.describe TypesDeChamp::PrefillTypeDeChamp, type: :model do
 
       it { expect(too_many_possible_values).to eq(false) }
     end
+  end
+
+  describe '#transform_value_to_assignable_attributes' do
+    let(:type_de_champ) { build(:type_de_champ_email) }
+    let(:value) { "any@email.org" }
+    subject(:transform_value_to_assignable_attributes) { described_class.build(type_de_champ).transform_value_to_assignable_attributes(value) }
+
+    it { is_expected.to match({ value: value }) }
   end
 end

--- a/spec/support/shared_examples_for_prefilled_dossier.rb
+++ b/spec/support/shared_examples_for_prefilled_dossier.rb
@@ -19,5 +19,6 @@ shared_examples "the user has got a prefilled dossier, owned by themselves" do
     expect(page).to have_field(type_de_champ_phone.libelle, with: phone_value)
     expect(page).to have_css('label', text: type_de_champ_phone.libelle)
     expect(page).to have_field(type_de_champ_datetime.libelle, with: datetime_value)
+    expect(page).to have_field(type_de_champ_epci.libelle, with: epci_value.last)
   end
 end

--- a/spec/system/users/dossier_prefill_post_spec.rb
+++ b/spec/system/users/dossier_prefill_post_spec.rb
@@ -1,4 +1,6 @@
 describe 'Prefilling a dossier (with a POST request):' do
+  let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+
   let(:password) { 'my-s3cure-p4ssword' }
 
   let(:procedure) { create(:procedure, :published) }
@@ -7,9 +9,24 @@ describe 'Prefilling a dossier (with a POST request):' do
   let(:type_de_champ_text) { create(:type_de_champ_text, procedure: procedure) }
   let(:type_de_champ_phone) { create(:type_de_champ_phone, procedure: procedure) }
   let(:type_de_champ_datetime) { create(:type_de_champ_datetime, procedure: procedure) }
+  let(:type_de_champ_epci) { create(:type_de_champ_epci, procedure: procedure) }
   let(:text_value) { "My Neighbor Totoro is the best movie ever" }
   let(:phone_value) { "invalid phone value" }
   let(:datetime_value) { "2023-02-01T10:32" }
+  let(:epci_value) { ['01', '200029999'] }
+
+  before do
+    allow(Rails).to receive(:cache).and_return(memory_store)
+    Rails.cache.clear
+
+    VCR.insert_cassette('api_geo_departements')
+    VCR.insert_cassette('api_geo_epcis')
+  end
+
+  after do
+    VCR.eject_cassette('api_geo_departements')
+    VCR.eject_cassette('api_geo_epcis')
+  end
 
   scenario "the user get the URL of a prefilled orphan brouillon dossier" do
     dossier_url = create_and_prefill_dossier_with_post_request
@@ -98,7 +115,8 @@ describe 'Prefilling a dossier (with a POST request):' do
       params: {
         "champ_#{type_de_champ_text.to_typed_id}" => text_value,
         "champ_#{type_de_champ_phone.to_typed_id}" => phone_value,
-        "champ_#{type_de_champ_datetime.to_typed_id}" => datetime_value
+        "champ_#{type_de_champ_datetime.to_typed_id}" => datetime_value,
+        "champ_#{type_de_champ_epci.to_typed_id}" => epci_value
       }.to_json
     JSON.parse(session.response.body)["dossier_url"].gsub("http://www.example.com", "")
   end


### PR DESCRIPTION
On permet le préremplissage de champ EPCI : 


![image](https://user-images.githubusercontent.com/1193334/217261108-2879e1e0-d6f7-4d4b-bf88-48f10f920f04.png)


Ce qui donne : 

![image](https://user-images.githubusercontent.com/1193334/217261246-ff7cd89f-8ad6-4e64-b236-296fa0bd750b.png)


# À propos de toutes les valeurs possibles

Depuis la page "préremplir", quand on clique sur "Toutes les valeurs possibles", j'ai choisi d'afficher les liens vers le service geo.api.gouv.fr. Sinon la page aurait du afficher des tonnes et des tonnes d'infos, ça ne tenait pas la route.

Ainsi, ça me semble à la fois lisible et utilisable : 

![image](https://user-images.githubusercontent.com/1193334/217261482-4b9682ee-8bc1-454f-86dd-15bcb4a7823d.png)

Idéalement, on aurait pu souhaiter avoir des liens ici, mais ça introduit une complexité qui ne me semble pas très légitime.



# À propos des données

J'ai ajouté une validation dans cette PR, mais le champ EPCI étant récent, je ne pense pas qu'une migration de données soit nécessaire.

