### PR TITLE
fix(date): ne crash pas lorsqu'un champ date n'as pas une date standard

### DIFF
--- a/app/models/champs/date_champ.rb
+++ b/app/models/champs/date_champ.rb
@@ -30,11 +30,11 @@ class Champs::DateChamp < Champ
 
   def to_s
     value.present? ? I18n.l(Time.zone.parse(value), format: '%d %B %Y') : ""
+  rescue ArgumentError
+    value.presence || "" # old dossiers can have not parseable dates
   end
 
-  def for_tag
-    value.present? ? I18n.l(Time.zone.parse(value), format: '%d %B %Y') : ""
-  end
+  alias for_tag to_s
 
   private
 

--- a/spec/models/champs/date_champ_spec.rb
+++ b/spec/models/champs/date_champ_spec.rb
@@ -45,6 +45,18 @@ describe Champs::DateChamp do
     end
   end
 
+  describe "#to_s" do
+    it "format the date" do
+      champ_with_value("2020-06-20")
+      expect(date_champ.to_s).to eq("20 juin 2020")
+    end
+
+    it "does not fail when value is not iso" do
+      champ_with_value("2023-30-01")
+      expect(date_champ.to_s).to eq("2023-30-01")
+    end
+  end
+
   def champ_with_value(number)
     date_champ.tap { |c| c.value = number }
   end


### PR DESCRIPTION
On a des vieux dossiers pour lesquelles les dates ne sont pas normalisables et parsables, ce qui provoque des crash à l'affichage

https://demarches-simplifiees.sentry.io/issues/3891411025
https://demarches-simplifiees.sentry.io/issues/4052234392