### PR TITLE
liste toutes les démarches, même celles non associées à des zones

### DIFF
--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -410,7 +410,7 @@ module Administrateurs
     private
 
     def filter_procedures(filter)
-      procedures_result = Procedure.select(:id).joins(:procedures_zones).distinct.publiees_ou_closes
+      procedures_result = Procedure.select(:id).left_joins(:procedures_zones).distinct.publiees_ou_closes
       procedures_result = procedures_result.where(procedures_zones: { zone_id: filter.zone_ids }) if filter.zone_ids.present?
       procedures_result = procedures_result.where(aasm_state: filter.statuses) if filter.statuses.present?
       procedures_result = procedures_result.where("? = ANY(tags)", filter.tag) if filter.tag.present?

--- a/app/views/administrateurs/procedures/_detail.html.haml
+++ b/app/views/administrateurs/procedures/_detail.html.haml
@@ -11,7 +11,7 @@
   %td= procedure.estimated_dossiers_count
   %td= procedure.administrateurs.count
   %td= t procedure.aasm_state, scope: 'activerecord.attributes.procedure.aasm_state'
-  %td= l(procedure.published_at, format: :message_date_without_time)
+  %td= l(procedure.published_at, format: :message_date_without_time) if procedure.published_at
   %td= link_to('Cloner', admin_procedure_clone_path(procedure.id, from_new_from_existing: true), 'data-method' => :put, class: 'fr-btn fr-btn--tertiary fr-btn--sm')
 
 

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -132,6 +132,16 @@ describe Administrateurs::ProceduresController, type: :controller do
         expect(assigns(:procedures).any? { |p| p.id == procedure2.id }).to be_truthy
         expect(assigns(:procedures).any? { |p| p.id == procedure1.id }).to be_falsey
       end
+
+      context "without zones" do
+        let!(:procedure) { create(:procedure, :published, zones: []) }
+        subject { get :all }
+
+        it 'displays procedures without zones' do
+          subject
+          expect(assigns(:procedures).any? { |p| p.id == procedure.id }).to be_truthy
+        end
+      end
     end
 
     context 'for specific status' do


### PR DESCRIPTION
Actuellement, les démarches qui ne sont pas associées à des zones ne sont pas remontées dans la liste de toutes les démarches. Or, on peut imaginer que la vue 'toutes les demarches" peut intéresser également les instances dont le zonage est désactivé.

L'idée est ici de pouvoir lister toutes les démarches lorsqu'aucune zone n'est cochée même celles qui ne sont associées à aucune zone.

close #8705 