### PR TITLE
[refonte usager] Tableau de bord - Déplacer la barre de recherche proche des dossiers

### DIFF
--- a/app/views/layouts/_header.haml
+++ b/app/views/layouts/_header.haml
@@ -60,16 +60,13 @@
 
 
           - if params[:controller] == 'recherche'
-            = render partial: 'layouts/search_dossiers_form', locals: { search_endpoint: recherche_index_path }
+            = render partial: 'layouts/search_dossiers_form'
 
           - if is_instructeur_context
-            = render partial: 'layouts/search_dossiers_form', locals: { search_endpoint: recherche_index_path }
+            = render partial: 'layouts/search_dossiers_form'
 
           - if is_expert_context
-            = render partial: 'layouts/search_dossiers_form', locals: { search_endpoint: recherche_index_path }
-
-          - if is_user_context && current_user.dossiers.count > 2
-            = render partial: 'layouts/search_dossiers_form', locals: { search_endpoint: recherche_dossiers_path }
+            = render partial: 'layouts/search_dossiers_form'
 
   - has_header = [is_instructeur_context, is_expert_context, is_user_context]
   #burger-menu.fr-header__menu.fr-modal

--- a/app/views/layouts/_search_dossiers_form.html.haml
+++ b/app/views/layouts/_search_dossiers_form.html.haml
@@ -2,7 +2,7 @@
   .fr-container.fr-container-lg--fluid
     %button.fr-btn--close.fr-btn{ "aria-controls" => "search-modal", :title => t('close_modal', scope: [:layouts, :header]) }= t('close_modal', scope: [:layouts, :header])
     #search-473.fr-search-bar.fr-search-bar--lg
-      = form_tag "#{search_endpoint}", method: :get, :role => "search", class: "flex width-100" do
+      = form_tag recherche_index_path, method: :get, :role => "search", class: "flex width-100" do
         = label_tag "q", t('views.users.dossiers.search.search_file'), class: 'fr-label'
         = text_field_tag "q", "#{@search_terms if @search_terms.present?}", placeholder: t('views.users.dossiers.search.search_file'), class: "fr-input"
         %button.fr-btn

--- a/app/views/users/dossiers/index.html.haml
+++ b/app/views/users/dossiers/index.html.haml
@@ -8,12 +8,16 @@
 
 .dossiers-headers.sub-header
   .container
-    - if @search_terms.present?
-      %h1.page-title Résultat de la recherche pour « #{@search_terms} »
-      = render partial: "dossiers_list", locals: { dossiers: @dossiers }
+    %h1.page-title= t('views.users.dossiers.index.dossiers')
+    - if current_user.dossiers.count > 2
+      #search-2.fr-search-bar.fr-search-bar--lg{ role: "search", "aria-label": t('views.users.dossiers.search.search_file') }
+        = form_tag recherche_dossiers_path, method: :get, :role => "search", class: "flex width-100 fr-mb-5w" do
+          = label_tag "q", t('views.users.dossiers.search.search_file'), class: 'fr-label'
+          = text_field_tag "q", "#{@search_terms if @search_terms.present?}", placeholder: t('views.users.dossiers.search.search_file'), class: "fr-input"
+          %button.fr-btn
+            = t('views.users.dossiers.search.simple')
 
-    - else
-      %h1.page-title= t('views.users.dossiers.index.dossiers')
+    - if @search_terms.blank?
       %nav.tabs{ role: 'navigation', 'aria-label': t('views.users.dossiers.secondary_menu') }
         %ul
           - if @user_dossiers.present?
@@ -59,23 +63,28 @@
               badge: number_with_html_delimiter(@dossier_transfers.count))
 
 .container
-  - if @statut == "en-cours"
-    = render partial: "dossiers_list", locals: { dossiers: @user_dossiers }
+  - if @search_terms.present?
+    %h2.page-title Résultat de la recherche pour « #{@search_terms} »
+    = render partial: "dossiers_list", locals: { dossiers: @dossiers }
 
-  - if @statut == "traites"
-    = render partial: "dossiers_list", locals: { dossiers: @dossiers_traites }
+  - else
+    - if @statut == "en-cours"
+      = render partial: "dossiers_list", locals: { dossiers: @user_dossiers }
 
-  - if @statut == "dossiers-invites"
-    = render partial: "dossiers_list", locals: { dossiers: @dossiers_invites }
+    - if @statut == "traites"
+      = render partial: "dossiers_list", locals: { dossiers: @dossiers_traites }
 
-  - if @statut == "dossiers-supprimes-recemment"
-    = render partial: "hidden_dossiers_list", locals: { hidden_dossiers: @dossiers_supprimes_recemment }
+    - if @statut == "dossiers-invites"
+      = render partial: "dossiers_list", locals: { dossiers: @dossiers_invites }
 
-  - if @statut == "dossiers-supprimes-definitivement"
-    = render partial: "deleted_dossiers_list", locals: { deleted_dossiers: @dossiers_supprimes_definitivement }
+    - if @statut == "dossiers-supprimes-recemment"
+      = render partial: "hidden_dossiers_list", locals: { hidden_dossiers: @dossiers_supprimes_recemment }
 
-  - if @statut == "dossiers-transferes"
-    = render partial: "transfered_dossiers_list", locals: { dossier_transfers: @dossier_transfers }
+    - if @statut == "dossiers-supprimes-definitivement"
+      = render partial: "deleted_dossiers_list", locals: { deleted_dossiers: @dossiers_supprimes_definitivement }
 
-  - if @statut == "dossiers-expirant"
-    = render partial: "dossiers_list", locals: { dossiers: @dossiers_close_to_expiration }
+    - if @statut == "dossiers-transferes"
+      = render partial: "transfered_dossiers_list", locals: { dossier_transfers: @dossier_transfers }
+
+    - if @statut == "dossiers-expirant"
+      = render partial: "dossiers_list", locals: { dossiers: @dossiers_close_to_expiration }


### PR DESCRIPTION
closes #8877 

Tableau de bord - Déplacer la barre de recherche proche des dossiers

<img width="1263" alt="Capture d’écran 2023-04-14 à 16 30 54" src="https://user-images.githubusercontent.com/6756627/232074299-74e53fea-94f5-43df-aecb-e1712013f5e2.png">
<img width="1240" alt="Capture d’écran 2023-04-14 à 16 30 30" src="https://user-images.githubusercontent.com/6756627/232074307-fccec30d-157c-4102-9f70-bf27753920b8.png">
