### PR TITLE
[Design] Implémentation des classes DSFR pour les badges d'état des dossiers

### DIFF
--- a/app/assets/stylesheets/02_utils.scss
+++ b/app/assets/stylesheets/02_utils.scss
@@ -143,6 +143,20 @@
   vertical-align: super;
 }
 
+// Labels that we only want for screen readers
+// https://www.coolfields.co.uk/2016/05/text-for-screen-readers-only-updated/
+.sr-only {
+  border: none;
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  width: 1px;
+  overflow: hidden;
+  position: absolute !important;
+  word-wrap: normal !important;
+}
+
 // generate spacer utility like bootstrap my-2 -> margin-left/right: 2 * $default-spacer
 // using $direction.key as css modifier, $direction.values to set css properties
 // scale it using $steps

--- a/app/assets/stylesheets/dossiers_table.scss
+++ b/app/assets/stylesheets/dossiers_table.scss
@@ -58,13 +58,7 @@
   }
 
   .status-col {
-    width: 110px;
-
-    .label {
-      width: 110px;
-      text-align: center;
-      margin: 0 4px;
-    }
+    width: 175px;
   }
 
   .updated-at-col {

--- a/app/assets/stylesheets/labels.scss
+++ b/app/assets/stylesheets/labels.scss
@@ -1,13 +1,13 @@
-// Labels that we only want for screen readers
-// https://www.coolfields.co.uk/2016/05/text-for-screen-readers-only-updated/
-.sr-only {
-  border: none;
-  clip: rect(1px, 1px, 1px, 1px);
-  clip-path: inset(50%);
-  height: 1px;
-  margin: -1px;
-  width: 1px;
-  overflow: hidden;
-  position: absolute !important;
-  word-wrap: normal !important;
+@import "colors";
+@import "constants";
+
+.label {
+  display: inline-block;
+  padding: 4px $default-spacer;
+  background: $dark-grey;
+  border: 1px solid transparent;
+  color: #FFFFFF;
+  border-radius: 4px;
+  font-size: 12px;
+  line-height: 18px;
 }

--- a/app/assets/stylesheets/labels.scss
+++ b/app/assets/stylesheets/labels.scss
@@ -1,61 +1,3 @@
-@import "colors";
-@import "constants";
-
-.label {
-  display: inline-block;
-  padding: 4px $default-spacer;
-  background: $dark-grey;
-  border: 1px solid transparent;
-  color: #FFFFFF;
-  border-radius: 4px;
-  font-size: 12px;
-  line-height: 18px;
-
-  &.instruction {
-    background-color: #FFFFFF;
-    color: $blue-france-500;
-    border: 1px solid $blue-france-500;
-  }
-
-  &.en-instruction {
-    @extend .instruction;
-  }
-
-  &.construction {
-    background-color: #FFFFFF;
-    color: $black;
-    border: 1px solid $black;
-  }
-
-  &.en-construction {
-    @extend .construction;
-  }
-
-  &.accepted {
-    background-color: $green;
-  }
-
-  &.accepte {
-    @extend .accepted;
-  }
-
-  &.refused {
-    background-color: $dark-red;
-  }
-
-  &.refuse {
-    @extend .refused;
-  }
-
-  &.without-continuation {
-    background-color: $black;
-  }
-
-  &.sans-suite {
-    @extend .without-continuation;
-  }
-}
-
 // Labels that we only want for screen readers
 // https://www.coolfields.co.uk/2016/05/text-for-screen-readers-only-updated/
 .sr-only {
@@ -68,11 +10,4 @@
   overflow: hidden;
   position: absolute !important;
   word-wrap: normal !important;
-}
-
-.label-bold {
-  font-size: 18px;
-  margin-bottom: 16px;
-  display: block;
-  font-weight: bold;
 }

--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -60,10 +60,28 @@ module DossierHelper
     end
   end
 
+  def class_badge_state(state)
+    case state
+    when Dossier.states.fetch(:en_construction)
+      'fr-badge--info'
+    when Dossier.states.fetch(:en_instruction)
+      'fr-badge--info'
+    when Dossier.states.fetch(:accepte)
+      'fr-badge--success'
+    when Dossier.states.fetch(:refuse)
+      'fr-badge--warning'
+    when Dossier.states.fetch(:sans_suite)
+      'fr-badge--new'
+    when Dossier.states.fetch(:brouillon)
+      ''
+    else
+      ''
+    end
+  end
+
   def status_badge(state, alignment_class = '')
     status_text = dossier_display_state(state, lower: true)
-    status_class = state.tr('_', '-')
-    tag.span(status_text, class: "label #{status_class} #{alignment_class}", role: 'status')
+    tag.span(status_text, class: "fr-badge #{class_badge_state(state)} fr-badge--no-icon #{alignment_class}", role: 'status')
   end
 
   def deletion_reason_badge(reason)

--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -62,9 +62,7 @@ module DossierHelper
 
   def class_badge_state(state)
     case state
-    when Dossier.states.fetch(:en_construction)
-      'fr-badge--info'
-    when Dossier.states.fetch(:en_instruction)
+    when Dossier.states.fetch(:en_construction), Dossier.states.fetch(:en_instruction)
       'fr-badge--info'
     when Dossier.states.fetch(:accepte)
       'fr-badge--success'

--- a/spec/system/instructeurs/instruction_spec.rb
+++ b/spec/system/instructeurs/instruction_spec.rb
@@ -41,7 +41,7 @@ describe 'Instructing a dossier:', js: true do
 
     expect(page).to have_text('Dossier passé en instruction.')
     expect(page).to have_text('Instruire le dossier')
-    expect(page).to have_selector('.label.en-instruction')
+    expect(page).to have_selector('.fr-badge', text: 'en instruction')
 
     dossier.reload
     expect(dossier.state).to eq(Dossier.states.fetch(:en_instruction))


### PR DESCRIPTION
En parallèle de l'issue https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/8602 pour simplifier les actions pour les instructeurs.
J'en ai profité pour implémenter les badges DSFR pour l'etat des dossiers.


**AVANT**
<img width="916" alt="Capture d’écran 2023-02-28 à 16 09 54" src="https://user-images.githubusercontent.com/6756627/221896294-c2bb8981-12b7-4274-9616-2247732868cb.png">

**APRES**
<img width="920" alt="Capture d’écran 2023-02-28 à 16 06 11" src="https://user-images.githubusercontent.com/6756627/221896229-26c133e0-cde2-4161-8ab1-a05ae1a58404.png">
