### PR TITLE
fix(filter): fix find type de champ by stable_id

### DIFF
--- a/app/models/procedure_presentation.rb
+++ b/app/models/procedure_presentation.rb
@@ -336,7 +336,7 @@ class ProcedurePresentation < ApplicationRecord
         end
       end
     else
-      TypeDeChamp.find_by(stable_id: field['column']).options_for_select
+      find_type_de_champ(field['column']).options_for_select
     end
   end
 


### PR DESCRIPTION
`stable_id` n'est pas unique. Il faut chercher dans un subset des revisions. Nous avons un helper pour ça.