### PR TITLE
feat(procedure): update association to defaut groupe instructeur

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -207,7 +207,7 @@ class Procedure < ApplicationRecord
   has_one :refused_mail, class_name: "Mails::RefusedMail", dependent: :destroy
   has_one :without_continuation_mail, class_name: "Mails::WithoutContinuationMail", dependent: :destroy
 
-  has_one :defaut_groupe_instructeur, -> { active.order(:label) }, class_name: 'GroupeInstructeur', inverse_of: false
+  has_one :defaut_groupe_instructeur, -> { active.order(id: :asc) }, class_name: 'GroupeInstructeur', inverse_of: false
 
   has_one_attached :logo
   has_one_attached :notice
@@ -906,7 +906,7 @@ class Procedure < ApplicationRecord
 
   def ensure_defaut_groupe_instructeur
     if self.groupe_instructeurs.empty?
-      groupe_instructeurs.create(label: GroupeInstructeur::DEFAUT_LABEL)
+      self.create_defaut_groupe_instructeur(label: GroupeInstructeur::DEFAUT_LABEL)
     end
   end
 end

--- a/spec/models/instructeur_spec.rb
+++ b/spec/models/instructeur_spec.rb
@@ -572,7 +572,7 @@ describe Instructeur, type: :model do
     let(:instructeur_2) { create(:instructeur) }
     let(:instructeur_3) { create(:instructeur) }
     let(:procedure) { create(:procedure, instructeurs: [instructeur_2, instructeur_3], procedure_expires_when_termine_enabled: true) }
-    let(:gi_1) { procedure.groupe_instructeurs.first }
+    let(:gi_1) { procedure.defaut_groupe_instructeur }
     let(:gi_2) { procedure.groupe_instructeurs.create(label: '2') }
     let(:gi_3) { procedure.groupe_instructeurs.create(label: '3') }
 


### PR DESCRIPTION
Voir https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/8620
-  Le groupe d'instructeurs par défaut est celui créé en 1er, parmi les groupes actifs