### PR TITLE
Can update defaut groupe instructeur

### DIFF
--- a/app/assets/stylesheets/groupe_instructeur.scss
+++ b/app/assets/stylesheets/groupe_instructeur.scss
@@ -1,6 +1,10 @@
 .groupe-instructeur {
-  .actions {
-    width: 200px;
+  .setup {
     text-align: center;
+    width: 100px;
+  }
+  .actions {
+    text-align: center;
+    width: 250px;
   }
 }

--- a/app/assets/stylesheets/routing_rules_component.scss
+++ b/app/assets/stylesheets/routing_rules_component.scss
@@ -29,6 +29,10 @@
 
     .value {
       width: 200px;
+
+      select {
+        width: 100%;
+      }
     }
   }
 
@@ -54,6 +58,15 @@
     input.alert,
     select.alert {
       border-color: $dark-red;
+    }
+  }
+
+  .form.defaut-groupe {
+    padding: $default-spacer;
+
+    label {
+      width: 600px;
+      font-size: 16px;
     }
   }
 }

--- a/app/components/procedure/routing_rules_component/routing_rules_component.fr.yml
+++ b/app/components/procedure/routing_rules_component/routing_rules_component.fr.yml
@@ -1,7 +1,7 @@
 ---
 fr:
   select: Sélectionner
-  apply_routing_rules: Appliquer des règles de routage
+  apply_routing_rules: Règles de routage
   routing_rules_notice_html: |
     <p>Ajoutez des règles de routage à partir de champs « choix simple » créés dans le <a href="%{path}">formulaire</a>.</p>
     <p>Les dossiers seront routées vers le premier groupe affiché dont la règle correspond.</p>

--- a/app/components/procedure/routing_rules_component/routing_rules_component.html.haml
+++ b/app/components/procedure/routing_rules_component/routing_rules_component.html.haml
@@ -1,6 +1,5 @@
 .card#routing-rules
-  .card-title
-    = t('.apply_routing_rules')
+  %h2.card-title= t('.apply_routing_rules')
   - if can_route?
     .notice
       = t('.routing_rules_notice_html', path: champs_admin_procedure_path(@procedure_id))

--- a/app/components/procedure/routing_rules_component/routing_rules_component.html.haml
+++ b/app/components/procedure/routing_rules_component/routing_rules_component.html.haml
@@ -28,5 +28,14 @@
                 %td.target= targeted_champ_tag(targeted_champ, row_index)
                 %td.operator est égal à
                 %td.value= value_tag(targeted_champ, value, row_index)
+
+    = form_tag admin_procedure_update_defaut_groupe_instructeur_path,
+      class: 'form flex align-baseline defaut-groupe',
+      data: { controller: 'autosave' } do
+      = label_tag :defaut_groupe_instructeur_id, 'Et si aucune règle ne correspond, router vers :'
+      = select_tag :defaut_groupe_instructeur_id,
+        options_for_select(@groupe_instructeurs.pluck(:label, :id), selected: @revision.procedure.defaut_groupe_instructeur.id),
+        class: 'width-100'
+
   - else
     .notice= t('.routing_rules_warning_html', path: champs_admin_procedure_path(@procedure_id))

--- a/app/controllers/administrateurs/routing_controller.rb
+++ b/app/controllers/administrateurs/routing_controller.rb
@@ -12,6 +12,10 @@ module Administrateurs
       groupe_instructeur.update!(routing_rule: ds_eq(left, right))
     end
 
+    def update_defaut_groupe_instructeur
+      @procedure.update!(defaut_groupe_instructeur_id: defaut_groupe_instructeur_id)
+    end
+
     private
 
     def targeted_champ_changed?
@@ -34,8 +38,12 @@ module Administrateurs
       routing_params[:groupe_instructeur_id]
     end
 
+    def defaut_groupe_instructeur_id
+      routing_params[:defaut_groupe_instructeur_id]
+    end
+
     def routing_params
-      params.permit(:targeted_champ, :value, :groupe_instructeur_id)
+      params.permit(:targeted_champ, :value, :groupe_instructeur_id, :defaut_groupe_instructeur_id)
     end
   end
 end

--- a/app/controllers/administrateurs/routing_controller.rb
+++ b/app/controllers/administrateurs/routing_controller.rb
@@ -23,11 +23,11 @@ module Administrateurs
     end
 
     def targeted_champ
-      Logic.from_json(routing_params[:targeted_champ])
+      Logic.from_json(params[:targeted_champ])
     end
 
     def value
-      Logic.from_json(routing_params[:value])
+      Logic.from_json(params[:value])
     end
 
     def groupe_instructeur
@@ -35,15 +35,11 @@ module Administrateurs
     end
 
     def groupe_instructeur_id
