### PR TITLE
ETQ Instructeur, je ne veux pas voir les dossiers terminés dans l'onglet "suivis"

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -432,8 +432,8 @@ class Dossier < ApplicationRecord
     when 'suivis'
       instructeur
         .followed_dossiers
-        .en_cours
         .merge(visible_by_administration)
+        .en_cours
     when 'traites'
       visible_by_administration.termine
     when 'tous'


### PR DESCRIPTION
Pour mémoire : depuis Rails 7, le merge écrase une même condition plutôt que les fusionner (ici dossiers.state)