### PR TITLE
feat(groupe instructeur): allow import of many groups when procedure is not routed yet

### DIFF
--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -212,10 +212,11 @@ module Administrateurs
             added_instructeurs_by_group, invalid_emails = InstructeursImportService.import_groupes(procedure, groupes_emails)
 
             added_instructeurs_by_group.each do |groupe, added_instructeurs|
-              GroupeInstructeurMailer
-                .notify_added_instructeurs(groupe, added_instructeurs, current_administrateur.email)
-                .deliver_later
-
+              if added_instructeurs.present?
+                GroupeInstructeurMailer
+                  .notify_added_instructeurs(groupe, added_instructeurs, current_administrateur.email)
+                  .deliver_later
+              end
               flash_message_for_import(invalid_emails)
             end
 
@@ -223,11 +224,11 @@ module Administrateurs
             instructors_emails = csv_content.map(&:to_h)
 
             added_instructeurs, invalid_emails = InstructeursImportService.import_instructeurs(procedure, instructors_emails)
-
-            GroupeInstructeurMailer
-              .notify_added_instructeurs(groupe_instructeur, added_instructeurs, current_administrateur.email)
-              .deliver_later
-
+            if added_instructeurs.present?
+              GroupeInstructeurMailer
+                .notify_added_instructeurs(groupe_instructeur, added_instructeurs, current_administrateur.email)
+                .deliver_later
+            end
             flash_message_for_import(invalid_emails)
           else
             flash_message_for_invalid_csv

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -204,43 +204,33 @@ module Administrateurs
           file = csv_file.read
           base_encoding = CharlockHolmes::EncodingDetector.detect(file)
 
-          if params[:group_csv_file]
-            groupes_emails = ACSV::CSV.new_for_ruby3(file.encode("UTF-8", base_encoding[:encoding], invalid: :replace, replace: ""), headers: true, header_converters: :downcase)
-              .map { |r| r.to_h.slice('groupe', 'email') }
+          csv_content = ACSV::CSV.new_for_ruby3(file.encode("UTF-8", base_encoding[:encoding], invalid: :replace, replace: ""), headers: true, header_converters: :downcase).map(&:to_h)
 
-            groupes_emails_has_keys = groupes_emails.first.has_key?("groupe") && groupes_emails.first.has_key?("email")
+          if csv_content.first.has_key?("groupe") && csv_content.first.has_key?("email")
+            groupes_emails = csv_content.map { |r| r.to_h.slice('groupe', 'email') }
 
-            if groupes_emails_has_keys.blank?
-              flash[:alert] = "Importation impossible, veuillez importer un csv #{view_context.link_to('suivant ce modèle', "/csv/#{I18n.locale}/import-groupe-test.csv")}"
-            else
-              added_instructeurs_by_group, invalid_emails = InstructeursImportService.import_groupes(procedure, groupes_emails)
+            added_instructeurs_by_group, invalid_emails = InstructeursImportService.import_groupes(procedure, groupes_emails)
 
-              added_instructeurs_by_group.each do |groupe, added_instructeurs|
-                GroupeInstructeurMailer
-                  .notify_added_instructeurs(groupe, added_instructeurs, current_administrateur.email)
-                  .deliver_later
-              end
-
-              flash_message_for_import(invalid_emails)
-            end
-
-          elsif params[:instructeurs_csv_file]
-            instructors_emails = ACSV::CSV.new_for_ruby3(file.encode("UTF-8", base_encoding[:encoding], invalid: :replace, replace: ""), headers: true, header_converters: :downcase)
-              .map(&:to_h)
-
-            instructors_emails_has_key = instructors_emails.first.has_key?("email") && !instructors_emails.first.keys.many?
-
-            if instructors_emails_has_key.blank?
-              flash[:alert] = "Importation impossible, veuillez importer un csv #{view_context.link_to('suivant ce modèle', "/csv/import-instructeurs-test.csv")}"
-            else
-              added_instructeurs, invalid_emails = InstructeursImportService.import_instructeurs(procedure, instructors_emails)
-
+            added_instructeurs_by_group.each do |groupe, added_instructeurs|
               GroupeInstructeurMailer
