### PR TITLE
ETQ intégrateur API, je voudrais avoir des codes d'erreur plus précis

### DIFF
--- a/app/graphql/api/v2/schema.rb
+++ b/app/graphql/api/v2/schema.rb
@@ -133,6 +133,7 @@ class API::V2::Schema < GraphQL::Schema
 
   class Timeout < GraphQL::Schema::Timeout
     def handle_timeout(error, query)
+      error.extensions = { code: :timeout }
       Sentry.capture_exception(error, extra: query.context.query_info)
     end
   end

--- a/app/graphql/api/v2/schema.rb
+++ b/app/graphql/api/v2/schema.rb
@@ -50,7 +50,7 @@ class API::V2::Schema < GraphQL::Schema
     when GroupeInstructeur
       Types::GroupeInstructeurType
     else
-      raise GraphQL::ExecutionError.new("Unexpected object: #{object}")
+      type_definition
     end
   end
 

--- a/app/graphql/api/v2/stored_query.rb
+++ b/app/graphql/api/v2/stored_query.rb
@@ -8,7 +8,7 @@ class API::V2::StoredQuery
     when 'introspection'
       GraphQL::Introspection::INTROSPECTION_QUERY
     else
-      raise GraphQL::ExecutionError.new("No query with id \"#{query_id}\"")
+      raise GraphQL::ExecutionError.new("No query with id \"#{query_id}\"", extensions: { code: :bad_request })
     end
   end
 

--- a/app/graphql/loaders/champ.rb
+++ b/app/graphql/loaders/champ.rb
@@ -13,7 +13,7 @@ module Loaders
 
     def perform(keys)
       query(keys).each { |record| fulfill(record.stable_id, [record].compact) }
-      keys.each { |key| fulfill(key, nil) unless fulfilled?(key) }
+      keys.each { |key| fulfill(key, []) unless fulfilled?(key) }
     end
 
     private

--- a/app/graphql/loaders/record.rb
+++ b/app/graphql/loaders/record.rb
@@ -21,7 +21,7 @@ module Loaders
         fulfilled_value = @array ? [record].compact : record
         fulfill(record.public_send(@column), fulfilled_value)
       end
-      keys.each { |key| fulfill(key, nil) unless fulfilled?(key) }
+      keys.each { |key| fulfill(key, @array ? [] : nil) unless fulfilled?(key) }
     end
 
     private

--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -1,5 +1,11 @@
 module Types
   class BaseObject < GraphQL::Schema::Object
     field_class BaseField
+
+    class InvalidNullError < GraphQL::InvalidNullError
+      def to_h
+        super.merge(extensions: { code: :invalid_null })
+      end
+    end
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -26,13 +26,11 @@ module Types
       demarche_number = demarche.number.presence || ApplicationRecord.id_from_typed_id(demarche.id)
       Procedure
         .includes(draft_revision: :procedure, published_revision: :procedure)
-        .find_by(id: demarche_number)
+        .find(demarche_number)
     end
 
     def demarche(number:)
       Procedure.for_api_v2.find(number)
-    rescue => e
-      raise GraphQL::ExecutionError.new(e.message, extensions: { code: :not_found })
     end
 
     def dossier(number:)
@@ -42,14 +40,10 @@ module Types
         Dossier.visible_by_administration.for_api_v2.find(number)
       end
       DossierPreloader.load_one(dossier)
-    rescue => e
-      raise GraphQL::ExecutionError.new(e.message, extensions: { code: :not_found })
     end
 
     def groupe_instructeur(number:)
       GroupeInstructeur.for_api_v2.find(number)
-    rescue => e
-      raise GraphQL::ExecutionError.new(e.message, extensions: { code: :not_found })
     end
 
     def self.accessible?(context)

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -684,7 +684,7 @@ describe API::V2::GraphqlController do
           end
 
           it "should return an error" do
