### PR TITLE
ETQ administrateur, je veux pouvoir limiter le nombre de caractères dans les champs "texte long"

### DIFF
--- a/app/assets/stylesheets/dossier_edit.scss
+++ b/app/assets/stylesheets/dossier_edit.scss
@@ -42,6 +42,11 @@ $dossier-actions-bar-border-width: 1px;
     }
   }
 
+  .characters-count {
+    position: relative;
+    top: -1rem;
+  }
+
   .warning {
     margin-bottom: 20px;
     background-color: #f9b91666;

--- a/app/components/editable_champ/textarea_component/textarea_component.en.yml
+++ b/app/components/editable_champ/textarea_component/textarea_component.en.yml
@@ -1,0 +1,3 @@
+en:
+  remaining_characters: You have %{remaining_words} characters remaining.
+  excess_characters: You have %{excess_words} characters too many.

--- a/app/components/editable_champ/textarea_component/textarea_component.fr.yml
+++ b/app/components/editable_champ/textarea_component/textarea_component.fr.yml
@@ -1,0 +1,3 @@
+fr:
+  remaining_characters: Il vous reste %{remaining_words} caractères.
+  excess_characters: Vous avez dépassé la taille conseillée de %{excess_words} caractères.

--- a/app/components/editable_champ/textarea_component/textarea_component.html.haml
+++ b/app/components/editable_champ/textarea_component/textarea_component.html.haml
@@ -1,7 +1,3 @@
-- character_limit = @champ.textarea_character_limit.to_i if !@champ.textarea_character_limit&.empty?
-- character_count = @champ.character_count(@champ.value)
-- analyze_character_count = @champ.analyze_character_count(character_count, character_limit)
-
 ~ @form.text_area :value,
   id: @champ.input_id,
   aria: { describedby: @champ.describedby_id },
@@ -9,12 +5,10 @@
   required: @champ.required?,
   value: html_to_string(@champ.value)
 
-- if @champ.textarea_character_limit?
+- if @champ.character_limit_info?
+  %span.fr-icon-information-fill.fr-text-default--info.characters-count
+    = t('.remaining_characters', remaining_words: @champ.remaining_characters)
 
-  - if analyze_character_count == :info
-    %span.fr-icon-information-fill.fr-text-default--info.characters-count
-      = t('.remaining_characters', remaining_words: @champ.remaining_characters(character_count, character_limit))
-
-  - if analyze_character_count == :warning
-    %span.fr-icon-close-circle-fill.fr-text-default--error.characters-count
-      = t('.excess_characters', excess_words: @champ.excess_characters(character_count, character_limit))
+- if @champ.character_limit_warning?
+  %span.fr-icon-close-circle-fill.fr-text-default--error.characters-count
+    = t('.excess_characters', excess_words: @champ.excess_characters)

--- a/app/components/editable_champ/textarea_component/textarea_component.html.haml
+++ b/app/components/editable_champ/textarea_component/textarea_component.html.haml
@@ -1,6 +1,20 @@
+- character_limit = @champ.textarea_character_limit.to_i if !@champ.textarea_character_limit&.empty?
+- character_count = @champ.character_count(@champ.value)
+- analyze_character_count = @champ.analyze_character_count(character_count, character_limit)
+
 ~ @form.text_area :value,
   id: @champ.input_id,
   aria: { describedby: @champ.describedby_id },
   rows: 6,
   required: @champ.required?,
   value: html_to_string(@champ.value)
+
+- if @champ.textarea_character_limit?
+
+  - if analyze_character_count == :info
+    %span.fr-icon-information-fill.fr-text-default--info.characters-count
+      = t('.remaining_characters', remaining_words: @champ.remaining_characters(character_count, character_limit))
+
+  - if analyze_character_count == :warning
+    %span.fr-icon-close-circle-fill.fr-text-default--error.characters-count
+      = t('.excess_characters', excess_words: @champ.excess_characters(character_count, character_limit))

--- a/app/components/procedure/revision_changes_component/revision_changes_component.fr.yml
+++ b/app/components/procedure/revision_changes_component/revision_changes_component.fr.yml
@@ -36,8 +36,8 @@ fr:
     add_condition: Une condition a été ajoutée sur le champ « %{label} ». La nouvelle condition est « %{to} ».
     remove_condition: La condition du champ « %{label} » a été supprimée.
     update_condition: La condition du champ « %{label} » a été modifiée. La nouvelle condition est « %{to} ».
-    update_textarea_character_limit: La limite de caractères du champ texte « %{label} » a été modifiée. La nouvelle limite est « %{to} ».
-    remove_textarea_character_limit: La limite de caractères du champ texte « %{label} » a été supprimée.
+    update_character_limit: La limite de caractères du champ texte « %{label} » a été modifiée. La nouvelle limite est « %{to} ».
+    remove_character_limit: La limite de caractères du champ texte « %{label} » a été supprimée.
   private:
     add: L’annotation privée « %{label} » a été ajoutée.
     remove: L’annotation privée « %{label} » a été supprimée.

--- a/app/components/procedure/revision_changes_component/revision_changes_component.fr.yml
+++ b/app/components/procedure/revision_changes_component/revision_changes_component.fr.yml
@@ -36,6 +36,8 @@ fr:
     add_condition: Une condition a été ajoutée sur le champ « %{label} ». La nouvelle condition est « %{to} ».
     remove_condition: La condition du champ « %{label} » a été supprimée.
     update_condition: La condition du champ « %{label} » a été modifiée. La nouvelle condition est « %{to} ».
+    update_textarea_character_limit: La limite de caractères du champ texte « %{label} » a été modifiée. La nouvelle limite est « %{to} ».
+    remove_textarea_character_limit: La limite de caractères du champ texte « %{label} » a été supprimée.
   private:
     add: L’annotation privée « %{label} » a été ajoutée.
     remove: L’annotation privée « %{label} » a été supprimée.

--- a/app/components/procedure/revision_changes_component/revision_changes_component.html.haml
+++ b/app/components/procedure/revision_changes_component/revision_changes_component.html.haml
@@ -131,13 +131,13 @@
             - if !total_dossiers.zero? && !change.can_rebase?
               .fr-alert.fr-alert--warning.fr-mt-1v
                 %p= t('.breakigng_change', count: total_dossiers)
-      - when :textarea_character_limit
-        - if change.to.nil?
+      - when :character_limit
+        - if change.to.blank?
           - list.with_item do
-            = t(".#{prefix}.remove_textarea_character_limit", label: change.label, to: change.to)
+            = t(".#{prefix}.remove_character_limit", label: change.label, to: change.to)
         - else
           - list.with_item do
-            = t(".#{prefix}.update_textarea_character_limit", label: change.label, to: change.to)
+            = t(".#{prefix}.update_character_limit", label: change.label, to: change.to)
 
   - if @public_move_changes.present?
     - list.with_item do

--- a/app/components/procedure/revision_changes_component/revision_changes_component.html.haml
+++ b/app/components/procedure/revision_changes_component/revision_changes_component.html.haml
@@ -130,7 +130,14 @@
             = t(".#{prefix}.update_condition", label: change.label, to: change.to)
             - if !total_dossiers.zero? && !change.can_rebase?
               .fr-alert.fr-alert--warning.fr-mt-1v
-                %p= t('.breaking_change', count: total_dossiers)
+                %p= t('.breakigng_change', count: total_dossiers)
+      - when :textarea_character_limit
+        - if change.to.nil?
+          - list.with_item do
+            = t(".#{prefix}.remove_textarea_character_limit", label: change.label, to: change.to)
+        - else
+          - list.with_item do
+            = t(".#{prefix}.update_textarea_character_limit", label: change.label, to: change.to)
 
   - if @public_move_changes.present?
     - list.with_item do

--- a/app/components/types_de_champ_editor/champ_component.rb
+++ b/app/components/types_de_champ_editor/champ_component.rb
@@ -121,4 +121,14 @@ class TypesDeChampEditor::ChampComponent < ApplicationComponent
   def conditional_enabled?
     !type_de_champ.private?
   end
+
+  def options_for_character_limit
+    [
+      [t('.character_limit.unlimited'), nil],
+      [t('.character_limit.limit', limit: 400), 400],
+      [t('.character_limit.limit', limit: 1000), 1000],
+      [t('.character_limit.limit', limit: 5000), 5000],
+      [t('.character_limit.limit', limit: 10000), 10000]
+    ]
+  end
 end

--- a/app/components/types_de_champ_editor/champ_component/champ_component.fr.yml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.fr.yml
@@ -10,3 +10,6 @@ fr:
     natura_2000: Natura 2000
     zones_humides: Zones humides d’importance internationale
     znieff: ZNIEFF
+  character_limit:
+    unlimited: Pas de limite de charactères
+    limit: Limité à %{limit} caractères

--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
@@ -103,9 +103,9 @@
               = form.text_area :collapsible_explanation_text, class: "small-margin small", id: dom_id(type_de_champ, :collapsible_explanation_text)
         - if type_de_champ.textarea?
           .cell
-            = form.label :textarea_character_limit, for: dom_id(type_de_champ, :textarea_character_limit) do
+            = form.label :character_limit, for: dom_id(type_de_champ, :character_limit) do
               Spécifier un nombre maximal de caractères (non restrictif) :
-            = form.number_field :textarea_character_limit, min: 400, value: form.object.textarea_character_limit, id: dom_id(type_de_champ, :textarea_character_limit)
+            = form.select :character_limit, options_for_character_limit, id: dom_id(type_de_champ, :character_limit)
 
   - if type_de_champ.block?
     .flex.justify-start.section.ml-1

--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
@@ -101,8 +101,11 @@
               = form.label :collapsible_explanation_text, for: dom_id(type_de_champ, :collapsible_explanation_text) do
                 = "Texte à afficher quand l'utiliser a choisi de l'afficher"
               = form.text_area :collapsible_explanation_text, class: "small-margin small", id: dom_id(type_de_champ, :collapsible_explanation_text)
-
-
+        - if type_de_champ.textarea?
+          .cell
+            = form.label :textarea_character_limit, for: dom_id(type_de_champ, :textarea_character_limit) do
+              Spécifier un nombre maximal de caractères (non restrictif) :
+            = form.number_field :textarea_character_limit, min: 400, value: form.object.textarea_character_limit, id: dom_id(type_de_champ, :textarea_character_limit)
 
   - if type_de_champ.block?
     .flex.justify-start.section.ml-1

--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -129,7 +129,7 @@ module Administrateurs
         :collapsible_explanation_enabled,
         :collapsible_explanation_text,
         :header_section_level,
-        :textarea_character_limit,
+        :character_limit,
         editable_options: [
           :cadastres,
           :unesco,

--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -119,28 +119,29 @@ module Administrateurs
 
     def type_de_champ_update_params
       params.required(:type_de_champ).permit(:type_champ,
-                                             :libelle,
-                                             :description,
-                                             :mandatory,
-                                             :drop_down_list_value,
-                                             :drop_down_other,
-                                             :drop_down_secondary_libelle,
-                                             :drop_down_secondary_description,
-                                             :collapsible_explanation_enabled,
-                                             :collapsible_explanation_text,
-                                             :header_section_level,
-                                             editable_options: [
-                                               :cadastres,
-                                               :unesco,
-                                               :arretes_protection,
-                                               :conservatoire_littoral,
-                                               :reserves_chasse_faune_sauvage,
-                                               :reserves_biologiques,
-                                               :reserves_naturelles,
-                                               :natura_2000,
-                                               :zones_humides,
-                                               :znieff
-                                             ])
+        :libelle,
+        :description,
+        :mandatory,
+        :drop_down_list_value,
+        :drop_down_other,
+        :drop_down_secondary_libelle,
+        :drop_down_secondary_description,
+        :collapsible_explanation_enabled,
+        :collapsible_explanation_text,
+        :header_section_level,
+        :textarea_character_limit,
+        editable_options: [
+          :cadastres,
+          :unesco,
+          :arretes_protection,
+          :conservatoire_littoral,
+          :reserves_chasse_faune_sauvage,
+          :reserves_biologiques,
+          :reserves_naturelles,
+          :natura_2000,
+          :zones_humides,
+          :znieff
+        ])
     end
 
     def draft

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -75,8 +75,8 @@ class Champ < ApplicationRecord
     :mandatory?,
     :prefillable?,
     :refresh_after_update?,
-    :textarea_character_limit?,
-    :textarea_character_limit,
+    :character_limit?,
+    :character_limit,
     to: :type_de_champ
 
   delegate :to_typed_id, :to_typed_id_for_query, to: :type_de_champ, prefix: true

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -75,6 +75,8 @@ class Champ < ApplicationRecord
     :mandatory?,
     :prefillable?,
     :refresh_after_update?,
+    :textarea_character_limit?,
+    :textarea_character_limit,
     to: :type_de_champ
 
   delegate :to_typed_id, :to_typed_id_for_query, to: :type_de_champ, prefix: true

--- a/app/models/champs/textarea_champ.rb
+++ b/app/models/champs/textarea_champ.rb
@@ -25,28 +25,43 @@ class Champs::TextareaChamp < Champs::TextChamp
     value.present? ? ActionView::Base.full_sanitizer.sanitize(value) : nil
   end
 
-  def character_count(text)
-    return text&.bytesize
+  def remaining_characters
+    character_limit_base - character_count if character_count >= character_limit_threshold_75
   end
 
-  def analyze_character_count(characters, limit)
-    if characters
-      threshold_75 = limit * 0.75
+  def excess_characters
+    character_count - character_limit_base if character_count > character_limit_base
+  end
 
-      if characters >= limit
+  def character_limit_info?
+    analyze_character_count == :info
+  end
+
+  def character_limit_warning?
+    analyze_character_count == :warning
+  end
+
+  private
+
+  def character_count
+    return value&.bytesize
+  end
+
+  def character_limit_base
+    character_limit&.to_i
+  end
+
+  def character_limit_threshold_75
+    character_limit_base * 0.75
+  end
+
+  def analyze_character_count
+    if character_limit? && character_count.present?
+      if character_count >= character_limit_base
         return :warning
-      elsif characters >= threshold_75
+      elsif character_count >= character_limit_threshold_75
         return :info
       end
     end
-  end
-
-  def remaining_characters(characters, limit)
-    threshold_75 = limit * 0.75
-    limit - characters if characters >= threshold_75
-  end
-
-  def excess_characters(characters, limit)
-    characters - limit if characters > limit
   end
 end

--- a/app/models/champs/textarea_champ.rb
+++ b/app/models/champs/textarea_champ.rb
@@ -24,4 +24,29 @@ class Champs::TextareaChamp < Champs::TextChamp
   def for_export
     value.present? ? ActionView::Base.full_sanitizer.sanitize(value) : nil
   end
+
+  def character_count(text)
+    return text&.bytesize
+  end
+
+  def analyze_character_count(characters, limit)
+    if characters
+      threshold_75 = limit * 0.75
+
+      if characters >= limit
+        return :warning
+      elsif characters >= threshold_75
+        return :info
+      end
+    end
+  end
+
+  def remaining_characters(characters, limit)
+    threshold_75 = limit * 0.75
+    limit - characters if characters >= threshold_75
+  end
+
+  def excess_characters(characters, limit)
+    characters - limit if characters > limit
+  end
 end

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -377,6 +377,13 @@ class ProcedureRevision < ApplicationRecord
           from_type_de_champ.piece_justificative_template_filename,
           to_type_de_champ.piece_justificative_template_filename)
       end
