### PR TITLE
Usager: améliore la visibilité du bouton action dans le tableau dossiers des usagers

### DIFF
--- a/app/assets/stylesheets/dsfr.scss
+++ b/app/assets/stylesheets/dsfr.scss
@@ -74,6 +74,11 @@ fieldset {
   box-shadow: 0px 0px 0px 1px $light-red;
 }
 
+.fr-table table.hack-to-display-dropdown {
+  padding-bottom: 300px;
+  margin-bottom: -300px;
+}
+
 // on utilise le dropdown de sélecteur de langue pour un autre usage donc on veut retirer l'icone
 .fr-translate .fr-translate__btn.custom-fr-translate-no-icon::before {
   display: none;

--- a/app/views/users/dossiers/_dossiers_list.html.haml
+++ b/app/views/users/dossiers/_dossiers_list.html.haml
@@ -2,7 +2,7 @@
   %span.fr-h6.fr-mr-2w
     = page_entries_info dossiers
   .fr-table.fr-table--bordered.fr-table--no-caption.fr-mt-2w
-    %table.table.dossiers-table.hoverable
+    %table.table.dossiers-table.hoverable.hack-to-display-dropdown
       %caption= t('views.users.dossiers.dossiers_list.caption')
       %thead
         %tr


### PR DESCRIPTION
Dans les tableaux usagers - il y a des dropdowns d'action qui sont difficilement utilisables si elles apparaissent en bord de tableau : s'il y a peu de dossiers ou les derniers dossiers d'une longue liste.

Il faudrait surement gérer ça avec du JS ou autre mais comme il va y avoir une refonte du design pour cette partie la - on a penché pour un quickfix - qui permet de laisser apparaitre le dropdown en entier. (CF capture ecran)

**APRES**
<img width="1075" alt="Capture d’écran 2023-05-10 à 17 13 21" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/4cc53e97-0001-4141-b54b-88d5b43093d0">

**AVANT**
<img width="1085" alt="Capture d’écran 2023-05-10 à 17 12 26" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/88179453-2d32-4289-b71c-4ef25cd62e58">
