### PR TITLE
Usager: plus de détails sur les raisons qui expliquent pourquoi je ne reçois pas l'email "mot de passe perdu"

### DIFF
--- a/app/views/users/passwords/reset_link_sent.html.haml
+++ b/app/views/users/passwords/reset_link_sent.html.haml
@@ -12,7 +12,7 @@
 
   %section.link-sent-info
     %p
-      = t('views.users.passwords.reset_link_sent.email_sent_html', email: @email)
+      = t('views.users.passwords.reset_link_sent.email_sent_html', email: @email, application_name: APPLICATION_NAME)
     %p
       = t('views.users.passwords.reset_link_sent.click_link_to_reset_password')
     %p
@@ -28,5 +28,8 @@
       - if FranceConnectService.enabled?
         %li
           = t('views.users.passwords.reset_link_sent.check_france_connect_html', href: france_connect_particulier_path)
+
+      %li
+        = t('views.users.passwords.reset_link_sent.check_gpdr')
     %p
       = t('views.users.shared.contact_us_if_any_trouble_html', href: contact_url)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -498,12 +498,13 @@ en:
         reset_link_sent:
           got_it: Got it!
           open_your_mailbox: Now open your mailbox.
-          email_sent_html: We have sent you an email to the address <strong>%{email}</strong>.
+          email_sent_html: "If a <strong>%{application_name}</strong> account exists with the address <strong>%{email}</strong>, we have sent you an email."
           click_link_to_reset_password: Click on the link in the email to change your password.
           no_mail: Didn't receive the email?
           check_spams: Check your junk or spam email.
           check_account: Have you created a %{application_name} account with the adress %{email}? You will not receive any message if no account is linked to your email adress.
           check_france_connect_html: Have you once logged in with France Connect? If yes, <a href=\"%{href}\">try again with France Connect</a>.
+          check_gpdr: "The account may have been deleted in the event of prolonged inactivity and no current file. In this case you will have to recreate an account from a procedure."
       shared:
         email_can_take_a_while_html: <strong>Please note</strong> that this message can take up to 15 minutes to arrive.
         contact_us_if_any_trouble_html: 'You can contact us <a href="%{href}">through this form</a> if a problem still exists.'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -497,12 +497,13 @@ fr:
           submit: Changer le mot de passe
           submit_loading: Envoi…
         reset_link_sent:
-          email_sent_html: "Nous vous avons envoyé un email à l’adresse <strong>%{email}</strong>."
+          email_sent_html: "Si un compte <strong>%{application_name}</strong> existe avec l’adresse <strong>%{email}</strong>, nous vous avons envoyé un email."
           click_link_to_reset_password: "Cliquez sur le lien contenu dans l’email pour changer votre mot de passe."
           no_mail: "Vous n’avez pas reçu l’email ?"
           check_spams: "Vérifiez la boite Indésirables ou Spam de votre boite email."
-          check_account: "Avez-vous bien créé un compte %{application_name} avec l’adresse %{email} ? Si aucun compte n’existe avec cette adresse, vous ne recevrez pas de message."
+          check_account: "Avez-vous bien créé un compte %{application_name} avec l’adresse %{email} ? Si aucun compte n’existe avec cette adresse, vous ne recevrez pas de message."
           check_france_connect_html: "Vous êtes-vous connecté avec France Connect par le passé ? Dans ce cas <a href=\"%{href}\">essayez à nouveau avec France Connect</a>."
+          check_gpdr: "Le compte a pu être supprimé en cas d’inactivité prolongée et sans dossier en cours. Dans ce cas vous devrez recréer un compte à partir d’une démarche."
           got_it: "Bien reçu !"
           open_your_mailbox: "Maintenant ouvrez votre boite email."
           title: "Lien de réinitialisation du mot de passe envoyé"

--- a/spec/system/users/managing_password_spec.rb
+++ b/spec/system/users/managing_password_spec.rb
@@ -15,7 +15,7 @@ describe 'Managing password:', js: true do
       perform_enqueued_jobs do
         click_on 'Demander un nouveau mot de passe'
       end
-      expect(page).to have_text 'Nous vous avons envoyé un email'
+      expect(page).to have_text 'nous vous avons envoyé un email'
       expect(page).to have_text user.email
 
       click_reset_password_link_for user.email
@@ -46,7 +46,7 @@ describe 'Managing password:', js: true do
       perform_enqueued_jobs do
         click_on 'Demander un nouveau mot de passe'
       end
-      expect(page).to have_text 'Nous vous avons envoyé un email'
+      expect(page).to have_text 'nous vous avons envoyé un email'
       expect(page).to have_text user.email
 
       click_reset_password_link_for user.email


### PR DESCRIPTION
Nombreux retours au support alors que l'usager n'a pas de compte. On exprime plus clairement qu'il faut avoir créé un compte pour recevoir l'email.

![Capture d’écran 2023-05-10 à 18 49 02](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/148a160b-343d-4ccd-a555-7bf4e3e2d627)
