### PR TITLE
feat(API): notify instructeurs when added or removed from procedure

### DIFF
--- a/app/graphql/mutations/groupe_instructeur_ajouter_instructeurs.rb
+++ b/app/graphql/mutations/groupe_instructeur_ajouter_instructeurs.rb
@@ -13,7 +13,12 @@ module Mutations
       ids, emails = partition_instructeurs_by(instructeurs)
       _, invalid_emails = groupe_instructeur.add_instructeurs(ids:, emails:)
 
-      groupe_instructeur.reload
+      if instructeurs.present?
+        groupe_instructeur.reload
+        GroupeInstructeurMailer
+          .notify_added_instructeurs(groupe_instructeur, instructeurs, current_administrateur.email)
+          .deliver_later
+      end
 
       result = { groupe_instructeur: }
 

--- a/app/graphql/mutations/groupe_instructeur_supprimer_instructeurs.rb
+++ b/app/graphql/mutations/groupe_instructeur_supprimer_instructeurs.rb
@@ -12,10 +12,10 @@ module Mutations
       ids, emails = partition_instructeurs_by(instructeurs)
       instructeurs = groupe_instructeur.instructeurs.find_all_by_identifier(ids:, emails:)
 
-      instructeurs.each { groupe_instructeur.remove(_1) }
-      groupe_instructeur.reload
-
       if instructeurs.present?
+        instructeurs.each { groupe_instructeur.remove(_1) }
+        groupe_instructeur.reload
+
         GroupeInstructeurMailer
           .notify_group_when_instructeurs_removed(groupe_instructeur, instructeurs, current_administrateur.email)
           .deliver_later

--- a/app/graphql/mutations/groupe_instructeur_supprimer_instructeurs.rb
+++ b/app/graphql/mutations/groupe_instructeur_supprimer_instructeurs.rb
@@ -14,11 +14,8 @@ module Mutations
 
       if instructeurs.present?
         instructeurs.each { groupe_instructeur.remove(_1) }
-        groupe_instructeur.reload
 
-        GroupeInstructeurMailer
-          .notify_group_when_instructeurs_removed(groupe_instructeur, instructeurs, current_administrateur.email)
-          .deliver_later
+        groupe_instructeur.reload
 
         instructeurs.each do |instructeur|
           GroupeInstructeurMailer

--- a/app/graphql/mutations/groupe_instructeur_supprimer_instructeurs.rb
+++ b/app/graphql/mutations/groupe_instructeur_supprimer_instructeurs.rb
@@ -19,6 +19,12 @@ module Mutations
         GroupeInstructeurMailer
           .notify_group_when_instructeurs_removed(groupe_instructeur, instructeurs, current_administrateur.email)
           .deliver_later
+
+        instructeurs.each do |instructeur|
+          GroupeInstructeurMailer
+            .notify_removed_instructeur(groupe_instructeur, instructeur, current_administrateur.email)
+            .deliver_later
+        end
       end
 
       { groupe_instructeur: }

--- a/app/graphql/mutations/groupe_instructeur_supprimer_instructeurs.rb
+++ b/app/graphql/mutations/groupe_instructeur_supprimer_instructeurs.rb
@@ -14,6 +14,13 @@ module Mutations
 
       instructeurs.each { groupe_instructeur.remove(_1) }
       groupe_instructeur.reload
+
+      if instructeurs.present?
+        GroupeInstructeurMailer
+          .notify_group_when_instructeurs_removed(groupe_instructeur, instructeurs, current_administrateur.email)
+          .deliver_later
+      end
+
       { groupe_instructeur: }
     end
   end

--- a/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
@@ -372,11 +372,6 @@ describe API::V2::GraphqlController do
         expect(gql_data[:groupeInstructeurAjouterInstructeurs][:groupeInstructeur][:id]).to eq(groupe_instructeur.to_typed_id)
         expect(groupe_instructeur.instructeurs.count).to eq(2)
         expect(gql_data[:groupeInstructeurAjouterInstructeurs][:groupeInstructeur][:instructeurs]).to eq([{ id: existing_instructeur.to_typed_id, email: existing_instructeur.email }, { id: Instructeur.last.to_typed_id, email: }])
-        expect(GroupeInstructeurMailer).to have_received(:notify_added_instructeurs).with(
-          groupe_instructeur,
-          [Instructeur.last],
-          admin.email
-        )
       }
     end
 
@@ -390,8 +385,6 @@ describe API::V2::GraphqlController do
       let(:operation_name) { 'groupeInstructeurSupprimerInstructeurs' }
 
       before do
-        allow(GroupeInstructeurMailer).to receive(:notify_group_when_instructeurs_removed)
-          .and_return(double(deliver_later: true))
         allow(GroupeInstructeurMailer).to receive(:notify_removed_instructeur)
           .and_return(double(deliver_later: true))
         existing_instructeur
