### PR TITLE
[fix] bug dans le sujet des mails de notification si le libelle de la procedure contient un apostrophe

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -26,7 +26,7 @@ class NotificationMailer < ApplicationMailer
     attachments[@attachment[:filename]] = @attachment[:content] if @attachment.present?
 
     I18n.with_locale(@dossier.user_locale) do
-      mail(subject: @subject, to: @email, template_name: 'send_notification')
+      mail(subject: Nokogiri::HTML.parse(@subject).text, to: @email, template_name: 'send_notification')
     end
   end
 

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -124,4 +124,21 @@ RSpec.describe NotificationMailer, type: :mailer do
       it { expect(mail.subject.length).to be <= 100 }
     end
   end
+
+  describe 'subject with apostrophe' do
+    let(:procedure) { create(:simple_procedure, libelle: "Mon titre avec l'apostrophe") }
+    let(:dossier) { create(:dossier, :en_instruction, :with_individual, :with_service, user: user, procedure: procedure) }
+    let(:email_template) { create(:closed_mail, subject:, body: 'Your dossier was accepted. Thanks.') }
+
+    before do
+      dossier.procedure.closed_mail = email_template
+    end
+
+    subject(:mail) { described_class.send_accepte_notification(dossier) }
+
+    context "subject has a special character" do
+      let(:subject) { '--libellé démarche--' }
+      it { expect(mail.subject).to eq("Mon titre avec l'apostrophe") }
+    end
+  end
 end


### PR DESCRIPTION
https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/8775