### PR TITLE
passe le flag opendata à false pour certaines procédures

### DIFF
--- a/app/services/falsify_opendata_service.rb
+++ b/app/services/falsify_opendata_service.rb
@@ -1,0 +1,15 @@
+class FalsifyOpendataService
+  def self.call(lines)
+    errors = []
+    lines.each do |line|
+      id = line["id"]
+      procedure = Procedure.find_by(id: id)
+      if procedure
+        procedure.update(opendata: false)
+      else
+        errors << "Procedure #{id} introuvable"
+      end
+    end
+    errors
+  end
+end

--- a/lib/tasks/falsify_opendata_procedures.rake
+++ b/lib/tasks/falsify_opendata_procedures.rake
@@ -1,0 +1,23 @@
+require Rails.root.join("lib", "tasks", "task_helper")
+
+namespace :procedures do
+  desc <<~EOD
+    falsify opendata flag for some procedures
+    rails procedures:falsify_opendata_procedures\[csv_path\]
+  EOD
+  task :falsify_opendata_procedures, [:csv] => :environment do |_t, args|
+    csv = args[:csv]
+    lines = CSV.readlines(csv, headers: true)
+
+    rake_puts "Passage du flag opendata à false pour certaines procédures en cours..."
+
+    errors =
+      FalsifyOpendataService.call(lines)
+
+    if errors.present?
+      errors.each { |error| rake_puts error }
+    end
+
+    rake_puts "Mise à jour terminée"
+  end
+end

--- a/spec/services/falsify_opendata_service_spec.rb
+++ b/spec/services/falsify_opendata_service_spec.rb
@@ -1,0 +1,43 @@
+describe FalsifyOpendataService do
+  before(:each) do
+  end
+
+  after(:each) do
+  end
+
+  describe '#call' do
+    let(:procedure1) { create(:procedure, opendata: true) }
+    let(:procedure2) { create(:procedure, opendata: true) }
+
+    subject { described_class.call(lines) }
+
+    context 'nominal case' do
+      let(:lines) do
+        [
+          { "id" => procedure1.id },
+          { "id" => procedure2.id }
+        ]
+      end
+
+      it 'falsifies opendatas' do
+        errors = subject
+
+        expect(errors).to eq []
+        expect(procedure1.reload.opendata).to be_falsey
+        expect(procedure2.reload.opendata).to be_falsey
+      end
+    end
+
+    context 'with unknown procedure' do
+      let(:lines) do
+        [
+          { "id" => procedure1.id + procedure2.id }
+        ]
+      end
+      it 'returns errors' do
+        errors = subject
+        expect(errors).to eq ["Procedure #{procedure1.id + procedure2.id} introuvable"]
+      end
+    end
+  end
+end


### PR DESCRIPTION
`procedures:falsify_opendata_procedures` rake task allows to falsify opndata flag for procedures listed in csv file given in input (with only one column : id column)

close #8715 