### PR TITLE
fix(admin/conditionnel): quand une valeur cible est soumise sans son champ cible

### DIFF
--- a/app/components/types_de_champ_editor/conditions_errors_component.rb
+++ b/app/components/types_de_champ_editor/conditions_errors_component.rb
@@ -31,6 +31,7 @@ class TypesDeChampEditor::ConditionsErrorsComponent < ApplicationComponent
   def humanize(error)
     case error
     in { type: :not_available }
+    in { type: :incompatible, stable_id: nil }
       t('not_available', scope: '.errors')
     in { type: :unmanaged, stable_id: stable_id }
       targeted_champ = @upper_tdcs.find { |tdc| tdc.stable_id == stable_id }

--- a/spec/components/types_de_champ_editor/conditions_errors_component_spec.rb
+++ b/spec/components/types_de_champ_editor/conditions_errors_component_spec.rb
@@ -71,5 +71,15 @@ describe TypesDeChampEditor::ConditionsErrorsComponent, type: :component do
 
       it { expect(page).to have_content("« another choice » ne fait pas partie de « #{tdc.libelle} ».") }
     end
+
+    context 'when target became unavailable but a right still references the value' do
+      # Cf https://demarches-simplifiees.sentry.io/issues/3625488398/events/53164e105bc94d55a004d69f96d58fb2/?project=1429550
+      # However maybe we should not have empty at left with still a constant at right
+      let(:tdc) { create(:type_de_champ_integer_number) }
+      let(:upper_tdcs) { [tdc] }
+      let(:conditions) { [ds_eq(empty, constant('a text'))] }
+
+      it { expect(page).to have_content("Un champ cible n'est plus disponible") }
+    end
   end
 end


### PR DESCRIPTION
https://demarches-simplifiees.sentry.io/issues/3625488398/events/53164e105bc94d55a004d69f96d58fb2/?project=1429550

Visiblement on pourrait avoir des edge cases côté navigateur avec l'auto submit (race conditions, requêtes turbo qui reviennent pas dans le bon ordre etc…) où le form serait soumis avec une valeur mais sans le champ cible. Pas réussi à reproduire