### PR TITLE
add external id index to champs

### DIFF
--- a/db/migrate/20230207105539_add_external_id_index_to_champs.rb
+++ b/db/migrate/20230207105539_add_external_id_index_to_champs.rb
@@ -1,0 +1,7 @@
+class AddExternalIdIndexToChamps < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :champs, :external_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20230207105539_add_external_id_index_to_champs.rb
+++ b/db/migrate/20230207105539_add_external_id_index_to_champs.rb
@@ -1,7 +1,13 @@
 class AddExternalIdIndexToChamps < ActiveRecord::Migration[6.1]
+  include Database::MigrationHelpers
+
   disable_ddl_transaction!
 
-  def change
-    add_index :champs, :external_id, algorithm: :concurrently
+  def up
+    add_concurrent_index :champs, :external_id
+  end
+
+  def down
+    remove_index :champs, column: :external_id
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_03_134127) do
+ActiveRecord::Schema.define(version: 2023_02_07_105539) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -233,6 +233,7 @@ ActiveRecord::Schema.define(version: 2023_02_03_134127) do
     t.jsonb "value_json"
     t.index ["dossier_id"], name: "index_champs_on_dossier_id"
     t.index ["etablissement_id"], name: "index_champs_on_etablissement_id"
+    t.index ["external_id"], name: "index_champs_on_external_id"
     t.index ["parent_id"], name: "index_champs_on_parent_id"
     t.index ["private"], name: "index_champs_on_private"
     t.index ["row_id"], name: "index_champs_on_row_id"


### PR DESCRIPTION
Dans le but de jouer les migrations de normalisation des champs Départements et Régions, on a besoin de pouvoir faire des requêtes sur les champs, par l'`external_id`. On ajoute donc un index pour rendre cela possible.