### PR TITLE
fix(groupe-instructeur): un groupe instructeur inactif est valide tant qu'il reste un groupe actif

### DIFF
--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -22,7 +22,7 @@ class GroupeInstructeur < ApplicationRecord
 
   validates :label, presence: true, allow_nil: false
   validates :label, uniqueness: { scope: :procedure }
-  validates :closed, acceptance: { accept: [false] }, if: -> { self.procedure.groupe_instructeurs.active.one? }
+  validates :closed, acceptance: { accept: [false] }, if: -> { closed_changed? && self.procedure.groupe_instructeurs.active.one? }
 
   before_validation -> { label&.strip! }
   after_save :toggle_routing

--- a/spec/models/groupe_instructeur_spec.rb
+++ b/spec/models/groupe_instructeur_spec.rb
@@ -98,6 +98,24 @@ describe GroupeInstructeur, type: :model do
     end
   end
 
+  describe "active group validations" do
+    context "there is at least one active groupe instructeur" do
+      let!(:gi_active) { create(:groupe_instructeur, procedure:, closed: false) }
+      let!(:gi_closed) { create(:groupe_instructeur, procedure:, closed: true) }
+      before { procedure.defaut_groupe_instructeur.destroy! }
+
+      it "closed is valid when there is one other active groupe" do
+        expect(gi_active).to be_valid
+        expect(gi_closed).to be_valid
+      end
+
+      it "closed is invalid when there is no active groupe" do
+        gi_active.closed = true
+        expect(gi_active).not_to be_valid
+      end
+    end
+  end
+
   private
 
   def assign(procedure_to_assign, instructeur_assigne: instructeur)


### PR DESCRIPTION
Contexte: une démarche qui a 2 groupes instructeurs, l'un actif, l'autre inactif, avec un compte instructeur rattaché aux 2.  C'est censé être parfaitement valide, or jusqu'à présent le validateur du groupe instructeur inactif était considéré comme invalide.

En créant un export, les groupes instructeurs sont validés, et empêchait silencieusement la génération de l'export à cause de l'erreur de validation sur le groupe instructeur inactif.

