### PR TITLE
fix(procedures/all): table layout issue

### DIFF
--- a/app/views/administrateurs/procedures/_detail.html.haml
+++ b/app/views/administrateurs/procedures/_detail.html.haml
@@ -16,7 +16,7 @@
 
 - if show_detail
   %tr.procedure{ id: "procedure_detail_#{procedure.id}" }
-    %td.fr-highlight--beige-gris-galet{ colspan: '6' }
+    %td.fr-highlight--beige-gris-galet{ colspan: '7' }
       .fr-container
         .fr-grid-row
           .fr-col-6


### PR DESCRIPTION
suite à l'ajout du `td` pour cloner, il manquait la modif du colspan sur le détail d'une démarche

Closes #8614 