### PR TITLE
Fix champ explication: cache le texte qui doit être caché

### DIFF
--- a/app/components/editable_champ/explication_component/explication_component.html.haml
+++ b/app/components/editable_champ/explication_component/explication_component.html.haml
@@ -6,5 +6,5 @@
     - if @champ.collapsible_explanation_enabled? && @champ.collapsible_explanation_text.present?
       %p.fr-my-2w
         %button{ type: "button", "aria-controls": dom_id(@champ, :explanation), "aria-expanded": "false", href: dom_id(@champ, :explanation), class: "fr-btn ft-btn--sm fr-btn--secondary" } Lire plus
-      %p.fr-collapse{ id: dom_id(@champ, :explanation) }
+      .fr-collapse{ id: dom_id(@champ, :explanation) }
         = render SimpleFormatComponent.new(@champ.collapsible_explanation_text, allow_a: true)

--- a/spec/components/editable_champ/explication_component/explication_component_spec.rb
+++ b/spec/components/editable_champ/explication_component/explication_component_spec.rb
@@ -1,0 +1,24 @@
+describe EditableChamp::ExplicationComponent, type: :component do
+  let(:component) {
+    described_class.new(form: instance_double(ActionView::Helpers::FormBuilder, object_name: "dossier[champs_public_attributes]"), champ:)
+  }
+
+  let(:champ) { create(:champ_explication) }
+
+  describe 'no description' do
+    subject { render_inline(component).to_html }
+
+    it { is_expected.not_to have_button("Lire plus") }
+  end
+
+  describe 'collapsed text is collapsed' do
+    subject { render_inline(component).to_html }
+
+    before do
+      champ.type_de_champ.update!(collapsible_explanation_enabled: "1", collapsible_explanation_text: "hide me")
+    end
+
+    it { is_expected.to have_button("Lire plus") }
+    it { is_expected.to have_selector(".fr-collapse", text: "hide me") }
+  end
+end


### PR DESCRIPTION
le simple formatter wrap le texte dans un `<p>`,  qui n'est pas imbricable dans un autre `<p>`

https://secure.helpscout.net/conversation/2198960649/2025293?folderId=1653799