-            expect(gql_errors).to eq([{ message: "Cannot return null for non-nullable field PersonneMorale.siegeSocial" }])
+            expect(gql_errors).to eq([{ message: "Cannot return null for non-nullable field PersonneMorale.siegeSocial", extensions: { code: "invalid_null" } }])
           end
         end
       end

--- a/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
@@ -76,6 +76,15 @@ describe API::V2::GraphqlController do
         expect(gql_data[:dossier][:demandeur][:prenom]).to eq(dossier.individual.prenom)
       }
 
+      context 'not found' do
+        let(:variables) { { dossierNumber: 0 } }
+
+        it {
+          expect(gql_errors.first[:message]).to eq('Dossier not found')
+          expect(gql_errors.first[:extensions]).to eq({ code: 'not_found' })
+        }
+      end
+
       context 'with entreprise' do
         let(:procedure) { create(:procedure, :published, :with_service, administrateurs: [admin], types_de_champ_public:) }
         let(:dossier) { create(:dossier, :en_construction, :with_entreprise, procedure: procedure) }
@@ -113,6 +122,15 @@ describe API::V2::GraphqlController do
         expect(gql_data[:demarche][:id]).to eq(procedure.to_typed_id)
         expect(gql_data[:demarche][:dossiers]).to be_nil
       }
+
+      context 'not found' do
+        let(:variables) { { demarcheNumber: 0 } }
+
+        it {
+          expect(gql_errors.first[:message]).to eq('Demarche not found')
+          expect(gql_errors.first[:extensions]).to eq({ code: 'not_found' })
+        }
+      end
 
       context 'include Dossiers' do
         let(:variables) { { demarcheNumber: procedure.id, includeDossiers: true } }
@@ -182,6 +200,15 @@ describe API::V2::GraphqlController do
         expect(gql_data[:groupeInstructeur][:dossiers]).to be_nil
       }
 
+      context 'not found' do
+        let(:variables) { { groupeInstructeurNumber: 0 } }
+
+        it {
+          expect(gql_errors.first[:message]).to eq('GroupeInstructeurWithDossiers not found')
+          expect(gql_errors.first[:extensions]).to eq({ code: 'not_found' })
+        }
+      end
+
       context 'include Dossiers' do
         let(:variables) { { groupeInstructeurNumber: groupe_instructeur.id, includeDossiers: true } }
 
@@ -204,6 +231,15 @@ describe API::V2::GraphqlController do
           expect(gql_errors).to be_nil
           expect(gql_data[:demarcheDescriptor][:id]).to eq(procedure.to_typed_id)
           expect(gql_data[:demarcheDescriptor][:demarcheUrl]).to match("commencer/#{procedure.path}")
+        }
+      end
+
+      context 'not found' do
+        let(:variables) { { demarche: { number: 0 } } }
+
+        it {
+          expect(gql_errors.first[:message]).to eq('DemarcheDescriptor not found')
+          expect(gql_errors.first[:extensions]).to eq({ code: 'not_found' })
         }
       end
 

--- a/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
@@ -64,6 +64,18 @@ describe API::V2::GraphqlController do
       }
     end
 
+    context 'timeout' do
+      let(:variables) { { dossierNumber: dossier.id } }
+      let(:operation_name) { 'getDossier' }
+
+      before { allow_any_instance_of(API::V2::Schema::Timeout).to receive(:max_seconds).and_return(0) }
+
+      it {
+        expect(gql_errors.first[:message]).to eq('Timeout on Query.dossier')
+        expect(gql_errors.first[:extensions]).to eq({ code: 'timeout' })
+      }
+    end
+
     context 'getDossier' do
       let(:variables) { { dossierNumber: dossier.id } }
       let(:operation_name) { 'getDossier' }


### PR DESCRIPTION
On ajoute des codes à tout les erreurs inspiré de ce que fait [apollographql](https://www.apollographql.com/docs/apollo-server/data/errors/#built-in-error-codes)