### PR TITLE
[bug] Changer couleur de fond pour faire apparaitre bouton conditionnelle sur les sections

### DIFF
--- a/app/assets/stylesheets/_colors.scss
+++ b/app/assets/stylesheets/_colors.scss
@@ -23,5 +23,6 @@ $light-yellow: #FFFFDE;
 $blue-france-700: #00006D;
 $blue-france-500: #000091;
 $blue-france-400: #7F7FC8;
+$blue-cumulus-950: #E6EEFE;
 $g700: #383838;
 $alt-blue-france: rgba(245, 245, 254, 1);

--- a/app/assets/stylesheets/procedure_champs_editor.scss
+++ b/app/assets/stylesheets/procedure_champs_editor.scss
@@ -67,7 +67,7 @@
     }
 
     .head {
-      background-color: #D9ECFF;
+      background-color: #FAFDFF;
 
       select {
         margin-bottom: 0px;
@@ -75,23 +75,10 @@
     }
 
     &.type-header-section {
-      &,
+      background-color: $blue-cumulus-950;
+
       .head {
-        background-color: $blue-france-500;
-      }
-
-      .handle.icon {
-        filter: contrast(0%) brightness(200%);
-        opacity: 0.9;
-      }
-
-      label {
-        color: $light-grey;
-      }
-
-      .conditionnel,
-      p {
-        color: $white;
+        background-color: $blue-cumulus-950;
       }
     }
 

--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
@@ -1,5 +1,5 @@
 %li.type-de-champ.flex.column.justify-start{ html_options }
-  .flex.justify-start.section.head{ class: type_de_champ.header_section? ? '' : 'hr' }
+  .flex.justify-start.section.head.hr
     .handle.small.icon-only.icon.move-handle{ title: "Déplacer le champ vers le haut ou vers le bas" }
     .flex.justify-start.delete
       = button_to type_de_champ_path, class: 'button small icon-only danger', method: :delete, form: { data: { turbo_confirm: 'Êtes vous sûr de vouloir supprimer ce champ ?' } } do


### PR DESCRIPTION
Closes #8700 

Vu avec Olivier. On en profite pour se rapprocher un peu plus de la futur refonte.

**AVANT (le bouton n'est pas visible sur le fond foncé)**  
<img width="742" alt="Capture d’écran 2023-04-04 à 10 41 04" src="https://user-images.githubusercontent.com/6756627/229737296-cae8a013-1a54-4eda-87ed-67b4263e78be.png">

**APRES**
<img width="728" alt="Capture d’écran 2023-04-04 à 10 40 42" src="https://user-images.githubusercontent.com/6756627/229737302-baea5252-53af-4082-9e33-24b66856cce3.png">