+    elsif to_type_de_champ.textarea?
+      if from_type_de_champ.textarea_character_limit != to_type_de_champ.textarea_character_limit
+        changes << ProcedureRevisionChange::UpdateChamp.new(from_type_de_champ,
+          :textarea_character_limit,
+          from_type_de_champ.textarea_character_limit,
+          to_type_de_champ.textarea_character_limit)
+      end
     end
     changes
   end

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -378,11 +378,11 @@ class ProcedureRevision < ApplicationRecord
           to_type_de_champ.piece_justificative_template_filename)
       end
     elsif to_type_de_champ.textarea?
-      if from_type_de_champ.textarea_character_limit != to_type_de_champ.textarea_character_limit
+      if from_type_de_champ.character_limit != to_type_de_champ.character_limit
         changes << ProcedureRevisionChange::UpdateChamp.new(from_type_de_champ,
-          :textarea_character_limit,
-          from_type_de_champ.textarea_character_limit,
-          to_type_de_champ.textarea_character_limit)
+          :character_limit,
+          from_type_de_champ.character_limit,
+          to_type_de_champ.character_limit)
       end
     end
     changes

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -19,6 +19,7 @@ class TypeDeChamp < ApplicationRecord
 
   FILE_MAX_SIZE = 200.megabytes
   FEATURE_FLAGS = {}
