### PR TITLE
a11y: augmente le contraste de la barre de progression lorsqu'elle a le focus

### DIFF
--- a/app/assets/stylesheets/direct_uploads.scss
+++ b/app/assets/stylesheets/direct_uploads.scss
@@ -11,7 +11,7 @@
 }
 
 .direct-upload--pending {
-  opacity: 0.6;
+  opacity: 0.7;
 }
 
 .direct-upload__progress {
@@ -19,18 +19,21 @@
   top: 0;
   left: 0;
   bottom: 0;
-  opacity: 0.2;
-  background: #0076ff;
+  background-color: var(--background-contrast-grey);
   transition: width 120ms ease-out, opacity 60ms 60ms ease-in;
   transform: translate3d(0, 0, 0);
 }
 
+.direct-upload__filename {
+  position: relative; // set a position so it appears above the progress bar
+}
+
 .direct-upload--complete .direct-upload__progress {
-  opacity: 0.4;
+  background-color: var(--background-overlap-grey);
 }
 
 .direct-upload--error {
-  border-color: red;
+  border-color: var(--border-plain-error);
 }
 
 input[type=file][data-direct-upload-url][disabled],


### PR DESCRIPTION
Réutilise les couleurs des forms du dsfr

Closes #8555



<img width="1459" alt="Capture d’écran 2023-03-22 à 11 01 51" src="https://user-images.githubusercontent.com/150279/226869723-1ee83cb2-4f77-4cb4-9c4e-a2aac9667ae2.png">
<img width="1459" alt="Capture d’écran 2023-03-22 à 11 02 04" src="https://user-images.githubusercontent.com/150279/226869729-6a41be23-5a7c-4ca1-8fff-09288bd617f5.png">
