### PR TITLE
fix(dossier/démarche en test): peut détruire des dossiers référencés dans des opérations de masse 

### DIFF
--- a/app/controllers/administrateurs/administrateur_controller.rb
+++ b/app/controllers/administrateurs/administrateur_controller.rb
@@ -7,6 +7,10 @@ module Administrateurs
       id = params[:procedure_id] || params[:id]
 
       @procedure = current_administrateur.procedures.find(id)
+
+      Sentry.configure_scope do |scope|
+        scope.set_tags(procedure: @procedure.id)
+      end
     rescue ActiveRecord::RecordNotFound
       flash.alert = 'Démarche inexistante'
       redirect_to admin_procedures_path, status: 404

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -147,7 +147,7 @@ class Dossier < ApplicationRecord
   belongs_to :user, optional: true
   belongs_to :parent_dossier, class_name: 'Dossier', optional: true
   belongs_to :batch_operation, optional: true
-  has_many :dossier_batch_operations
+  has_many :dossier_batch_operations, dependent: :destroy
   has_many :batch_operations, through: :dossier_batch_operations
   has_one :france_connect_information, through: :user
 


### PR DESCRIPTION
Contexte: une démarche en test, avec des dossiers tests manipulés avec les batch opérations. Tout changement sur une procédure test détruit les dossiers, mais c'était impossible et provoquait une erreur lorsqu'il y en a référéncés dans les batch operations.


https://demarches-simplifiees.sentry.io/issues/3778275065/events/b04b2cf67df7437d9a3206ce95edc939/?project=1429550