### PR TITLE
feat(prefill): harmonize prefill buttons

### DIFF
--- a/app/controllers/concerns/query_params_store_concern.rb
+++ b/app/controllers/concerns/query_params_store_concern.rb
@@ -8,9 +8,9 @@ module QueryParamsStoreConcern
   def store_query_params
     # Don't override already stored params, because we could do goings and comings with authentication, and
     # lost previously stored params
-    return if stored_query_params? || request.query_parameters.empty?
+    return if stored_query_params? || filtered_query_params.empty?
 
-    session[:stored_params] = request.query_parameters.to_json
+    session[:stored_params] = filtered_query_params.to_json
   end
 
   def retrieve_and_delete_stored_query_params
@@ -21,5 +21,11 @@ module QueryParamsStoreConcern
 
   def stored_query_params?
     session[:stored_params].present?
+  end
+
+  private
+
+  def filtered_query_params
+    request.query_parameters.except(:locale, "locale")
   end
 end

--- a/app/controllers/concerns/query_params_store_concern.rb
+++ b/app/controllers/concerns/query_params_store_concern.rb
@@ -1,17 +1,25 @@
 module QueryParamsStoreConcern
   extend ActiveSupport::Concern
 
+  included do
+    helper_method :stored_query_params?
+  end
+
   def store_query_params
     # Don't override already stored params, because we could do goings and comings with authentication, and
     # lost previously stored params
-    return if session[:stored_params].present? || request.query_parameters.empty?
+    return if stored_query_params? || request.query_parameters.empty?
 
     session[:stored_params] = request.query_parameters.to_json
   end
 
   def retrieve_and_delete_stored_query_params
-    return {} if session[:stored_params].blank?
+    return {} unless stored_query_params?
 
     JSON.parse(session.delete(:stored_params))
+  end
+
+  def stored_query_params?
+    session[:stored_params].present?
   end
 end

--- a/app/views/commencer/show.html.haml
+++ b/app/views/commencer/show.html.haml
@@ -16,15 +16,18 @@
     - drafts = dossiers.merge(Dossier.state_brouillon)
     - not_drafts = dossiers.merge(Dossier.state_not_brouillon)
 
-    - if dossiers.empty?
-      = link_to t('views.commencer.show.start_procedure'), url_for_new_dossier(@revision), class: 'fr-btn fr-btn--lg fr-my-2w'
-
-    - elsif @prefilled_dossier
+    - if @prefilled_dossier
       %h2.huge-title= t('views.commencer.show.prefilled_draft')
-      %p
-        = t('views.commencer.show.prefilled_draft_detail_html', time_ago: time_ago_in_words(@prefilled_dossier.created_at), procedure: @prefilled_dossier.procedure.libelle)
-      = link_to t('views.commencer.show.continue_file'), brouillon_dossier_path(@prefilled_dossier), class: 'fr-btn fr-btn--lg fr-my-2w'
-      = link_to t('views.commencer.show.start_new_file'), url_for_new_dossier(@revision), class: 'fr-btn fr-btn--lg fr-btn--secondary fr-my-2w'
+      %p= t('views.commencer.show.prefilled_draft_detail_html', time_ago: time_ago_in_words(@prefilled_dossier.created_at), procedure: @prefilled_dossier.procedure.libelle)
+      = link_to t('views.commencer.show.go_to_prefilled_file'), brouillon_dossier_path(@prefilled_dossier), class: 'fr-btn fr-btn--lg fr-my-2w'
+
+    - elsif stored_query_params?
+      %h2.huge-title= t('views.commencer.show.prefilled_draft')
+      %p= t('views.commencer.show.prefill_dossier_detail_html')
+      = link_to t('views.commencer.show.go_to_prefilled_file'), url_for_new_dossier(@revision), class: 'fr-btn fr-btn--lg fr-my-2w'
+
+    - elsif dossiers.empty?
+      = link_to t('views.commencer.show.start_procedure'), url_for_new_dossier(@revision), class: 'fr-btn fr-btn--lg fr-my-2w'
 
     - elsif drafts.size == 1 && not_drafts.empty?
       - dossier = drafts.first

--- a/app/views/commencer/show.html.haml
+++ b/app/views/commencer/show.html.haml
@@ -18,12 +18,12 @@
 
     - if @prefilled_dossier
       %h2.huge-title= t('views.commencer.show.prefilled_draft')