@@ -406,11 +399,6 @@ describe API::V2::GraphqlController do
         expect(gql_data[:groupeInstructeurSupprimerInstructeurs][:groupeInstructeur][:id]).to eq(groupe_instructeur.to_typed_id)
         expect(groupe_instructeur.instructeurs.count).to eq(1)
         expect(gql_data[:groupeInstructeurSupprimerInstructeurs][:groupeInstructeur][:instructeurs]).to eq([{ id: existing_instructeur.to_typed_id, email: existing_instructeur.email }])
-        expect(GroupeInstructeurMailer).to have_received(:notify_group_when_instructeurs_removed).with(
-          groupe_instructeur,
-          [instructeur_2, instructeur_3],
-          admin.email
-        )
         expect(GroupeInstructeurMailer).to have_received(:notify_removed_instructeur).twice
       }
     end

--- a/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
@@ -379,6 +379,8 @@ describe API::V2::GraphqlController do
       let(:operation_name) { 'groupeInstructeurSupprimerInstructeurs' }
 
       before do
+        allow(GroupeInstructeurMailer).to receive(:notify_group_when_instructeurs_removed)
+          .and_return(double(deliver_later: true))
         existing_instructeur
         groupe_instructeur.add(new_instructeur)
       end
@@ -390,6 +392,11 @@ describe API::V2::GraphqlController do
         expect(gql_data[:groupeInstructeurSupprimerInstructeurs][:groupeInstructeur][:id]).to eq(groupe_instructeur.to_typed_id)
         expect(groupe_instructeur.instructeurs.count).to eq(1)
         expect(gql_data[:groupeInstructeurSupprimerInstructeurs][:groupeInstructeur][:instructeurs]).to eq([{ id: existing_instructeur.to_typed_id, email: existing_instructeur.email }])
+        expect(GroupeInstructeurMailer).to have_received(:notify_group_when_instructeurs_removed).with(
+          groupe_instructeur,
+          [new_instructeur],
+          admin.email
+        )
       }
     end
 

--- a/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
@@ -384,19 +384,23 @@ describe API::V2::GraphqlController do
       let(:email) { 'test@test.com' }
       let(:groupe_instructeur) { procedure.groupe_instructeurs.first }
       let(:existing_instructeur) { groupe_instructeur.instructeurs.first }
-      let(:new_instructeur) { create(:instructeur) }
-      let(:variables) { { input: { groupeInstructeurId: groupe_instructeur.to_typed_id, instructeurs: [{ email: }, { id: new_instructeur.to_typed_id }] }, includeInstructeurs: true } }
+      let(:instructeur_2) { create(:instructeur) }
+      let(:instructeur_3) { create(:instructeur) }
+      let(:variables) { { input: { groupeInstructeurId: groupe_instructeur.to_typed_id, instructeurs: [{ email: }, { id: instructeur_2.to_typed_id }, { id: instructeur_3.to_typed_id }] }, includeInstructeurs: true } }
       let(:operation_name) { 'groupeInstructeurSupprimerInstructeurs' }
 
       before do
         allow(GroupeInstructeurMailer).to receive(:notify_group_when_instructeurs_removed)
           .and_return(double(deliver_later: true))
+        allow(GroupeInstructeurMailer).to receive(:notify_removed_instructeur)
+          .and_return(double(deliver_later: true))
         existing_instructeur
-        groupe_instructeur.add(new_instructeur)
+        groupe_instructeur.add(instructeur_2)
+        groupe_instructeur.add(instructeur_3)
       end
 
       it {
-        expect(groupe_instructeur.reload.instructeurs.count).to eq(2)
+        expect(groupe_instructeur.reload.instructeurs.count).to eq(3)
         expect(gql_errors).to be_nil
         expect(gql_data[:groupeInstructeurSupprimerInstructeurs][:errors]).to be_nil
         expect(gql_data[:groupeInstructeurSupprimerInstructeurs][:groupeInstructeur][:id]).to eq(groupe_instructeur.to_typed_id)
@@ -404,9 +408,10 @@ describe API::V2::GraphqlController do
         expect(gql_data[:groupeInstructeurSupprimerInstructeurs][:groupeInstructeur][:instructeurs]).to eq([{ id: existing_instructeur.to_typed_id, email: existing_instructeur.email }])
         expect(GroupeInstructeurMailer).to have_received(:notify_group_when_instructeurs_removed).with(
           groupe_instructeur,
-          [new_instructeur],
+          [instructeur_2, instructeur_3],
           admin.email
         )
+        expect(GroupeInstructeurMailer).to have_received(:notify_removed_instructeur).twice
       }
     end
 


### PR DESCRIPTION
Avec cette PR, les instructeurs sont notifiés lorsqu'ils sont ajoutés ou retirés d'une démarche via l'API
Pas de notification au reste du groupe lors du retrait ou de l'ajout d'instructeurs.