### PR TITLE
[fix] Pagination interface usager - onglets disparaissent si pas sur la page 1

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -17,17 +17,34 @@ module Users
     before_action :store_user_location!, only: :new
 
     def index
-      dossiers = Dossier.includes(:procedure).order_by_updated_at.page(page)
+      dossiers = Dossier.includes(:procedure).order_by_updated_at
       dossiers_visibles = dossiers.visible_by_user
 
       @user_dossiers = current_user.dossiers.state_not_termine.merge(dossiers_visibles)
       @dossiers_traites = current_user.dossiers.state_termine.merge(dossiers_visibles)
-      @dossiers_close_to_expiration = current_user.dossiers.close_to_expiration.merge(dossiers_visibles)
       @dossiers_invites = current_user.dossiers_invites.merge(dossiers_visibles)
       @dossiers_supprimes_recemment = current_user.dossiers.hidden_by_user.merge(dossiers)
-      @dossiers_supprimes_definitivement = current_user.deleted_dossiers.order_by_updated_at.page(page)
-      @dossier_transfers = DossierTransfer.for_email(current_user.email).page(page)
+      @dossiers_supprimes_definitivement = current_user.deleted_dossiers.order_by_updated_at
+      @dossier_transfers = DossierTransfer.for_email(current_user.email)
+      @dossiers_close_to_expiration = current_user.dossiers.close_to_expiration.merge(dossiers_visibles)
       @statut = statut(@user_dossiers, @dossiers_traites, @dossiers_invites, @dossiers_supprimes_recemment, @dossiers_supprimes_definitivement, @dossier_transfers, @dossiers_close_to_expiration, params[:statut])
+
+      @dossiers = case @statut
+      when 'en-cours'
+        @user_dossiers
+      when 'traites'
+        @dossiers_traites
+      when 'dossiers-invites'
+        @dossiers_invites
+      when 'dossiers-supprimes-recemment'
+        @dossiers_supprimes_recemment
+      when 'dossiers-supprimes-definitivement'
+        @dossiers_supprimes_definitivement
+      when 'dossiers-transferes'
+        @dossier_transfers
+      when 'dossiers-expirant'
+        @dossiers_close_to_expiration
+      end.page(page)
 
       @first_brouillon_recently_updated = current_user.dossiers.visible_by_user.brouillons_recently_updated.first
     end

--- a/app/views/users/dossiers/index.html.haml
+++ b/app/views/users/dossiers/index.html.haml
@@ -91,6 +91,7 @@
       = render partial: "deleted_dossiers_list", locals: { deleted_dossiers: @dossiers }
 
     - if @statut == "dossiers-transferes"
+      -# /!\ in this context, @dossiers is a collection of DossierTransfer not Dossier
       = render partial: "transfered_dossiers_list", locals: { dossier_transfers: @dossiers }
 
     - if @statut == "dossiers-expirant"

--- a/app/views/users/dossiers/index.html.haml
+++ b/app/views/users/dossiers/index.html.haml
@@ -62,7 +62,7 @@
               active: @statut == 'dossiers-transferes',
               badge: number_with_html_delimiter(@dossier_transfers.count))
 
-.container
+.fr-container
   - if @search_terms.present?
     %h2.page-title Résultat de la recherche pour « #{@search_terms} »
     = render partial: "dossiers_list", locals: { dossiers: @dossiers }
@@ -76,22 +76,22 @@
               = t('users.dossiers.header.callout.first_brouillon_recently_updated_text', time_ago: time_ago_in_words(@first_brouillon_recently_updated.created_at), libelle: @first_brouillon_recently_updated.procedure.libelle  )
             = link_to t('users.dossiers.header.callout.first_brouillon_recently_updated_button'), modifier_dossier_path(@first_brouillon_recently_updated), class: 'fr-btn'
 
-      = render partial: "dossiers_list", locals: { dossiers: @user_dossiers }
+      = render partial: "dossiers_list", locals: { dossiers: @dossiers }
 
     - if @statut == "traites"
-      = render partial: "dossiers_list", locals: { dossiers: @dossiers_traites }
+      = render partial: "dossiers_list", locals: { dossiers: @dossiers }
 
     - if @statut == "dossiers-invites"
