### PR TITLE
Fix: autolink manuellement les liens qui ne sont pas des urls

### DIFF
--- a/app/lib/redcarpet/bare_renderer.rb
+++ b/app/lib/redcarpet/bare_renderer.rb
@@ -23,9 +23,14 @@ module Redcarpet
     end
 
     def autolink(link, link_type)
-      return super unless link_type == :url
-
-      link(link, nil, link)
+      case link_type
+      when :url
+        link(link, nil, link)
+      when :email
+        content_tag(:a, link, { href: "mailto:#{link}" })
+      else
+        link
+      end
     end
 
     # rubocop:enable Rails/ContentTag

--- a/spec/components/simple_format_component_spec.rb
+++ b/spec/components/simple_format_component_spec.rb
@@ -58,6 +58,8 @@ TEXT
     let(:text) do
       <<~TEXT
         bonjour https://www.demarches-simplifiees.fr
+        nohttp www.ds.io
+        ecrivez à ds@rspec.io
       TEXT
     end
 
@@ -66,6 +68,19 @@ TEXT
       it { expect(page).to have_selector("a") }
       it "inject expected attributes" do
         link = page.find_link("https://www.demarches-simplifiees.fr").native
+        expect(link[:rel]).to eq("noopener noreferrer")
+        expect(link[:title]).to eq("Nouvel onglet")
+      end
+
+      it "convert email autolinks" do
+        link = page.find_link("ds@rspec.io").native
+        expect(link[:href]).to eq("mailto:ds@rspec.io")
+        expect(link[:rel]).to be_nil
+      end
+
+      it "convert www only" do
+        link = page.find_link("www.ds.io").native
+        expect(link[:href]).to eq("http://www.ds.io")
         expect(link[:rel]).to eq("noopener noreferrer")
         expect(link[:title]).to eq("Nouvel onglet")
       end


### PR DESCRIPTION
On ne peut pas appeler super() qui est une méthode en C, pas en ruby. Donc on doit gérer manuellement les cas possibles traités normalement en C.

https://demarches-simplifiees.sentry.io/issues/4045570438/?project=1429550