### PR TITLE
[Fix] Petites améliorations de la vue expert

### DIFF
--- a/app/views/experts/avis/_header.html.haml
+++ b/app/views/experts/avis/_header.html.haml
@@ -1,12 +1,15 @@
 .sub-header
   .container
     .flex.justify-between
-      %ul.breadcrumbs
-        %li= link_to('Avis', expert_all_avis_path)
-        %li
-          = link_to(dossier.procedure.libelle.truncate_words(10), procedure_expert_avis_index_path(avis.procedure), class: "fr-link")
-          = procedure_badge(dossier.procedure)
-        %li= link_to("Dossier nº #{dossier.id}", expert_avis_path(avis.procedure, avis))
+      %nav.fr-breadcrumb{"aria-label" => "vous êtes ici :", role: "navigation"}
+        %button.fr-breadcrumb__button{"aria-controls" => "breadcrumb-1", "aria-expanded" => "false"} Voir le fil d’Ariane
+        #breadcrumb-1.fr-collapse
+          %ol.fr-breadcrumb__list
+            %li= link_to('Avis', expert_all_avis_path, class: 'fr-breadcrumb__link')
+            %li
+              = link_to(dossier.procedure.libelle.truncate_words(10), procedure_expert_avis_index_path(avis.procedure), class: "fr-breadcrumb__link")
+              = procedure_badge(dossier.procedure)
+            %li= content_tag("a","Dossier nº #{dossier.id}", class: 'fr-breadcrumb__link', 'aria-current': 'page')
 
       .header-actions
         .fr-download

--- a/app/views/experts/avis/_header.html.haml
+++ b/app/views/experts/avis/_header.html.haml
@@ -1,8 +1,8 @@
 .sub-header
   .container
     .flex.justify-between
-      %nav.fr-breadcrumb{"aria-label" => "vous êtes ici :", role: "navigation"}
-        %button.fr-breadcrumb__button{"aria-controls" => "breadcrumb-1", "aria-expanded" => "false"} Voir le fil d’Ariane
+      %nav.fr-breadcrumb{ "aria-label" => "vous êtes ici :", role: "navigation" }
+        %button.fr-breadcrumb__button{ "aria-controls" => "breadcrumb-1", "aria-expanded" => "false" } Voir le fil d’Ariane
         #breadcrumb-1.fr-collapse
           %ol.fr-breadcrumb__list
             %li= link_to('Avis', expert_all_avis_path, class: 'fr-breadcrumb__link')

--- a/config/locales/models/avis/en.yml
+++ b/config/locales/models/avis/en.yml
@@ -28,7 +28,7 @@ en:
       give_avis: Give your opinion
       see_avis: Read opinions
       ask_avis: Ask for an opinion
-      ask_new_avis: Ask for a new opinion
+      ask_new_avis: Ask for another opinion
     information_text:
       no_new_avis_text: The file has been proceed
       no_new_avis_text_detail: Opinion requests are closed

--- a/config/locales/models/avis/fr.yml
+++ b/config/locales/models/avis/fr.yml
@@ -28,7 +28,7 @@ fr:
       give_avis: Donner votre avis
       see_avis: Voir les avis
       ask_avis: Demander un avis
-      ask_new_avis: Demander un nouvel avis
+      ask_new_avis: Demander un autre avis
     information_text:
       no_new_avis_text: Le dossier a été traité
       no_new_avis_text_detail: Les demandes d'avis ne sont plus autorisées

--- a/spec/system/experts/expert_spec.rb
+++ b/spec/system/experts/expert_spec.rb
@@ -78,7 +78,7 @@ describe 'Inviting an expert:' do
       expect(page).to have_content('Ma réponse d’expert : c’est un oui.')
       expect(page).to have_content('RIB.pdf')
 
-      within('.breadcrumbs') { click_on 'Avis' }
+      within('.fr-breadcrumb__list') { click_on 'Avis' }
       expect(page).to have_text('0 avis à donner')
       expect(page).to have_text('1 avis donné')
     end
@@ -114,7 +114,7 @@ describe 'Inviting an expert:' do
       expect(page).to have_text('Vous')
       expect(page).to have_text('non')
 
-      within('.breadcrumbs') { click_on 'Avis' }
+      within('.fr-breadcrumb__list') { click_on 'Avis' }
       expect(page).to have_text('1 avis donné')
     end
 


### PR DESCRIPTION
Dans la suite de la PR https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/8770 pour améliorer l'UX de la demande d'avis, 2 petits améliorations : 
- fix du fil d'ariane pour la vue expert
- amélioration du wording pour le rendre plus compréhensif.

**APRES**
<img width="1228" alt="Capture d’écran 2023-03-30 à 17 29 37" src="https://user-images.githubusercontent.com/6756627/228888695-a8db4e6d-1c8d-42f1-806d-5271e5ec6aea.png">

**AVANT**

<img width="1240" alt="Capture d’écran 2023-03-30 à 17 33 54" src="https://user-images.githubusercontent.com/6756627/228888699-875446dd-0496-4258-8f65-eee13c3bab9a.png">