+  MINIMUM_TEXTAREA_CHARACTER_LIMIT_LENGTH = 400
 
   STRUCTURE = :structure
   ETAT_CIVIL = :etat_civil
@@ -118,6 +119,7 @@ class TypeDeChamp < ApplicationRecord
                  :drop_down_secondary_libelle,
                  :drop_down_secondary_description,
                  :drop_down_other,
+                 :textarea_character_limit,
                  :collapsible_explanation_enabled,
                  :collapsible_explanation_text,
                  :header_section_level
@@ -177,6 +179,11 @@ class TypeDeChamp < ApplicationRecord
 
   validates :libelle, presence: true, allow_blank: false, allow_nil: false
   validates :type_champ, presence: true, allow_blank: false, allow_nil: false
+  validates :textarea_character_limit, numericality: {
+    greater_than_or_equal_to: MINIMUM_TEXTAREA_CHARACTER_LIMIT_LENGTH,
+    only_integer: true,
+    allow_nil: true
+  }
 
   before_validation :check_mandatory
   before_validation :normalize_libelle
@@ -233,6 +240,10 @@ class TypeDeChamp < ApplicationRecord
 
   def drop_down_other?
     drop_down_other == "1" || drop_down_other == true
+  end
+
+  def textarea_character_limit?
+    textarea_character_limit.present?
   end
 
   def collapsible_explanation_enabled?
