### PR TITLE
Fix: masque le nom de l'entreprise aux usagers lorsqu'elle exerce sont droit de non diffusion

### DIFF
--- a/app/helpers/etablissement_helper.rb
+++ b/app/helpers/etablissement_helper.rb
@@ -1,4 +1,8 @@
 module EtablissementHelper
+  def pretty_siret(siret)
+    "#{siret[0..2]} #{siret[3..5]} #{siret[6..8]} #{siret[9..]}"
+  end
+
   def pretty_currency(capital_social, unit: '€')
     number_to_currency(capital_social, locale: :fr, unit: unit, precision: 0)
   end

--- a/app/views/shared/dossiers/_identite_entreprise.html.haml
+++ b/app/views/shared/dossiers/_identite_entreprise.html.haml
@@ -20,14 +20,14 @@
     %tbody
       - if etablissement.diffusable_commercialement == false && profile != 'instructeur'
         %tr
-          %td= t('warning_for_private_info', scope: 'views.shared.dossiers.identite_entreprise', siret: etablissement.siret)
+          %td= t('warning_for_private_info', scope: 'views.shared.dossiers.identite_entreprise', siret: pretty_siret(etablissement.siret))
       - else
         %tr
           %td.libelle Dénomination :
           %td= raison_sociale_or_name(etablissement)
         %tr
           %td.libelle SIRET :
-          %td= etablissement.siret
+          %td= pretty_siret(etablissement.siret)
 
         - unless local_assigns[:short_identity]
           - if etablissement.siret != etablissement.entreprise.siret_siege_social

--- a/app/views/shared/dossiers/_identite_entreprise.html.haml
+++ b/app/views/shared/dossiers/_identite_entreprise.html.haml
@@ -20,7 +20,7 @@
     %tbody
       - if etablissement.diffusable_commercialement == false && profile != 'instructeur'
         %tr
-          %td= t('warning_for_private_info', scope: 'views.shared.dossiers.identite_entreprise', etablissement: raison_sociale_or_name(etablissement))
+          %td= t('warning_for_private_info', scope: 'views.shared.dossiers.identite_entreprise', siret: etablissement.siret)
       - else
         %tr
           %td.libelle Dénomination :

--- a/app/views/users/dossiers/etablissement.html.haml
+++ b/app/views/users/dossiers/etablissement.html.haml
@@ -25,7 +25,7 @@
               Vérifier dans l'annuaire des entreprises
 
     - elsif etablissement.diffusable_commercialement == false
-      %p= t('warning_for_private_info', scope: 'views.shared.dossiers.identite_entreprise', etablissement: raison_sociale_or_name(etablissement))
+      %p= t('warning_for_private_info', scope: 'views.shared.dossiers.identite_entreprise', siret: etablissement.siret)
 
     - else
       %p

--- a/app/views/users/dossiers/etablissement.html.haml
+++ b/app/views/users/dossiers/etablissement.html.haml
@@ -17,7 +17,7 @@
             %br
             %br
             Veuillez vérifier par vous-même que le numéro
-            %strong= etablissement.siret
+            %strong= pretty_siret(etablissement.siret)
             correspond bien à votre entreprise :
 
           %p
@@ -25,7 +25,7 @@
               Vérifier dans l'annuaire des entreprises
 
     - elsif etablissement.diffusable_commercialement == false
-      %p= t('warning_for_private_info', scope: 'views.shared.dossiers.identite_entreprise', siret: etablissement.siret)
+      %p= t('warning_for_private_info', scope: 'views.shared.dossiers.identite_entreprise', siret: pretty_siret(etablissement.siret))
 
     - else
       %p

--- a/app/views/users/dossiers/etablissement/_infos_entreprise.html.haml
+++ b/app/views/users/dossiers/etablissement/_infos_entreprise.html.haml
@@ -1,7 +1,7 @@
 %ul.etablissement-infos-entreprise
   %li
     Siret :
-    = etablissement.siret
+    = pretty_siret(etablissement.siret)
 
   %li
     Libellé NAF :

--- a/config/locales/views/shared/en.yml
+++ b/config/locales/views/shared/en.yml
@@ -3,7 +3,7 @@ en:
     shared:
       dossiers:
         identite_entreprise:
-          warning_for_private_info: "The establishment %{etablissement} applied his right to not publish information regarding his identity. These informaiton won't be visible from instructor services"
+          warning_for_private_info: "The establishment SIRET %{siret} applied his right to not publish information regarding his identity. These informaiton won't be visible from instructor services."
       avis:
         demande_envoyee_le: "Feedback send at %{date}"
         demande_revoquee_le: "Feedback revoked at %{date}"

--- a/config/locales/views/shared/fr.yml
+++ b/config/locales/views/shared/fr.yml
@@ -3,7 +3,7 @@ fr:
     shared:
       dossiers:
         identite_entreprise:
