### PR TITLE
feat(dossier): prefill dossier link champ

### DIFF
--- a/app/models/champs/dossier_link_champ.rb
+++ b/app/models/champs/dossier_link_champ.rb
@@ -21,4 +21,13 @@
 #  type_de_champ_id               :integer
 #
 class Champs::DossierLinkChamp < Champ
+  validate :value_integerable, if: -> { value.present? }, on: :prefill
+
+  private
+
+  def value_integerable
+    Integer(value)
+  rescue ArgumentError
+    errors.add(:value, :not_integerable)
+  end
 end

--- a/app/models/prefill_params.rb
+++ b/app/models/prefill_params.rb
@@ -37,7 +37,8 @@ class PrefillParams
       TypeDeChamp.type_champs.fetch(:regions),
       TypeDeChamp.type_champs.fetch(:departements),
       TypeDeChamp.type_champs.fetch(:multiple_drop_down_list),
-      TypeDeChamp.type_champs.fetch(:epci)
+      TypeDeChamp.type_champs.fetch(:epci),
+      TypeDeChamp.type_champs.fetch(:dossier_link)
     ]
 
     attr_reader :champ, :value, :dossier

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -273,6 +273,7 @@ class TypeDeChamp < ApplicationRecord
       TypeDeChamp.type_champs.fetch(:repetition),
       TypeDeChamp.type_champs.fetch(:multiple_drop_down_list),
       TypeDeChamp.type_champs.fetch(:epci),
+      TypeDeChamp.type_champs.fetch(:dossier_link),
       TypeDeChamp.type_champs.fetch(:siret),
       TypeDeChamp.type_champs.fetch(:rna)
     ])

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -509,6 +509,10 @@ en:
               not_in_departement_epci_codes: "must be a valid EPCI code of the matching department"
             value:
               not_in_departement_epci_names: "must be a valid EPCI name of the matching department"
+        "champs/dossier_link_champ":
+          attributes:
+            value:
+              not_integerable: "must be an integer"
   errors:
     format: "Field « %{attribute} » %{message}"
     messages:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -140,6 +140,7 @@ en:
           rna_html: A RNA number
           repetition_html: A array of hashes with possible values for each field of the repetition.
           epci_html: An array of the department code and the <a href="https://geo.api.gouv.fr/epcis" target="_blank" rel="noopener noreferrer">EPCI one</a>.
+          dossier_link_html: The file ID, as integer.
         examples:
           title: Example
           text: Short text
@@ -156,6 +157,7 @@ en:
           date: "2023-02-01"
           datetime: "2023-02-01T10:30"
           checkbox: "true"
+          dossier_link: 42
           rna: "W503726238"
           siret: "13002526500013"
         prefill_link_title: Prefill link (GET)

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -131,6 +131,7 @@ fr:
           siret_html: Un numéro de SIRET
           repetition_html: Un tableau de dictionnaires avec les valeurs possibles pour chaque champ de la répétition.
           epci_html: Un tableau contenant le code de département et <a href="https://geo.api.gouv.fr/epcis" target="_blank" rel="noopener noreferrer">celui de l'EPCI</a>.
+          dossier_link_html: L'identifiant du dossier, sous forme de nombre entier.
         examples:
           title: Exemple
           text: Texte court
@@ -148,6 +149,7 @@ fr:
           date: "2023-02-01"
           datetime: "2023-02-01T10:30"
           checkbox: "true"
+          dossier_link: 42
           rna: "W503726238"
           siret: "13002526500013"
         prefill_link_title: Lien de préremplissage (GET)

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -504,6 +504,10 @@ fr:
               not_in_departement_epci_codes: "doit être un code d'EPCI du département correspondant"
             value:
               not_in_departement_epci_names: "doit être un nom d'EPCI du département correspondant"
+        "champs/dossier_link_champ":
+          attributes:
+            value:
+              not_integerable: "doit être un entier"
   errors:
     format: "Le champ « %{attribute} » %{message}"
     messages:

--- a/spec/models/champs/dossier_link_champ_spec.rb
+++ b/spec/models/champs/dossier_link_champ_spec.rb
@@ -1,0 +1,37 @@
+describe Champs::DossierLinkChamp, type: :model do
+  describe 'prefilling validations' do
+    describe 'value' do
+      subject { build(:champ_dossier_link, value: value).valid?(:prefill) }
+
+      context 'when nil' do
+        let(:value) { nil }
+
+        it { expect(subject).to eq(true) }
+      end
+
+      context 'when empty' do
+        let(:value) { '' }
+
+        it { expect(subject).to eq(true) }
+      end
+
+      context 'when an integer' do
+        let(:value) { 42 }
+
+        it { expect(subject).to eq(true) }
+      end
+
+      context 'when a string representing an integer' do
+        let(:value) { "42" }
+
+        it { expect(subject).to eq(true) }
+      end
+
+      context 'when it can be casted as integer' do
+        let(:value) { 'totoro' }
+
+        it { expect(subject).to eq(false) }
+      end
+    end
+  end
+end

