### PR TITLE
ETQ instructeur je veux pouvoir supprimer la pj pendant l'instruction

### DIFF
--- a/app/components/dossiers/batch_operation_inline_buttons_component/batch_operation_inline_buttons_component.html.haml
+++ b/app/components/dossiers/batch_operation_inline_buttons_component/batch_operation_inline_buttons_component.html.haml
@@ -1,5 +1,5 @@
 - if opt[:operation] == 'accepter'
-  .dropdown{ data: { controller: 'menu-button', popover: 'true', operation: opt[:operation] } }
+  .dropdown{ data: { controller: 'menu-button', popover: 'true', operation: opt[:operation] }, id: 'dropdown_batch' }
     -# Dropdown button title
     %button{ disabled: true, class: ['fr-btn fr-btn--sm fr-btn--icon-left fr-ml-1w', icons[opt[:operation].to_sym]], disabled: true, name: "#{form.object_name}[operation]" , data: { menu_button_target: 'button' } }
       = opt[:label]
@@ -17,12 +17,15 @@
               .motivation.accept
                 = form.text_area :motivation, class: 'fr-input'
                 #justificatif_motivation_suggest_accept.optional-justificatif
-                  %button.button{ type: 'button', onclick: "DS.showImportJustificatif('accept');" } Ajouter un justificatif (optionnel)
+                  %button.fr-btn.fr-btn--sm.fr-btn--tertiary-no-outline.fr-btn--icon-left.fr-icon-attachment-line.fr-ml-0{ type: 'button', onclick: "DS.showImportJustificatif('accept');" } Ajouter un justificatif (optionnel)
                 #justificatif_motivation_import_accept.hidden
-                  = form.file_field :justificatif_motivation, direct_upload: true
+                  = form.file_field :justificatif_motivation, direct_upload: true, id: "dossier_justificatif_motivation_accept", onchange: "DS.showDeleteJustificatif('accept');"
 
+                .hidden{ id: "delete_motivation_import_accept" }
+                  %button.fr-btn.fr-btn--sm.fr-btn--tertiary-no-outline.fr-btn--icon-left.fr-icon-delete-line.fr-ml-0.fr-mt-1w.js_delete_motivation{ type: 'button', onclick: "DS.deleteJustificatif('accept');"} Supprimer le  justificatif
 
-                = form.button "Valider la décision", class: ['fr-btn fr-mt-2w'], disabled: true, name: "#{form.object_name}[operation]", value: opt[:operation]
+                = button_tag "Annuler", type: :reset, class: 'fr-btn fr-btn--sm fr-btn--secondary', onclick: 'DS.motivationCancelBatch();'
+                = form.button "Valider la décision", class: ['fr-btn fr-btn--sm fr-mt-2w'], disabled: true, name: "#{form.object_name}[operation]", value: opt[:operation]
 
 - else
   = form.button opt[:label], class: ['fr-btn fr-btn--sm fr-btn--icon-left fr-ml-1w', icons[opt[:operation].to_sym]], disabled: true, name: "#{form.object_name}[operation]", value: opt[:operation], data: { operation: opt[:operation] }

--- a/app/components/dossiers/batch_operation_inline_buttons_component/batch_operation_inline_buttons_component.html.haml
+++ b/app/components/dossiers/batch_operation_inline_buttons_component/batch_operation_inline_buttons_component.html.haml
@@ -22,7 +22,7 @@
                   = form.file_field :justificatif_motivation, direct_upload: true, id: "dossier_justificatif_motivation_accept", onchange: "DS.showDeleteJustificatif('accept');"
 
                 .hidden{ id: "delete_motivation_import_accept" }
