### PR TITLE
ETQ usager, je veux que les champs de type adresse électronique soit validé

### DIFF
--- a/app/models/champs/email_champ.rb
+++ b/app/models/champs/email_champ.rb
@@ -21,4 +21,11 @@
 #  type_de_champ_id               :integer
 #
 class Champs::EmailChamp < Champs::TextChamp
+  validates :value,
+    format: {
+      with: Devise.email_regexp,
+      message: I18n.t('invalid', scope: 'activerecord.errors.models.email_champ.attributes.value')
+    },
+    allow_nil: true,
+    if: -> { validation_context != :brouillon }
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -561,6 +561,10 @@ en:
           attributes:
             email:
               taken: ': Invitation already sent'
+        email_champ:
+          attributes:
+            value:
+              invalid: "is invalid. Fill in a valid email address, example: john.doe@example.fr"
 
         user:
           attributes: &error_attributes

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -562,6 +562,10 @@ fr:
           attributes:
             email:
               taken: ': Invitation déjà envoyée'
+        email_champ:
+          attributes:
+            value:
+              invalid: "est invalide. Saisir une adresse éléctronique valide, exemple : john.doe@exemple.fr"
         user:
           attributes: &error_attributes
             reset_password_token:

--- a/spec/models/champs/email_champ_spec.rb
+++ b/spec/models/champs/email_champ_spec.rb
@@ -1,0 +1,29 @@
+describe Champs::EmailChamp do
+  subject { build(:champ_email, value: value).tap(&:valid?) }
+
+  describe '#valid?' do
+    context 'when the value is an email' do
+      let(:value) { 'jean@dupont.fr' }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'when the value is not an email' do
+      let(:value) { 'jean@' }
+
+      it { is_expected.to_not be_valid }
+    end
+
+    context 'when the value is blank' do
+      let(:value) { '' }
+
+      it { is_expected.to_not be_valid }
+    end
+
+    context 'when the value is nil' do
+      let(:value) { nil }
+
+      it { is_expected.to be_valid }
+    end
+  end
+end


### PR DESCRIPTION
close #8738

Avec cette PR, un utilisateur ne peut pas saisir dans un champ "Adresse electronique" autre chose qu'une chaîne de caractères ayant le format d'une adresse email.