-                .notify_added_instructeurs(groupe_instructeur, added_instructeurs, current_administrateur.email)
+                .notify_added_instructeurs(groupe, added_instructeurs, current_administrateur.email)
                 .deliver_later
 
               flash_message_for_import(invalid_emails)
             end
+
+          elsif csv_content.first.has_key?("email") && !csv_content.map(&:to_h).first.keys.many? && procedure.groupe_instructeurs.one?
+            instructors_emails = csv_content.map(&:to_h)
+
+            added_instructeurs, invalid_emails = InstructeursImportService.import_instructeurs(procedure, instructors_emails)
+
+            GroupeInstructeurMailer
+              .notify_added_instructeurs(groupe_instructeur, added_instructeurs, current_administrateur.email)
+              .deliver_later
+
+            flash_message_for_import(invalid_emails)
+          else
+            flash_message_for_invalid_csv
           end
           redirect_to admin_procedure_groupe_instructeurs_path(procedure)
         end
@@ -316,7 +306,7 @@ module Administrateurs
     end
 
     def csv_file
-      params[:group_csv_file] || params[:instructeurs_csv_file]
+      params[:csv_file]
     end
 
     def marcel_content_type
@@ -337,6 +327,10 @@ module Administrateurs
       else
         flash[:alert] = "Import terminé. Cependant les emails suivants ne sont pas pris en compte: #{result.join(', ')}"
       end
+    end
+
+    def flash_message_for_invalid_csv
+      flash[:alert] = "Importation impossible, veuillez importer un csv suivant #{view_context.link_to('ce modèle', "/csv/import-instructeurs-test.csv")} pour une procédure sans routage ou #{view_context.link_to('celui-ci', "/csv/#{I18n.locale}/import-groupe-test.csv")} pour une procédure routée"
     end
   end
 end

--- a/app/services/instructeurs_import_service.rb
+++ b/app/services/instructeurs_import_service.rb
@@ -15,7 +15,7 @@ class InstructeursImportService
 
     if missing_labels.present?
       created_at = Time.zone.now
-      GroupeInstructeur.insert_all(missing_labels.map { |label| { procedure_id: procedure.id, label:, created_at:, updated_at: created_at } })
+      GroupeInstructeur.create!(missing_labels.map { |label| { procedure_id: procedure.id, label:, created_at:, updated_at: created_at } })
     end
 
     emails_in_groupe = groupes_emails

--- a/app/views/administrateurs/groupe_instructeurs/_edit.html.haml
+++ b/app/views/administrateurs/groupe_instructeurs/_edit.html.haml
@@ -28,13 +28,10 @@
     = form_tag import_admin_procedure_groupe_instructeurs_path(procedure), method: :post, multipart: true, class: "mt-4 form" do
       = label_tag t('.csv_import.title')
       %p.notice
-        = procedure.routing_enabled? ? t('.csv_import.routing_enabled.notice_1') : t('.csv_import.routing_disabled.notice_1')
+        = t('.csv_import.notice_1_html')
       %p.notice
         = t('.csv_import.notice_2', csv_max_size: number_to_human_size(csv_max_size))
-      - sample_file_path = procedure.routing_enabled? ? "/csv/#{I18n.locale}/import-groupe-test.csv" : "/csv/import-instructeurs-test.csv"
-      %p.mt-2.mb-2= link_to t('.csv_import.download_exemple'), sample_file_path
-      - csv_params = procedure.routing_enabled? ? :group_csv_file : :instructeurs_csv_file
-      = file_field_tag csv_params, required: true, accept: 'text/csv', size: "1"
+      = file_field_tag :csv_file, required: true, accept: 'text/csv', size: "1"
       = submit_tag t('.csv_import.import_file'), class: 'button primary send', data: { disable_with: "Envoi...", confirm: t('.csv_import.import_file_alert') }
   - else
     %p.mt-4.form.font-weight-bold.mb-2.text-lg

--- a/config/locales/views/administrateurs/groupe_instructeurs/en.yml
+++ b/config/locales/views/administrateurs/groupe_instructeurs/en.yml
@@ -41,12 +41,8 @@ en:
           notice: This group will be a choice from the list "%{routing_criteria_name}"
         csv_import:
           title: CSV Import