-      %p= t('views.commencer.show.prefilled_draft_detail_html', time_ago: time_ago_in_words(@prefilled_dossier.created_at), procedure: @prefilled_dossier.procedure.libelle)
+      %p= t('views.commencer.show.prefilled_draft_detail_html', time_ago: time_ago_in_words(@prefilled_dossier.created_at), procedure: @procedure.libelle)
       = link_to t('views.commencer.show.go_to_prefilled_file'), brouillon_dossier_path(@prefilled_dossier), class: 'fr-btn fr-btn--lg fr-my-2w'
 
     - elsif stored_query_params?
       %h2.huge-title= t('views.commencer.show.prefilled_draft')
-      %p= t('views.commencer.show.prefill_dossier_detail_html')
+      %p= t('views.commencer.show.prefill_dossier_detail_html', procedure: @procedure.libelle)
       = link_to t('views.commencer.show.go_to_prefilled_file'), url_for_new_dossier(@revision), class: 'fr-btn fr-btn--lg fr-my-2w'
 
     - elsif dossiers.empty?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -93,8 +93,8 @@ en:
         existing_dossiers: You already have files for this procedure
         show_dossiers: View my current files
         prefilled_draft: "You have a prefilled file"
-        prefilled_draft_detail_html: "You prefilled a file for the \"%{procedure}\" procedure <strong>%{time_ago} ago</strong>"
-        prefill_dossier_detail_html: "You are ready to continue a prefilled file."
+        prefilled_draft_detail_html: "You are ready to continue a prefilled file for the \"%{procedure}\" procedure, started <strong>%{time_ago} ago</strong>."
+        prefill_dossier_detail_html: "You are ready to continue a prefilled file for the \"%{procedure}\" procedure."
         already_draft: "You already started to fill a file"
         already_draft_detail_html: "You started to fill a file for the \"%{procedure}\" procedure <strong>%{time_ago} ago</strong>"
         already_not_draft: "You already submitted a file"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,10 +94,12 @@ en:
         show_dossiers: View my current files
         prefilled_draft: "You have a prefilled file"
         prefilled_draft_detail_html: "You prefilled a file for the \"%{procedure}\" procedure <strong>%{time_ago} ago</strong>"
+        prefill_dossier_detail_html: "You are ready to continue a prefilled file."
         already_draft: "You already started to fill a file"
         already_draft_detail_html: "You started to fill a file for the \"%{procedure}\" procedure <strong>%{time_ago} ago</strong>"
         already_not_draft: "You already submitted a file"
         already_not_draft_detail_html: "You submitted a file for the \"%{procedure}\" procedure <strong>%{time_ago} ago</strong>."
+        go_to_prefilled_file: 'Continue to fill my prefilled file'
         continue_file: "Continue to fill my file"
         start_new_file: "Start a new file"
         show_my_submitted_file: 'Show my submitted file'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -85,10 +85,12 @@ fr:
         show_dossiers: Voir mes dossiers en cours
         prefilled_draft: "Vous avez un dossier prérempli"
         prefilled_draft_detail_html: "Il y a <strong>%{time_ago}</strong>, vous avez prérempli un dossier sur la démarche « %{procedure} »."
+        prefill_dossier_detail_html: "Vous êtes prêt·e à poursuivre un dossier prérempli."
         already_draft: "Vous avez déjà commencé à remplir un dossier"
         already_draft_detail_html: "Il y a <strong>%{time_ago}</strong>, vous avez commencé à remplir un dossier sur la démarche « %{procedure} »."
         already_not_draft: "Vous avez déjà déposé un dossier"
         already_not_draft_detail_html: "Il y a <strong>%{time_ago}</strong>, vous avez déposé un dossier sur la démarche « %{procedure} »."
+        go_to_prefilled_file: 'Poursuivre mon dossier prérempli'
         continue_file: 'Continuer à remplir mon dossier'
         start_new_file: 'Commencer un nouveau dossier'
         show_my_submitted_file: 'Voir mon dossier déposé'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -84,8 +84,8 @@ fr:
         existing_dossiers: Vous avez déjà des dossiers pour cette démarche
         show_dossiers: Voir mes dossiers en cours
         prefilled_draft: "Vous avez un dossier prérempli"
