### PR TITLE
fix display of yes/no in english locale

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,8 +45,8 @@ en:
     help_filled_dossier: "A question about your file?"
     contact_instructeur: Send a message directly to the instructor.
   utils:
-    'yes': Yes
-    'no': No
+    'yes': 'Yes'
+    'no': 'No'
     deconnexion: "Log out"
     pj: "Attachments"
     asterisk_html: Fields marked by an asterisk ( <span class = mandatory>*</span> ) are mandatory.


### PR DESCRIPTION
In yaml, values Yes/No are translated to true/false whereas 'Yes'/'No' are correctly stored as a string.
DS uses these values as strings (french locale is set to Oui/Non)
![true_false](https://user-images.githubusercontent.com/15379878/222628669-34883d70-e0ac-47d3-a519-a7d8da8105f9.png)
