### PR TITLE
Migre les données pour le nouveau mode de routage

### DIFF
--- a/lib/tasks/deployment/20230417083259_migrate_data_for_routing_with_dropdown_list.rake
+++ b/lib/tasks/deployment/20230417083259_migrate_data_for_routing_with_dropdown_list.rake
@@ -1,0 +1,65 @@
+namespace :after_party do
+  desc 'Deployment task: migrate_data_for_routing_with_dropdown_list'
+  task migrate_data_for_routing_with_dropdown_list: :environment do
+    include Logic
+    puts "Running deploy task 'migrate_data_for_routing_with_dropdown_list'"
+
+    # Put your task implementation HERE.
+    procedure_ids = GroupeInstructeur
+      .joins(:procedure)
+      .where(procedures: { migrated_champ_routage: [nil, false] })
+      .group(:procedure_id)
+      .having("count(groupe_instructeurs.id) > 1")
+      .pluck(:procedure_id)
+
+    progress = ProgressReport.new(procedure_ids.count)
+
+    procedure_ids.each do |procedure_id|
+      procedure = Procedure.with_discarded.find(procedure_id)
+      procedure.transaction do
+        routage_type_de_champ = TypeDeChamp.create!(
+          type_champ: 'drop_down_list',
+          libelle: procedure.routing_criteria_name || 'Votre ville',
+          options: { "drop_down_options" => [''] + procedure.groupe_instructeurs.active.pluck(:label) },
+          private: false,
+          mandatory: true
+        )
+
+        ProcedureRevisionTypeDeChamp
+          .joins(:revision)
+          .where(procedure_revisions: { procedure_id: }, parent_id: nil)
+          .update_all('position = position + 1')
+
+        # add routage_type_de_champ sur les positions
+        now = Time.zone.now
+        to_insert = procedure.revisions.ids.map do |revision_id|
+          { revision_id:, type_de_champ_id: routage_type_de_champ.id, position: 0, created_at: now, updated_at: now }
+        end
+        ProcedureRevisionTypeDeChamp.insert_all(to_insert)
+
+        procedure.groupe_instructeurs.each do |gi|
+          gi.update_columns(routing_rule: ds_eq(champ_value(routage_type_de_champ.stable_id), constant(gi.label)))
+        end
+
+        procedure.update_columns(migrated_champ_routage: true)
+
+        #  Ajouter un chp drpdwn ds chq dossier
+        insert_dropdown_champ_sql = <<~EOF
+          INSERT INTO champs ( type, value, type_de_champ_id, dossier_id, private, created_at, updated_at )
+          #{procedure.dossiers.left_joins(:groupe_instructeur).select("'Champs::DropDownListChamp', groupe_instructeurs.label, '#{routage_type_de_champ.id}', dossiers.id, false, dossiers.created_at, dossiers.created_at").to_sql}
+        EOF
+        ActiveRecord::Base.connection.execute(insert_dropdown_champ_sql)
+
+        Flipper.enable(:routing_rules, procedure)
+      end
+      Flipper.enable(:routing_rules)
+      progress.inc
+    end
+    progress.finish
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/lib/tasks/deployment/lib/tasks/deployment/20230417083259_migrate_data_for_routing_with_dropdown_list_spec.rake
+++ b/spec/lib/tasks/deployment/lib/tasks/deployment/20230417083259_migrate_data_for_routing_with_dropdown_list_spec.rake
@@ -1,0 +1,58 @@
+describe '20230417083259_migrate_data_for_routing_with_dropdown_list' do
+  include Logic
+  let(:rake_task) { Rake::Task['after_party:migrate_data_for_routing_with_dropdown_list'] }
+  subject(:run_task) { rake_task.invoke }
+  after(:each) { rake_task.reenable }
+
+  describe 'migrates data for routing with drop down lists' do
+    context 'with a non routed procedure' do
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :yes_no }]) }
+      it 'works' do
+        expect(procedure.draft_types_de_champ_public.pluck(:type_champ)).to match(['yes_no'])
+
+        run_task
+
+        procedure.reload
+
+        expect(procedure.draft_types_de_champ_public.pluck(:type_champ)).to match(['yes_no'])
+        expect(procedure.migrated_champ_routage).to be nil
+      end
+    end
+
+    context 'with a routed procedure' do
+      let(:procedure) do
+        create(:procedure, routing_criteria_name: 'Ma région', types_de_champ_public: [{ type: :yes_no }, { type: :repetition, children: [{ type: :text }] }]).tap do |p|
+          p.groupe_instructeurs.create(label: "a second group")
+        end
+      end
+      let(:dossier_without_gi) { create(:dossier, procedure:) }
+      let(:dossier_with_gi) { create(:dossier, procedure:, groupe_instructeur: defaut_groupe_instructeur) }
+      let(:drop_down_list) { procedure.reload.draft_types_de_champ_public.first }
+      let(:defaut_groupe_instructeur) { procedure.defaut_groupe_instructeur }
+
+      it 'works' do
+        expect(procedure.draft_revision.types_de_champ.pluck(:type_champ, :position)).to match([["yes_no", 0], ["text", 0], ["repetition", 1]])
+        expect(dossier_without_gi.champs.pluck(:type)).to match(["Champs::YesNoChamp", "Champs::RepetitionChamp"])
+        expect(dossier_with_gi.champs.pluck(:type)).to match(["Champs::YesNoChamp", "Champs::RepetitionChamp"])
+
+        run_task
+
+        [procedure, defaut_groupe_instructeur, dossier_without_gi, dossier_with_gi].each(&:reload)
+
+        expect(procedure.draft_revision.types_de_champ.pluck(:type_champ, :position)).to match([["text", 0], ["drop_down_list", 0], ["yes_no", 1], ["repetition", 2]])
+        expect(drop_down_list.libelle).to eq('Ma région')
+        expect(drop_down_list.options).to eq({ "drop_down_options" => ["", "a second group", "défaut"] })
+        expect(defaut_groupe_instructeur.routing_rule).to eq(ds_eq(champ_value(drop_down_list.stable_id), constant(defaut_groupe_instructeur.label)))
+        expect(procedure.migrated_champ_routage).to be_truthy
+        expect(dossier_without_gi.champs.pluck(:type)).to match_array(["Champs::DropDownListChamp", "Champs::YesNoChamp", "Champs::RepetitionChamp"])
+        expect(drop_down(dossier_without_gi).value).to eq nil
+        expect(dossier_with_gi.champs.pluck(:type)).to match_array(["Champs::DropDownListChamp", "Champs::YesNoChamp", "Champs::RepetitionChamp"])
+        expect(drop_down(dossier_with_gi).value).to eq procedure.defaut_groupe_instructeur.label
+      end
+    end
+
+    def drop_down(dossier)
+      dossier.champs.find_by(type: 'Champs::DropDownListChamp')
+    end
+  end
+end


### PR DESCRIPTION
On a pensé à vérifier : 
- toutes les révisions des procédures routées et unscoped
- dossiers avec et sans groupe d'instructeurs
- on augmente la position de tous les tdcs sauf des enfants
- le feature flag est activée sur toutes les procédures migrées, puis à la fin du script sur toutes les procédures
- on ajoute la routing rule dans chaque groupe d'instructeurs
Hésitez pas si vous voyez d'autres choses à tester !