-          routing_enabled:
-            notice_1: The csv file must have 2 columns (Group, Email) and be separated by commas. The import does not overwrite existing groups and instructors.
-          routing_disabled:
-            notice_1: The csv file must have 1 column with instructors emails.
+          notice_1_html: The csv file must have 1 column with instructors emails. For routed procedures, the csv file must have 2 columns (Group, Email) and be separated by commas. The import does not overwrite existing groups and instructors.
           notice_2: The size of the file must be less than %{csv_max_size}.
-          download_exemple: Download sample CSV file
           import_file: Import file
           import_file_procedure_not_published: The import of instructors by CSV file is available once the process has been published
           import_file_alert: Instructors added to the procedure will receive an email. Are you sure you want to continue ?"

--- a/config/locales/views/administrateurs/groupe_instructeurs/fr.yml
+++ b/config/locales/views/administrateurs/groupe_instructeurs/fr.yml
@@ -47,12 +47,10 @@ fr:
           notice: Ce groupe sera un choix de la liste "%{routing_criteria_name}"
         csv_import:
           title: Importer par CSV
-          routing_enabled:
-            notice_1: Le fichier csv doit comporter 2 colonnes (Groupe, Email) et être séparé par des virgules.
-          routing_disabled:
-            notice_1: Le fichier csv doit comporter 1 seule colonne (Email) avec une adresse email d'instructeur par ligne.
-          notice_2: L’import n’écrase pas les groupes et les instructeurs existants. La modification du fichier csv ne s’opère que pour l’ajout de nouveaux instructeurs. La suppression d’un instructeur s’opère manuellement en cliquant sur le bouton « retirer ». Le poids du fichier doit être inférieur à %{csv_max_size}.
-          download_exemple: Télécharger l’exemple de fichier CSV
+          notice_1_html: |
+            Pour une procédure standard, le fichier csv doit comporter 1 seule colonne (Email) avec une adresse email d'instructeur par ligne (<a href=\"/csv/import-instructeurs-test.csv\">exemple de fichier</a>).
+            Pour une procédure routée, le fichier doit comporter 2 colonnes (Groupe, Email) et être séparé par des virgules (<a href=\"/csv/fr/import-groupe-test.csv\">exemple de fichier</a>).
+          notice_2: L’import n’écrase pas les instructeurs existants. Il permet uniquement d'en ajouter. Pour supprimer un instructeur, cliquez sur le bouton « retirer ». Le poids du fichier doit être inférieur %{csv_max_size}.
           import_file: Importer le fichier
           import_file_procedure_not_published: L’import d’instructeurs par fichier CSV est disponible une fois la démarche publiée
           import_file_alert: Tous les instructeurs ajoutés à la procédure vont être notifiés par email. Voulez-vous continuer ?

--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -521,6 +521,7 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
         it { expect(response.status).to eq(302) }
         it { expect(flash.alert).to be_present }
         it { expect(flash.alert).to eq("Import terminé. Cependant les emails suivants ne sont pas pris en compte: kara") }
+        it { expect(procedure_non_routee.reload.routing_enabled?).to be_truthy }
       end
 
       context 'when the file content type is application/vnd.ms-excel' do

--- a/spec/fixtures/files/groupe-instructeur-emails-invalides.csv
+++ b/spec/fixtures/files/groupe-instructeur-emails-invalides.csv
@@ -1,0 +1,4 @@
+Email,Groupe
+instructeur1, Paris
+instructeur2,Paris
+instructeur3,Marseille

--- a/spec/fixtures/files/instructeurs-emails-invalides.csv
+++ b/spec/fixtures/files/instructeurs-emails-invalides.csv
@@ -1,0 +1,4 @@
+Email
+instructeur1.test
+instructeur2
+instructeur3


### PR DESCRIPTION
Le but de la PR est de permettre à l'admin d'importer un csv avec plusieurs groupes même quand la procédure n'est pas encore routée.
Pour ça j'ai du changer la façon dont on crée les groupes lors de l'import, avec un `create!` au lieu d'un `insert_all` (le `insert_all` ne lance pas les callbacks du modèle. On aurait donc créé des groupes sans activer le routage, qui se fait par un `after_save`).
J'ai aussi un peu ré-écrit le fichier de test `administrateurs/groupe_instructeurs_controller_spec.rb` qui utilisait pour la plupart des tests une procédure routée avec un seul groupe (ce qui n'est pas censé arriver).