@@ -338,6 +349,10 @@ class TypeDeChamp < ApplicationRecord
 
   def legacy_number?
     type_champ == TypeDeChamp.type_champs.fetch(:number)
+  end
+
+  def textarea?
+    type_champ == TypeDeChamp.type_champs.fetch(:textarea)
   end
 
   def titre_identite?
@@ -539,7 +554,8 @@ class TypeDeChamp < ApplicationRecord
       type_champs.fetch(:multiple_drop_down_list),
       type_champs.fetch(:dossier_link),
       type_champs.fetch(:linked_drop_down_list),
-      type_champs.fetch(:drop_down_list)
+      type_champs.fetch(:drop_down_list),
+      type_champs.fetch(:textarea)
       true
     else
       false

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -119,7 +119,7 @@ class TypeDeChamp < ApplicationRecord
                  :drop_down_secondary_libelle,
                  :drop_down_secondary_description,
                  :drop_down_other,
-                 :textarea_character_limit,
+                 :character_limit,
                  :collapsible_explanation_enabled,
                  :collapsible_explanation_text,
                  :header_section_level
@@ -179,10 +179,10 @@ class TypeDeChamp < ApplicationRecord
 
   validates :libelle, presence: true, allow_blank: false, allow_nil: false
   validates :type_champ, presence: true, allow_blank: false, allow_nil: false
