### PR TITLE
correctif(a11y): utilise un <button> a la place d'un <a> lorsqu'on effectue l'action de supprimer un attachement

### DIFF
--- a/app/components/attachment/edit_component/edit_component.html.haml
+++ b/app/components/attachment/edit_component/edit_component.html.haml
@@ -3,7 +3,8 @@
     %div{ id: dom_id(attachment, :persisted_row) }
       .flex.flex-gap-2{ class: class_names("attachment-error": attachment.virus_scanner_error?) }
         - if user_can_destroy?
-          = link_to(t('.delete'), destroy_attachment_path, **remove_button_options, class: "fr-btn fr-btn--tertiary fr-btn--sm fr-icon-delete-line", title: t(".delete_file", filename: attachment.filename))
+          = button_tag(name: "action", formaction: destroy_attachment_path, class: "fr-btn fr-btn--tertiary fr-btn--sm fr-icon-delete-line", title: t(".delete_file", filename: attachment.filename), form: dom_id(ActiveStorage::Attachment.new, :delete), data: {turbo: true, 'turbo-method': 'delete'}) do
+            = t('.delete')
         - elsif user_can_replace?
           = button_tag t('.replace'), **replace_button_options, class: "fr-btn fr-btn--tertiary fr-btn--sm", title: t(".replace_file", filename: attachment.filename)
 

--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -10,6 +10,10 @@
   - else
     - form_options = { url: modifier_dossier_url(dossier), method: :patch }
 
+  %div
+    = form_tag('/attachments/:id', method: :delete, data: { 'turbo-method': :delete, turbo: true }, id: dom_id(ActiveStorage::Attachment.new, :delete)) do
+      -# otherwise the closing tag bugs
+
   = form_for dossier, form_options.merge({ html: { id: 'dossier-edit-form', class: 'form', multipart: true, novalidate: 'novalidate' } }) do |f|
 
     %header.mb-6

--- a/spec/components/attachment/edit_component_spec.rb
+++ b/spec/components/attachment/edit_component_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Attachment::EditComponent, type: :component do
       it 'displays the filename, but doesn’t allow to download the file' do
         expect(attachment.watermark_pending?).to be_truthy
         expect(subject).to have_text(filename)
-        expect(subject).to have_link('Supprimer')
+        expect(subject).to have_button('Supprimer')
         expect(subject).to have_no_link(text: filename) # don't match "Delete" link which also include filename in title attribute
         expect(subject).to have_text('Traitement en cours')
       end
@@ -152,8 +152,12 @@ RSpec.describe Attachment::EditComponent, type: :component do
       end
     end
 
-    context 'when the file is scanned and safe' do
+    context 'when the file is scanned, watermarked_at, and viewed as download and safe' do
+      let(:kwargs) { { view_as: :download } }
       let(:virus_scan_result) { ActiveStorage::VirusScanner::SAFE }
+      before do
+        attachment.blob.touch(:watermarked_at)
+      end
 
       it 'allows to download the file' do
         expect(subject).to have_link(filename)

--- a/spec/components/attachment/multiple_component_spec.rb
+++ b/spec/components/attachment/multiple_component_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe Attachment::MultipleComponent, type: :component do
     end
 
     it 'shows the Delete button by default' do
-      expect(subject).to have_link(title: "Supprimer le fichier #{attached_file.attachments[0].filename}")
-      expect(subject).to have_link(title: "Supprimer le fichier #{attached_file.attachments[1].filename}")
+      expect(subject).to have_button(title: "Supprimer le fichier #{attached_file.attachments[0].filename}")
+      expect(subject).to have_button(title: "Supprimer le fichier #{attached_file.attachments[1].filename}")
     end
 
     it 'renders a form field for uploading a new file' do


### PR DESCRIPTION
see: https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/8553

il est recommandé d'utilser un boutton pour la suppr…ession d'un element. le bouton etant deja dans un form, nous ne pouvons pas utiliser le button_to. Extraction d'un form pour soumettre la suppression des pjs par des input pointant sur ce form