### PR TITLE
Filtrer les démarches par service

### DIFF
--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -416,11 +416,17 @@ module Administrateurs
     private
 
     def filter_procedures(filter)
+      if filter.service_siret.present?
+        service = Service.find_by(siret: filter.service_siret)
+        return Procedure.none if service.nil?
+      end
+
       procedures_result = Procedure.select(:id).left_joins(:procedures_zones).distinct.publiees_ou_closes
       procedures_result = procedures_result.where(procedures_zones: { zone_id: filter.zone_ids }) if filter.zone_ids.present?
       procedures_result = procedures_result.where(aasm_state: filter.statuses) if filter.statuses.present?
       procedures_result = procedures_result.where("tags @> ARRAY[?]::text[]", filter.tags) if filter.tags.present?
       procedures_result = procedures_result.where('published_at >= ?', filter.from_publication_date) if filter.from_publication_date.present?
+      procedures_result = procedures_result.where(service: service) if filter.service_siret.present?
       procedures_result = procedures_result.where('unaccent(libelle) ILIKE unaccent(?)', "%#{filter.libelle}%") if filter.libelle.present?
       procedures_sql = procedures_result.to_sql
 

--- a/app/models/procedures_filter.rb
+++ b/app/models/procedures_filter.rb
@@ -5,7 +5,7 @@ class ProceduresFilter
 
   def initialize(admin, params)
     @admin = admin
-    @params = params.permit(:page, :libelle, :email, :from_publication_date, tags: [], zone_ids: [], statuses: [])
+    @params = params.permit(:page, :libelle, :email, :from_publication_date, :service_siret, tags: [], zone_ids: [], statuses: [])
   end
 
   def admin_zones
@@ -30,6 +30,10 @@ class ProceduresFilter
 
   def tags
     params[:tags].compact_blank.uniq if params[:tags].present?
+  end
+
+  def service_siret
+    params[:service_siret].presence
   end
 
   def from_publication_date

--- a/app/views/administrateurs/procedures/all.html.haml
+++ b/app/views/administrateurs/procedures/all.html.haml
@@ -22,6 +22,9 @@
       - if @filter.libelle
         .selected-query.fr-mb-2w
           = link_to @filter.libelle, all_admin_procedures_path(@filter.without(:libelle)), class: 'fr-tag fr-tag--dismiss fr-mb-1w'
+      - if @filter.service_siret
+        .selected-query.fr-mb-2w
+          = link_to @filter.service_siret, all_admin_procedures_path(@filter.without(:service_siret)), class: 'fr-tag fr-tag--dismiss fr-mb-1w'
       - if @filter.selected_zones.present?
         .selected-zones.fr-mb-2w
           - @filter.selected_zones.each do |zone|

--- a/app/views/layouts/all.html.haml
+++ b/app/views/layouts/all.html.haml
@@ -43,6 +43,14 @@
                       .fr-checkbox-group.fr-ml-2w.fr-py-1w
                         = b.check_box(checked: @filter.zone_filtered?(b.value))
                         = b.label(class: 'fr-label') { b.text }
+                %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
+                  .fr-mb-1w
+                    %button{ 'data-action': 'expand#toggle' }
+                      %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
+                      Service
+                  .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
+                    %div
+                      = f.text_field :service_siret, placeholder: 'Indiquez le SIRET', class: 'fr-input'
                 %li.fr-py-2w{ 'data-controller': "expand" }
                   .fr-mb-1w.fr-pl-2w
                     %button{ 'data-action': 'click->expand#toggle' }

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -175,6 +175,31 @@ describe Administrateurs::ProceduresController, type: :controller do
       end
     end
 
+    context 'with specific service' do
+      let(:requested_siret) { '13001501900024' }
+      let(:another_siret) { '11000004900012' }
+      let(:requested_service) { create(:service, siret: requested_siret) }
+      let(:another_service) { create(:service, siret: another_siret) }
+      let!(:procedure1) { create(:procedure, :published, service: another_service) }
+      let!(:procedure2) { create(:procedure, :published, service: requested_service) }
+      it 'display only procedures with specific service (identified by siret)' do
+        get :all, params: { service_siret: requested_siret }
+        expect(assigns(:procedures).any? { |p| p.id == procedure1.id }).to be_falsey
+        expect(assigns(:procedures).any? { |p| p.id == procedure2.id }).to be_truthy
+      end
+    end
+
+    context 'with a siret which does not identify a service' do
+      let(:requested_siret) { '13001501900024' }
+      let(:another_siret) { '11000004900012' }
+      let(:another_service) { create(:service, siret: another_siret) }
+      let!(:procedure1) { create(:procedure, :published, service: another_service) }
+      it 'displays none procedure' do
+        get :all, params: { service_siret: requested_siret }
+        expect(assigns(:procedures)).to be_empty
+      end
+    end
+
     context 'with specific tag' do
       let!(:tags_procedure) { create(:procedure, :published, tags: ['environnement', 'diplomatie']) }
 


### PR DESCRIPTION
close #8839 

Cette PR permet de filtrer les démarches par service à partir du n° de SIRET.

<img width="290" alt="Capture d’écran 2023-04-10 à 13 46 51" src="https://user-images.githubusercontent.com/1111966/230895867-aea8465c-fd37-4a2a-b2a4-5b6506fbcc4c.png">
