### PR TITLE
ETQ développeur je veux pouvoir utiliser les urls d'attachments en local

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -92,6 +92,10 @@ Rails.application.configure do
     protocol: :http
   }
 
+  Rails.application.config.after_initialize do # allow attachment.url with disk service
+    ActiveStorage::Current.url_options = { host: ENV.fetch("APP_HOST") }
+  end
+
   # Use Content-Security-Policy-Report-Only headers
   config.content_security_policy_report_only = true
 


### PR DESCRIPTION
En local on utilise le service "disk" d'ActiveStorage, qui nécessite de configurer le host pour pouvoir générer les urls.

Ça permet (par exemple) de tester les générations d'export avec pièces justificatives