### PR TITLE
[design] Corriger l'alignement des badges du dossier côté usager

### DIFF
--- a/app/assets/stylesheets/dossier_views.scss
+++ b/app/assets/stylesheets/dossier_views.scss
@@ -3,22 +3,6 @@
 
 .dossier-container {
   .sub-header {
-    .label {
-      float: right;
-      margin-left: $default-spacer;
-    }
-
-    .title-container {
-      margin-bottom: $default-spacer;
-      padding-left: 32px;
-
-      .icon.folder {
-        float: left;
-        margin-left: -32px;
-        margin-top: 3px;
-      }
-    }
-
     h1 {
       color: $black;
       font-size: 22px;

--- a/app/views/shared/dossiers/_header.html.haml
+++ b/app/views/shared/dossiers/_header.html.haml
@@ -1,18 +1,17 @@
-.title-container
-  %h1
-    = procedure_libelle(dossier.procedure)
-    = status_badge(dossier.state, 'super')
-  %h2
-    = t('views.users.dossiers.show.header.dossier_number', dossier_id: dossier.id)
-    = t('views.users.dossiers.show.header.created_date', date_du_dossier: I18n.l(dossier.created_at))
+%h1
+  = procedure_libelle(dossier.procedure)
+  = status_badge(dossier.state, 'super')
+%h2
+  = t('views.users.dossiers.show.header.dossier_number', dossier_id: dossier.id)
+  = t('views.users.dossiers.show.header.created_date', date_du_dossier: I18n.l(dossier.created_at))
 
-  = render(partial: 'users/dossiers/expiration_banner', locals: {dossier: dossier})
+= render(partial: 'users/dossiers/expiration_banner', locals: {dossier: dossier})
 
-  - if dossier.show_procedure_state_warning?
-    = render(partial: 'users/dossiers/procedure_removed_banner', locals: { dossier: dossier })
-  - elsif current_user.owns?(dossier)
-    .header-actions
-      = render partial: 'invites/dropdown', locals: { dossier: dossier, morphing: false }
+- if dossier.show_procedure_state_warning?
+  = render(partial: 'users/dossiers/procedure_removed_banner', locals: { dossier: dossier })
+- elsif current_user.owns?(dossier)
+  .header-actions
+    = render partial: 'invites/dropdown', locals: { dossier: dossier, morphing: false }
 
-      - unless dossier.read_only?
-        = render partial: 'users/dossiers/identity_dropdown', locals: { dossier: dossier }
+    - unless dossier.read_only?
+      = render partial: 'users/dossiers/identity_dropdown', locals: { dossier: dossier }

--- a/app/views/shared/dossiers/_header.html.haml
+++ b/app/views/shared/dossiers/_header.html.haml
@@ -1,7 +1,7 @@
-= status_badge(dossier.state)
 .title-container
-  %span.icon.folder
-  %h1= procedure_libelle(dossier.procedure)
+  %h1
+    = procedure_libelle(dossier.procedure)
+    = status_badge(dossier.state, 'super')
   %h2
     = t('views.users.dossiers.show.header.dossier_number', dossier_id: dossier.id)
     = t('views.users.dossiers.show.header.created_date', date_du_dossier: I18n.l(dossier.created_at))

--- a/app/views/users/dossiers/show/_header.html.haml
+++ b/app/views/users/dossiers/show/_header.html.haml
@@ -1,10 +1,9 @@
 .sub-header
   .container
-    = status_badge(dossier.state)
-
     .title-container
-      %span.icon.folder
-      %h1= dossier.procedure.libelle
+      %h1
+        = dossier.procedure.libelle
+        = status_badge(dossier.state, 'super')
       %h2
         = t('views.users.dossiers.show.header.dossier_number', dossier_id: dossier.id)
         - if dossier.depose_at.present?

--- a/app/views/users/dossiers/show/_header.html.haml
+++ b/app/views/users/dossiers/show/_header.html.haml
@@ -1,15 +1,14 @@
 .sub-header
   .container
-    .title-container
-      %h1
-        = dossier.procedure.libelle
-        = status_badge(dossier.state, 'super')
-      %h2
-        = t('views.users.dossiers.show.header.dossier_number', dossier_id: dossier.id)
-        - if dossier.depose_at.present?
-          = t('views.users.dossiers.show.header.submit_date', date_du_dossier: I18n.l(dossier.depose_at))
+    %h1
+      = dossier.procedure.libelle
+      = status_badge(dossier.state, 'super')
+    %h2
+      = t('views.users.dossiers.show.header.dossier_number', dossier_id: dossier.id)
+      - if dossier.depose_at.present?
+        = t('views.users.dossiers.show.header.submit_date', date_du_dossier: I18n.l(dossier.depose_at))
 
-      = render(partial: 'users/dossiers/expiration_banner', locals: {dossier: dossier})
+    = render(partial: 'users/dossiers/expiration_banner', locals: {dossier: dossier})
 
     - if dossier.show_procedure_state_warning?
       = render(partial: 'users/dossiers/procedure_removed_banner', locals: { dossier: dossier })


### PR DESCRIPTION
Suite à la PR pour utiliser les badges du DSFR https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/8710 - ça a bougé l'alignement des badges côté usager.
Cette PR permet de les réaligner correctement.

J'en ai profité pour retirer l'icone dossier qui ne sera plus utilisé dans les futurs maquettes et qui n'etait pas tres heureux en terme d'alignement.

**AVANT**
<img width="1179" alt="Capture d’écran 2023-03-10 à 17 54 41" src="https://user-images.githubusercontent.com/6756627/224376684-2baf26de-1735-458d-aedf-688b01bef6b9.png">

**APRES**
<img width="1208" alt="Capture d’écran 2023-03-10 à 17 52 34" src="https://user-images.githubusercontent.com/6756627/224376697-61cb31dc-562b-4733-bbbc-5fd25721f1bc.png">
