### PR TITLE
[usager] peut révoquer une demande de transfert

### DIFF
--- a/app/assets/stylesheets/02_utils.scss
+++ b/app/assets/stylesheets/02_utils.scss
@@ -157,6 +157,10 @@
   word-wrap: normal !important;
 }
 
+.ml-auto {
+  margin-left: auto;
+}
+
 // generate spacer utility like bootstrap my-2 -> margin-left/right: 2 * $default-spacer
 // using $direction.key as css modifier, $direction.values to set css properties
 // scale it using $steps

--- a/app/assets/stylesheets/dossiers_table.scss
+++ b/app/assets/stylesheets/dossiers_table.scss
@@ -8,10 +8,6 @@
     padding: (2 * $default-spacer) $default-spacer;
   }
 
-  td {
-    padding: 0;
-  }
-
   a {
     background-image: none; // remove DSFR underline
   }
@@ -90,4 +86,8 @@
   &:hover {
     background-color: rgba(242, 137, 0, 0.6) !important;
   }
+}
+
+table.display-table {
+  display: table;
 }

--- a/app/assets/stylesheets/dossiers_table.scss
+++ b/app/assets/stylesheets/dossiers_table.scss
@@ -78,6 +78,10 @@
       margin-bottom: 0;
     }
   }
+
+  .no-border {
+    background-image: none;
+  }
 }
 
 .file-hidden-by-user {

--- a/app/controllers/users/transfers_controller.rb
+++ b/app/controllers/users/transfers_controller.rb
@@ -19,7 +19,10 @@ module Users
     end
 
     def destroy
-      transfer = DossierTransfer.find_by!(id: params[:id], email: current_user.email)
+      transfer = DossierTransfer.find(params[:id])
+
+      authorized_email = (transfer.email == current_user.email || transfer.dossiers.where(dossiers: { user: current_user }).present?)
+      return if !authorized_email
 
       transfer.destroy_and_nullify
       redirect_to dossiers_path

--- a/app/controllers/users/transfers_controller.rb
+++ b/app/controllers/users/transfers_controller.rb
@@ -20,11 +20,14 @@ module Users
 
     def destroy
       transfer = DossierTransfer.find(params[:id])
+      authorized = (transfer.email == current_user.email || transfer.dossiers.exists?(dossiers: { user: current_user }))
 
-      authorized_email = (transfer.email == current_user.email || transfer.dossiers.where(dossiers: { user: current_user }).present?)
-      return if !authorized_email
-
-      transfer.destroy_and_nullify
+      if authorized
+        transfer.destroy_and_nullify
+        flash.notice = t("users.dossiers.transferer.destroy")
+      else
+        flash.alert = t("users.dossiers.transferer.unauthorized_destroy")
+      end
       redirect_to dossiers_path
     end
 

--- a/app/views/users/dossiers/_dossier_actions.html.haml
+++ b/app/views/users/dossiers/_dossier_actions.html.haml
@@ -7,7 +7,7 @@
 
 
 - if has_actions
-  = render Dropdown::MenuComponent.new(wrapper: :div, wrapper_options: {class: 'invite-user-actions'}, menu_options: {id: dom_id(dossier, :actions_menu)}, button_options: {class: 'fr-btn--sm fr-btn--secondary'}) do |menu|
+  = render Dropdown::MenuComponent.new(wrapper: :div, wrapper_options: {class: 'invite-user-actions'}, menu_options: {id: dom_id(dossier, :actions_menu)}, button_options: {class: 'fr-btn--sm'}) do |menu|
     - menu.with_button_inner_html do
       = t('views.users.dossiers.dossier_action.actions')
 

--- a/app/views/users/dossiers/_dossiers_list.html.haml
+++ b/app/views/users/dossiers/_dossiers_list.html.haml
@@ -1,36 +1,45 @@
 - if dossiers.present?
-  %table.table.dossiers-table.hoverable
-    %caption= t('views.users.dossiers.dossiers_list.caption')
-    %thead
-      %tr
-        %th.number-col{ scope: :col }= t('views.users.dossiers.dossiers_list.n_dossier')
-        %th{ scope: :col }= t('views.users.dossiers.dossiers_list.procedure')
-        - if dossiers.present?
-          %th{ scope: :col }= t('views.users.dossiers.dossiers_list.requester')
-        %th.status-col{ scope: :col }= t('views.users.dossiers.dossiers_list.status')
-        %th.updated-at-col{ scope: :col }= t('views.users.dossiers.dossiers_list.updated')
-        %th.sr-only{ scope: :col }= t('views.users.dossiers.dossiers_list.actions')
-    %tbody
-      - dossiers.each do |dossier|
-        %tr{ data: { 'dossier-id': dossier.id } }
-          %th.number-col{ scope: :row }
-            = link_to(url_for_dossier(dossier), class: 'cell-link', tabindex: -1) do
-              %span.icon.folder
-              = dossier.id
-          %td
-            = link_to(url_for_dossier(dossier), class: 'cell-link') do
-              = procedure_libelle(dossier.procedure)
+  .fr-table.fr-table--bordered
+    %table.table.dossiers-table.hoverable
+      %caption= t('views.users.dossiers.dossiers_list.caption')
+      %thead
+        %tr
+          %th.number-col{ scope: :col }= t('views.users.dossiers.dossiers_list.n_dossier')
+          %th{ scope: :col }= t('views.users.dossiers.dossiers_list.procedure')
           - if dossiers.present?
-            %td
-              %span.cell-link= demandeur_dossier(dossier)
-          %td.status-col
-            = status_badge(dossier.state)
-          %td.updated-at-col.cell-link
-            = try_format_date(dossier.updated_at)
-          %td.action-col
-            = render partial: 'dossier_actions', locals: { dossier: dossier }
+            %th{ scope: :col }= t('views.users.dossiers.dossiers_list.requester')
+          %th.status-col{ scope: :col }= t('views.users.dossiers.dossiers_list.status')
+          %th.updated-at-col{ scope: :col }= t('views.users.dossiers.dossiers_list.updated')
+          %th.sr-only{ scope: :col }= t('views.users.dossiers.dossiers_list.actions')
+      %tbody
+        - dossiers.each do |dossier|
+          - if dossier.transfer.present?
+            %tr.fr-background-alt--blue-france.no-border
+              %td.fr-py-2w.text-center{ colspan: 100 }
+                %p
+                  %small
+                    = t('views.users.dossiers.transfers.demande_en_cours', id: dossier.id, email: dossier.transfer.email)
+                    = link_to t('views.users.dossiers.transfers.revoke'), transfer_path(dossier.transfer), class: 'fr-btn fr-btn--sm fr-btn--tertiary-no-outline', method: :delete
 
-  = paginate(dossiers)
+          %tr{ data: { 'dossier-id': dossier.id } }
+            %th.number-col{ scope: :row }
+              = link_to(url_for_dossier(dossier), class: 'cell-link', tabindex: -1) do
+                %span.icon.folder
+                = dossier.id
+            %td
+              = link_to(url_for_dossier(dossier), class: 'cell-link') do
+                = procedure_libelle(dossier.procedure)
+            - if dossiers.present?
+              %td
+                %span.cell-link= demandeur_dossier(dossier)
+            %td.status-col
+              = status_badge(dossier.state)
+            %td.updated-at-col.cell-link
+              = try_format_date(dossier.updated_at)
+            %td.action-col
+              = render partial: 'dossier_actions', locals: { dossier: dossier }
+
+    = paginate(dossiers)
 
 - else
   .blank-tab

--- a/app/views/users/dossiers/_dossiers_list.html.haml
+++ b/app/views/users/dossiers/_dossiers_list.html.haml
@@ -10,15 +10,17 @@
             %th{ scope: :col }= t('views.users.dossiers.dossiers_list.requester')
           %th.status-col{ scope: :col }= t('views.users.dossiers.dossiers_list.status')
           %th.updated-at-col{ scope: :col }= t('views.users.dossiers.dossiers_list.updated')
-          %th.sr-only{ scope: :col }= t('views.users.dossiers.dossiers_list.actions')
+          %th.action-col.follow-col{ scope: :col }= t('views.users.dossiers.dossiers_list.actions')
       %tbody
         - dossiers.each do |dossier|
           - if dossier.transfer.present?
             %tr.fr-background-alt--blue-france.no-border
-              %td.fr-py-2w.text-center{ colspan: 100 }
-                %p
-                  %small
-                    = t('views.users.dossiers.transfers.demande_en_cours', id: dossier.id, email: dossier.transfer.email)
+              %td.fr-py-2w{ colspan: 100 }
+                .flex.align-center
+                  %p.fr-mb-0
+                    %small
+                      = t('views.users.dossiers.transfers.sender_demande_en_cours', id: dossier.id, email: dossier.transfer.email)
+                  .ml-auto
                     = link_to t('views.users.dossiers.transfers.revoke'), transfer_path(dossier.transfer), class: 'fr-btn fr-btn--sm fr-btn--tertiary-no-outline', method: :delete
 
           %tr{ data: { 'dossier-id': dossier.id } }
@@ -36,7 +38,7 @@
               = status_badge(dossier.state)
             %td.updated-at-col.cell-link
               = try_format_date(dossier.updated_at)
-            %td.action-col
+            %td.action-col.follow-col
               = render partial: 'dossier_actions', locals: { dossier: dossier }
 
     = paginate(dossiers)

--- a/app/views/users/dossiers/_transfered_dossiers_list.html.haml
+++ b/app/views/users/dossiers/_transfered_dossiers_list.html.haml
@@ -1,31 +1,34 @@
 - if dossier_transfers.present?
-  %ul.dossiers-transfers.mb-2
-    - dossier_transfers.each do |transfer|
-      %li.mb-4
-        .transfer-details.mb-2
-          Demande de transfert Nº #{transfer.id} envoyé par #{transfer.dossiers.first.user.email}
-        %table.table.dossiers-table.hoverable
-          %thead
-            %tr
-              %th.number-col= t('views.users.dossiers.dossiers_list.n_dossier')
-              %th= t('views.users.dossiers.dossiers_list.procedure')
-              %th= t('views.users.dossiers.dossiers_list.status')
-              %th Date de dépot
-          %tbody
-            - transfer.dossiers.each do |dossier|
-              %tr{ data: { 'transfer-id': transfer.id } }
-                %td.number-col
-                  %span.icon.folder
-                  = dossier.id
-                %td= dossier.procedure.libelle
-                %td= status_badge(dossier.state)
-                %td{ style: 'padding: 18px;' }= (dossier.depose_at || dossier.created_at).strftime('%d/%m/%Y')
+  .fr-table.fr-table--bordered
+    %table.table.dossiers-table.display-table
+      %thead
+        %tr
+          %th.number-col= t('views.users.dossiers.dossiers_list.n_dossier')
+          %th= t('views.users.dossiers.dossiers_list.procedure')
+          %th= t('views.users.dossiers.dossiers_list.status')
+          %th.action-col.follow-col Date de dépot
+      %tbody
+        - dossier_transfers.each do |transfer|
+          - transfer.dossiers.each do |dossier|
+            %tr.fr-background-alt--blue-france.no-border
+              %td.fr-py-2w{ colspan: 100 }
+                .flex.align-center
+                  %p.fr-mb-0
+                    %small
+                      = t('views.users.dossiers.transfers.receiver_demande_en_cours', id: dossier.id, email: transfer.dossiers.first.user.email)
+                  .ml-auto
+                    = link_to t('views.users.dossiers.transfers.accept'), transfer_path(transfer), class: "fr-btn fr-btn--sm fr-btn--tertiary", method: :put
 
-        .transfer-actions.mt-4
-          = link_to "Accepter", transfer_path(transfer), class: "button primary", method: :put
-          = link_to "Rejeter", transfer_path(transfer), class: "button danger", method: :delete
+                    = link_to t('views.users.dossiers.transfers.reject'), transfer_path(transfer), class: "fr-btn fr-btn--sm fr-btn--tertiary-no-outline", method: :delete
+            %tr{ data: { 'transfer-id': transfer.id } }
+              %th.number-col{ scope: :row }
+                %span.icon.folder
+                = dossier.id
+              %td= dossier.procedure.libelle
+              %td= status_badge(dossier.state)
+              %td.action-col.follow-col{ style: 'padding: 18px;' }= (dossier.depose_at || dossier.created_at).strftime('%d/%m/%Y')
 
-  = paginate(dossier_transfers)
+    = paginate(dossier_transfers)
 
 - else
   .blank-tab

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -358,8 +358,11 @@ en:
           updated: "Updated"
           actions: "Actions"
         transfers:
-          demande_en_cours: "Une demande de transfert est en cours sur le dossier %{id} pour %{email}"
-          revoke: Révoquer cette demande
+          sender_demande_en_cours: "A transfer request is pending on file Nº %{id} to %{email}"
+          receiver_demande_en_cours: "Transfer request on file Nº %{id} sent by %{email}"
+          revoke: Revoke this request
+          accept: Accept
+          reject: Reject
         dossier_action:
           edit_dossier: "Edit the file"
           start_other_dossier: "Start another empty file"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -357,6 +357,9 @@ en:
           status: "Status"
           updated: "Updated"
           actions: "Actions"
+        transfers:
+          demande_en_cours: "Une demande de transfert est en cours sur le dossier %{id} pour %{email}"
+          revoke: Révoquer cette demande
         dossier_action:
           edit_dossier: "Edit the file"
           start_other_dossier: "Start another empty file"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -361,6 +361,9 @@ fr:
           transfer_dossier: "Transférer le dossier"
           edit_draft: "Modifier le brouillon"
           actions: "Actions"
+        transfers:
+          demande_en_cours: "Une demande de transfert est en cours sur le dossier %{id} pour %{email}"
+          revoke: Révoquer cette demande
       sessions:
         new:
           sign_in: Connexion à %{application_name}

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -362,8 +362,11 @@ fr:
           edit_draft: "Modifier le brouillon"
           actions: "Actions"
         transfers:
-          demande_en_cours: "Une demande de transfert est en cours sur le dossier %{id} pour %{email}"
+          sender_demande_en_cours: "Une demande de transfert est en cours sur le dossier Nº %{id} pour %{email}"
+          receiver_demande_en_cours: "Demande de transfert pour le dossier Nº %{id} envoyé par %{email}"
           revoke: Révoquer cette demande
+          accept: Accepter
+          reject: Rejeter
       sessions:
         new:
           sign_in: Connexion à %{application_name}

--- a/config/locales/views/users/dossier_transfer/en.yml
+++ b/config/locales/views/users/dossier_transfer/en.yml
@@ -9,3 +9,5 @@ en:
         email_label: Email of the recipient account
         submit: Send transfer request
         notice_sent: The transfer request has been sent successfully
+        destroy: The transfer request has been deleted successfully
+        unauthorized_destroy: You don't have the authorization to delete this transfer request

--- a/config/locales/views/users/dossier_transfer/fr.yml
+++ b/config/locales/views/users/dossier_transfer/fr.yml
@@ -9,3 +9,5 @@ fr:
         email_label: Email du compte destinataire
         submit: Envoyer la demande de transfert
         notice_sent: L'invitation au transfert a été envoyée avec succès
+        destroy: La demande de transfert a été supprimée avec succès
+        unauthorized_destroy: Vous n'avez pas l'autorisation pour supprimer cette demande de transfert

--- a/spec/controllers/users/transfers_controller_spec.rb
+++ b/spec/controllers/users/transfers_controller_spec.rb
@@ -4,19 +4,38 @@ describe Users::TransfersController, type: :controller do
   let(:dossier) { create(:dossier, user: sender_user) }
 
   describe 'DELETE destroy' do
-    let(:dossier_transfert) { DossierTransfer.initiate(recipient_user.email, [dossier]) }
+    context "as transfer receiver" do
+      let(:dossier_transfert) { DossierTransfer.initiate(recipient_user.email, [dossier]) }
 
-    subject { delete :destroy, params: { id: dossier_transfert.id } }
+      subject { delete :destroy, params: { id: dossier_transfert.id } }
 
-    before do
-      sign_in(recipient_user)
+      before do
+        sign_in(recipient_user)
+      end
+
+      it { expect { subject }.not_to raise_error }
+
+      it "deletes dossier transfert" do
+        subject
+        expect { dossier_transfert.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
     end
 
-    it { expect { subject }.not_to raise_error }
+    context "as transfer sender" do
+      let(:dossier_transfert) { DossierTransfer.initiate(recipient_user.email, [dossier]) }
 
-    it "deletes dossier transfert" do
-      subject
-      expect { dossier_transfert.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      subject { delete :destroy, params: { id: dossier_transfert.id } }
+
+      before do
+        sign_in(sender_user)
+      end
+
+      it { expect { subject }.not_to raise_error }
+
+      it "deletes dossier transfert" do
+        subject
+        expect { dossier_transfert.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
     end
   end
 

--- a/spec/controllers/users/transfers_controller_spec.rb
+++ b/spec/controllers/users/transfers_controller_spec.rb
@@ -18,6 +18,8 @@ describe Users::TransfersController, type: :controller do
       it "deletes dossier transfert" do
         subject
         expect { dossier_transfert.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { (flash.notice).to eq('La demande de transfert a été supprimée avec succès') }
+        expect { (subject).to redirect_to dossiers_path }
       end
     end
 
@@ -35,6 +37,27 @@ describe Users::TransfersController, type: :controller do
       it "deletes dossier transfert" do
         subject
         expect { dossier_transfert.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "as transfer unauthorized" do
+      let(:dossier_transfert) { DossierTransfer.initiate(recipient_user.email, [dossier]) }
+      let(:random_user) { create(:user) }
+
+      subject { delete :destroy, params: { id: dossier_transfert.id } }
+
+      before do
+        sign_in(random_user)
+      end
+
+      it { expect { subject }.not_to raise_error }
+
+      it "does not delete dossier transfert" do
+        subject
+
+        expect { dossier_transfert.reload.to eq(dossier_transfert) }
+        expect { (flash.alert).to eq("Vous n'avez pas l'autorisation pour supprimer cette demande de transfert") }
+        expect { (subject).to redirect_to dossiers_path }
       end
     end
   end

--- a/spec/system/users/transfer_dossier_spec.rb
+++ b/spec/system/users/transfer_dossier_spec.rb
@@ -25,7 +25,7 @@ describe 'Transfer dossier:' do
     login_as other_user, scope: :user
     visit dossiers_path
 
-    expect(page).to have_content("Demande de transfert Nº #{dossier.reload.transfer.id} envoyé par #{user.email}")
+    expect(page).to have_content("Demande de transfert pour le dossier Nº #{dossier.id} envoyé par #{user.email}")
     click_on 'Accepter'
     expect(page).to have_current_path(dossiers_path)
   end


### PR DESCRIPTION
issue #8378 
Les usagers ont maintenant la possibilité de révoquer une demande de transfert de dossier envoyée en cas d'erreur.
J'ai profité de ce ticket pour utiliser le tableau DSFR sur les vues usagers.
J'ai également harmonisé l'affichage de la vue "je recois un transfert" / "j'ai fait une demande de transfert"

**AVANT**
<img width="1092" alt="Capture d’écran 2023-03-02 à 15 37 07" src="https://user-images.githubusercontent.com/6756627/222459156-2d30f283-3ac4-4b39-8aa8-e41e7f8e866e.png">
<img width="1036" alt="Capture d’écran 2023-03-02 à 15 36 56" src="https://user-images.githubusercontent.com/6756627/222459178-81096220-2af9-49c0-b09b-b9f7f3ab711b.png">


**APRES**
<img width="1105" alt="Capture d’écran 2023-03-02 à 15 36 19" src="https://user-images.githubusercontent.com/6756627/222459201-6e18227e-ad50-4a31-b3d7-299f461efdbc.png">
<img width="1107" alt="Capture d’écran 2023-03-02 à 15 36 05" src="https://user-images.githubusercontent.com/6756627/222459207-f0b163ce-7e0f-4dd3-ab45-b0b17ea42f46.png">
