### PR TITLE
Revert "fix(a11y): add a title in simple renderer links and autolinks"

### DIFF
--- a/app/components/simple_format_component.rb
+++ b/app/components/simple_format_component.rb
@@ -28,9 +28,13 @@ class SimpleFormatComponent < ApplicationComponent
       .join("\n\n")   #
     @allow_a = allow_a
     @renderer = Redcarpet::Markdown.new(
-      Redcarpet::BareRenderer.new(class_names_map:),
+      Redcarpet::BareRenderer.new(link_attributes: external_link_attributes, class_names_map: class_names_map),
       REDCARPET_EXTENSIONS.merge(autolink: @allow_a)
     )
+  end
+
+  def external_link_attributes
+    { target: '_blank', rel: 'noopener noreferrer' }
   end
 
   def tags
@@ -42,6 +46,6 @@ class SimpleFormatComponent < ApplicationComponent
   end
 
   def attributes
-    ['target', 'rel', 'href', 'class', 'title']
+    ['target', 'rel', 'href', 'class']
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -142,7 +142,7 @@ module ApplicationHelper
   end
 
   def new_tab_suffix(title)
-    [title, I18n.t('utils.new_tab')].compact.join(' — ')
+    "#{title} — #{I18n.t('utils.new_tab')}"
   end
 
   def download_details(attachment)

--- a/app/lib/redcarpet/bare_renderer.rb
+++ b/app/lib/redcarpet/bare_renderer.rb
@@ -1,7 +1,6 @@
 module Redcarpet
   class BareRenderer < Redcarpet::Render::HTML
     include ActionView::Helpers::TagHelper
-    include ApplicationHelper
 
     # won't use rubocop tag method because it is missing output buffer
     # rubocop:disable Rails/ContentTag
@@ -17,17 +16,6 @@ module Redcarpet
     def paragraph(text)
       content_tag(:p, text, { class: @options[:class_names_map].fetch(:paragraph) {} }, false)
     end
-
-    def link(href, title, content)
-      content_tag(:a, content, { href:, title: new_tab_suffix(title), **external_link_attributes }, false)
-    end
-
-    def autolink(link, link_type)
-      return super unless link_type == :url
-
-      link(link, nil, link)
-    end
-
     # rubocop:enable Rails/ContentTag
   end
 end

--- a/spec/components/simple_format_component_spec.rb
+++ b/spec/components/simple_format_component_spec.rb
@@ -64,11 +64,6 @@ TEXT
     context 'enabled' do
       let(:allow_a) { true }
       it { expect(page).to have_selector("a") }
-      it "inject expected attributes" do
-        link = page.find_link("https://www.demarches-simplifiees.fr").native
-        expect(link[:rel]).to eq("noopener noreferrer")
-        expect(link[:title]).to eq("Nouvel onglet")
-      end
     end
 
     context 'disabled' do


### PR DESCRIPTION
This reverts commit 40a303f6a601e386ca83222871eb3f66d77345ca.