### PR TITLE
Email: limite le sujet généré à 100 caractères et utilise le sujet par défaut si le modèle est vide

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -7,6 +7,7 @@
 #
 class NotificationMailer < ApplicationMailer
   include ActionView::Helpers::SanitizeHelper
+  include ActionView::Helpers::TextHelper
 
   before_action :set_dossier
   before_action :set_services_publics_plus, only: :send_notification
@@ -67,7 +68,7 @@ class NotificationMailer < ApplicationMailer
         mail_template = @dossier.procedure.mail_template_for(params[:state])
 
         @email = @dossier.user_email_for(:notification)
-        @subject = mail_template.subject_for_dossier(@dossier)
+        @subject = truncate(mail_template.subject_for_dossier(@dossier), length: 100)
         @body = mail_template.body_for_dossier(@dossier)
         @actions = mail_template.actions_for_dossier(@dossier)
         @attachment = mail_template.attachment_for_dossier(@dossier)

--- a/app/models/concerns/mail_template_concern.rb
+++ b/app/models/concerns/mail_template_concern.rb
@@ -10,7 +10,7 @@ module MailTemplateConcern
   end
 
   def subject_for_dossier(dossier)
-    replace_tags(subject, dossier)
+    replace_tags(subject, dossier).presence || replace_tags(self.class::DEFAULT_SUBJECT, dossier)
   end
 
   def body_for_dossier(dossier)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -395,6 +395,19 @@ en:
         zone: This procedure is run by
       champs:
         value: Value
+      default_mail_attributes: &default_mail_attributes
+        hints:
+          subject: The generated subject will be truncated if it exceeds 100 characters.
+      mails/closed_mail:
+        << : *default_mail_attributes
+      mails/initiated_mail:
+        << : *default_mail_attributes
+      mails/received_mail:
+        << : *default_mail_attributes
+      mails/refused_mail:
+        << : *default_mail_attributes
+      mails/without_continuation_mail:
+        << : *default_mail_attributes
 
     errors:
       messages:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -392,6 +392,19 @@ fr:
         zone: La démarche est mise en œuvre par
       champs:
         value: Valeur du champ
+      default_mail_attributes: &default_mail_attributes
+        hints:
+          subject: "L’objet généré sera tronqué s’il dépasse 100 caractères."
+      mails/closed_mail:
+        << : *default_mail_attributes
+      mails/initiated_mail:
+        << : *default_mail_attributes
+      mails/received_mail:
+        << : *default_mail_attributes
+      mails/refused_mail:
+        << : *default_mail_attributes
+      mails/without_continuation_mail:
+        << : *default_mail_attributes
 
     errors:
       messages:

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -117,5 +117,11 @@ RSpec.describe NotificationMailer, type: :mailer do
       let(:subject) { 'Un long libellé --libellé démarche--' }
       it { expect(mail.subject.length).to be <= 100 }
     end
+
+    context "subject should fallback to default" do
+      let(:subject) { "" }
+      it { expect(mail.subject).to match(/^Votre dossier .+ a été accepté \(My super long title/) }
+      it { expect(mail.subject.length).to be <= 100 }
+    end
   end
 end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -101,4 +101,21 @@ RSpec.describe NotificationMailer, type: :mailer do
       end
     end
   end
+
+  describe 'subject length' do
+    let(:procedure) { create(:simple_procedure, libelle: "My super long title " + ("xo " * 100)) }
+    let(:dossier) { create(:dossier, :en_instruction, :with_individual, :with_service, user: user, procedure: procedure) }
+    let(:email_template) { create(:closed_mail, subject:, body: 'Your dossier was accepted. Thanks.') }
+
+    before do
+      dossier.procedure.closed_mail = email_template
+    end
+
+    subject(:mail) { described_class.send_accepte_notification(dossier) }
+
+    context "subject is too long" do
+      let(:subject) { 'Un long libellé --libellé démarche--' }
+      it { expect(mail.subject.length).to be <= 100 }
+    end
+  end
 end


### PR DESCRIPTION
On a des noms de démarche à rallonge qui viennent faire planter des emails qui reprennent ce libellé. Pas trouvé de moyen pas cher de l'afficher dans le cadre du preview.

Et j'ai vu passer des emails générés sans sujet (template vidé, erreur lors de la substitution des tags etc…)

Closes #8448

![Capture d’écran 2023-02-09 à 17 51 10](https://user-images.githubusercontent.com/150279/217882490-be16f606-2089-4f1c-b8eb-02894b459a51.png)
