### PR TITLE
feat(dossier): use coldwired focus managment

### DIFF
--- a/app/components/editable_champ/multiple_drop_down_list_component/multiple_drop_down_list_component.html.haml
+++ b/app/components/editable_champ/multiple_drop_down_list_component/multiple_drop_down_list_component.html.haml
@@ -8,7 +8,7 @@
     - if @champ.selected_options.present?
       .fr-mb-2w{ "data-turbo": "true" }
         - @champ.selected_options.each do |option|
-          = render NestedForms::OwnedButtonComponent.new(formaction: champs_options_path(@champ.id, option:), http_method: :delete, opt: { class: 'fr-tag fr-tag--dismiss fr-mb-1w fr-mr-1w', id: @champ.checkbox_id(option) }) do
+          = render NestedForms::OwnedButtonComponent.new(formaction: champs_options_path(@champ.id, option:), http_method: :delete, opt: { class: 'fr-tag fr-tag--dismiss fr-mb-1w fr-mr-1w', id: @champ.checkbox_id(option), data: { turbo_focus: true } }) do
             = option
     - if @champ.unselected_options.present?
-      = @form.select :value, @champ.unselected_options, { selected: '', include_blank: '' }, id: @champ.input_id, aria: { describedby: @champ.describedby_id }
+      = @form.select :value, @champ.unselected_options, { selected: '', include_blank: '' }, id: @champ.input_id, aria: { describedby: @champ.describedby_id }, data: { turbo_focus: true }

--- a/app/controllers/champs/options_controller.rb
+++ b/app/controllers/champs/options_controller.rb
@@ -3,7 +3,6 @@ class Champs::OptionsController < ApplicationController
 
   def remove
     @champ = policy_scope(Champ).includes(:champs).find(params[:champ_id])
-    @next_checkbox_id = @champ.next_checkbox_id(params[:option])
     @champ.remove_option([params[:option]].compact)
   end
 end

--- a/app/models/champs/multiple_drop_down_list_champ.rb
+++ b/app/models/champs/multiple_drop_down_list_champ.rb
@@ -85,20 +85,12 @@ class Champs::MultipleDropDownListChamp < Champ
     "#{input_id}-#{Digest::MD5.hexdigest(value)}"
   end
 
-  def next_checkbox_id(value)
-    return nil if value.blank? || !selected_options.include?(value)
-    index = selected_options.index(value)
-    next_values = selected_options.reject { _1 == value }
-    next_value = next_values[index] || next_values.last
-    next_value ? checkbox_id(next_value) : nil
-  end
-
   def unselected_options
     enabled_non_empty_options - selected_options
   end
 
   def value=(value)
-    return super(nil) if value.blank?
+    return super(nil) if value.nil?
 
     values = if value.is_a?(Array)
       value

--- a/app/views/champs/options/remove.turbo_stream.haml
+++ b/app/views/champs/options/remove.turbo_stream.haml
@@ -1,8 +1,3 @@
 = fields_for @champ.input_name, @champ do |form|
   = turbo_stream.replace @champ.input_group_id do
     = render EditableChamp::EditableChampComponent.new champ: @champ, form:
-
-- if @next_checkbox_id.present?
-  = turbo_stream.focus @next_checkbox_id
-- else
-  = turbo_stream.focus @champ.input_id

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "@coldwired/actions": "^0.8.1",
-    "@coldwired/turbo-stream": "^0.8.1",
+    "@coldwired/actions": "^0.9.0",
+    "@coldwired/turbo-stream": "^0.9.0",
     "@gouvfr/dsfr": "^1.7.2",
     "@graphiql/plugin-explorer": "^0.1.15",
     "@graphiql/toolkit": "^0.8.3",

--- a/spec/models/champs/multiple_drop_down_list_champ_spec.rb
+++ b/spec/models/champs/multiple_drop_down_list_champ_spec.rb
@@ -34,28 +34,4 @@ describe Champs::MultipleDropDownListChamp do
       end
     end
   end
