### PR TITLE
API Entreprise: supporte la nouvelle valeur qui indique qu'une entreprise est fermée/a cessé

### DIFF
--- a/app/lib/api_entreprise/entreprise_adapter.rb
+++ b/app/lib/api_entreprise/entreprise_adapter.rb
@@ -50,7 +50,7 @@ class APIEntreprise::EntrepriseAdapter < APIEntreprise::Adapter
 
     case raw_value
     when 'A' then 'actif'
-    when 'F' then 'fermé'
+    when 'F', 'C' then 'fermé'
     end
   end
 


### PR DESCRIPTION
Pour éviter les breaking changes dans notre API, on conserve pour le moment  le mapping vers "fermé" mais il semble que la domination soit maintenant "cessé", à faire en v3.