### PR TITLE
Email (Dolist): pas d'erreur lorsqu'un mail n'a pas pu être envoyé vers un nouveau contact

### DIFF
--- a/app/lib/dolist/api.rb
+++ b/app/lib/dolist/api.rb
@@ -152,7 +152,11 @@ module Dolist
         }
       }.to_json
 
-      post(url, body)["FieldList"].find { _1['ID'] == 72 }['Value']
+      fields = post(url, body).fetch("FieldList", [])
+
+      return nil if fields.empty?
+
+      fields.find { _1['ID'] == 72 }.fetch('Value')
     end
 
     def ignorable_error?(response, mail)


### PR DESCRIPTION
La réponse pour récupérer le status du contact ne contient pas de `FieldList` quand le contact n'existe pas encore

https://demarches-simplifiees.sentry.io/issues/4131878671