### PR TITLE
amelioration(dossier#submit_brouillon): ETQ usager, je souhaite pouvoir acceder aux champs en erreur facilement

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -1068,7 +1068,7 @@ class Dossier < ApplicationRecord
       .filter(&:visible?)
       .filter(&:mandatory_blank?)
       .map do |champ|
-        "Le champ #{champ.libelle.truncate(200)} doit être rempli."
+        champ.errors.add(:value, message: champ.errors.generate_message(:value, :missing))
       end
   end
 

--- a/app/validators/iban_validator.rb
+++ b/app/validators/iban_validator.rb
@@ -4,7 +4,7 @@ class IbanValidator < ActiveModel::Validator
   def validate(record)
     if record.value.present?
       unless IBANTools::IBAN.valid?(record.value)
-        record.errors.add :iban, record.errors.generate_message(:value, :invalid)
+        record.errors.add :value, message: record.errors.generate_message(:value, :invalid_iban)
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -389,6 +389,7 @@ en:
           empty: "No file"
           detail_one: "To complete a procedure, contact your administration and ask for the link to the procedure."
           detail_two: "This one should look like"
+        fix_champ: "fill in this field"
         archived_dossier: "Your file will be kept %{duree_conservation_dossiers_dans_ds} more months"
         identite:
           identity_data: Identity data
@@ -595,6 +596,11 @@ en:
               taken: is already used for procedure. You cannot use it because it belongs to another administrator.
               taken_can_be_claimed: Is the same as another of your procedure. If you publish this procedure, the other one will be unpublished
               invalid: is not valid. It must countain between 3 and 50 characters among a-z, 0-9, '_' and '-'.
+        "dossier/champs":
+          format: "%{message}"
+          attributes:
+            value:
+              format: "%{message}"
         "champs/cnaf_champ":
           attributes:
             numero_allocataire:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -390,6 +390,7 @@ fr:
           empty: "Aucun dossier"
           detail_one: "Pour remplir une démarche, contactez votre administration en lui demandant le lien de la démarche."
           detail_two: "Celui ci doit ressembler à"
+        fix_champ: "corriger l'erreur"
         archived_dossier: "Votre dossier sera conservé %{duree_conservation_dossiers_dans_ds} mois supplémentaire"
         identite:
           identity_data: Données d’identité
@@ -595,6 +596,12 @@ fr:
               taken: est déjà utilisé par une démarche. Vous ne pouvez pas l’utiliser car il appartient à un autre administrateur.
               taken_can_be_claimed: est identique à celui d’une autre de vos démarches publiées. Si vous publiez cette démarche, l’ancienne sera dépubliée et ne sera plus accessible au public. Les utilisateurs qui ont commencé un brouillon vont pouvoir le déposer.
               invalid: n’est pas valide. Il doit comporter au moins 3 caractères, au plus 50 caractères et seuls les caractères a-z, 0-9, '_' et '-' sont autorisés.
+        "dossier/champs":
+          format: "%{message}"
+          attributes:
+            value:
+              format: "%{message}"
+
         "champs/cnaf_champ":
           attributes:
             numero_allocataire:

--- a/config/locales/models/champs/champs.en.yml
+++ b/config/locales/models/champs/champs.en.yml
@@ -1,0 +1,10 @@
+fr:
+  activerecord:
+    errors:
+      models:
+        champ:
+          attributes:
+            value:
+              format: '%{message}'
+              missing: must be filled
+

--- a/config/locales/models/champs/champs.fr.yml
+++ b/config/locales/models/champs/champs.fr.yml
@@ -1,0 +1,10 @@
+fr:
+  activerecord:
+    errors:
+      models:
+        champ:
+          attributes:
+            value:
+              format: '%{message}'
+              missing: doit être rempli
+

--- a/config/locales/models/champs/iban_champ/en.yml
+++ b/config/locales/models/champs/iban_champ/en.yml
@@ -1,0 +1,9 @@
+en:
+  activerecord:
+    errors:
+      models:
+        champs/iban_champ:
+          attributes:
+            value:
+              invalid_iban: is not a valid IBAN
+

--- a/config/locales/models/champs/iban_champ/fr.yml
+++ b/config/locales/models/champs/iban_champ/fr.yml
@@ -1,0 +1,9 @@
+fr:
+  activerecord:
+    errors:
+      models:
+        champs/iban_champ:
+          attributes:
+            value:
+              invalid_iban: n'est pas au format IBAN
+

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1240,7 +1240,7 @@ describe Dossier do
 
       it 'should have errors' do
         expect(errors).not_to be_empty
-        expect(errors.first).to eq("Le champ #{champ_with_error.libelle} doit être rempli.")
+        expect(errors.first.full_message).to eq("doit être rempli")
       end
 
       context "conditionaly visible" do
@@ -1273,7 +1273,7 @@ describe Dossier do
 
         it 'should have errors' do
           expect(errors).not_to be_empty
-          expect(errors.first).to eq("Le champ #{champ_siret.libelle} doit être rempli.")
+          expect(errors.first.full_message).to eq("doit être rempli")
         end
       end
     end
@@ -1290,7 +1290,7 @@ describe Dossier do
           dossier.champs_public.first.champs.destroy_all
           expect(dossier.champs_public.first.rows).to be_empty
           expect(errors).not_to be_empty
-          expect(errors.first).to eq("Le champ #{champ_with_error.libelle} doit être rempli.")
+          expect(errors.first.full_message).to eq("doit être rempli")
         end
       end
 
@@ -1299,8 +1299,7 @@ describe Dossier do
 
         it 'should have errors' do
           expect(dossier.champs_public.first.rows).not_to be_empty
-          expect(errors).not_to be_empty
-          expect(errors.first).to eq("Le champ #{champ_with_error.libelle} doit être rempli.")
+          expect(errors.first.full_message).to eq("doit être rempli")
         end
 
         context "conditionaly visible" do
@@ -1317,7 +1316,7 @@ describe Dossier do
             dossier.champs_public.first.update(value: 'true')
             expect(dossier.champs_public.second.rows).not_to be_empty
             expect(errors).not_to be_empty
-            expect(errors.first).to eq("Le champ #{champ_with_error.libelle} doit être rempli.")
+            expect(errors.first.full_message).to eq("doit être rempli")
           end
         end
       end


### PR DESCRIPTION
c'est a devenir dingue 
https://secure.helpscout.net/conversation/2202674693/2025725/
https://secure.helpscout.net/conversation/2226253935/2028035?folderId=1653799
https://secure.helpscout.net/conversation/2225903258/2027944?folderId=1653799

le prob: 
ETQ usagers, quand un champs requis n'est pas renseigné, je n'arrive pas a le localiser sur le formulaire (et je vais jusqu'à contacter le support disant que ça ne marche pas)
`+` ETQ mfo jpp de faire du support pour un champ non renseigné

solution: des liens sur les libelles et les input dans le resumé des erreurs 

https://user-images.githubusercontent.com/125964/235921194-07799849-c5ed-468f-93a6-eee3851db78c.mov





