### PR TITLE
Fix(dossier): ne numérote pas automatiquement les titres de section dans les répétitions

### DIFF
--- a/app/models/concerns/dossier_sections_concern.rb
+++ b/app/models/concerns/dossier_sections_concern.rb
@@ -17,6 +17,8 @@ module DossierSectionsConcern
     end
 
     def auto_numbering_section_headers_for?(champ)
+      return false if champ.child?
+
       sections_for(champ)&.none?(&:libelle_with_section_index?)
     end
 

--- a/spec/models/concern/dossier_sections_concern_spec.rb
+++ b/spec/models/concern/dossier_sections_concern_spec.rb
@@ -24,6 +24,20 @@ describe DossierSectionsConcern do
       it { expect(dossier.auto_numbering_section_headers_for?(dossier.champs_public[1])).to eq(true) }
       it { expect(dossier.auto_numbering_section_headers_for?(dossier.champs_private[1])).to eq(false) }
     end
+
+    context "header_section in a repetition are not auto-numbered" do
+      let(:types_de_champ_public) { [{ type: :header_section, libelle: public_libelle }, { type: :repetition, mandatory: true, children: [{ type: :header_section, libelle: "Enfant" }, { type: :text }] }] }
+
+      context "with parent section having headers with number" do
+        let(:public_libelle) { "1. Infos" }
+        it { expect(dossier.auto_numbering_section_headers_for?(dossier.champs_public[1].rows[0][0])).to eq(false) }
+      end
+
+      context "with parent section having headers without number" do
+        let(:public_libelle) { "infos" }
+        it { expect(dossier.auto_numbering_section_headers_for?(dossier.champs_public[1].rows[0][0])).to eq(false) }
+      end
+    end
   end
 
   describe '#index_for_section_header' do


### PR DESCRIPTION
En attendant de mieux gérer les niveaux de sections, on arrête la numérotation auto des titres dans les répétitions qui ne fonctionne pas bien. On pourra revenir dessus une fois correctement sectionné, et en adaptant le counter css