### PR TITLE
Corrige des utilisations incorrectes du verbe notifier

### DIFF
--- a/app/views/administrateurs/procedures/_informations.html.haml
+++ b/app/views/administrateurs/procedures/_informations.html.haml
@@ -122,7 +122,7 @@
     = f.label :web_hook_url do
       Lien de rappel HTTP (webhook)
     %p.notice
-      Vous pouvez définir un lien de rappel HTTP (aussi appelé webhook) pour notifier un service tiers du changement de l'état d’un dossier de cette démarche sur #{APPLICATION_NAME}.
+      Vous pouvez définir un lien de rappel HTTP (aussi appelé webhook) pour informer un service tiers du changement de l'état d’un dossier de cette démarche sur #{APPLICATION_NAME}.
       = link_to("Consulter la documentation du webhook", WEBHOOK_DOC_URL, target: "_blank", rel: "noopener")
     = f.text_field :web_hook_url, class: 'form-control', placeholder: 'https://callback.exemple.fr/'
 
@@ -151,4 +151,3 @@
         Champ “Pièce justificative” avec multiples fichiers
     %p.notice
       Autorise les usagers à envoyer plusieurs fichiers pour les champs de type “Pièce justificative”. L'activation de cette option est irréversible et peut nécessiter des modifications si vous utilisez des systèmes automatisés pour traiter les dossiers.
-

--- a/app/views/instructeurs/dossiers/_instruction_button.html.haml
+++ b/app/views/instructeurs/dossiers/_instruction_button.html.haml
@@ -8,7 +8,7 @@
         %span.icon.accept
         .dropdown-description
           %h4 Accepter
-          L’usager sera notifié que son dossier a été accepté
+          L’usager sera informé que son dossier a été accepté
 
     - menu.with_item(class: "hidden inactive form-inside") do
       = render partial: 'instructeurs/dossiers/instruction_button_motivation', locals: { dossier: dossier, placeholder: 'Expliquez au demandeur pourquoi ce dossier est accepté (facultatif)', popup_class: 'accept', process_action: 'accepter', title: 'Accepter', confirm: "Confirmez-vous l'acceptation ce dossier ?" }
@@ -19,7 +19,7 @@
         %span.icon.without-continuation
         .dropdown-description
           %h4 Classer sans suite
-          L’usager sera notifié que son dossier a été classé sans suite
+          L’usager sera informé que son dossier a été classé sans suite
 
     - menu.with_item(class: "hidden inactive form-inside") do
       = render partial: 'instructeurs/dossiers/instruction_button_motivation', locals: { dossier: dossier, placeholder: 'Expliquez au demandeur pourquoi ce dossier est classé sans suite (obligatoire)', popup_class: 'without-continuation', process_action: 'classer_sans_suite', title: 'Classer sans suite', confirm: 'Confirmez-vous le classement sans suite de ce dossier ?' }
@@ -29,7 +29,7 @@
         %span.icon.refuse
         .dropdown-description
           %h4 Refuser
-          L’usager sera notifié que son dossier a été refusé
+          L’usager sera informé que son dossier a été refusé
 
     - menu.with_item(class: "hidden inactive form-inside") do
       = render partial: 'instructeurs/dossiers/instruction_button_motivation', locals: { dossier: dossier, placeholder: 'Expliquez au demandeur pourquoi ce dossier est refusé (obligatoire)', popup_class: 'refuse', process_action: 'refuser', title: 'Refuser', confirm: 'Confirmez-vous le refus de ce dossier ?' }

--- a/config/locales/views/administrateurs/groupe_instructeurs/fr.yml
+++ b/config/locales/views/administrateurs/groupe_instructeurs/fr.yml
@@ -53,7 +53,7 @@ fr:
           notice_2: L’import n’écrase pas les instructeurs existants. Il permet uniquement d'en ajouter. Pour supprimer un instructeur, cliquez sur le bouton « retirer ». Le poids du fichier doit être inférieur %{csv_max_size}.
           import_file: Importer le fichier
           import_file_procedure_not_published: L’import d’instructeurs par fichier CSV est disponible une fois la démarche publiée
-          import_file_alert: Tous les instructeurs ajoutés à la procédure vont être notifiés par email. Voulez-vous continuer ?
+          import_file_alert: Tous les instructeurs ajoutés à la procédure vont être informés par email. Voulez-vous continuer ?
           link_text: exemple de fichier
           instructeurs_file_path: /csv/import-instructeurs-test.csv
           groupes_file_path: /csv/fr/import-groupe-test.csv


### PR DESCRIPTION
Notifier est une verbe transitif, on dit "notifier quelque chose à quelqu'un" et pas "notifier quelqu'un"

Voir ce retour au support : https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_14046b0d-d916-4534-bba1-5aecaff21725/