### PR TITLE
ETQ instructeur, ne plante pas un export s'il contient des PJ avec des noms de fichiers invalides

### DIFF
--- a/app/lib/download_manager/parallel_download_queue.rb
+++ b/app/lib/download_manager/parallel_download_queue.rb
@@ -28,7 +28,7 @@ module DownloadManager
 
     # can't be used with typhoeus, otherwise block is closed before the request is run by hydra
     def download_one(attachment:, path_in_download_dir:, http_client:)
-      attachment_path = File.join(destination, path_in_download_dir)
+      attachment_path = File.join(destination, sanitize_filename(path_in_download_dir))
       attachment_dir = File.dirname(attachment_path)
 
       FileUtils.mkdir_p(attachment_dir) if !Dir.exist?(attachment_dir) # defensive, do not write in undefined dir
@@ -48,6 +48,17 @@ module DownloadManager
         end
         http_client.queue(request)
       end
+    end
+
+    private
+
+    def sanitize_filename(filename)
+      return filename if filename.bytesize <= 255
+
+      ext = File.extname(filename)
+      basename = File.basename(filename, ext).byteslice(0, 255 - ext.bytesize)
+
+      basename + ext
     end
   end
 end

--- a/spec/lib/download_manager/parallel_download_queue_spec.rb
+++ b/spec/lib/download_manager/parallel_download_queue_spec.rb
@@ -51,5 +51,27 @@ describe DownloadManager::ParallelDownloadQueue do
         expect(attachment.file.read).to eq(File.read(target))
       end
     end
+
+    context 'with filename containing unsafe characters for storage' do
+      let(:destination) { "file:éà\u{202e} K.txt" }
+
+      it 'sanitize the problematic chars' do
+        target = File.join(download_to_dir, 'file-éà- K.txt')
+        expect { subject }.to change { File.exist?(target) }
+        attachment.file.rewind
+        expect(attachment.file.read).to eq(File.read(target))
+      end
+
+      context 'with a destination tree' do
+        let(:destination) { 'subdir/file.txt' }
+
+        it 'preserves the destination tree' do
+          target = File.join(download_to_dir, 'subdir/file.txt')
+          expect { subject }.to change { File.exist?(target) }
+          attachment.file.rewind
+          expect(attachment.file.read).to eq(File.read(target))
+        end
+      end
+    end
   end
 end

--- a/spec/lib/download_manager/parallel_download_queue_spec.rb
+++ b/spec/lib/download_manager/parallel_download_queue_spec.rb
@@ -40,5 +40,16 @@ describe DownloadManager::ParallelDownloadQueue do
         # expect(downloadable_manager.errors).to have_key(destination)
       end
     end
+
+    context 'with a destination filename too long' do
+      let(:destination) { 'a' * 252 + '.txt' }
+
+      it 'limit the file path to 255 bytes' do
+        target = File.join(download_to_dir, 'a' * 251 + '.txt')
+        expect { subject }.to change { File.exist?(target) }
+        attachment.file.rewind
+        expect(attachment.file.read).to eq(File.read(target))
+      end
+    end
   end
 end


### PR DESCRIPTION
- nom de fichier > 255 bytes invalides sur la plupart des systèmes de fichiers
- nom de fichier avec des caractères unsafe pour un système de fichiers ou à l'intérieur d'un zip (pourrait fixer des pb de dezip sous windows)
- refacto avec Pathname pour mieux gérer les subdirectories

Cf https://demarches-simplifiees.sentry.io/issues/4151873729/

