### PR TITLE
desactive le 2FA suivant la config

### DIFF
--- a/app/models/super_admin.rb
+++ b/app/models/super_admin.rb
@@ -27,8 +27,12 @@
 class SuperAdmin < ApplicationRecord
   include PasswordComplexityConcern
 
-  devise :rememberable, :trackable, :validatable, :lockable, :recoverable,
-    :two_factor_authenticatable, :otp_secret_encryption_key => Rails.application.secrets.otp_secret_key
+  devise :rememberable, :trackable, :validatable, :lockable, :recoverable
+  if SUPER_ADMIN_OTP_ENABLED
+    devise :two_factor_authenticatable, :otp_secret_encryption_key => Rails.application.secrets.otp_secret_key
+  else
+    devise :database_authenticatable
+  end
 
   def enable_otp!
     self.otp_secret = SuperAdmin.generate_otp_secret

--- a/app/views/super_admins/sessions/new.html.haml
+++ b/app/views/super_admins/sessions/new.html.haml
@@ -12,8 +12,9 @@
         = f.label :password, "Mot de passe (#{PASSWORD_MIN_LENGTH} caractères minimum)"
         = f.password_field :password, autocomplete: 'current-password'
 
-        = f.label :otp_attempt, 'Code OTP (uniquement si vous avez déjà activé 2FA)'
-        = f.text_field :otp_attempt
+        - if SUPER_ADMIN_OTP_ENABLED
+          = f.label :otp_attempt, 'Code OTP (uniquement si vous avez déjà activé 2FA)'
+          = f.text_field :otp_attempt
 
         %p= link_to "Mot de passe oublié ou réinitialisation 2FA ?", new_super_admin_password_path, class: "link"
         = f.submit "Se connecter", class: "fr-btn fr-btn--lg"

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -237,7 +237,7 @@ Devise.setup do |config|
   # change the failure app, you can configure them inside the config.warden block.
   #
   config.warden do |manager|
-    manager.default_strategies(:scope => :administration).unshift :two_factor_authenticatable
+    manager.default_strategies(:scope => :administration).unshift :two_factor_authenticatable if SUPER_ADMIN_OTP_ENABLED
   end
 
   # ==> Mountable engine configurations


### PR DESCRIPTION
Le 2FA pour les superadmin est désactivé sauf si ` SUPER_ADMIN_OTP_ENABLED`  vaut `enabled`