-      routing_params[:groupe_instructeur_id]
+      params[:groupe_instructeur_id]
     end
 
     def defaut_groupe_instructeur_id
-      routing_params[:defaut_groupe_instructeur_id]
-    end
-
-    def routing_params
-      params.permit(:targeted_champ, :value, :groupe_instructeur_id, :defaut_groupe_instructeur_id)
+      params[:defaut_groupe_instructeur_id]
     end
   end
 end

--- a/app/controllers/administrateurs/routing_controller.rb
+++ b/app/controllers/administrateurs/routing_controller.rb
@@ -13,7 +13,8 @@ module Administrateurs
     end
 
     def update_defaut_groupe_instructeur
-      @procedure.update!(defaut_groupe_instructeur_id: defaut_groupe_instructeur_id)
+      new_defaut = @procedure.groupe_instructeurs.find(defaut_groupe_instructeur_id)
+      @procedure.update!(defaut_groupe_instructeur: new_defaut)
     end
 
     private

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -208,7 +208,7 @@ class Procedure < ApplicationRecord
   has_one :refused_mail, class_name: "Mails::RefusedMail", dependent: :destroy
   has_one :without_continuation_mail, class_name: "Mails::WithoutContinuationMail", dependent: :destroy
 
-  has_one :defaut_groupe_instructeur, -> { active.order(id: :asc) }, class_name: 'GroupeInstructeur', inverse_of: false
+  belongs_to :defaut_groupe_instructeur, class_name: 'GroupeInstructeur', inverse_of: false, optional: true
 
   has_one_attached :logo
   has_one_attached :notice

--- a/app/views/administrateurs/groupe_instructeurs/_edit.html.haml
+++ b/app/views/administrateurs/groupe_instructeurs/_edit.html.haml
@@ -44,13 +44,13 @@
         %tr
           // i18n-tasks-use t('.existing_groupe')
           %th{ colspan: 2 }= t(".existing_groupe", count: groupes_instructeurs.total_count)
-          %th
+          %th.actions
             = link_to "Exporter au format CSV", export_groupe_instructeurs_admin_procedure_groupe_instructeurs_path(procedure, format: :csv)
       %tbody
         - groupes_instructeurs.each do |group|
           %tr
             %td= group.label
-            %td.actions= link_to t('.set_up'), admin_procedure_groupe_instructeur_path(procedure, group)
+            %td.setup= link_to t('.set_up'), admin_procedure_groupe_instructeur_path(procedure, group)
             - if group.can_delete?
               %td.actions
                 = link_to admin_procedure_groupe_instructeur_path(procedure, group), { method: :delete, class: 'button', data: { confirm: t('.group_management.delete_confirmation', group_name: group.label) }} do

--- a/app/views/administrateurs/groupe_instructeurs/_edit.html.haml
+++ b/app/views/administrateurs/groupe_instructeurs/_edit.html.haml
@@ -11,8 +11,7 @@
       = f.submit t('.button.rename'), class: 'button primary send'
 
 .card
-  .card-title
-    = t('.group_management.title')
+  %h2.card-title= t('.group_management.title')
 
   = form_for :groupe_instructeur, html: { class: 'form' } do |f|
     = f.label :label do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -506,6 +506,7 @@ Rails.application.routes.draw do
       end
 
       patch :update, controller: 'routing', as: :routing_rules
+      patch :update_defaut_groupe_instructeur, controller: 'routing', as: :update_defaut_groupe_instructeur
 
       put 'clone'
       put 'archive'

--- a/spec/controllers/administrateurs/routing_controller_spec.rb
+++ b/spec/controllers/administrateurs/routing_controller_spec.rb
@@ -49,4 +49,22 @@ describe Administrateurs::RoutingController, type: :controller do
       end
     end
   end
+
+  describe "#update_defaut_groupe_instructeur" do
+    let(:procedure) { create(:procedure) }
+    let(:gi_2) { procedure.groupe_instructeurs.create(label: 'groupe 2') }
+    let(:params) do
+      {
+        procedure_id: procedure.id,
+        defaut_groupe_instructeur_id: gi_2.id
+      }
+    end
+
+    before do
+      post :update_defaut_groupe_instructeur, params: params, format: :turbo_stream
+      procedure.reload
+    end
+
+    it { expect(procedure.defaut_groupe_instructeur.id).to eq(gi_2.id) }
+  end
 end


### PR DESCRIPTION
L'administrateur peut choisir le groupe d'instruction par défaut. Celui qui prendra les dossiers qui ne correspondent à aucune règle de routage.

![Screenshot 2023-04-11 at 10-39-44 demarches-simplifiees fr](https://user-images.githubusercontent.com/907405/231104934-7cef04f2-d24e-443b-926b-694dd5d36fb9.png)
