### PR TITLE
Jobs: rallonge durée max pour les exports, fix des timeouts, isole DossierRebase

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -21,6 +21,10 @@ class ApplicationJob < ActiveJob::Base
     ENV.fetch("MAX_ATTEMPTS_JOBS", DEFAULT_MAX_ATTEMPTS_JOBS).to_i
   end
 
+  def max_run_time
+    4.hours # decrease run time by default
+  end
+
   def request_id
     @request_id ||= Current.request_id
   end

--- a/app/jobs/archive_creation_job.rb
+++ b/app/jobs/archive_creation_job.rb
@@ -1,6 +1,14 @@
 class ArchiveCreationJob < ApplicationJob
   queue_as :archives
 
+  before_perform do |job|
+    Sentry.set_tags(procedure: job.arguments.first.id)
+  end
+
+  def max_run_time
+    Archive::MAX_DUREE_GENERATION
+  end
+
   def perform(procedure, archive, administrateur_or_instructeur)
     archive.compute_with_safe_stale_for_purge do
       ProcedureArchiveService

--- a/app/jobs/cron/purge_old_email_event_job.rb
+++ b/app/jobs/cron/purge_old_email_event_job.rb
@@ -2,6 +2,6 @@ class Cron::PurgeOldEmailEventJob < Cron::CronJob
   self.schedule_expression = "every week at 3:00"
 
   def perform
-    EmailEvent.outdated.destroy_all
+    EmailEvent.outdated.in_batches.destroy_all
   end
 end

--- a/app/jobs/dossier_rebase_job.rb
+++ b/app/jobs/dossier_rebase_job.rb
@@ -1,4 +1,6 @@
 class DossierRebaseJob < ApplicationJob
+  queue_as :low_priority # they are massively enqueued, so don't interfere with others especially antivirus
+
   # If by the time the job runs the Dossier has been deleted, ignore the rebase
   discard_on ActiveRecord::RecordNotFound
 

--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -4,7 +4,7 @@ class ExportJob < ApplicationJob
   discard_on ActiveRecord::RecordNotFound
 
   before_perform do |job|
-    Sentry.set_tags(procedure_id: job.arguments.first.procedure.id)
+    Sentry.set_tags(procedure: job.arguments.first.procedure.id)
   end
 
   def perform(export)

--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -7,6 +7,10 @@ class ExportJob < ApplicationJob
     Sentry.set_tags(procedure: job.arguments.first.procedure.id)
   end
 
+  def max_run_time
+    Export::MAX_DUREE_GENERATION
+  end
+
   def perform(export)
     return if export.generated?
 

--- a/app/models/archive.rb
+++ b/app/models/archive.rb
@@ -14,7 +14,7 @@ class Archive < ApplicationRecord
   include TransientModelsWithPurgeableJobConcern
 
   RETENTION_DURATION = 4.days
-  MAX_DUREE_GENERATION = 24.hours
+  MAX_DUREE_GENERATION = 16.hours
   MAX_SIZE = 100.gigabytes
 
   has_and_belongs_to_many :groupe_instructeurs

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -1352,7 +1352,6 @@ class Dossier < ApplicationRecord
 
   def self.notify_draft_not_submitted
     brouillon_near_procedure_closing_date
-      .includes(:user)
       .find_each do |dossier|
         DossierMailer.notify_brouillon_not_submitted(dossier).deliver_later
       end

--- a/app/services/serializer_service.rb
+++ b/app/services/serializer_service.rb
@@ -10,7 +10,7 @@ class SerializerService
 
   def self.dossiers(procedure)
     Sentry.with_scope do |scope|
-      scope.set_tags(procedure_id: procedure.id)
+      scope.set_tags(procedure: procedure.id)
 
       data = execute_query('serializeDossiers', { number: procedure.id })
       data && data['demarche']['dossiers']

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,0 +1,4 @@
+# Set max_run_time at the highest job duration we want,
+# then at job level we'll decrease this value to a lower value
+# except for ExportJob.
+Delayed::Worker.max_run_time = 16.hours # same as Export::MAX_DUREE_GENERATION but we can't yet use this constant here


### PR DESCRIPTION
- **Exports/Archives**: Configure Delayed Job pour augmenter la hard-durée de 4h à 16h (la durée max qu'on autorise pour les exports). Mais au niveau d'ApplicationJob, on revient à la durée par défaut (4h) pour l'ensemble des jobs, sauf pour les exports qui peuvent donc prendre réellement jusqu'à 16h, en attendant un découpage unitaire. (on aurait pas pu directement augmenter la durée uniquement pour les exports). Doc : https://github.com/collectiveidea/delayed_job#custom-jobs

- Cron::NotifyDraftNotSubmittedJob : tentative de fix de pg timeout, pas besoin d'une couteux includes sur des milliers d'users vu qu'on `deliver_later` l'email qui s'en sert

- Cron::PurgeOldEmailEvent: en batch pour essayer d'aller plus vite et pas 


- `DossieRebaseJob`: isole dans une queue "low_priority" pour éviter les interférences avec d'autres jobs de la queue default comme l'analyse virus, car ces jobs peuvent être enqueue par dizaines de milliers d'un coup et être long à dépiler.

Au passage, pour Sentry, uniformisation du tag `procedure` qu'on a ailleurs pour éviter les doublons avec procedure_id