### PR TITLE
Add and backfill defaut groupe instructeur

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -917,7 +917,8 @@ class Procedure < ApplicationRecord
 
   def ensure_defaut_groupe_instructeur
     if self.groupe_instructeurs.empty?
-      groupe_instructeurs.create(label: GroupeInstructeur::DEFAUT_LABEL)
+      gi = groupe_instructeurs.create(label: GroupeInstructeur::DEFAUT_LABEL)
+      self.update(defaut_groupe_instructeur_id: gi.id)
     end
   end
 

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -50,6 +50,7 @@
 #  created_at                                :datetime         not null
 #  updated_at                                :datetime         not null
 #  canonical_procedure_id                    :bigint
+#  defaut_groupe_instructeur_id              :bigint
 #  draft_revision_id                         :bigint
 #  parent_procedure_id                       :bigint
 #  published_revision_id                     :bigint

--- a/db/migrate/20230331124617_add_defaut_groupe_instructeur_id_to_procedures.rb
+++ b/db/migrate/20230331124617_add_defaut_groupe_instructeur_id_to_procedures.rb
@@ -1,0 +1,8 @@
+class AddDefautGroupeInstructeurIdToProcedures < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :procedures, :defaut_groupe_instructeur, index: {algorithm: :concurrently}
+  end
+
+end

--- a/db/migrate/20230331125409_add_defaut_groupe_instructeur_foreign_key_to_procedures.rb
+++ b/db/migrate/20230331125409_add_defaut_groupe_instructeur_foreign_key_to_procedures.rb
@@ -1,0 +1,5 @@
+class AddDefautGroupeInstructeurForeignKeyToProcedures < ActiveRecord::Migration[6.1]
+  def change
+    add_foreign_key :procedures, :groupe_instructeurs, column: :defaut_groupe_instructeur_id, validate: false
+  end
+end

--- a/db/migrate/20230331125931_validate_add_defaut_groupe_instructeur_foreign_key_to_procedures.rb
+++ b/db/migrate/20230331125931_validate_add_defaut_groupe_instructeur_foreign_key_to_procedures.rb
@@ -1,0 +1,5 @@
+class ValidateAddDefautGroupeInstructeurForeignKeyToProcedures < ActiveRecord::Migration[6.1]
+  def change
+    validate_foreign_key :procedures, :groupe_instructeurs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_31_075755) do
+ActiveRecord::Schema.define(version: 2023_03_31_125931) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -699,6 +699,7 @@ ActiveRecord::Schema.define(version: 2023_03_31_075755) do
     t.datetime "closed_at"
     t.datetime "created_at", null: false
     t.string "declarative_with_state"
+    t.bigint "defaut_groupe_instructeur_id"
     t.string "description"
     t.string "direction"
     t.datetime "dossiers_count_computed_at"
@@ -744,6 +745,7 @@ ActiveRecord::Schema.define(version: 2023_03_31_075755) do
     t.bigint "zone_id"
     t.index ["api_particulier_sources"], name: "index_procedures_on_api_particulier_sources", using: :gin
     t.index ["declarative_with_state"], name: "index_procedures_on_declarative_with_state"
+    t.index ["defaut_groupe_instructeur_id"], name: "index_procedures_on_defaut_groupe_instructeur_id"
     t.index ["draft_revision_id"], name: "index_procedures_on_draft_revision_id"
     t.index ["hidden_at"], name: "index_procedures_on_hidden_at"
     t.index ["libelle"], name: "index_procedures_on_libelle"
@@ -1019,6 +1021,7 @@ ActiveRecord::Schema.define(version: 2023_03_31_075755) do
   add_foreign_key "procedure_revisions", "attestation_templates"
   add_foreign_key "procedure_revisions", "dossier_submitted_messages"
   add_foreign_key "procedure_revisions", "procedures"
+  add_foreign_key "procedures", "groupe_instructeurs", column: "defaut_groupe_instructeur_id"
   add_foreign_key "procedures", "procedure_revisions", column: "draft_revision_id"
   add_foreign_key "procedures", "procedure_revisions", column: "published_revision_id"
   add_foreign_key "procedures", "services"

--- a/lib/tasks/deployment/20230407124517_back_fill_procedure_defaut_groupe_instructeur_id.rake
+++ b/lib/tasks/deployment/20230407124517_back_fill_procedure_defaut_groupe_instructeur_id.rake
@@ -1,0 +1,23 @@
+namespace :after_party do
+  desc 'Deployment task: back_fill_procedure_defaut_groupe_instructeur_id'
+  task back_fill_procedure_defaut_groupe_instructeur_id: :environment do
+    puts "Running deploy task 'back_fill_procedure_defaut_groupe_instructeur_id'"
+
+    # Put your task implementation HERE.
+    #
+
+    progress = ProgressReport.new(Procedure.unscoped.where(defaut_groupe_instructeur_id: nil).count)
+
+    Procedure.unscoped.where(defaut_groupe_instructeur_id: nil).find_each do |p|
+      p.update_columns(defaut_groupe_instructeur_id: p.defaut_groupe_instructeur.id)
+      progress.inc
+    end
+
+    progress.finish
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/lib/tasks/deployment/20230407124517_back_fill_procedure_defaut_groupe_instructeur_id_spec.rake
+++ b/spec/lib/tasks/deployment/20230407124517_back_fill_procedure_defaut_groupe_instructeur_id_spec.rake
@@ -1,0 +1,16 @@
+describe '20230407124517_back_fill_procedure_defaut_groupe_instructeur_id' do
+  let(:rake_task) { Rake::Task['after_party:back_fill_procedure_defaut_groupe_instructeur_id'] }
+  let(:procedure) { create(:procedure) }
+
+  subject(:run_task) { rake_task.invoke }
+  after(:each) { rake_task.reenable }
+
+  it 'populates defaut_groupe_instructeur_id' do
+    expect(procedure.defaut_groupe_instructeur_id).to be_nil
+
+    run_task
+
+    procedure.reload
+    expect(procedure.defaut_groupe_instructeur_id).to eq(procedure.defaut_groupe_instructeur.id)
+  end
+end

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -1274,10 +1274,13 @@ describe Procedure do
   end
 
   describe '.ensure_a_groupe_instructeur_exists' do
-    let!(:procedure) { create(:procedure) }
+    let(:procedure) { create(:procedure, groupe_instructeurs: []) }
 
-    it { expect(procedure.groupe_instructeurs.count).to eq(1) }
-    it { expect(procedure.groupe_instructeurs.first.label).to eq(GroupeInstructeur::DEFAUT_LABEL) }
+    it do
+      expect(procedure.groupe_instructeurs.count).to eq(1)
+      expect(procedure.groupe_instructeurs.first.label).to eq(GroupeInstructeur::DEFAUT_LABEL)
+      expect(procedure.defaut_groupe_instructeur_id).not_to be_nil
+    end
   end
 
   describe '.missing_instructeurs?' do


### PR DESCRIPTION
Cette pr ajoute la colonne procedure.defaut_groupe_instructeur_id et la back fill.

Le but de la manoeuvre étant dans un second temps de permettre aux admins de choisir leur groupe par defaut.