### PR TITLE
amelioration(dolist): ne log erreurs pas les erreurs dans sentry lorsque le contact chez dolist est injoingable ou hardbounce

### DIFF
--- a/app/lib/dolist/api.rb
+++ b/app/lib/dolist/api.rb
@@ -154,6 +154,18 @@ class Dolist::API
     post(url, body)["FieldList"].find { _1['ID'] == 72 }['Value']
   end
 
+  def ignorable_error?(response, mail)
+    error_code = response&.dig("ResponseStatus", "ErrorCode")
+    invalid_contact_status = if ignorable_api_error_code?(error_code)
+      fetch_contact_status(mail.to.first)
+    else
+      nil
+    end
+    [error_code, invalid_contact_status]
+  end
+
+  private
+
   def ignorable_api_error_code?(api_error_code)
     IGNORABLE_API_ERROR_CODE.include?(api_error_code)
   end
@@ -161,8 +173,6 @@ class Dolist::API
   def ignorable_contact_status?(contact_status)
     IGNORABLE_CONTACT_STATUSES.include?(contact_status)
   end
-
-  private
 
   def format_url(base)
     format(base, account_id: account_id)

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -28,16 +28,31 @@ RSpec.describe ApplicationMailer, type: :mailer do
 
   describe 'dealing with Dolist API error' do
     let(:dossier) { create(:dossier, procedure: create(:simple_procedure)) }
-    before do
-      ActionMailer::Base.delivery_method = :dolist_api
-      api_error_response = { "ResponseStatus": { "ErrorCode": "Forbidden", "Message": "Blocked non authorized request", "Errors": [] } }
-      allow_any_instance_of(Dolist::API).to receive(:send_email).and_return(api_error_response)
-    end
     subject { DossierMailer.with(dossier:).notify_new_draft.deliver_now }
+    context 'not ignored error' do
+      before do
+        ActionMailer::Base.delivery_method = :dolist_api
+        api_error_response = { "ResponseStatus": { "ErrorCode": "Forbidden", "Message": "Blocked non authorized request", "Errors": [] } }
+        allow_any_instance_of(Dolist::API).to receive(:send_email).and_return(api_error_response)
+      end
 
-    it 'raise classic error to retry' do
-      expect { subject }.to raise_error(MailDeliveryError)
-      expect(EmailEvent.dolist_api.dispatch_error.count).to eq(1)
+      it 'raise classic error to retry' do
+        expect { subject }.to raise_error(MailDeliveryError)
+        expect(EmailEvent.dolist_api.dispatch_error.count).to eq(1)
+      end
+    end
+
+    context 'ignored error' do
+      before do
+        ActionMailer::Base.delivery_method = :dolist_api
+        api_error_response = { "ResponseStatus" => { "ErrorCode" => "458", "Message" => "The contact is disabled.", "Errors" => [] } }
+        allow_any_instance_of(Dolist::API).to receive(:send_email).and_return(api_error_response)
+        allow_any_instance_of(Dolist::API).to receive(:fetch_contact_status).with(dossier.user.email).and_return("7")
+      end
+
+      it 'does not raise' do
+        expect { subject }.not_to raise_error
+      end
     end
   end
 


### PR DESCRIPTION
# contexte

suite a un echange avec tchak/colin ; on aimerait mettre en sourdine certaines erreurs dolist. 

# solution

comme suggéré par dolist, il faut vérifier le status du contact (chez dolist, ca equivaut a requeter la clé 72 du contact), de la on a differents status

# pas très sûre de moi

on va se retrouver a faire bcp de requete exterieur pour savoir si il faut ou pas reporter l'erreur...