-                  %button.fr-btn.fr-btn--sm.fr-btn--tertiary-no-outline.fr-btn--icon-left.fr-icon-delete-line.fr-ml-0.fr-mt-1w.js_delete_motivation{ type: 'button', onclick: "DS.deleteJustificatif('accept');"} Supprimer le  justificatif
+                  %button.fr-btn.fr-btn--sm.fr-btn--tertiary-no-outline.fr-btn--icon-left.fr-icon-delete-line.fr-ml-0.fr-mt-1w.js_delete_motivation{ type: 'button', onclick: "DS.deleteJustificatif('accept');" } Supprimer le  justificatif
 
                 = button_tag "Annuler", type: :reset, class: 'fr-btn fr-btn--sm fr-btn--secondary', onclick: 'DS.motivationCancelBatch();'
                 = form.button "Valider la décision", class: ['fr-btn fr-btn--sm fr-mt-2w'], disabled: true, name: "#{form.object_name}[operation]", value: opt[:operation]

--- a/app/components/dossiers/batch_operation_inline_buttons_component/batch_operation_inline_buttons_component.html.haml
+++ b/app/components/dossiers/batch_operation_inline_buttons_component/batch_operation_inline_buttons_component.html.haml
@@ -21,8 +21,8 @@
                 #justificatif_motivation_import_accept.hidden
                   = form.file_field :justificatif_motivation, direct_upload: true, id: "dossier_justificatif_motivation_accept", onchange: "DS.showDeleteJustificatif('accept');"
 
-                .hidden{ id: "delete_motivation_import_accept" }
-                  %button.fr-btn.fr-btn--sm.fr-btn--tertiary-no-outline.fr-btn--icon-left.fr-icon-delete-line.fr-ml-0.fr-mt-1w.js_delete_motivation{ type: 'button', onclick: "DS.deleteJustificatif('accept');" } Supprimer le  justificatif
+                .hidden.js_delete_motivation{ id: "delete_motivation_import_accept" }
+                  %button.fr-btn.fr-btn--sm.fr-btn--tertiary-no-outline.fr-btn--icon-left.fr-icon-delete-line.fr-ml-0.fr-mt-1w{ type: 'button', onclick: "DS.deleteJustificatif('accept');" } Supprimer le  justificatif
 
                 = button_tag "Annuler", type: :reset, class: 'fr-btn fr-btn--sm fr-btn--secondary', onclick: 'DS.motivationCancelBatch();'
                 = form.button "Valider la décision", class: ['fr-btn fr-btn--sm fr-mt-2w'], disabled: true, name: "#{form.object_name}[operation]", value: opt[:operation]

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -20,6 +20,7 @@ import {
   motivationCancel,
   showImportJustificatif,
   showDeleteJustificatif,
+  motivationCancelBatch,
   deleteJustificatif
 } from '../new_design/instruction-button';
 import { showFusion, showNewAccount } from '../new_design/fc-fusion';
