### PR TITLE
ETQ Usager: correctifs pour les modifications en construction

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -15,6 +15,7 @@ module Users
     before_action :ensure_dossier_can_be_viewed, only: [:show]
     before_action :forbid_invite_submission!, only: [:submit_brouillon]
     before_action :forbid_closed_submission!, only: [:submit_brouillon]
+    before_action :set_dossier_as_editing_fork, only: [:submit_en_construction]
     before_action :show_demarche_en_test_banner
     before_action :store_user_location!, only: :new
 
@@ -215,7 +216,6 @@ module Users
     end
 
     def submit_en_construction
-      @dossier = dossier.find_editing_fork(dossier.user)
       @dossier = dossier_with_champs(pj_template: false)
       errors = submit_dossier_and_compute_errors
 
@@ -469,6 +469,15 @@ module Users
 
     def dossier_with_champs(pj_template: true)
       DossierPreloader.load_one(dossier, pj_template:)
+    end
+
+    def set_dossier_as_editing_fork
+      @dossier = dossier.find_editing_fork(dossier.user)
+
+      return if @dossier.present?
+
+      flash[:alert] = t('users.dossiers.en_construction_submitted')
+      redirect_to dossier_path(dossier)
     end
 
     def should_change_groupe_instructeur?

--- a/app/views/champs/piece_justificative/show.turbo_stream.haml
+++ b/app/views/champs/piece_justificative/show.turbo_stream.haml
@@ -5,3 +5,7 @@
   - last_attached_file = @champ.piece_justificative_file.attachments.last
   - if last_attached_file
     = turbo_stream.focus_all "#persisted_row_attachment_#{last_attached_file.id} .attachment-filename a"
+
+- if @champ.dossier.editing_fork?
+  = turbo_stream.replace_all '.dossier-edit-sticky-footer' do
+    = render Dossiers::EditFooterComponent.new(dossier: @champ.dossier, annotation: @champ.private?)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -740,6 +740,7 @@ en:
       test_procedure: "This file is submitted on a test procedure. Any modification of the procedure by the administrator (addition of a field, publication of the procedure, etc.) will result in the removal of the file."
       no_access: "You do not have access to this file"
       no_longer_editable: "Your file can no longer be edited"
+      en_construction_submitted: "The modifications have already been submitted"
       create_commentaire:
         message_send: "Your message has been sent to the instructor in charge of your file."
       cloned_success: "Your file has been duplicated. Please review it then you can submit it"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -745,6 +745,7 @@ fr:
       test_procedure: "Ce dossier est déposé sur une démarche en test. Toute modification de la démarche par l’administrateur (ajout d’un champ, publication de la démarche...) entraînera sa suppression."
       no_access: "Vous n’avez pas accès à ce dossier"
       no_longer_editable: "Votre dossier ne peut plus être modifié"
+      en_construction_submitted: "Les modifications ont déjà été déposées"
       create_commentaire:
         message_send: "Votre message a bien été envoyé à l’instructeur en charge de votre dossier."
       cloned_success: "Votre dossier a bien été dupliqué. Vous pouvez maintenant le vérifier, l’adapter puis le déposer."

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -512,6 +512,17 @@ describe Users::DossiersController, type: :controller do
         expect(response).to redirect_to(dossier_path(dossier))
       end
     end
+
+    context 'when dossier was already submitted' do
+      before { post :submit_en_construction, params: payload }
+
+      it 'redirects to the dossier' do
+        subject
+
+        expect(response).to redirect_to(dossier_path(dossier))
+        expect(flash.alert).to eq("Les modifications ont déjà été déposées")
+      end
+    end
   end
 
   describe '#update brouillon' do


### PR DESCRIPTION
- s'assure qu'on affiche le bouton "déposer les modifications" après avoir ajouté une PJ (c'est moche, en attendant de virer les controllers PJ ça fait le job)
- pas d'erreur lorsqu'un usager dépose 2x les modifications, par exemple depuis 2 onglets différents