### PR TITLE
fix(groupe instructeur): always display instructeurs_self_management toggle to admin

### DIFF
--- a/app/views/administrateurs/groupe_instructeurs/index.html.haml
+++ b/app/views/administrateurs/groupe_instructeurs/index.html.haml
@@ -19,9 +19,9 @@
         instructeurs: @instructeurs,
         available_instructeur_emails: @available_instructeur_emails,
         disabled_as_super_admin: administrateur_as_manager? }
-  - if !@procedure.routing_enabled?
-    = render partial: 'administrateurs/groupe_instructeurs/instructeurs_self_management', locals: { procedure: @procedure }
 
   = render partial: 'administrateurs/groupe_instructeurs/routing', locals: { procedure: @procedure }
 
   = render partial: 'administrateurs/groupe_instructeurs/edit', locals: { procedure: @procedure, groupes_instructeurs: @groupes_instructeurs }
+
+  = render partial: 'administrateurs/groupe_instructeurs/instructeurs_self_management', locals: { procedure: @procedure }


### PR DESCRIPTION
Je me suis rendu compte qu'on avait enlevé ce toggle de la vue admin pour les procédures routées. Or l'admin peut tout à fait vouloir activer ou désactiver cette fonctionnalité pour les instructeurs une fois que la procédure est routée. -> on affiche le toggle systématiquement
