### PR TITLE
fix(dolist): n'envoie pas de mail par Dolist API s'il contient des destinataires cachés

### DIFF
--- a/app/lib/dolist/api.rb
+++ b/app/lib/dolist/api.rb
@@ -32,6 +32,9 @@ class Dolist::API
     end
 
     def sendable?(mail)
+      return false if mail.to.blank? # recipient are mandatory
+      return false if mail.bcc.present? # no bcc support
+
       # Mail having attachments are not yet supported in our account
       mail.attachments.none? { !_1.inline? }
     end


### PR DESCRIPTION
Car c'est pas supporté par l'API.