### PR TITLE
Fix avis: n'affiche pas le form de réponse à la question s'il n'y a pas de question

### DIFF
--- a/app/models/avis.rb
+++ b/app/models/avis.rb
@@ -47,6 +47,7 @@ class Avis < ApplicationRecord
   validates :piece_justificative_file, size: { less_than: FILE_MAX_SIZE }
   validates :introduction_file, size: { less_than: FILE_MAX_SIZE }
   before_validation -> { sanitize_email(:email) }
+  before_validation -> { strip_attribute(:question_label) }
 
   default_scope { joins(:dossier) }
   scope :with_answer, -> { where.not(answer: nil) }
@@ -110,5 +111,11 @@ class Avis < ApplicationRecord
   def remind_by!(revocator)
     return false if !remindable_by?(revocator) || answer.present?
     update!(reminded_at: Time.zone.now)
+  end
+
+  private
+
+  def strip_attribute(attribute)
+    self[attribute] = self[attribute]&.strip&.presence
   end
 end

--- a/app/views/experts/avis/instruction.html.haml
+++ b/app/views/experts/avis/instruction.html.haml
@@ -22,7 +22,7 @@
           = render Attachment::DeleteFormComponent.new
           = form_for @avis, url: expert_avis_path(@avis.procedure, @avis), html: { data: { controller: 'persisted-form', persisted_form_key_value: dom_id(@avis) }, multipart: true } do |f|
 
-            - if @avis.question_label
+            - if @avis.question_label.present?
               .fr-form-group
                 %fieldset.fr-fieldset.fr-fieldset--inline
                   %legend#radio-inline-legend.fr-fieldset__legend.fr-text--regular

--- a/app/views/shared/avis/_form.html.haml
+++ b/app/views/shared/avis/_form.html.haml
@@ -1,4 +1,4 @@
-%section.ask-avis
+%section.ask-avis.fr-mb-4w
   %h1.tab-title Inviter des personnes à donner leur avis
   %p.avis-notice Les invités pourront consulter le dossier, donner un avis et contribuer au fil de messagerie. Ils ne pourront pas modifier le dossier.
   - if @dossier.procedure.experts_require_administrateur_invitation

--- a/spec/models/avis_spec.rb
+++ b/spec/models/avis_spec.rb
@@ -149,4 +149,16 @@ RSpec.describe Avis, type: :model do
       end
     end
   end
+
+  describe "question_label cleanup" do
+    it "nullify empty" do
+      avis = create(:avis, question_label: " ")
+      expect(avis.question_label).to be_nil
+    end
+
+    it "strip" do
+      avis = create(:avis, question_label: "my question ")
+      expect(avis.question_label).to eq("my question")
+    end
+  end
 end

--- a/spec/views/experts/avis/instruction.html.haml_spec.rb
+++ b/spec/views/experts/avis/instruction.html.haml_spec.rb
@@ -3,6 +3,7 @@ describe 'experts/avis/instruction.html.haml', type: :view do
   let(:claimant) { create(:instructeur) }
   let(:procedure) { create(:procedure) }
   let(:experts_procedure) { create(:experts_procedure, expert: expert, procedure: procedure) }
+  let(:confidentiel) { false }
   let(:avis) { create(:avis, confidentiel: confidentiel, claimant: claimant, experts_procedure: experts_procedure) }
 
   before do
@@ -22,5 +23,17 @@ describe 'experts/avis/instruction.html.haml', type: :view do
   context 'with a not confidential avis' do
     let(:confidentiel) { false }
     it { is_expected.to have_text("Cet avis est partagé avec les autres experts") }
+  end
+
+  context 'when the avis has a question' do
+    let(:avis) { create(:avis, question_label: "is it useful?", claimant: claimant, experts_procedure: experts_procedure) }
+
+    it { is_expected.to have_text(avis.question_label) }
+    it { is_expected.to have_unchecked_field("oui") }
+  end
+
+  context 'when the avis has no question' do
+    let(:avis) { create(:avis, question_label: "", claimant: claimant, experts_procedure: experts_procedure) }
+    it { is_expected.not_to have_unchecked_field("oui") }
   end
 end


### PR DESCRIPTION
Le formulaire de demande d'avis envoyant une string vide quand il n'y a pas de question, on nullify ce string vide avant insertion en base
introduit par https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/8789