-
-  describe '#next_checkbox_id' do
-    let(:value) { ["val1", "val2", "val3"] }
-
-    context 'when the value has next value' do
-      it {
-        expect(subject.next_checkbox_id("val1")).to eq(subject.checkbox_id("val2"))
-        expect(subject.next_checkbox_id("val2")).to eq(subject.checkbox_id("val3"))
-      }
-    end
-
-    context 'when the value is last' do
-      it { expect(subject.next_checkbox_id("val3")).to eq(subject.checkbox_id("val2")) }
-    end
-
-    context 'when the value is invalid' do
-      it { expect(subject.next_checkbox_id("val4")).to eq(nil) }
-    end
-
-    context 'when the values are empty' do
-      let(:value) { [] }
-      it { expect(subject.next_checkbox_id("val1")).to eq(nil) }
-    end
-  end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1287,21 +1287,21 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
-"@coldwired/actions@^0.8.1":
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/@coldwired/actions/-/actions-0.8.1.tgz#c309a2a38f5a0af11c03c4cf8e16c6496c7f9894"
-  integrity sha512-d+rgz+FHeKRcqPS8c8mPRuwYsbfDwIExJIOdpexAmhhW67c1V3xo4+oAwNSE395/qU5/JXmOnHPeqA6t6Fx9ew==
+"@coldwired/actions@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@coldwired/actions/-/actions-0.9.0.tgz#674c652c3e20628ed6f7ea1d21bfbfb3758c4e62"
+  integrity sha512-/7zNkx5e9iygtWvXyOd2IT2DdHMd+wdTXD/sjmo73rOfzY5S3BFS/SUJf74FSZMB574VoW0QCpRm4SBfLaP9VQ==
   dependencies:
     "@coldwired/utils" "^0.8.1"
-    morphdom "^2.6.1"
+    morphdom "^2.7.0"
     tiny-invariant "^1.3.1"
 
-"@coldwired/turbo-stream@^0.8.1":
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/@coldwired/turbo-stream/-/turbo-stream-0.8.1.tgz#3f2f52b8cd59906c2387b78949c66fad79cb0eae"
-  integrity sha512-rxDzEObIZ4MQQzM2joXV2yjOLcveHBDkghDu6EiiCAMl95wV/O6dMTM1KW3+l6tjd0a5hTTKrhoNJKuWLTV5GA==
+"@coldwired/turbo-stream@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@coldwired/turbo-stream/-/turbo-stream-0.9.0.tgz#e1f9ff8cbac6532a4b0618f5d719749c0fef6c7b"
+  integrity sha512-+s0iEFmmLCoIKz1ir7mHugIOfYwzNruEa3JgnC3wd7VwGWYHunR3PnwMo4P1Ls6y1fiOXuoxBUopX/DMTsx6SQ==
   dependencies:
-    "@coldwired/actions" "^0.8.1"
+    "@coldwired/actions" "^0.9.0"
     "@coldwired/utils" "^0.8.1"
     tiny-invariant "^1.3.1"
 
@@ -4849,10 +4849,10 @@ mlly@^1.1.0:
     pkg-types "^1.0.1"
     ufo "^1.0.1"
 
-morphdom@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/morphdom/-/morphdom-2.6.1.tgz#e868e24f989fa3183004b159aed643e628b4306e"
-  integrity sha512-Y8YRbAEP3eKykroIBWrjcfMw7mmwJfjhqdpSvoqinu8Y702nAwikpXcNFDiIkyvfCLxLM9Wu95RZqo4a9jFBaA==
+morphdom@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/morphdom/-/morphdom-2.7.0.tgz#9ef0c4bc15ac8725df398d127c6984f62e7f89e8"
+  integrity sha512-8L8DwbdjjWwM/aNqj7BSoSn4G7SQLNiDcxCnMWbf506jojR6lNQ5YOmQqXEIE8u3C492UlkN4d0hQwz97+M1oQ==
 
 ms@2.1.2:
   version "2.1.2"


### PR DESCRIPTION
Nous commençons à introduire beaucoup de code complexe pour la gestion du focus en combinaison avec `turbo`. J'ai introduit une fonctionnalité dans `@coldwired/actions` pour tenter de résoudre ce problème.

Le comportement proposé est le suivant :

Après chaque application d'un `turbo-stream`, nous prenons tous les éléments avec l'attribut `data-turbo-focus` dans le fragment qui vient d'être appliqué. Si un élément sur la page a déjà le focus, alors nous prenons uniquement ceux dont la valeur de l'attribut est `force`. Nous donnons le focus au premier élément de cette sélection.

https://github.com/tchak/coldwired/commit/8be84e2af5dce823cd5c08f96e81f47f4d54c4c4

Je suis preneur de vos retours. En écrivant ces explications, je me rends compte qu'il y a le cas de la suppression d'un élément sans `morph` du parent (par exemple la suppression d'une ligne dans un bloc répétable) qui n'est pas géré par ce système. Je vais y réfléchir à un mécanisme pour ces cas.

cc @mfo @colinux 