### PR TITLE
Fix (manager): ne trie pas par created_at pour ne pas casser la prod

### DIFF
--- a/app/controllers/manager/application_controller.rb
+++ b/app/controllers/manager/application_controller.rb
@@ -5,7 +5,7 @@ module Manager
 
     def default_params
       request.query_parameters[resource_name] ||= {
-        order: "created_at",
+        order: "id",
         direction: "desc"
       }
     end
@@ -23,6 +23,15 @@ module Manager
     end
 
     private
+
+    def sorting_attribute
+      attribute = super
+
+      # do not sort by non-indexed created_at. This require a full table scan, locking every other transactions.
+      return :id if attribute.to_sym == :created_at
+
+      attribute
+    end
 
     # private method called by rails fwk
     # see https://github.com/roidrage/lograge

--- a/app/dashboards/administrateur_dashboard.rb
+++ b/app/dashboards/administrateur_dashboard.rb
@@ -24,6 +24,7 @@ class AdministrateurDashboard < Administrate::BaseDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = [
+    :id,
     :user,
     :created_at,
     :procedures,

--- a/app/dashboards/instructeur_dashboard.rb
+++ b/app/dashboards/instructeur_dashboard.rb
@@ -23,6 +23,7 @@ class InstructeurDashboard < Administrate::BaseDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = [
+    :id,
     :user,
     :created_at
   ].freeze

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -23,6 +23,7 @@ class UserDashboard < Administrate::BaseDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = [
+    :id,
     :email,
     :created_at
   ].freeze


### PR DESCRIPTION
incident du 30/03 14h

Un tri par created_at, non indexé, cause un full scan de la table, ce qui lock les transactions en écriture sur la table `dossiers`, et provoque une grosse charge CPU de la base et des timeout en cascade.

On override ce tri par id , qui est fonctionnement équivalent.