### PR TITLE
ETQ usager, je peux créer de nouveaux dossiers sur la démarche qui remplace la démarche fermée

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -453,6 +453,10 @@ class Procedure < ApplicationRecord
     publiee? || brouillon?
   end
 
+  def replaced_by_procedure?
+    replaced_by_procedure_id.present?
+  end
+
   def dossier_can_transition_to_en_construction?
     accepts_new_dossiers? || depubliee?
   end

--- a/app/views/users/dossiers/_dossier_actions.html.haml
+++ b/app/views/users/dossiers/_dossier_actions.html.haml
@@ -1,6 +1,6 @@
 - has_edit_action = !dossier.read_only?
 - has_delete_action = dossier.can_be_deleted_by_user?
-- has_new_dossier_action = dossier.procedure.accepts_new_dossiers?
+- has_new_dossier_action = dossier.procedure.accepts_new_dossiers? || dossier.procedure.replaced_by_procedure?
 - has_transfer_action = dossier.user == current_user
 - has_actions = has_edit_action || has_delete_action || has_new_dossier_action || has_transfer_action
 

--- a/spec/views/users/dossiers/_dossier_actions.html.haml_spec.rb
+++ b/spec/views/users/dossiers/_dossier_actions.html.haml_spec.rb
@@ -18,4 +18,9 @@ describe 'users/dossiers/dossier_actions.html.haml', type: :view do
     let(:procedure) { create(:procedure, :closed) }
     it { is_expected.not_to have_link('Commencer un autre dossier') }
   end
+
+  context 'when the procedure is closed and replaced' do
+    let(:procedure) { create(:procedure, :closed, replaced_by_procedure: create(:procedure)) }
+    it { is_expected.to have_link('Commencer un autre dossier') }
+  end
 end


### PR DESCRIPTION
On ne peut pas changer l'implémentation de `accepts_new_dossiers?` car elle est utilisée dans d'autres contextes où l'on ne veut pas prendre en compte la démarche qui la remplace.