### PR TITLE
WIP - correctif(a11y): utiliser un <button> plutot qu'un <a> pour une action de suppression

### DIFF
--- a/app/components/attachment/edit_component/edit_component.html.haml
+++ b/app/components/attachment/edit_component/edit_component.html.haml
@@ -3,7 +3,8 @@
     %div{ id: dom_id(attachment, :persisted_row) }
       .flex.flex-gap-2{ class: class_names("attachment-error": attachment.virus_scanner_error?) }
         - if user_can_destroy?
-          = link_to(t('.delete'), destroy_attachment_path, **remove_button_options, class: "fr-btn fr-btn--tertiary fr-btn--sm fr-icon-delete-line", title: t(".delete_file", filename: attachment.filename))
+          = button_tag(name: "action", value: destroy_attachment_path, class: "fr-btn fr-btn--tertiary fr-btn--sm fr-icon-delete-line", title: t(".delete_file", filename: attachment.filename), form: dom_id(ActiveStorage::Attachment.new, :delete)) do
+            = t('.delete')
         - elsif user_can_replace?
           = button_tag t('.replace'), **replace_button_options, class: "fr-btn fr-btn--tertiary fr-btn--sm", title: t(".replace_file", filename: attachment.filename)
 

--- a/app/javascript/controllers/delete_attachment_controller.ts
+++ b/app/javascript/controllers/delete_attachment_controller.ts
@@ -1,0 +1,27 @@
+import { httpRequest } from '@utils';
+import { ApplicationController } from './application_controller';
+
+// When dealing with dossiers.attachements.
+// their is the main form to submit each champs
+// plus their is another form (not nested in the main form) to submit a delete request
+// this controller connect each <button> submitting an attachment destroy request
+// to the form that submit the request
+export class DeleteAttachmentController extends ApplicationController {
+  static targets = ['form'];
+
+  declare readonly formTarget: HTMLFormElement;
+
+  onSubmit(event: SubmitEvent) {
+    const submitter = event.submitter;
+    const action = submitter ? submitter.getAttribute('value') : null;
+
+    event.preventDefault();
+    if (submitter && action) {
+      httpRequest(action, {
+        method: 'post',
+        body: new FormData(this.formTarget)
+      }).turbo();
+    }
+    return false;
+  }
+}

--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -2,13 +2,17 @@
   - content_for(:notice_info) do
     = render partial: "shared/dossiers/france_connect_informations_notice", locals: { user_information: dossier.france_connect_information }
 
-.dossier-edit.container
+.dossier-edit.container{ 'data-controller': 'delete-attachment' }
   = render partial: "shared/dossiers/submit_is_over", locals: { dossier: dossier }
 
   - if dossier.brouillon?
     - form_options = { url: brouillon_dossier_url(dossier), method: :patch, data: { save_on_input: true } }
   - else
     - form_options = { url: modifier_dossier_url(dossier), method: :patch }
+
+  = form_for(:attachment, url: { controller: "/attachments", action: "destroy", id: ""}, method: :delete, data: { action: "delete-attachment#onSubmit", 'delete-attachment-target': 'form' }, html: { class: 'form', id: dom_id(ActiveStorage::Attachment.new, :delete) }) {}
+
+  }
 
   = form_for dossier, form_options.merge({ html: { id: 'dossier-edit-form', class: 'form', multipart: true, novalidate: 'novalidate' } }) do |f|
 

--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -12,8 +12,6 @@
 
   = form_for(:attachment, url: { controller: "/attachments", action: "destroy", id: ""}, method: :delete, data: { action: "delete-attachment#onSubmit", 'delete-attachment-target': 'form' }, html: { class: 'form', id: dom_id(ActiveStorage::Attachment.new, :delete) }) {}
 
-  }
-
   = form_for dossier, form_options.merge({ html: { id: 'dossier-edit-form', class: 'form', multipart: true, novalidate: 'novalidate' } }) do |f|
 
     %header.mb-6

--- a/spec/components/attachment/edit_component_spec.rb
+++ b/spec/components/attachment/edit_component_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Attachment::EditComponent, type: :component do
       it 'displays the filename, but doesn’t allow to download the file' do
         expect(attachment.watermark_pending?).to be_truthy
         expect(subject).to have_text(filename)
-        expect(subject).to have_link('Supprimer')
+        expect(subject).to have_button('Supprimer')
         expect(subject).to have_no_link(text: filename) # don't match "Delete" link which also include filename in title attribute
         expect(subject).to have_text('Traitement en cours')
       end


### PR DESCRIPTION
il est recommandé d'utilser un boutton pour la suppr…ession d'un element. le bouton etant deja dans un form, nous ne pouvons pas utiliser le button_to. Extraction d'un form pour soumettre la suppression des pjs par des input pointant sur ce form

cf: https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/8553