### PR TITLE
fix(flash messages): allow links in flash messages

### DIFF
--- a/app/helpers/sanitize_with_link_helper.rb
+++ b/app/helpers/sanitize_with_link_helper.rb
@@ -1,0 +1,6 @@
+module SanitizeWithLinkHelper
+  def sanitize_with_link(value)
+    tags = Rails.configuration.action_view.sanitized_allowed_tags + ['a']
+    sanitize(value, tags:)
+  end
+end

--- a/app/views/layouts/_flash_messages.html.haml
+++ b/app/views/layouts/_flash_messages.html.haml
@@ -7,8 +7,8 @@
         - if value.class == Array
           .alert{ class: flash_class(key, sticky: sticky, fixed: fixed), role: flash_role(key) }
             - value.each do |message|
-              = sanitize(message)
+              = sanitize_with_link(message)
               %br
         - else
           .alert{ class: flash_class(key, sticky: sticky, fixed: fixed), role: flash_role(key) }
-            = sanitize(value)
+            = sanitize_with_link(value)


### PR DESCRIPTION
ETQ admin, quand on importe une liste d'instructeurs avec un fichier csv au mauvais format, le message d'alerte flash contient un lien vers un fichier au bon format.
Ce lien n'apparaissait plus depuis la mise en place du Mail Scrubber
On le rétablit