### PR TITLE
docs: add DATAGOUV_STATISTICS_DATASET environment variable  to env.example.optional

### DIFF
--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -134,14 +134,16 @@ VITE_LEGACY=""
 
 # around july 2022, we changed the duree_conservation_dossiers_dans_ds, allow instances to choose their own duration
 NEW_MAX_DUREE_CONSERVATION=12
-#
-OPENDATA_ENABLED="enabled"
 
-# Publish to datagouv
+# Open data
+OPENDATA_ENABLED="enabled" # disabled by default if `OPENDATA_ENABLED` not set
+
+# Open data, publish to data.gouv.fr
 DATAGOUV_API_KEY="thisisasecret"
 DATAGOUV_API_URL="https://www.data.gouv.fr/api/1"
-DATAGOUV_DESCRIPTIF_DEMARCHES_DATASET="datasetid"
-DATAGOUV_DESCRIPTIF_DEMARCHES_RESOURCE="resourceid"
+DATAGOUV_STATISTICS_DATASET="dataset-id1"
+DATAGOUV_DESCRIPTIF_DEMARCHES_DATASET="dataset-id2"
+DATAGOUV_DESCRIPTIF_DEMARCHES_RESOURCE="resource-id-of-dataset-id2"
 
 # Zonage
 ZONAGE_ENABLED='enabled' # zonage disabled by default if `ZONAGE_ENABLED` not set


### PR DESCRIPTION
Fixed  #8615  "Documentation pour la variable d'environnement DATAGOUV_STATISTICS_DATASET"

Pour faire suite à l'échange avec @krichtof sur l'**opendata**.

##  Actuellement

Une variable d'environnement  `DATAGOUV_STATISTICS_DATASET` est dans le fichier  [`config/secrets.yml`](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/blob/main/config/secrets.yml#L86)
```ruby
  datagouv:
    api_key: <%= ENV['DATAGOUV_API_KEY'] %>
    api_url: <%= ENV['DATAGOUV_API_URL'] %>
    descriptif_demarches_dataset: <%= ENV['DATAGOUV_DESCRIPTIF_DEMARCHES_DATASET'] %>
    descriptif_demarches_resource: <%= ENV['DATAGOUV_DESCRIPTIF_DEMARCHES_RESOURCE'] %>
    statistics_dataset: <%= ENV['DATAGOUV_STATISTICS_DATASET'] %>
```

Actuellement, cette variable d'environnement `DATAGOUV_STATISTICS_DATASET`   ne semble pas présente dans le fichier [`config/env.example`](https://github.com/betagouv/demarches-simplifiees.fr/blob/main/config/env.example) ou le fichier  [`env.example.optional`](https://github.com/betagouv/demarches-simplifiees.fr/blob/main/config/env.example.optional).


## Correctif proposé

Compléter la documentation sur les variables d'environnements en ajoutant cette  variable d'environnement optionnelle `DATAGOUV_STATISTICS_DATASET`  dans le fichier [`env.example.optional`](https://github.com/betagouv/demarches-simplifiees.fr/blob/main/config/env.example.optional)
```diff
  # Publish to datagouv
  DATAGOUV_API_KEY="thisisasecret"
  DATAGOUV_API_URL="https://www.data.gouv.fr/api/1"
+ DATAGOUV_STATISTICS_DATASET="dataset-id1"
+ DATAGOUV_DESCRIPTIF_DEMARCHES_DATASET="dataset-id2"
- DATAGOUV_DESCRIPTIF_DEMARCHES_DATASET="datasetid"
+ DATAGOUV_DESCRIPTIF_DEMARCHES_RESOURCE="resource-id-of-dataset-id2"
- DATAGOUV_DESCRIPTIF_DEMARCHES_RESOURCE="resourceid"
```


# Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et / ou ajouter un utilisateur https://github.com/betagouv pour intervenir directement sur notre dépôt.

--------------------
> `trackingAdullactContrib `
