### PR TITLE
Fix: crash d'annotations privées à cause d'une incohérence avec leur type de champ

### DIFF
--- a/app/components/procedure/revision_changes_component/revision_changes_component.fr.yml
+++ b/app/components/procedure/revision_changes_component/revision_changes_component.fr.yml
@@ -44,10 +44,10 @@ fr:
     remove_description: La description de l’annotation privée « %{label} » a été supprimée.
     update_drop_down_secondary_libelle: Le libellé secondaire de l’annotation « %{label} » a été modifié. Le nouveau libellé est « %{to} ».
     update_drop_down_secondary_description: La description secondaire de l’annotation « %{label} » a été modifiée. La nouvelle description est « %{to} ».
-    update_type_champ_private: Le type de l’annotation privée « %{label} » a été modifié. Elle est maintenant de type « %{to} ».
-    update_piece_justificative_template_private: Le modèle de pièce justificative de l’annotation privée « %{label} » a été modifié.
-    update_drop_down_options_private: "Les options de sélection de l’annotation privée « %{label} » ont été modifiées :"
-    update_carte_layers_private: "Les référentiels cartographiques de l’annotation privée « %{label} » ont été modifiés :"
+    update_type_champ: Le type de l’annotation privée « %{label} » a été modifié. Elle est maintenant de type « %{to} ».
+    update_piece_justificative_template: Le modèle de pièce justificative de l’annotation privée « %{label} » a été modifié.
+    update_drop_down_options: "Les options de sélection de l’annotation privée « %{label} » ont été modifiées :"
+    update_carte_layers: "Les référentiels cartographiques de l’annotation privée « %{label} » ont été modifiés :"
     enable_drop_down_other: L’annotation privée « %{label} » comporte maintenant un choix « Autre ».
     disable_drop_down_other: L’annotation privée « %{label} » ne comporte plus de choix « Autre ».
     enable_collapsible_explanation: Le texte complementaire affichable au clique de l’annotation privée « %{label} » a été ajouté.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -190,6 +190,13 @@ class ApplicationController < ActionController::Base
     Sentry.set_user(sentry_user)
   end
 
+  def set_sentry_dossier(dossier)
+    Sentry.configure_scope do |scope|
+      scope.set_tags(procedure: dossier.procedure.id)
+      scope.set_tags(dossier: dossier.id)
+    end
+  end
+
   # private method called by rails fwk
   # see https://github.com/roidrage/lograge
   def append_info_to_payload(payload)

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -303,7 +303,9 @@ module Instructeurs
     end
 
     def dossier
-      @dossier ||= DossierPreloader.load_one(dossier_scope.find(params[:dossier_id]))
+      @dossier ||= DossierPreloader.load_one(dossier_scope.find(params[:dossier_id])).tap do
+        set_sentry_dossier(_1)
+      end
     end
 
     def dossier_with_champs

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -405,13 +405,9 @@ module Users
     end
 
     def dossier
-      @dossier ||= dossier_scope.find(params[:id] || params[:dossier_id]).tap do |dossier|
-                       # Ease search & groupments by tags
-                       Sentry.configure_scope do |scope|
-                         scope.set_tags(procedure: dossier.procedure.id)
-                         scope.set_tags(dossier: dossier.id)
-                       end
-                     end
+      @dossier ||= dossier_scope.find(params[:id] || params[:dossier_id]).tap do
+        set_sentry_dossier(_1)
+      end
     end
 
     def dossier_with_champs(pj_template: true)

--- a/lib/tasks/deployment/20230316125244_fix_champ_type_mismatch.rake
+++ b/lib/tasks/deployment/20230316125244_fix_champ_type_mismatch.rake
@@ -1,0 +1,25 @@
+namespace :after_party do
+  desc 'Deployment task: fix_champ_type_mismatch'
+  task fix_private_champ_type_mismatch: :environment do
+    puts "Running deploy task 'fix_champ_type_mismatch'"
+
+    champs = Champ.private_only
+
+    # count of large champs count is too slow, so we're using an progress approximation based on id
+    progress = ProgressReport.new(champs.last.id)
+
+    champs.includes(:type_de_champ).in_batches.each_record do |champ|
+      type_champ = champ.type_de_champ.type_champ
+      expected_type = "Champs::#{type_champ.classify}Champ"
+
+      if champ.type != expected_type
+        puts "Fixing champ #{champ.id} (#{champ.type} -> #{expected_type})"
+        champ.update_column(:type, expected_type)
+      end
+
+      progress.set(champ.id)
+    end
+
+    progress.finish
+  end
+end

--- a/lib/tasks/task_helper.rb
+++ b/lib/tasks/task_helper.rb
@@ -40,6 +40,14 @@ class ProgressReport
     end
   end
 
+  def set(count)
+    set_progress(count: count)
+
+    if @per_10_000 % 10 == 0
+      print_progress
+    end
+  end
+
   def finish
     if @count > 0 && @per_10_000 != 10_000
       set_progress(total: @count)


### PR DESCRIPTION
- after party qui fix quelques bad data d'incohérence Champ.type <> TypeDeChamp dans les annotations privées (elle prend une grosse heure sur ma machine) ; essentiellement DatetimeChamp > TextChamp d'une grosse démarche et qui ne posaient pas problème, mais quelques dizaines d'autres champs qui corrigent ceci https://demarches-simplifiees.sentry.io/issues/3989449229/?project=1429550
- fix quelques clés de traduction pour la liste des révisions


NB: @tchak j'ai pas encore réussi à écrire un test d'un rebase d'annotations privées qui met en évidence et fix le pb à cause du `if brouillon?` mais je vais m'y remettre la semaine pro dans une autre PR