### PR TITLE
fix(geo_area): geo_area.geometry must be valid JSON, not nil

### DIFF
--- a/lib/tasks/deployment/20230208154144_fix_geo_area_without_geometry.rake
+++ b/lib/tasks/deployment/20230208154144_fix_geo_area_without_geometry.rake
@@ -1,0 +1,18 @@
+namespace :after_party do
+  desc 'Deployment task: fix_geo_area_without_geometry'
+  task fix_geo_area_without_geometry: :environment do
+    puts "Running deploy task 'fix_geo_area_without_geometry'"
+
+    geo_areas = GeoArea.where(geometry: nil)
+
+    geo_areas.find_each do |geo_area|
+      geo_area.geometry = {}
+      geo_area.save!
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
Fix 1 export qui cale à cause d'un vieux geo area invalide créé avant qu'on valide la geometry

https://demarches-simplifiees.sentry.io/issues/3708484528/?project=1429550&query=ExportJob&referrer=issue-stream&statsPeriod=14d
