### PR TITLE
[fix] css multi select react

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -575,6 +575,16 @@
     padding: $default-padding;
     margin: $default-spacer;
     margin-top: 0;
+    width: 100%;
+  }
+
+  ul {
+    list-style: none;
+
+    li {
+      margin-right: $default-spacer;
+      display: inline-block;
+    }
   }
 }
 


### PR DESCRIPTION
Fix du css du multi-select - en regardant rapidement je n'ai pas trouvé d'où ça venait.

**après**
<img width="1071" alt="Capture d’écran 2023-03-22 à 10 08 33" src="https://user-images.githubusercontent.com/6756627/226854383-6e1c4780-0e91-489a-924e-18c1f82c1a95.png">

**avant**
<img width="1069" alt="Capture d’écran 2023-03-22 à 10 09 04" src="https://user-images.githubusercontent.com/6756627/226854392-163973db-8341-4300-a2d9-13fb8d958253.png">