-        prefilled_draft_detail_html: "Il y a <strong>%{time_ago}</strong>, vous avez prérempli un dossier sur la démarche « %{procedure} »."
-        prefill_dossier_detail_html: "Vous êtes prêt·e à poursuivre un dossier prérempli."
+        prefilled_draft_detail_html: "Vous êtes prêt·e à poursuivre un dossier prérempli sur la démarche « %{procedure} », commencé il y a <strong>%{time_ago}</strong>."
+        prefill_dossier_detail_html: "Vous êtes prêt·e à poursuivre un dossier prérempli sur la démarche « %{procedure} »."
         already_draft: "Vous avez déjà commencé à remplir un dossier"
         already_draft_detail_html: "Il y a <strong>%{time_ago}</strong>, vous avez commencé à remplir un dossier sur la démarche « %{procedure} »."
         already_not_draft: "Vous avez déjà déposé un dossier"

--- a/spec/controllers/concerns/query_params_store_concern_spec.rb
+++ b/spec/controllers/concerns/query_params_store_concern_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe QueryParamsStoreConcern, type: :controller do
       let(:params) { { param1: "param1" } }
 
       it "does nothing" do
-        session[:stored_params] = "there is alread something in there"
+        session[:stored_params] = "there is already something in there"
 
         expect { store_query_params }.not_to change { session[:stored_params] }
       end
@@ -61,6 +61,23 @@ RSpec.describe QueryParamsStoreConcern, type: :controller do
       it 'returns the stored params' do
         expect(retrieve_and_delete_stored_query_params).to match(params.with_indifferent_access)
       end
+    end
+  end
+
+  describe '#stored_query_params?' do
+    subject(:stored_query_params?) { controller.stored_query_params? }
+
+    before { controller.store_query_params }
+    context 'when query params have been stored' do
+      let(:params) { { param1: "param1", param2: "param2" } }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when query params have not been stored' do
+      let(:params) { {} }
+
+      it { is_expected.to eq(false) }
     end
   end
 end

--- a/spec/controllers/concerns/query_params_store_concern_spec.rb
+++ b/spec/controllers/concerns/query_params_store_concern_spec.rb
@@ -36,6 +36,14 @@ RSpec.describe QueryParamsStoreConcern, type: :controller do
         expect { store_query_params }.to change { session[:stored_params] }.from(nil).to(params.to_json)
       end
     end
+
+    context 'when params contain a locale' do
+      let(:params) { { locale: "fr", param2: "param2" } }
+
+      it "does not store the locale" do
+        expect { store_query_params }.to change { session[:stored_params] }.from(nil).to({ param2: "param2" }.to_json)
+      end
+    end
   end
 
   describe '#retrieve_and_delete_stored_query_params' do

--- a/spec/system/users/dossier_prefill_get_spec.rb
+++ b/spec/system/users/dossier_prefill_get_spec.rb
@@ -23,7 +23,7 @@ describe 'Prefilling a dossier (with a GET request):' do
           "champ_#{type_de_champ_phone.to_typed_id}" => phone_value
         )
 
-        click_on "Commencer la démarche"
+        click_on "Poursuivre mon dossier prérempli"
       end
     end
   end
@@ -45,7 +45,7 @@ describe 'Prefilling a dossier (with a GET request):' do
           click_on "J’ai déjà un compte"
           sign_in_with user.email, password
 
-          click_on "Commencer la démarche"
+          click_on "Poursuivre mon dossier prérempli"
         end
       end
     end
@@ -64,7 +64,7 @@ describe 'Prefilling a dossier (with a GET request):' do
           click_confirmation_link_for user_email
           expect(page).to have_content('Votre compte a bien été confirmé.')
 
-          click_on "Commencer la démarche"
+          click_on "Poursuivre mon dossier prérempli"
         end
       end
     end
@@ -79,7 +79,7 @@ describe 'Prefilling a dossier (with a GET request):' do
 
           page.find('.fr-connect').click
 
-          click_on "Commencer la démarche"
+          click_on "Poursuivre mon dossier prérempli"
         end
       end
     end

--- a/spec/system/users/dossier_prefill_post_spec.rb
+++ b/spec/system/users/dossier_prefill_post_spec.rb
@@ -27,7 +27,7 @@ describe 'Prefilling a dossier (with a POST request):' do
           visit create_and_prefill_dossier_with_post_request
 
           expect(page).to have_content('Vous avez un dossier prérempli')
-          click_on 'Continuer à remplir mon dossier'
+          click_on 'Poursuivre mon dossier prérempli'
         end
       end
     end
@@ -44,7 +44,7 @@ describe 'Prefilling a dossier (with a POST request):' do
             sign_in_with user.email, password
 
             expect(page).to have_content('Vous avez un dossier prérempli')
-            click_on 'Continuer à remplir mon dossier'
+            click_on 'Poursuivre mon dossier prérempli'
           end
         end
       end