@@ -34,6 +35,7 @@ const DS = {
   motivationCancel,
   showImportJustificatif,
   showDeleteJustificatif,
+  motivationCancelBatch,
   deleteJustificatif,
   showFusion,
   showNewAccount

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -18,9 +18,9 @@ import { toggleCondidentielExplanation } from '../new_design/avis';
 import {
   showMotivation,
   motivationCancel,
+  motivationCancelBatchDropdown,
   showImportJustificatif,
   showDeleteJustificatif,
-  motivationCancelBatch,
   deleteJustificatif
 } from '../new_design/instruction-button';
 import { showFusion, showNewAccount } from '../new_design/fc-fusion';
@@ -33,9 +33,9 @@ const DS = {
   toggleCondidentielExplanation,
   showMotivation,
   motivationCancel,
+  motivationCancelBatchDropdown,
   showImportJustificatif,
   showDeleteJustificatif,
-  motivationCancelBatch,
   deleteJustificatif,
   showFusion,
   showNewAccount

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -18,7 +18,9 @@ import { toggleCondidentielExplanation } from '../new_design/avis';
 import {
   showMotivation,
   motivationCancel,
-  showImportJustificatif
+  showImportJustificatif,
+  showDeleteJustificatif,
+  deleteJustificatif
 } from '../new_design/instruction-button';
 import { showFusion, showNewAccount } from '../new_design/fc-fusion';
 
@@ -31,6 +33,8 @@ const DS = {
   showMotivation,
   motivationCancel,
   showImportJustificatif,
+  showDeleteJustificatif,
+  deleteJustificatif,
   showFusion,
   showNewAccount
 };

--- a/app/javascript/new_design/instruction-button.js
+++ b/app/javascript/new_design/instruction-button.js
@@ -17,6 +17,13 @@ export function motivationCancel() {
     .forEach((el) => hide(el.parentElement));
 
   show(document.querySelector('.dropdown-items'));
+
+  document.querySelectorAll('.js_delete_motivation').forEach(hide);
+}
+
+export function motivationCancelBatch() {
+  document.querySelector('#dropdown_batch' ).classList.remove("open");;
+  hide(document.querySelector('.js_delete_motivation'));
 }
 
 export function showDeleteJustificatif(name) {

--- a/app/javascript/new_design/instruction-button.js
+++ b/app/javascript/new_design/instruction-button.js
@@ -19,6 +19,19 @@ export function motivationCancel() {
   show(document.querySelector('.dropdown-items'));
 }
 
+export function showDeleteJustificatif(name) {
+  const justificatif = document.querySelector('#dossier_justificatif_motivation_' + name)
+  if (justificatif.value != '') {
+    show(document.querySelector('#delete_motivation_import_' + name));
+  }
+}
+
+export function deleteJustificatif(name) {
+  const justificatif = document.querySelector('#dossier_justificatif_motivation_' + name)
+  justificatif.value = ''
+  hide(document.querySelector('#delete_motivation_import_' + name));
+}
+
 export function showImportJustificatif(name) {
   show(document.querySelector('#justificatif_motivation_import_' + name));
   hide(document.querySelector('#justificatif_motivation_suggest_' + name));

--- a/app/javascript/new_design/instruction-button.js
+++ b/app/javascript/new_design/instruction-button.js
@@ -22,20 +22,24 @@ export function motivationCancel() {
 }
 
 export function motivationCancelBatch() {
-  document.querySelector('#dropdown_batch' ).classList.remove("open");;
+  document.querySelector('#dropdown_batch').classList.remove('open');
   hide(document.querySelector('.js_delete_motivation'));
 }
 
 export function showDeleteJustificatif(name) {
-  const justificatif = document.querySelector('#dossier_justificatif_motivation_' + name)
+  const justificatif = document.querySelector(
+    '#dossier_justificatif_motivation_' + name
+  );
   if (justificatif.value != '') {
     show(document.querySelector('#delete_motivation_import_' + name));
   }
 }
 
 export function deleteJustificatif(name) {
-  const justificatif = document.querySelector('#dossier_justificatif_motivation_' + name)
-  justificatif.value = ''
+  const justificatif = document.querySelector(
+    '#dossier_justificatif_motivation_' + name
+  );
+  justificatif.value = '';
   hide(document.querySelector('#delete_motivation_import_' + name));
 }
 

--- a/app/javascript/new_design/instruction-button.js
+++ b/app/javascript/new_design/instruction-button.js
@@ -21,7 +21,7 @@ export function motivationCancel() {
   document.querySelectorAll('.js_delete_motivation').forEach(hide);
 }
 
-export function motivationCancelBatch() {
+export function motivationCancelBatchDropdown() {
   document.querySelector('#dropdown_batch').classList.remove('open');
   hide(document.querySelector('.js_delete_motivation'));
 }

--- a/app/javascript/new_design/instruction-button.js
+++ b/app/javascript/new_design/instruction-button.js
@@ -30,8 +30,10 @@ export function showDeleteJustificatif(name) {
   const justificatif = document.querySelector(
     '#dossier_justificatif_motivation_' + name
   );
+
   if (justificatif.value != '') {
     show(document.querySelector('#delete_motivation_import_' + name));
+    document.querySelector('#delete_motivation_import_' + name);
   }
 }
 

--- a/app/views/instructeurs/dossiers/_instruction_button_motivation.html.haml
+++ b/app/views/instructeurs/dossiers/_instruction_button_motivation.html.haml
@@ -32,7 +32,7 @@
     .hidden{ id: "justificatif_motivation_import_#{popup_class}" }
       = file_field :dossier, :justificatif_motivation, direct_upload: true, id: "dossier_justificatif_motivation_#{popup_class}",onchange: "DS.showDeleteJustificatif('#{popup_class}');"
     .hidden{ id: "delete_motivation_import_#{popup_class}" }
-      %button.fr-btn.fr-btn--tertiary-no-outline.fr-btn--icon-left.fr-icon-delete-line.fr-ml-0.fr-mt-1w.js_delete_motivation{ type: 'button', onclick: "DS.deleteJustificatif('#{popup_class}');"} Supprimer le  justificatif
+      %button.fr-btn.fr-btn--tertiary-no-outline.fr-btn--icon-left.fr-icon-delete-line.fr-ml-0.fr-mt-1w.js_delete_motivation{ type: 'button', onclick: "DS.deleteJustificatif('#{popup_class}');" } Supprimer le  justificatif
     .fr-mt-2w
       = button_tag "Annuler", type: :reset, class: 'fr-btn fr-btn--secondary', onclick: 'DS.motivationCancel();'
       = button_tag 'Valider la décision', name: :process_action, value: process_action, class: 'fr-btn fr-mr-0', title: title

--- a/app/views/instructeurs/dossiers/_instruction_button_motivation.html.haml
+++ b/app/views/instructeurs/dossiers/_instruction_button_motivation.html.haml
@@ -32,5 +32,5 @@
     .hidden{ id: "justificatif_motivation_import_#{popup_class}" }
       = file_field :dossier, :justificatif_motivation, direct_upload: true
     .text-right.fr-mt-2w
-      %span.fr-btn.fr-btn--secondary{ onclick: 'DS.motivationCancel();' } Annuler
+      = button_tag "Annuler", type: :reset, class: 'fr-btn fr-btn--secondary', onclick: 'DS.motivationCancel();'
       = button_tag 'Valider la décision', name: :process_action, value: process_action, class: 'fr-btn fr-mr-0', title: title

--- a/app/views/instructeurs/dossiers/_instruction_button_motivation.html.haml
+++ b/app/views/instructeurs/dossiers/_instruction_button_motivation.html.haml
@@ -31,8 +31,8 @@
       %button.fr-btn.fr-btn--tertiary-no-outline.fr-btn--icon-left.fr-icon-attachment-line.fr-ml-0{ type: 'button', onclick: "DS.showImportJustificatif('accept');" } Ajouter un justificatif (optionnel)
     .hidden{ id: "justificatif_motivation_import_#{popup_class}" }
       = file_field :dossier, :justificatif_motivation, direct_upload: true, id: "dossier_justificatif_motivation_#{popup_class}",onchange: "DS.showDeleteJustificatif('#{popup_class}');"
-    .hidden{ id: "delete_motivation_import_#{popup_class}" }
-      %button.fr-btn.fr-btn--tertiary-no-outline.fr-btn--icon-left.fr-icon-delete-line.fr-ml-0.fr-mt-1w.js_delete_motivation{ type: 'button', onclick: "DS.deleteJustificatif('#{popup_class}');" } Supprimer le  justificatif
+    .hidden.js_delete_motivation{ id: "delete_motivation_import_#{popup_class}" }
+      %button.fr-btn.fr-btn--tertiary-no-outline.fr-btn--icon-left.fr-icon-delete-line.fr-ml-0.fr-mt-1w{ type: 'button', onclick: "DS.deleteJustificatif('#{popup_class}');" } Supprimer le  justificatif
     .fr-mt-2w
       = button_tag "Annuler", type: :reset, class: 'fr-btn fr-btn--secondary', onclick: 'DS.motivationCancel();'
       = button_tag 'Valider la décision', name: :process_action, value: process_action, class: 'fr-btn fr-mr-0', title: title

--- a/app/views/instructeurs/dossiers/_instruction_button_motivation.html.haml
+++ b/app/views/instructeurs/dossiers/_instruction_button_motivation.html.haml
@@ -28,12 +28,11 @@
     - else
       = text_area :dossier, :motivation, class: 'fr-input', placeholder: placeholder, required: true
     .optional-justificatif{ id: "justificatif_motivation_suggest_#{popup_class}", onclick: "DS.showImportJustificatif('#{popup_class}');" }
-      .fr-btn.fr-btn--tertiary-no-outline.fr-btn--icon-left.fr-icon-attachment-line.fr-ml-0 Ajouter un justificatif (optionnel)
+      %button.fr-btn.fr-btn--tertiary-no-outline.fr-btn--icon-left.fr-icon-attachment-line.fr-ml-0{ type: 'button', onclick: "DS.showImportJustificatif('accept');" } Ajouter un justificatif (optionnel)
     .hidden{ id: "justificatif_motivation_import_#{popup_class}" }
       = file_field :dossier, :justificatif_motivation, direct_upload: true, id: "dossier_justificatif_motivation_#{popup_class}",onchange: "DS.showDeleteJustificatif('#{popup_class}');"
-
     .hidden{ id: "delete_motivation_import_#{popup_class}" }
-      .fr-btn.fr-btn--tertiary-no-outline.fr-btn--icon-left.fr-icon-delete-line.fr-ml-0{ onclick: "DS.deleteJustificatif('#{popup_class}');"} Supprimer le  justificatif
-    .text-right.fr-mt-2w
+      %button.fr-btn.fr-btn--tertiary-no-outline.fr-btn--icon-left.fr-icon-delete-line.fr-ml-0.fr-mt-1w.js_delete_motivation{ type: 'button', onclick: "DS.deleteJustificatif('#{popup_class}');"} Supprimer le  justificatif
+    .fr-mt-2w
       = button_tag "Annuler", type: :reset, class: 'fr-btn fr-btn--secondary', onclick: 'DS.motivationCancel();'
       = button_tag 'Valider la décision', name: :process_action, value: process_action, class: 'fr-btn fr-mr-0', title: title

--- a/app/views/instructeurs/dossiers/_instruction_button_motivation.html.haml
+++ b/app/views/instructeurs/dossiers/_instruction_button_motivation.html.haml
@@ -30,7 +30,10 @@
     .optional-justificatif{ id: "justificatif_motivation_suggest_#{popup_class}", onclick: "DS.showImportJustificatif('#{popup_class}');" }
       .fr-btn.fr-btn--tertiary-no-outline.fr-btn--icon-left.fr-icon-attachment-line.fr-ml-0 Ajouter un justificatif (optionnel)
     .hidden{ id: "justificatif_motivation_import_#{popup_class}" }
-      = file_field :dossier, :justificatif_motivation, direct_upload: true
+      = file_field :dossier, :justificatif_motivation, direct_upload: true, id: "dossier_justificatif_motivation_#{popup_class}",onchange: "DS.showDeleteJustificatif('#{popup_class}');"
+
+    .hidden{ id: "delete_motivation_import_#{popup_class}" }
+      .fr-btn.fr-btn--tertiary-no-outline.fr-btn--icon-left.fr-icon-delete-line.fr-ml-0{ onclick: "DS.deleteJustificatif('#{popup_class}');"} Supprimer le  justificatif
     .text-right.fr-mt-2w
       = button_tag "Annuler", type: :reset, class: 'fr-btn fr-btn--secondary', onclick: 'DS.motivationCancel();'
       = button_tag 'Valider la décision', name: :process_action, value: process_action, class: 'fr-btn fr-mr-0', title: title


### PR DESCRIPTION
https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/8312

L'instructeur peut désormais retirer une PJ avant de soumettre le formulaire 
- soit en utilisant le bouton "supprimer le justificatif" 
- soit en utilisant le bouton "annuler". Ce dernier reset tout le formulaire.

<img width="516" alt="Capture d’écran 2023-03-27 à 17 42 28" src="https://user-images.githubusercontent.com/6756627/227993254-879e7aba-0854-4fe7-9678-e00f714cc416.png">