--- a/spec/models/prefill_params_spec.rb
+++ b/spec/models/prefill_params_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe PrefillParams do
     it_behaves_like "a champ public value that is unauthorized", :decimal_number, "non decimal string"
     it_behaves_like "a champ public value that is unauthorized", :integer_number, "non integer string"
     it_behaves_like "a champ public value that is unauthorized", :number, "value"
-    # TODO: SEB    it_behaves_like "a champ public value that is unauthorized", :dossier_link, "value"
+    it_behaves_like "a champ public value that is unauthorized", :dossier_link, "value"
     it_behaves_like "a champ public value that is unauthorized", :titre_identite, "value"
     it_behaves_like "a champ public value that is unauthorized", :civilite, "value"
     it_behaves_like "a champ public value that is unauthorized", :date, "value"

--- a/spec/models/prefill_params_spec.rb
+++ b/spec/models/prefill_params_spec.rb
@@ -141,6 +141,7 @@ RSpec.describe PrefillParams do
     it_behaves_like "a champ public value that is authorized", :departements, "03"
     it_behaves_like "a champ public value that is authorized", :communes, ['01', '01457']
     it_behaves_like "a champ public value that is authorized", :multiple_drop_down_list, ["val1", "val2"]
+    it_behaves_like "a champ public value that is authorized", :dossier_link, "1"
     it_behaves_like "a champ public value that is authorized", :epci, ['01', '200042935']
     it_behaves_like "a champ public value that is authorized", :siret, "13002526500013"
     it_behaves_like "a champ public value that is authorized", :rna, "value"
@@ -182,6 +183,7 @@ RSpec.describe PrefillParams do
     it_behaves_like "a champ private value that is authorized", :departements, "03"
     it_behaves_like "a champ private value that is authorized", :communes, ['01', '01457']
     it_behaves_like "a champ private value that is authorized", :multiple_drop_down_list, ["val1", "val2"]
+    it_behaves_like "a champ private value that is authorized", :dossier_link, "1"
     it_behaves_like "a champ private value that is authorized", :epci, ['01', '200042935']
 
     context "when the private type de champ is authorized (repetition)" do
@@ -201,7 +203,7 @@ RSpec.describe PrefillParams do
     it_behaves_like "a champ public value that is unauthorized", :decimal_number, "non decimal string"
     it_behaves_like "a champ public value that is unauthorized", :integer_number, "non integer string"
     it_behaves_like "a champ public value that is unauthorized", :number, "value"
-    it_behaves_like "a champ public value that is unauthorized", :dossier_link, "value"
+    # TODO: SEB    it_behaves_like "a champ public value that is unauthorized", :dossier_link, "value"
     it_behaves_like "a champ public value that is unauthorized", :titre_identite, "value"
     it_behaves_like "a champ public value that is unauthorized", :civilite, "value"
     it_behaves_like "a champ public value that is unauthorized", :date, "value"

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -255,11 +255,11 @@ describe TypeDeChamp do
     it_behaves_like "a prefillable type de champ", :type_de_champ_repetition
     it_behaves_like "a prefillable type de champ", :type_de_champ_multiple_drop_down_list
     it_behaves_like "a prefillable type de champ", :type_de_champ_epci
+    it_behaves_like "a prefillable type de champ", :type_de_champ_dossier_link
     it_behaves_like "a prefillable type de champ", :type_de_champ_siret
     it_behaves_like "a prefillable type de champ", :type_de_champ_rna
 
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_number
-    it_behaves_like "a non-prefillable type de champ", :type_de_champ_dossier_link
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_titre_identite
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_linked_drop_down_list
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_header_section

--- a/spec/support/shared_examples_for_prefilled_dossier.rb
+++ b/spec/support/shared_examples_for_prefilled_dossier.rb
@@ -24,6 +24,7 @@ shared_examples "the user has got a prefilled dossier, owned by themselves" do
     expect(page).to have_content(multiple_drop_down_list_values.first)
     expect(page).to have_content(multiple_drop_down_list_values.last)
     expect(page).to have_field(type_de_champ_epci.libelle, with: epci_value.last)
+    expect(page).to have_field(type_de_champ_dossier_link.libelle, with: dossier_link_value)
     expect(page).to have_selector("input[value='Vonnas (01540)']")
   end
 end

