### PR TITLE
publish opendata demarches only if they are publiees or closes

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -19,7 +19,7 @@ module Types
     field :demarches_publiques, DemarcheDescriptorType.connection_type, null: false, internal: true
 
     def demarches_publiques
-      Procedure.opendata.includes(draft_revision: :procedure, published_revision: :procedure)
+      Procedure.publiees_ou_closes.opendata.includes(draft_revision: :procedure, published_revision: :procedure)
     end
 
     def demarche_descriptor(demarche:)


### PR DESCRIPTION
Cette PR permet de publier sur datagouv uniquement les procédures opendata qui sont publiées ou closes (avant, les procédures brouillons étaient égalemen publiées)