-      = render partial: "dossiers_list", locals: { dossiers: @dossiers_invites }
+      = render partial: "dossiers_list", locals: { dossiers: @dossiers }
 
     - if @statut == "dossiers-supprimes-recemment"
-      = render partial: "hidden_dossiers_list", locals: { hidden_dossiers: @dossiers_supprimes_recemment }
+      = render partial: "hidden_dossiers_list", locals: { hidden_dossiers: @dossiers }
 
     - if @statut == "dossiers-supprimes-definitivement"
-      = render partial: "deleted_dossiers_list", locals: { deleted_dossiers: @dossiers_supprimes_definitivement }
+      = render partial: "deleted_dossiers_list", locals: { deleted_dossiers: @dossiers }
 
     - if @statut == "dossiers-transferes"
-      = render partial: "transfered_dossiers_list", locals: { dossier_transfers: @dossier_transfers }
+      = render partial: "transfered_dossiers_list", locals: { dossier_transfers: @dossiers }
 
     - if @statut == "dossiers-expirant"
-      = render partial: "dossiers_list", locals: { dossiers: @dossiers_close_to_expiration }
+      = render partial: "dossiers_list", locals: { dossiers: @dossiers }

--- a/spec/system/users/list_dossiers_spec.rb
+++ b/spec/system/users/list_dossiers_spec.rb
@@ -3,6 +3,7 @@ describe 'user access to the list of their dossiers', js: true do
   let!(:dossier_brouillon)       { create(:dossier, user: user) }
   let!(:dossier_en_construction) { create(:dossier, :with_populated_champs, :en_construction, user: user) }
   let!(:dossier_en_instruction)  { create(:dossier, :en_instruction, user: user) }
+  let!(:dossier_traite)          { create(:dossier, :accepte, user: user) }
   let!(:dossier_archived)        { create(:dossier, :en_instruction, :archived, user: user) }
   let(:dossiers_per_page) { 25 }
   let(:last_updated_dossier) { dossier_en_construction }
@@ -26,6 +27,8 @@ describe 'user access to the list of their dossiers', js: true do
     expect(page).to have_content(dossier_en_construction.procedure.libelle)
     expect(page).to have_content(dossier_en_instruction.procedure.libelle)
     expect(page).to have_content(dossier_archived.procedure.libelle)
+    expect(page).to have_text('4 en cours')
+    expect(page).to have_text('1 traité')
   end
 
   it 'the list must be ordered by last updated' do
@@ -47,6 +50,8 @@ describe 'user access to the list of their dossiers', js: true do
       expect(page).not_to have_content(dossier_en_instruction.procedure.libelle)
       page.click_link("Suivant")
       expect(page).to have_content(dossier_en_instruction.procedure.libelle)
+      expect(page).to have_text('4 en cours')
+      expect(page).to have_text('1 traité')
     end
   end
 

--- a/spec/views/users/dossiers/index.html.haml_spec.rb
+++ b/spec/views/users/dossiers/index.html.haml_spec.rb
@@ -17,6 +17,7 @@ describe 'users/dossiers/index.html.haml', type: :view do
     assign(:dossiers_traites, Kaminari.paginate_array(user_dossiers).page(1))
     assign(:dossier_transfers, Kaminari.paginate_array([]).page(1))
     assign(:dossiers_close_to_expiration, Kaminari.paginate_array([]).page(1))
+    assign(:dossiers, Kaminari.paginate_array(user_dossiers).page(1))
     assign(:statut, statut)
     render
   end


### PR DESCRIPTION
Sur l'interface usager lorsqu'on utilise la pagination elle s'applique sur tous les onglets et font donc disparaitre les onglets s'il n'y a pas de dossiers correspondants

**AVANT**
<img width="1194" alt="Capture d’écran 2023-04-27 à 15 30 12" src="https://user-images.githubusercontent.com/6756627/234877724-47e3f685-3c16-4bc5-8996-4ed4f2c4491f.png">

**APRES**
<img width="1310" alt="Capture d’écran 2023-04-27 à 15 32 47" src="https://user-images.githubusercontent.com/6756627/234878109-7bd57015-562c-48d0-88a4-3b08335f45af.png">

