### PR TITLE
a11y : optimization return to the line of longs links

### DIFF
--- a/app/assets/stylesheets/procedure_admin.scss
+++ b/app/assets/stylesheets/procedure_admin.scss
@@ -26,6 +26,7 @@
 .container {
   a {
     cursor: pointer;
+    overflow-wrap: break-word;
   }
 }
 


### PR DESCRIPTION
[Affichage contenus sans défilement horizontal - Fenêtre 320px (Critère 10.11) - Création dossier (Brouillon)#8119](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/8119)