### PR TITLE
feat(admin): permet l'import de groupes instructeurs en CSV quand la démarche est close

### DIFF
--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -192,7 +192,7 @@ module Administrateurs
     end
 
     def import
-      if procedure.publiee?
+      if procedure.publiee_or_close?
         if !CSV_ACCEPTED_CONTENT_TYPES.include?(group_csv_file.content_type) && !CSV_ACCEPTED_CONTENT_TYPES.include?(marcel_content_type)
           flash[:alert] = "Importation impossible : veuillez importer un fichier CSV"
 

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -823,6 +823,10 @@ class Procedure < ApplicationRecord
     published_at || created_at
   end
 
+  def publiee_or_close?
+    publiee? || close?
+  end
+
   def self.tags
     unnest = Arel::Nodes::NamedFunction.new('UNNEST', [self.arel_table[:tags]])
     query = self.select(unnest.as('tags')).publiees.distinct.order('tags')

--- a/app/views/administrateurs/groupe_instructeurs/_edit.html.haml
+++ b/app/views/administrateurs/groupe_instructeurs/_edit.html.haml
@@ -24,7 +24,7 @@
     = f.submit t('.button.add_group'), class: "button primary send"
 
   - csv_max_size = Administrateurs::GroupeInstructeursController::CSV_MAX_SIZE
-  - if procedure.publiee?
+  - if procedure.publiee_or_close?
     = form_tag import_admin_procedure_groupe_instructeurs_path(procedure), method: :post, multipart: true, class: "mt-4 form" do
       = label_tag t('.csv_import.title')
       %p.notice

--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -431,6 +431,16 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
       it { expect(flash.alert).to be_present }
       it { expect(flash.alert).to eq("Importation impossible, veuillez importer un csv <a href=\"/csv/#{I18n.locale}/import-groupe-test.csv\">suivant ce modèle</a>") }
     end
+
+    context 'when procedure is closed' do
+      let(:procedure) { create(:procedure, :closed, administrateurs: [admin]) }
+      let(:csv_file) { fixture_file_upload('spec/fixtures/files/groupe-instructeur.csv', 'text/csv') }
+
+      before { subject }
+
+      it { expect(procedure.groupe_instructeurs.first.label).to eq("Afrique") }
+      it { expect(flash.alert).to eq("Import terminé. Cependant les emails suivants ne sont pas pris en compte: kara") }
+    end
   end
 
   describe '#export_groupe_instructeurs' do


### PR DESCRIPTION
https://secure.helpscout.net/conversation/2149717938/2013793?folderId=1653799

contexte :

Une démarche peut être close, mais les dossiers ont encore besoin d'être instruits. On permet d'ailleurs l'ajout des instructeurs 1 par 1, je propose donc de le permettre aussi en CSV.