### PR TITLE
a11y : add mobile environment test to accessibility statement

### DIFF
--- a/app/views/static_pages/accessibility_statement.html.haml
+++ b/app/views/static_pages/accessibility_statement.html.haml
@@ -59,6 +59,10 @@
               = t('views.accessibility_statement.preparation.environment_two')
             %li
               = t('views.accessibility_statement.preparation.environment_three')
+            %li
+              = t('views.accessibility_statement.preparation.environment_four')
+            %li
+              = t('views.accessibility_statement.preparation.environment_five')
           %h3
             = t('views.accessibility_statement.preparation.subtitle_three')
           %ul.fr-mb-2w

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -149,6 +149,8 @@ en:
         environment_one: "Firefox 111.0.1 and NVDA 2022.4"
         environment_two: "Safari and VoiceOver (version available on macOS Monterey 12.6.3)"
         environment_three: "Edge and JAWS 2020"
+        environment_four: "Google Chrome and TalkBack 9.1"
+        environment_five: "Safari and VoiceOver (version available on iOS 15.7.4)"
         subtitle_three: "Tools for assessing accessibility"
         tool_one: "RGAA Assistant (Firefox extension)"
         tool_two: "Web Developer (Firefox extension)"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -145,6 +145,8 @@ fr:
         environment_one: "Firefox 111.0.1 et NVDA 2022.4"
         environment_two: "Safari et VoiceOver (version disponible sur macOS Monterey 12.6.3)"
         environment_three: "Edge et JAWS 2020"
+        environment_four: "Google Chrome et TalkBack 9.1"
+        environment_five: "Safari et VoiceOver (version disponible sur iOS 15.7.4)"
         subtitle_three: "Outils pour évaluer l’accessibilité"
         tool_one: "Assistant RGAA (extension Firefox)"
         tool_two: "Web Developer (extension Firefox)"


### PR DESCRIPTION
[Pages Déclaration d’accessibilité et Mentions légales (hors Gitbook) #8589](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/8589)
<img width="838" alt="Capture d’écran 2023-04-04 à 08 38 31" src="https://user-images.githubusercontent.com/49035942/229708484-5c5d727a-08b5-4122-b27d-0462789902fe.png">
