### PR TITLE
fix(prefill) Commune exemple

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -251,7 +251,7 @@ en:
           pays_html: An <a href="https://en.wikipedia.org/wiki/ISO_3166-2" target="_blank" rel="noopener noreferrer">ISO 3166-2 country code</a>
           regions_html: An <a href="https://fr.wikipedia.org/wiki/R%C3%A9gion_fran%C3%A7aise" target="_blank" rel="noopener noreferrer">INSEE region code</a>
           departements_html: A <a href="https://fr.wikipedia.org/wiki/Num%C3%A9rotation_des_d%C3%A9partements_fran%C3%A7ais" target="_blank">department number</a>
-          communes_html: An array of the department code and the <a href="https://geo.api.gouv.fr/communes" target="_blank" rel="noopener noreferrer">INSEE commune code</a>
+          communes_html: An array of the postal code and the <a href="https://geo.api.gouv.fr/communes" target="_blank" rel="noopener noreferrer">INSEE commune code</a>
           address_html: An address EXACTLY formated as the label returned by <a href="https://adresse.data.gouv.fr" target="_blank" rel="noopener noreferrer">the Base Adresse Nationale</a>
           drop_down_list_html: A choice among those selected when the procedure was created
           date_html: ISO8601 date

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -247,7 +247,7 @@ fr:
           pays_html: Un <a href="https://en.wikipedia.org/wiki/ISO_3166-2" target="_blank" rel="noopener noreferrer">code pays ISO 3166-2</a>
           regions_html: Un <a href="https://fr.wikipedia.org/wiki/R%C3%A9gion_fran%C3%A7aise" target="_blank" rel="noopener noreferrer">code INSEE de région</a>
           departements_html: Un <a href="https://fr.wikipedia.org/wiki/Num%C3%A9rotation_des_d%C3%A9partements_fran%C3%A7ais" target="_blank">numéro de département</a>
-          communes_html: Un tableau contenant le code de département et <a href="https://geo.api.gouv.fr/communes" target="_blank" rel="noopener noreferrer">le code INSEE de la commune</a>
+          communes_html: Un tableau contenant le code postal et <a href="https://geo.api.gouv.fr/communes" target="_blank" rel="noopener noreferrer">le code INSEE de la commune</a>
           address_html: Une adresse EXACTEMENT formatée telle que le label retourné par <a href="https://adresse.data.gouv.fr" target="_blank" rel="noopener noreferrer">la Base Adresse Nationale</a>
           drop_down_list_html: Un choix parmi ceux sélectionnés à la création de la procédure
           datetime_html: Datetime au format ISO8601


### PR DESCRIPTION
L'exemple donné pour le préremplissage d'un champ de commune n'est pas cohérent avec le texte. En effet, l'exemple indiqué un code postal et le texte le code département.


Avant
![Screenshot 2023-04-03 at 16-38-32 Aide Beaumont-en-Verdunois · demarches-simplifiees fr](https://user-images.githubusercontent.com/1410356/229543111-2451caab-3cb8-4653-b2ae-c43d30eab866.png)

Après (normalement, j'avoue j'ai pas lancé en local)

![Screenshot 2023-04-03 at 16-39-10 Aide Beaumont-en-Verdunois · demarches-simplifiees fr](https://user-images.githubusercontent.com/1410356/229543136-8edb95ce-1702-4c2e-bd35-15ff949e0d95.png)
