### PR TITLE
fix(combo-address): provide a valid empty response

### DIFF
--- a/app/javascript/components/shared/queryClient.ts
+++ b/app/javascript/components/shared/queryClient.ts
@@ -75,7 +75,12 @@ const defaultQueryFn: QueryFunction<unknown, QueryKey> = async ({
 
   // BAN will error with queries less then 3 chars long
   if (scope == 'adresse' && term.length < 3) {
-    return [];
+    return {
+      type: 'FeatureCollection',
+      version: 'draft',
+      features: [],
+      query: term
+    };
   }
 
   const url = buildURL(scope, term, extra);


### PR DESCRIPTION
Le ComboSearch transforme les résultats depuis la clé `features`, qu'on doit a minima fournir pour ne pas crash le component

Fix : 

- https://demarches-simplifiees.sentry.io/issues/3961917889/?project=1429547
- https://demarches-simplifiees.sentry.io/issues/3961927928/?project=1429547