### PR TITLE
Accessibilité: traduit les menus contextuels d'aide, normalise l'affichage et les icônes (dsfr)

### DIFF
--- a/app/assets/stylesheets/help_dropdown.scss
+++ b/app/assets/stylesheets/help_dropdown.scss
@@ -3,7 +3,7 @@
 
 .help-dropdown {
   .dropdown-content {
-    width: 340px;
+    width: 360px;
   }
 
   .dropdown-description {

--- a/app/assets/stylesheets/help_dropdown.scss
+++ b/app/assets/stylesheets/help_dropdown.scss
@@ -5,14 +5,9 @@
   .dropdown-content {
     width: 360px;
   }
-
-  .dropdown-description {
-    font-size: 14px;
-  }
 }
 
 .help-dropdown-title {
-  font-size: 16px;
   color: $blue-france-500;
 }
 
@@ -37,15 +32,5 @@
 .help-dropdown-service-item {
   margin-top: $default-spacer;
   line-height: 18px;
-
-  .icon {
-    vertical-align: middle;
-    margin-right: 5px;
-
-    &.clock {
-      filter: contrast(0) brightness(120%);
-      vertical-align: -4px;
-    }
-  }
 }
 

--- a/app/components/attachment/edit_component/edit_component.en.yml
+++ b/app/components/attachment/edit_component/edit_component.en.yml
@@ -7,6 +7,7 @@ en:
   delete_file: Delete file %{filename}
   replace: Replace
   replace_file: Replace file %{filename}
+  open_file: Open file %{filename}
   errors:
     uploading: "An error occurred while sending the file."
     virus_infected: "Virus detected, please send another file."

--- a/app/components/attachment/edit_component/edit_component.fr.yml
+++ b/app/components/attachment/edit_component/edit_component.fr.yml
@@ -7,6 +7,7 @@ fr:
   delete_file: Supprimer le fichier %{filename}
   replace: Remplacer
   replace_file: Remplacer le fichier %{filename}
+  open_file: Ouvrir le fichier %{filename}
   errors:
     uploading: "Une erreur s’est produite pendant l’envoi du fichier."
     virus_infected: "Virus détecté, merci d’envoyer un autre fichier."

--- a/app/components/attachment/edit_component/edit_component.html.haml
+++ b/app/components/attachment/edit_component/edit_component.html.haml
@@ -12,7 +12,7 @@
           = render Dsfr::DownloadComponent.new(attachment:)
         - else
           .fr-py-1v
-            %span.attachment-filename.fr-mr-1w= link_to_if(viewable?, attachment.filename.to_s, helpers.url_for(attachment.blob), title: "Ouvrir le fichier #{attachment.filename.to_s}", **helpers.external_link_attributes)
+            %span.attachment-filename.fr-mr-1w= link_to_if(viewable?, attachment.filename.to_s, helpers.url_for(attachment.blob), title: t(".open_file", filename: attachment.filename), **helpers.external_link_attributes)
 
           = render Attachment::ProgressComponent.new(attachment: attachment)
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -337,6 +337,8 @@ class ApplicationController < ActionController::Base
       extract_locale_from_accept_language_header ||
       I18n.default_locale
 
+    gon.locale = locale
+
     I18n.with_locale(locale, &action)
   end
 

--- a/app/javascript/shared/track/crisp.ts
+++ b/app/javascript/shared/track/crisp.ts
@@ -1,11 +1,15 @@
 import { getConfig } from '@utils';
 const {
-  crisp: { key, enabled, administrateur }
+  crisp: { key, enabled, administrateur },
+  locale
 } = getConfig();
 
 declare const window: Window &
   typeof globalThis & {
     CRISP_WEBSITE_ID?: string | null;
+    CRISP_RUNTIME_CONFIG?: {
+      locale: string;
+    };
     $crisp: (
       | [cmd: string, key: string, value: unknown]
       | [key: string, value: unknown]
@@ -15,6 +19,9 @@ declare const window: Window &
 if (enabled) {
   window.$crisp = [];
   window.CRISP_WEBSITE_ID = key;
+  window.CRISP_RUNTIME_CONFIG = {
+    locale: locale
+  };
 
   const script = document.createElement('script');
   const firstScript = document.getElementsByTagName('script')[0];

--- a/app/javascript/shared/utils.ts
+++ b/app/javascript/shared/utils.ts
@@ -16,6 +16,7 @@ const Gon = z
         api_education_url: z.string().optional()
       })
       .default({}),
+    locale: z.string().default('fr'),
     matomo: z
       .object({
         cookieDomain: z.string().optional(),

--- a/app/views/layouts/_skiplinks.html.haml
+++ b/app/views/layouts/_skiplinks.html.haml
@@ -1,5 +1,5 @@
 .fr-skiplinks
-  %nav.fr-container{ role: "navigation", 'aria-label': "Accès rapide" }
+  %nav.fr-container{ role: "navigation", 'aria-label': t("skiplinks.quick") }
     %ul.fr-skiplinks__list
       %li
-        %a.fr-link{ href: "#contenu" } Contenu
+        %a.fr-link{ href: "#contenu" }= t('skiplinks.content')

--- a/app/views/shared/help/_help_dropdown_dossier.html.haml
+++ b/app/views/shared/help/_help_dropdown_dossier.html.haml
@@ -1,7 +1,8 @@
 = render Dropdown::MenuComponent.new(wrapper: :span, wrapper_options: { class: ['help-dropdown']}, menu_options: { id: "help-menu" }) do |menu|
   - menu.with_button_inner_html do
     = t('help')
-  - title = dossier.brouillon? ? "Besoin d’aide pour remplir votre dossier ?" : "Une question sur votre dossier ?"
+
+  - title = dossier.brouillon? ? t("help_dropdown.help_brouillon_title") : t("help_dropdown.help_filled_dossier")
 
   - if dossier.messagerie_available?
     - menu.with_item do

--- a/app/views/shared/help/_help_dropdown_procedure.html.haml
+++ b/app/views/shared/help/_help_dropdown_procedure.html.haml
@@ -4,6 +4,6 @@
 
   - if procedure.service.present?
     - menu.with_item do
-      = render partial: 'shared/help/dropdown_items/service_item', locals: { service: procedure.service, title: "Une question sur cette démarche ?" }
+      = render partial: 'shared/help/dropdown_items/service_item', locals: { service: procedure.service, title: t('help_dropdown.procedure_title') }
   - menu.with_item do
     = render partial: 'shared/help/dropdown_items/faq_item'

--- a/app/views/shared/help/dropdown_items/_email_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_email_item.html.haml
@@ -1,8 +1,5 @@
-%li{ role: 'none' }
-  = mail_to CONTACT_EMAIL, role: 'menuitem' do
-    %span.icon.mail
-    .dropdown-description
-      %span.help-dropdown-title
-        = t('help_dropdown.technical_contact_title')
-      %p
-        = t('help_dropdown.technical_contact_description', contact_email: CONTACT_EMAIL)
+= mail_to CONTACT_EMAIL, role: 'menuitem' do
+  %span.fr-icon-mail-fill.fr-text-action-high--blue-france{ "aria-hidden": "true" }
+  .dropdown-description.fr-text--sm
+    %span.help-dropdown-title= t('help_dropdown.technical_contact_title')
+    %p.fr-text--sm= t('help_dropdown.technical_contact_description', contact_email: CONTACT_EMAIL)

--- a/app/views/shared/help/dropdown_items/_faq_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_faq_item.html.haml
@@ -1,7 +1,6 @@
 = link_to t("links.common.faq.url"), title: new_tab_suffix(t('help_dropdown.general_title')), **external_link_attributes, role: 'menuitem' do
-  %span.icon.help
-  .dropdown-description
+  %span.fr-icon-question-fill.fr-text-action-high--blue-france{ "aria-hidden": "true" }
+  .dropdown-description.fr-text--sm
     %span.help-dropdown-title
       = t('help_dropdown.problem_title')
-    %p
-      = t('help_dropdown.problem_description')
+    %p.fr-text--sm= t('help_dropdown.problem_description')

--- a/app/views/shared/help/dropdown_items/_messagerie_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_messagerie_item.html.haml
@@ -1,6 +1,5 @@
 = link_to messagerie_dossier_path(dossier), role: 'menuitem' do
-  %span.icon.mail
-  .dropdown-description
+  %span.fr-icon-mail-fill.fr-text-action-high--blue-france{ "aria-hidden": "true" }
   .dropdown-description.fr-text--sm
     %span.help-dropdown-title= title
     %p.fr-text--sm= t('help_dropdown.contact_instructeur')

--- a/app/views/shared/help/dropdown_items/_messagerie_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_messagerie_item.html.haml
@@ -1,5 +1,6 @@
 = link_to messagerie_dossier_path(dossier), role: 'menuitem' do
   %span.icon.mail
   .dropdown-description
+  .dropdown-description.fr-text--sm
     %span.help-dropdown-title= title
-    %p Envoyez directement un message à l’instructeur.
+    %p.fr-text--sm= t('help_dropdown.contact_instructeur')

--- a/app/views/shared/help/dropdown_items/_service_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_service_item.html.haml
@@ -2,7 +2,7 @@
 .dropdown-description
   %span.help-dropdown-title= title
   .help-dropdown-service-action
-    %p Contactez directement l’administration :
+    %p= t('help_dropdown.contact_administration')
     %p.help-dropdown-service-item
       %span.icon.small.mail
       = link_to service.email, "mailto:#{service.email}", role: 'menuitem'

--- a/app/views/shared/help/dropdown_items/_service_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_service_item.html.haml
@@ -1,14 +1,14 @@
-%span.icon.person
-.dropdown-description
+%span.fr-icon-user-fill.fr-text-action-high--blue-france{ "aria-hidden": "true" }
+.dropdown-description.fr-text--sm
   %span.help-dropdown-title= title
   .help-dropdown-service-action
-    %p= t('help_dropdown.contact_administration')
-    %p.help-dropdown-service-item
-      %span.icon.small.mail
+    %p.fr-text--sm= t('help_dropdown.contact_administration')
+    %p.fr-text--sm.help-dropdown-service-item
+      %span.fr-icon-mail-fill.fr-icon--sm{ "aria-hidden": "true" }
       = link_to service.email, "mailto:#{service.email}", role: 'menuitem'
-    %p.help-dropdown-service-item
-      %span.icon.small.phone
+    %p.fr-text--sm
+      %span.fr-icon-phone-fill.fr-icon--sm{ "aria-hidden": "true" }
       = link_to service.telephone, service.telephone_url, role: 'menuitem'
-    %p.help-dropdown-service-item
-      %span.icon.small.clock
+    %p.fr-text--sm
+      %span.fr-icon-time-fill.fr-icon--sm{ "aria-hidden": "true" }
       = service.horaires

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,10 +35,15 @@ en:
   help: 'Help'
   help_dropdown:
     general_title: "Online help"
+    procedure_title: "Do you have a question about this procedure?"
     problem_title: A problem with the website ?
     problem_description: Find your answer in the online help.
     technical_contact_title: Technical contact
     technical_contact_description: Send us a message to %{contact_email}.
+    contact_administration: "Contact the administration directly:"
+    help_brouillon_title: "Need help filling out your file?"
+    help_filled_dossier: "A question about your file?"
+    contact_instructeur: Send a message directly to the instructor.
   utils:
     'yes': Yes
     'no': No

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,6 +64,9 @@ en:
     commentaire:
       send_message_to_instructeur: "Send a message to the instructor"
       reply_in_mailbox: "Reply in mailbox"
+  skiplinks:
+    quick: Quick access
+    content: Content
   layouts:
     commencer:
       no_procedure:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -55,6 +55,9 @@ fr:
     commentaire:
       send_message_to_instructeur: "Envoyer un message à l’instructeur"
       reply_in_mailbox: "Répondre dans la messagerie"
+  skiplinks:
+    quick: Accès rapide
+    content: Contenu
   layouts:
     commencer:
       no_procedure:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -25,10 +25,15 @@ fr:
   help: 'Aide'
   help_dropdown:
     general_title: "Aide en ligne"
+    procedure_title: "Une question sur cette démarche ?"
     problem_title: Un problème avec le site ?
     problem_description: Trouvez votre réponse dans l’aide en ligne.
     technical_contact_title: Contact technique
     technical_contact_description: Envoyez nous un message à %{contact_email}.
+    contact_administration: "Contactez directement l’administration :"
+    help_brouillon_title: "Besoin d’aide pour remplir votre dossier ?"
+    help_filled_dossier: "Une question sur votre dossier ?"
+    contact_instructeur: Envoyez directement un message à l’instructeur.
   utils:
     'yes': Oui
     'no': Non


### PR DESCRIPTION
Cf #8665 

- menu d'aide
- quelques trads ici ou là manquantes (skiplinks…)
- on passe aussi la locale à crisp pour traduire l'interface dde crisp


<img width="401" alt="Capture d’écran 2023-02-22 à 09 58 17" src="https://user-images.githubusercontent.com/150279/220571395-1b3a2610-cfd7-4e4a-9f84-b2f40d1d1810.png">

<img width="401" alt="Capture d’écran 2023-02-22 à 09 59 46" src="https://user-images.githubusercontent.com/150279/220571664-f661f7af-00ac-45ba-944b-8972ba5aac6d.png">