-  validates :textarea_character_limit, numericality: {
+  validates :character_limit, numericality: {
     greater_than_or_equal_to: MINIMUM_TEXTAREA_CHARACTER_LIMIT_LENGTH,
     only_integer: true,
-    allow_nil: true
+    allow_blank: true
   }
 
   before_validation :check_mandatory
@@ -242,8 +242,8 @@ class TypeDeChamp < ApplicationRecord
     drop_down_other == "1" || drop_down_other == true
   end
 
-  def textarea_character_limit?
-    textarea_character_limit.present?
+  def character_limit?
+    character_limit.present?
   end
 
   def collapsible_explanation_enabled?


### PR DESCRIPTION
J'ai dû revert la PR sur la limite de caractères dans les textareas. Le principal problème était qu'il était impossible de désactiver la fonctionnalité une fois activée (`allow_nil` vs `allow_blank` pour les développeurs). Mais au-delà de ça, l'UX était inacceptable selon moi. On présentait un champ nombre ( beaucoup trop large). Si on essayait de mettre un chiffre plus petit que 400, on avait un bord rouge et une erreur en haut de la page. Si on modifiait un champ au milieu du formulaire, on ne voyait jamais l'erreur. Si on ne corrigeait pas le champ, tous les autres changements sur le champ n'étaient pas sauvegardés tant qu'on ne corrigeait pas. Du coup, dans cette PR, je propose de revenir vers un select qui ne présente pas les difficultés avec la gestion des erreurs. Si vous pensez que ce n'est pas acceptable, il faut revoir l'architecture de la gestion des erreurs et de la sauvegarde dans l'éditeur des champs. Ce n'est pas un chantier trivial, donc ça bloque cette fonctionnalité tant que nous n'avons pas l'affichage des erreurs "inline" et la sauvegarde partielle (à moins que vous ne me disiez que vous trouvez ça acceptable de perdre les autres changements si la valeur de ce champ est invalide).

PS: J'ai mis des valeurs un peu arbitraires dans le select, ont peut refaire un point pour en décider des valeurs plus pertinentes.

PS 2: J'ai changé `textarea_character_limit` en `character_limit` car je pense qu'on pourrait potentiellement vouloir réutiliser cette mécanique sur d'autres types de champs.

cc @kara22 @Olivier-Marcellin 