### PR TITLE
Instructeur: ne plante pas un export si un champ commune n'a pas de code département

### DIFF
--- a/app/models/champs/commune_champ.rb
+++ b/app/models/champs/commune_champ.rb
@@ -59,7 +59,7 @@ class Champs::CommuneChamp < Champs::TextChamp
   alias postal_code code_postal
 
   def name
-    if code?
+    if code? && code_departement.present?
       APIGeoService.commune_name(code_departement, code)
     else
       value.present? ? value.to_s : ''
@@ -67,7 +67,7 @@ class Champs::CommuneChamp < Champs::TextChamp
   end
 
   def to_s
-    if code?
+    if code? && code_departement.present?
       "#{APIGeoService.commune_name(code_departement, code)} (#{code_postal})"
     else
       value.present? ? value.to_s : ''


### PR DESCRIPTION
On a au moins un dossier pour lequel on a un code mais pas de `code_departement` , et ça fait planter les exports

https://demarches-simplifiees.sentry.io/issues/4109466010/

Je ne sais pas si c'est un cas lié à un bug (à trouver), ou à un effet de bord d'une migration ou autre. J'ai d'ailleurs pas réussi à écrire un test qui se met dans cette situation là.
NB: ça semble pas lié à un TOM car la démarche en question est pour la Seine en Marne.