@@ -64,7 +64,7 @@ describe 'Prefilling a dossier (with a POST request):' do
             expect(page).to have_content('Votre compte a bien été confirmé.')
 
             expect(page).to have_content('Vous avez un dossier prérempli')
-            click_on 'Continuer à remplir mon dossier'
+            click_on 'Poursuivre mon dossier prérempli'
           end
         end
       end
@@ -80,7 +80,7 @@ describe 'Prefilling a dossier (with a POST request):' do
             page.find('.fr-connect').click
 
             expect(page).to have_content('Vous avez un dossier prérempli')
-            click_on 'Continuer à remplir mon dossier'
+            click_on 'Poursuivre mon dossier prérempli'
           end
         end
       end

--- a/spec/views/commencer/show.html.haml_spec.rb
+++ b/spec/views/commencer/show.html.haml_spec.rb
@@ -74,5 +74,19 @@ RSpec.describe 'commencer/show.html.haml', type: :view do
         expect(rendered).to have_link('Voir mes dossiers en cours', href: dossiers_path)
       end
     end
+
+    context 'and they have a prefilled dossier' do
+      let!(:prefilled_dossier) { create(:dossier, :prefilled, user: user, procedure: procedure) }
+
+      before { assign(:prefilled_dossier, prefilled_dossier) }
+
+      it_behaves_like 'it renders a link to create a new dossier', 'Commencer un nouveau dossier'
+
+      it 'renders a link to resume the pending draft' do
+        subject
+        expect(rendered).to have_text(time_ago_in_words(prefilled_dossier.created_at))
+        expect(rendered).to have_link('Continuer à remplir mon dossier', href: brouillon_dossier_path(prefilled_dossier))
+      end
+    end
   end
 end

--- a/spec/views/commencer/show.html.haml_spec.rb
+++ b/spec/views/commencer/show.html.haml_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe 'commencer/show.html.haml', type: :view do
   include Rails.application.routes.url_helpers
 
+  let(:stored_query_params) { false }
   let(:procedure) { create(:procedure, :published, :for_individual, :with_service) }
 
   before do
@@ -9,6 +10,8 @@ RSpec.describe 'commencer/show.html.haml', type: :view do
     if user
       sign_in user
     end
+
+    allow(view).to receive(:stored_query_params?).and_return(stored_query_params)
   end
 
   subject { render }
@@ -80,13 +83,17 @@ RSpec.describe 'commencer/show.html.haml', type: :view do
 
       before { assign(:prefilled_dossier, prefilled_dossier) }
 
-      it_behaves_like 'it renders a link to create a new dossier', 'Commencer un nouveau dossier'
-
-      it 'renders a link to resume the pending draft' do
+      it 'renders a link to resume the prefilled dossier' do
         subject
         expect(rendered).to have_text(time_ago_in_words(prefilled_dossier.created_at))
-        expect(rendered).to have_link('Continuer à remplir mon dossier', href: brouillon_dossier_path(prefilled_dossier))
+        expect(rendered).to have_link('Poursuivre mon dossier prérempli', href: brouillon_dossier_path(prefilled_dossier))
       end
+    end
+
+    context 'and they have stored query params in order to prefill a dossier' do
+      let(:stored_query_params) { true }
+
+      it_behaves_like 'it renders a link to create a new dossier', 'Poursuivre mon dossier prérempli'
     end
   end
 end


### PR DESCRIPTION
# Problème rencontré

Du point de vue de l'usager•ère, lors du préremplissage : 


**Préremplissage en GET :**

![Image](https://user-images.githubusercontent.com/1193334/216329809-b74bf59e-ea92-4b03-9915-d4faa635deb6.png)


**Préremplissage en POST :**



![Image](https://user-images.githubusercontent.com/1193334/216330255-53961a2f-c1ae-444a-972f-0c1f874160c2.png)

Ce n'est pas très homogène.

# Solution retenue

La solution que je propose ici est toute simple : dans le cas d'un préremplissage, l'usager·ère est arrivé·e sur l'application à partir d'un lien bien spécifique. Que le remplissage soit fait en GET ou bien en POST, on lui présente donc un bouton "Poursuivre mon dossier prérempli".

**Préremplissage en GET :**

![image](https://user-images.githubusercontent.com/1193334/217550695-c079b7ba-8213-43c1-8340-692fe5220471.png)


**Préremplissage en POST :**

![image](https://user-images.githubusercontent.com/1193334/217551766-c766b12a-213e-443a-a7e6-5d82194fd5d2.png)
