### PR TITLE
fix(vite): target es2021 to have support for async generator

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,7 +39,7 @@ if (shouldBuildLegacy()) {
 
 export default defineConfig({
   resolve: { alias: { '@utils': '/shared/utils.ts' } },
-  build: { sourcemap: true },
+  build: { sourcemap: true, target: 'es2021' },
   plugins
 });
 


### PR DESCRIPTION
Pourrait fixer l'erreur de transpilation : 

`ERROR: Transforming async generator functions to the configured target environment ("chrome64", "edge79", "es2020", "firefox67", "safari11.1" + 2 overrides) is not supported yet`


mais j'ai un gros doute sur les effets de bord que ça produirait

