### PR TITLE
fix link for csv example file

### DIFF
--- a/app/views/administrateurs/groupe_instructeurs/_edit.html.haml
+++ b/app/views/administrateurs/groupe_instructeurs/_edit.html.haml
@@ -28,7 +28,9 @@
     = form_tag import_admin_procedure_groupe_instructeurs_path(procedure), method: :post, multipart: true, class: "mt-4 form" do
       = label_tag t('.csv_import.title')
       %p.notice
-        = t('.csv_import.notice_1_html')
+        = t('.csv_import.notice_1_html',
+          instructeurs_link: link_to(t('.csv_import.link_text'), t('.csv_import.instructeurs_file_path')),
+          groupes_link: link_to(t('.csv_import.link_text'), t('.csv_import.groupes_file_path')))
       %p.notice
         = t('.csv_import.notice_2', csv_max_size: number_to_human_size(csv_max_size))
       = file_field_tag :csv_file, required: true, accept: 'text/csv', size: "1"

--- a/config/locales/views/administrateurs/groupe_instructeurs/en.yml
+++ b/config/locales/views/administrateurs/groupe_instructeurs/en.yml
@@ -41,11 +41,14 @@ en:
           notice: This group will be a choice from the list "%{routing_criteria_name}"
         csv_import:
           title: CSV Import
-          notice_1_html: The csv file must have 1 column with instructors emails. For routed procedures, the csv file must have 2 columns (Group, Email) and be separated by commas. The import does not overwrite existing groups and instructors.
+          notice_1_html: The csv file must have 1 column with instructors emails(%{instructeurs_link}). For routed procedures, the csv file must have 2 columns (Group, Email) and be separated by commas (%{groupes_link}). The import does not overwrite existing groups and instructors.
           notice_2: The size of the file must be less than %{csv_max_size}.
           import_file: Import file
           import_file_procedure_not_published: The import of instructors by CSV file is available once the process has been published
           import_file_alert: Instructors added to the procedure will receive an email. Are you sure you want to continue ?"
+          link_text: file example
+          instructeurs_file_path: /csv/import-instructeurs-test.csv
+          groupes_file_path: /csv/en/import-groupe-test.csv
         set_up: set up
         button:
           add_group: Add group

--- a/config/locales/views/administrateurs/groupe_instructeurs/fr.yml
+++ b/config/locales/views/administrateurs/groupe_instructeurs/fr.yml
@@ -48,12 +48,15 @@ fr:
         csv_import:
           title: Importer par CSV
           notice_1_html: |
-            Pour une procédure standard, le fichier csv doit comporter 1 seule colonne (Email) avec une adresse email d'instructeur par ligne (<a href=\"/csv/import-instructeurs-test.csv\">exemple de fichier</a>).
-            Pour une procédure routée, le fichier doit comporter 2 colonnes (Groupe, Email) et être séparé par des virgules (<a href=\"/csv/fr/import-groupe-test.csv\">exemple de fichier</a>).
+            Pour une procédure standard, le fichier csv doit comporter 1 seule colonne (Email) avec une adresse email d'instructeur par ligne (%{instructeurs_link}).
+            Pour une procédure routée, le fichier doit comporter 2 colonnes (Groupe, Email) et être séparé par des virgules (%{groupes_link}).
           notice_2: L’import n’écrase pas les instructeurs existants. Il permet uniquement d'en ajouter. Pour supprimer un instructeur, cliquez sur le bouton « retirer ». Le poids du fichier doit être inférieur %{csv_max_size}.
           import_file: Importer le fichier
           import_file_procedure_not_published: L’import d’instructeurs par fichier CSV est disponible une fois la démarche publiée
           import_file_alert: Tous les instructeurs ajoutés à la procédure vont être notifiés par email. Voulez-vous continuer ?
+          link_text: exemple de fichier
+          instructeurs_file_path: /csv/import-instructeurs-test.csv
+          groupes_file_path: /csv/fr/import-groupe-test.csv
         view: voir
         set_up: paramétrer
         button:


### PR DESCRIPTION
La PR corrige les liens cassés pour télécharger les exemples de fichier csv pour l'import des instructeurs

![image](https://user-images.githubusercontent.com/29131404/231129908-06f73f87-8fa3-44c3-aae1-d46a7c5e2e17.png)
