### PR TITLE
ETQ Usager, champ carte: ne permet pas d'enregistrer une geometry null pour ne pas casser les exports

### DIFF
--- a/app/models/geo_area.rb
+++ b/app/models/geo_area.rb
@@ -51,7 +51,7 @@ class GeoArea < ApplicationRecord
   scope :selections_utilisateur, -> { where(source: sources.fetch(:selection_utilisateur)) }
   scope :cadastres, -> { where(source: sources.fetch(:cadastre)) }
 
-  validates :geometry, geo_json: true, allow_blank: false
+  validates :geometry, geo_json: true, allow_nil: false
   before_validation :normalize_geometry
 
   def to_feature

--- a/app/validators/geo_json_validator.rb
+++ b/app/validators/geo_json_validator.rb
@@ -1,9 +1,13 @@
 class GeoJSONValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
+    if options[:allow_nil] == false && value.nil?
+      record.errors.add(attribute, :blank, message: options[:message] || "ne peut pas être vide")
+    end
+
     begin
       RGeo::GeoJSON.decode(value.to_json, geo_factory: RGeo::Geographic.simple_mercator_factory)
     rescue RGeo::Error::InvalidGeometry
-      record.errors[attribute] << (options[:message] || "n'est pas un GeoJSON valide")
+      record.errors.add(attribute, :invalid_geometry, message: options[:message] || "n'est pas un GeoJSON valide")
     end
   end
 end

--- a/lib/tasks/deployment/20230421160218_fix_geo_area_without_geometry_again.rake
+++ b/lib/tasks/deployment/20230421160218_fix_geo_area_without_geometry_again.rake
@@ -1,0 +1,13 @@
+namespace :after_party do
+  desc 'Deployment task: fix_geo_area_without_geometry_again'
+  task fix_geo_area_without_geometry_again: :environment do
+    puts "Running deploy task 'fix_geo_area_without_geometry_again'"
+
+    Rake::Task['after_party:fix_geo_area_without_geometry'].invoke
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/factories/geo_area.rb
+++ b/spec/factories/geo_area.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :geo_area do
     association :champ
     properties { {} }
+    geometry { {} }
 
     trait :cadastre do
       source { GeoArea.sources.fetch(:cadastre) }

--- a/spec/models/geo_area_spec.rb
+++ b/spec/models/geo_area_spec.rb
@@ -81,6 +81,16 @@ RSpec.describe GeoArea, type: :model do
         let(:geo_area) { build(:geo_area, :invalid_right_hand_rule_polygon, champ: nil) }
         it { expect(geo_area.errors).to have_key(:geometry) }
       end
+
+      context "nil" do
+        let(:geo_area) { build(:geo_area, geometry: nil) }
+        it { expect(geo_area.errors).to have_key(:geometry) }
+      end
+
+      context "allow empty {}" do
+        let(:geo_area) { build(:geo_area, geometry: {}) }
+        it { expect(geo_area.errors).not_to have_key(:geometry) }
+      end
     end
   end
 


### PR DESCRIPTION
On a un nouveau cas d'un champ carte avec `geo_area#geometry == nil`, ce qui casse l'export de la démarche associée.

Pas certain de la cause à la source, mais maintenant on empêche d'avoir ça en base.

C'est pas parfait car on est pas censé avoir de `{}` non plus, il faudrait être encore plus restrictif (C'était déjà permis avant, malgré le `allow_blank`). Sauf qu'en attendant de trouver l'origine du pb, on transforme les `nil` existants par des `{}`. 