### PR TITLE
Fix dossier/pdf: remplace les feature collections du champ carte par les libellés de sélection utilisateur

### DIFF
--- a/app/views/dossiers/show.pdf.prawn
+++ b/app/views/dossiers/show.pdf.prawn
@@ -151,7 +151,17 @@ def add_single_champ(pdf, champ)
   when 'Champs::ExplicationChamp'
     format_in_2_lines(pdf, tdc.libelle, strip_tags(tdc.description))
   when 'Champs::CarteChamp'
-    format_in_2_lines(pdf, tdc.libelle, champ.to_feature_collection.to_json)
+    pdf.pad_bottom(4) do
+      pdf.font 'marianne', style: :bold, size: 12 do
+        pdf.text tdc.libelle
+      end
+
+      pdf.indent(default_margin) do
+        champ.geo_areas.each do |area|
+          pdf.text "- #{area.label}".tr(' ', ' ') # replace non breaking space, which are invalid in pdf
+        end
+      end
+    end
   when 'Champs::SiretChamp'
     pdf.font 'marianne', style: :bold do
       pdf.text tdc.libelle


### PR DESCRIPTION
Parfois des geo areas sont extrêmement détaillés avec des milliers de points, et font échouer la génération de PDF dans le délai normal imparti (60sec). Le PDF est censé être une représentation "humain" du dossier, le geojson n'y a pas sa place.

On remplace donc les feature collection par les libellés de geo area déjà, utilisés dans les exports. Le fichier geojson est déjà directement téléchargeable depuis l'interface.

<img width="969" alt="Capture d’écran 2023-03-16 à 15 28 59" src="https://user-images.githubusercontent.com/150279/225650383-7bd3ef22-9cc9-463f-b361-36a58aa8ce45.png">
