### PR TITLE
fix(annotations-privees): initialisation de la numérotation automatique

### DIFF
--- a/app/views/shared/dossiers/_edit_annotations.html.haml
+++ b/app/views/shared/dossiers/_edit_annotations.html.haml
@@ -1,6 +1,6 @@
 .container.dossier-edit
   - if dossier.champs_private.present?
-    %section
+    %section.counter-start-header-section
       = render Attachment::DeleteFormComponent.new
       = form_for dossier, url: annotations_instructeur_dossier_path(dossier.procedure, dossier), html: { class: 'form', multipart: true } do |f|
         - dossier.champs_private.each do |champ|


### PR DESCRIPTION
le counter css n'était pas initialisé, tous les titres restaient bloqués à `1.`