### PR TITLE
feat: add ability to use local sendmail binary to send emails

### DIFF
--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -183,3 +183,8 @@ SMTP_USER=""
 SMTP_PASS=""
 SMTP_TLS=""
 SMTP_AUTHENTICATION="plain"
+
+# Sendmail
+SENDMAIL_ENABLED="disabled"
+SENDMAIL_LOCATION="/usr/sbin/sendmail"
+SENDMAIL_ARGUMENTS="-i"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,7 +88,7 @@ Rails.application.configure do
       authentication:       ENV.fetch("SMTP_AUTHENTICATION"),
       enable_starttls_auto: ENV.fetch("SMTP_TLS").present?
     }
-  elsif ENV['SENDMAIL_ENABLED']  = 'enabled'
+  elsif ENV['SENDMAIL_ENABLED'] == 'enabled'
     config.action_mailer.delivery_method = :sendmail
     config.action_mailer.sendmail_settings = {
       location: ENV.fetch("SENDMAIL_LOCATION"),

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,6 +88,12 @@ Rails.application.configure do
       authentication:       ENV.fetch("SMTP_AUTHENTICATION"),
       enable_starttls_auto: ENV.fetch("SMTP_TLS").present?
     }
+  elsif ENV['SENDMAIL_ENABLED']  = 'enabled'
+    config.action_mailer.delivery_method = :sendmail
+    config.action_mailer.sendmail_settings = {
+      location: ENV.fetch("SENDMAIL_LOCATION"),
+      arguments: ENV.fetch("SENDMAIL_ARGUMENTS")
+    }
   else
     sendinblue_weigth = ENV.fetch('SENDINBLUE_BALANCING_VALUE') { 0 }.to_i
     dolist_weigth = ENV.fetch('DOLIST_BALANCING_VALUE') { 0 }.to_i


### PR DESCRIPTION
Cette branche permet de configurer l'instance de façon a pouvoir utiliser `sendmail` pour envoyer les email directement depuis un binaire local.

Cette PR est dans la même veine que la PR `feat-smtp-emails`.

Elle vient compléter et finaliser le ticket https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/8028