--- a/spec/system/users/dossier_prefill_get_spec.rb
+++ b/spec/system/users/dossier_prefill_get_spec.rb
@@ -13,6 +13,7 @@ describe 'Prefilling a dossier (with a GET request):', js: true do
   let(:type_de_champ_datetime) { create(:type_de_champ_datetime, procedure: procedure) }
   let(:type_de_champ_multiple_drop_down_list) { create(:type_de_champ_multiple_drop_down_list, procedure: procedure) }
   let(:type_de_champ_epci) { create(:type_de_champ_epci, procedure: procedure) }
+  let(:type_de_champ_dossier_link) { create(:type_de_champ_dossier_link, procedure: procedure) }
   let(:type_de_champ_commune) { create(:type_de_champ_communes, procedure: procedure) }
   let(:type_de_champ_repetition) { create(:type_de_champ_repetition, :with_types_de_champ, procedure: procedure) }
 
@@ -28,6 +29,7 @@ describe 'Prefilling a dossier (with a GET request):', js: true do
     ]
   }
   let(:epci_value) { ['01', '200029999'] }
+  let(:dossier_link_value) { '42' }
   let(:commune_value) { ['01', '01457'] } # Vonnas (01540)
   let(:sub_type_de_champs_repetition) { procedure.active_revision.children_of(type_de_champ_repetition) }
   let(:text_repetition_libelle) { sub_type_de_champs_repetition.first.libelle }
@@ -43,6 +45,7 @@ describe 'Prefilling a dossier (with a GET request):', js: true do
       "champ_#{type_de_champ_datetime.to_typed_id_for_query}" => datetime_value,
       "champ_#{type_de_champ_multiple_drop_down_list.to_typed_id_for_query}" => multiple_drop_down_list_values,
       "champ_#{type_de_champ_epci.to_typed_id_for_query}" => epci_value,
+      "champ_#{type_de_champ_dossier_link.to_typed_id_for_query}" => dossier_link_value,
       "champ_#{type_de_champ_commune.to_typed_id_for_query}" => commune_value,
       "champ_#{type_de_champ_siret.to_typed_id_for_query}" => siret_value,
       "champ_#{type_de_champ_rna.to_typed_id_for_query}" => rna_value,

--- a/spec/system/users/dossier_prefill_post_spec.rb
+++ b/spec/system/users/dossier_prefill_post_spec.rb
@@ -13,6 +13,7 @@ describe 'Prefilling a dossier (with a POST request):', js: true do
   let(:type_de_champ_datetime) { create(:type_de_champ_datetime, procedure: procedure) }
   let(:type_de_champ_multiple_drop_down_list) { create(:type_de_champ_multiple_drop_down_list, procedure: procedure) }
   let(:type_de_champ_epci) { create(:type_de_champ_epci, procedure: procedure) }
+  let(:type_de_champ_dossier_link) { create(:type_de_champ_dossier_link, procedure: procedure) }
   let(:type_de_champ_repetition) { create(:type_de_champ_repetition, :with_types_de_champ, procedure: procedure) }
   let(:type_de_champ_commune) { create(:type_de_champ_communes, procedure: procedure) }
 
@@ -34,6 +35,7 @@ describe 'Prefilling a dossier (with a POST request):', js: true do
   let(:integer_repetition_libelle) { sub_type_de_champs_repetition.second.libelle }
   let(:text_repetition_value) { "First repetition text" }
   let(:integer_repetition_value) { "42" }
+  let(:dossier_link_value) { '42' }
 
   before do
     allow(Rails).to receive(:cache).and_return(memory_store)
@@ -157,6 +159,7 @@ describe 'Prefilling a dossier (with a POST request):', js: true do
         "champ_#{type_de_champ_datetime.to_typed_id_for_query}" => datetime_value,
         "champ_#{type_de_champ_multiple_drop_down_list.to_typed_id_for_query}" => multiple_drop_down_list_values,
         "champ_#{type_de_champ_epci.to_typed_id_for_query}" => epci_value,
+        "champ_#{type_de_champ_dossier_link.to_typed_id_for_query}" => dossier_link_value,
         "champ_#{type_de_champ_commune.to_typed_id_for_query}" => commune_value
       }.to_json
     JSON.parse(session.response.body)["dossier_url"].gsub("http://www.example.com", "")


### PR DESCRIPTION
On permet le préremplissage de champ "dossier link".

Il n'est pas nécessaire de disposer d'un ID de dossier valide, car il y a un contrôle en front qui indique à l'usager·ère si le dossier est trouvé ou non. En revanche, on s'assure quand même qu'il s'agit d'un entier.

![image](https://user-images.githubusercontent.com/1193334/220663313-e076006b-ff11-434a-be9b-7cbe1a87c714.png)

Ce qui donne : 

![image](https://user-images.githubusercontent.com/1193334/220663529-c57e8624-8f1b-4040-a379-074ab97e7d7d.png)
