### PR TITLE
a11y(main_menu): utilise aria-current=true plutot que avec page

### DIFF
--- a/app/views/administrateurs/procedures/_main_menu.html.haml
+++ b/app/views/administrateurs/procedures/_main_menu.html.haml
@@ -1,6 +1,6 @@
 .fr-container
   %nav#header-navigation.fr-nav{ role: 'navigation', 'aria-label': 'Menu principal administrateur' }
     %ul.fr-nav__list
-      %li.fr-nav__item= link_to 'Mes démarches', admin_procedures_path, class:'fr-nav__link', 'aria-current': current_page?(admin_procedures_path) ? 'page' : nil
+      %li.fr-nav__item= link_to 'Mes démarches', admin_procedures_path, class:'fr-nav__link', 'aria-current': current_page?(controller: 'procedures', action: :index) ? 'true' : nil
       - if Rails.application.config.ds_zonage_enabled
         %li.fr-nav__item= link_to 'Toutes les démarches', all_admin_procedures_path(zone_ids: current_administrateur.zones), class:'fr-nav__link', 'aria-current': current_page?(all_admin_procedures_path) ? 'page' : nil

--- a/app/views/layouts/_header.haml
+++ b/app/views/layouts/_header.haml
@@ -87,18 +87,18 @@
             - if current_instructeur.procedures.any?
               - current_url = request.path_info
               %li.fr-nav__item
-                = active_link_to t('utils.procedure'), instructeur_procedures_path, active: ['dossiers','procedures'].include?(controller_name), class: 'fr-nav__link'
+                = active_link_to t('utils.procedure'), instructeur_procedures_path, active: ['dossiers','procedures'].include?(controller_name), class: 'fr-nav__link', aria: { current: current_url == instructeur_procedures_path ? 'page' : true }
             - if current_instructeur.user.expert && current_expert.avis_summary[:total] > 0
               = render partial: 'layouts/header/avis_tab', locals: { current_expert: current_expert }
 
           - if is_expert_context
             - if current_expert.user.instructeur && current_instructeur.procedures.any?
-              %li.fr-nav__item= active_link_to t('utils.procedure'), instructeur_procedures_path, active: ['dossiers','procedures'].include?(controller_name), class: 'fr-nav__link'
+              %li.fr-nav__item= active_link_to t('utils.procedure'), instructeur_procedures_path, active: ['dossiers','procedures'].include?(controller_name), class: 'fr-nav__link', aria: { current: true }
             - if current_expert.avis_summary[:total] > 0
               = render partial: 'layouts/header/avis_tab', locals: { current_expert: current_expert }
 
           - if is_user_context
-            %li.fr-nav__item= active_link_to t('.files'), dossiers_path, active: :inclusive, class: 'fr-nav__link'
+            %li.fr-nav__item= active_link_to t('.files'), dossiers_path, active: :inclusive, class: 'fr-nav__link', aria: { current: true }
             - if current_user.expert && current_expert.avis_summary[:total] > 0
               = render partial: 'layouts/header/avis_tab', locals: { current_expert: current_expert }
 


### PR DESCRIPTION
[#8559](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/8559)

@julieSalha ; pas certains d'avoir tout compris. de ma comprehension
* `aria-current=page` la page active
* `aria-current=true` une page précédente a la page active

donc j'ai adapté ainsi : 

ETQ admin, sur la page de "Mes démarches", le lien mes démarches est en `aria-current=true`. L'onglet actif est en `aria-current=page`
> <img width="1003" alt="Screenshot 2023-02-16 at 5 29 58 AM" src="https://user-images.githubusercontent.com/125964/219269791-d2804cee-f0db-44f4-8c10-32cfad913b77.png">

etc...
> <img width="1011" alt="Screenshot 2023-02-16 at 5 28 05 AM" src="https://user-images.githubusercontent.com/125964/219269795-7c410a3c-c263-46bd-bd24-189f1f8a1c28.png">

etc...
> <img width="1010" alt="Screenshot 2023-02-16 at 5 27 58 AM" src="https://user-images.githubusercontent.com/125964/219269800-94ab9968-5e4d-4a15-9d2c-afdc02f70961.png">

etc...
> <img width="1010" alt="Screenshot 2023-02-16 at 5 33 52 AM" src="https://user-images.githubusercontent.com/125964/219269786-b4bd0589-2c53-4ef2-bd66-7dbf6ef731ce.png">

@julieSalha , bon pour toi ?