### PR TITLE
fix(export/job): race condition when export was already generated

### DIFF
--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -3,6 +3,10 @@ class ExportJob < ApplicationJob
 
   discard_on ActiveRecord::RecordNotFound
 
+  before_perform do |job|
+    Sentry.set_tags(procedure_id: job.arguments.first.procedure.id)
+  end
+
   def perform(export)
     return if export.generated?
 

--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -4,6 +4,8 @@ class ExportJob < ApplicationJob
   discard_on ActiveRecord::RecordNotFound
 
   def perform(export)
+    return if export.generated?
+
     export.compute_with_safe_stale_for_purge do
       export.compute
     end

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -163,6 +163,10 @@ class Export < ApplicationRecord
     end
   end
 
+  def procedure
+    groupe_instructeurs.first.procedure
+  end
+
   private
 
   def load_snapshot!
@@ -203,9 +207,5 @@ class Export < ApplicationRecord
     when :json
       service.to_geo_json
     end
-  end
-
-  def procedure
-    groupe_instructeurs.first.procedure
   end
 end


### PR DESCRIPTION
Je l'explique pas mais on a des cas où un même export est re-généré après l'avoir déjà été, ce qui provoque une erreur de changement d'état. Je l'ai reproduit manuellement en local

https://demarches-simplifiees.sentry.io/issues/3702278731/?project=1429550&query=ExportJob&referrer=issue-stream&statsPeriod=14d

J'en profite pour set la procedure_id d'un exports dans sentry