-          warning_for_private_info: "L’établissement %{etablissement} a exercé son droit à la non publication des informations relatives à son identité. Les informations ne seront donc visibles que de la part des services instructeurs"
+          warning_for_private_info: "L’établissement SIRET %{siret} a exercé son droit à la non publication des informations relatives à son identité. Les informations ne seront donc visibles que de la part des services instructeurs."
       avis:
         demande_envoyee_le: "Demande d’avis envoyée le %{date}"
         demande_revoquee_le: "Demande d’avis révoquée le %{date}"

--- a/spec/helpers/etablissement_helper_spec.rb
+++ b/spec/helpers/etablissement_helper_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe EtablissementHelper, type: :helper do
   end
   let(:etablissement) { create(:etablissement, etablissement_params) }
 
+  describe "#pretty_siret" do
+    subject { pretty_siret("12345678900001") }
+
+    it { is_expected.to eq("123 456 789 00001") }
+  end
+
   describe '#raison_sociale_or_name' do
     subject { raison_sociale_or_name(etablissement) }
 

--- a/spec/views/shared/dossiers/_identite_entreprise.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_identite_entreprise.html.haml_spec.rb
@@ -14,10 +14,11 @@ describe 'shared/dossiers/identite_entreprise.html.haml', type: :view do
   end
 
   context "for an entreprise with private infos" do
-    let(:etablissement) { create(:etablissement, :non_diffusable) }
+    let(:etablissement) { create(:etablissement, :non_diffusable, siret: "12345678900001") }
 
-    it "displays only public infos" do
-      expect(rendered).to have_text(etablissement.entreprise_raison_sociale)
+    it "hide any info except siret" do
+      expect(rendered).to have_text("123 456 789 00001")
+      expect(rendered).not_to have_text(etablissement.entreprise_raison_sociale)
       expect(rendered).not_to have_text(etablissement.entreprise.forme_juridique)
     end
   end

--- a/spec/views/users/dossiers/etablissement.html.haml_spec.rb
+++ b/spec/views/users/dossiers/etablissement.html.haml_spec.rb
@@ -1,5 +1,5 @@
 describe 'users/dossiers/etablissement.html.haml', type: :view do
-  let(:etablissement) { create(:etablissement, :with_exercices) }
+  let(:etablissement) { create(:etablissement, :with_exercices, siret: "12345678900001") }
   let(:dossier) { create(:dossier, etablissement: etablissement) }
   let(:footer) { view.content_for(:footer) }
 
@@ -13,13 +13,15 @@ describe 'users/dossiers/etablissement.html.haml', type: :view do
   subject! { render }
 
   it 'affiche les informations de l’établissement' do
-    expect(rendered).to have_text(etablissement.siret)
+    expect(rendered).to have_text("12345678900001")
+    expect(rendered).to have_text(etablissement.entreprise_raison_sociale)
   end
 
   context 'etablissement avec infos non diffusables' do
-    let(:etablissement) { create(:etablissement, :with_exercices, :non_diffusable) }
-    it "affiche uniquement le nom de l'établissement si infos non diffusables" do
-      expect(rendered).to have_text(etablissement.entreprise_raison_sociale)
+    let(:etablissement) { create(:etablissement, :with_exercices, :non_diffusable, siret: "12345678900001") }
+    it "affiche uniquement le SIRET si infos non diffusables" do
+      expect(rendered).to have_text("12345678900001")
+      expect(rendered).not_to have_text(etablissement.entreprise_raison_sociale)
       expect(rendered).not_to have_text(etablissement.entreprise.forme_juridique)
     end
   end

--- a/spec/views/users/dossiers/etablissement.html.haml_spec.rb
+++ b/spec/views/users/dossiers/etablissement.html.haml_spec.rb
@@ -13,14 +13,14 @@ describe 'users/dossiers/etablissement.html.haml', type: :view do
   subject! { render }
 
   it 'affiche les informations de l’établissement' do
-    expect(rendered).to have_text("12345678900001")
+    expect(rendered).to have_text("123 456 789 00001")
     expect(rendered).to have_text(etablissement.entreprise_raison_sociale)
   end
 
   context 'etablissement avec infos non diffusables' do
     let(:etablissement) { create(:etablissement, :with_exercices, :non_diffusable, siret: "12345678900001") }
     it "affiche uniquement le SIRET si infos non diffusables" do
-      expect(rendered).to have_text("12345678900001")
+      expect(rendered).to have_text("123 456 789 00001")
       expect(rendered).not_to have_text(etablissement.entreprise_raison_sociale)
       expect(rendered).not_to have_text(etablissement.entreprise.forme_juridique)
     end
@@ -34,7 +34,7 @@ describe 'users/dossiers/etablissement.html.haml', type: :view do
     let(:etablissement) { Etablissement.create!(siret: '41816609600051') }
 
     it "affiche une notice avec un lien de vérification vers l'annuaire" do
-      expect(rendered).to have_text(etablissement.siret)
+      expect(rendered).to have_text("418 166 096 00051")
       expect(rendered).to have_link("Vérifier dans l'annuaire des entreprises", href: "https://annuaire-entreprises\.data\.gouv\.fr/rechercher?terme=#{etablissement.siret}")
     end
   end


### PR DESCRIPTION
Bonus: formate le SIRET comme le fait partout l'INSEE: XXX XXX XXX XXXXX