### PR TITLE
[Fix] Actions multiples - Corriger le compteur dans les alertes + ajouter des infos sur le créateur du batch

### DIFF
--- a/app/components/dossiers/batch_alert_component/batch_alert_component.en.yml
+++ b/app/components/dossiers/batch_alert_component/batch_alert_component.en.yml
@@ -7,7 +7,7 @@ en:
     in_progress:
       text_success:
         one: 1/1 is being archived
-        other: "%{progress_count}/%{count} files have been archived"
+        other: "%{success_count}/%{count} files have been archived"
   passer_en_instruction:
     finish:
       text_success:
@@ -16,7 +16,7 @@ en:
     in_progress:
       text_success:
         one: 1/1 is being changed to instructing
-        other: "%{progress_count}/%{count} files have been changed to instructing"
+        other: "%{success_count}/%{count} files have been changed to instructing"
   accepter:
     finish:
       text_success:
@@ -25,7 +25,7 @@ en:
     in_progress:
       text_success:
         one: 1/1 is being accepted
-        other: "%{progress_count}/%{count} files have been accepted"
+        other: "%{success_count}/%{count} files have been accepted"
   follow:
     finish:
       text_success:
@@ -34,7 +34,7 @@ en:
     in_progress:
       text_success:
         one: 1/1 is being followed
-        other: "%{progress_count}/%{count} files have been followed"
+        other: "%{success_count}/%{count} files have been followed"
   unfollow:
     finish:
       text_success:
@@ -43,7 +43,7 @@ en:
     in_progress:
       text_success:
         one: 1/1 is being unfollowed
-        other: "%{progress_count}/%{count} files have been unfollowed"
+        other: "%{success_count}/%{count} files have been unfollowed"
   repasser_en_construction:
     finish:
       text_success:
@@ -52,7 +52,7 @@ en:
     in_progress:
       text_success:
         one: 1/1 is being changed to in progress
-        other: "%{progress_count}/%{count} files have been changed to in progress"
+        other: "%{success_count}/%{count} files have been changed to in progress"
   title:
     finish: The bulk action is finished
     in_progress:  A bulk action is processing

--- a/app/components/dossiers/batch_alert_component/batch_alert_component.en.yml
+++ b/app/components/dossiers/batch_alert_component/batch_alert_component.en.yml
@@ -58,3 +58,4 @@ en:
     in_progress:  A bulk action is processing
   link_text: Refresh this webpage
   after_link_text: to check if the process is over.
+  context: This bulk action was created by %{mail}, %{time_ago}

--- a/app/components/dossiers/batch_alert_component/batch_alert_component.fr.yml
+++ b/app/components/dossiers/batch_alert_component/batch_alert_component.fr.yml
@@ -7,7 +7,7 @@ fr:
     in_progress:
       text_success:
         one: 1 dossier sera archivé
-        other: "%{progress_count}/%{count} dossiers ont été archivés"
+        other: "%{success_count}/%{count} dossiers ont été archivés"
   passer_en_instruction:
     finish:
       text_success:
@@ -16,7 +16,7 @@ fr:
     in_progress:
       text_success:
         one: 1 dossier sera passé en instruction
-        other: "%{progress_count}/%{count} dossiers ont été passés en instruction"
+        other: "%{success_count}/%{count} dossiers ont été passés en instruction"
   accepter:
     finish:
       text_success:
@@ -25,7 +25,7 @@ fr:
     in_progress:
       text_success:
         one: 1 dossier sera accepté
-        other: "%{progress_count}/%{count} dossiers ont été acceptés"
+        other: "%{success_count}/%{count} dossiers ont été acceptés"
   follow:
     finish:
       text_success:
@@ -34,7 +34,7 @@ fr:
     in_progress:
       text_success:
         one: 1 dossier sera suivi
-        other: "%{progress_count}/%{count} dossiers ont été suivis"
+        other: "%{success_count}/%{count} dossiers ont été suivis"
   unfollow:
     finish:
       text_success:
@@ -43,7 +43,7 @@ fr:
     in_progress:
       text_success:
         one: 1 dossier ne sera plus suivi
-        other: "%{progress_count}/%{count} dossiers ne sont plus suivis"
+        other: "%{success_count}/%{count} dossiers ne sont plus suivis"
   repasser_en_construction:
     finish:
       text_success:
@@ -52,7 +52,7 @@ fr:
     in_progress:
       text_success:
         one: 1 dossier sera repassé en construction
-        other: "%{progress_count}/%{count} dossiers ont été repassés en construction"
+        other: "%{success_count}/%{count} dossiers ont été repassés en construction"
   title:
     finish: L'action de masse est terminée
     in_progress: Une action de masse est en cours

--- a/app/components/dossiers/batch_alert_component/batch_alert_component.fr.yml
+++ b/app/components/dossiers/batch_alert_component/batch_alert_component.fr.yml
@@ -58,3 +58,4 @@ fr:
     in_progress: Une action de masse est en cours
   link_text: Recharger la page
   after_link_text: pour voir si l'opération est finie.
+  context: Cette opération a été lancée par %{mail}, il y a %{time_ago}

--- a/app/components/dossiers/batch_alert_component/batch_alert_component.html.haml
+++ b/app/components/dossiers/batch_alert_component/batch_alert_component.html.haml
@@ -14,3 +14,6 @@
         %p
           = link_to t('.link_text'), instructeur_procedure_path(@procedure, statut: params["statut"]), data: { action: 'turbo-poll#refresh' }
           = t('.after_link_text')
+
+        %p.fr-mt-2w
+          %small= t('.context', mail: @batch.instructeur.email, time_ago: time_ago_in_words(@batch.created_at))

--- a/app/components/dossiers/batch_alert_component/batch_alert_component.html.haml
+++ b/app/components/dossiers/batch_alert_component/batch_alert_component.html.haml
@@ -9,7 +9,7 @@
   - else
     = render Dsfr::AlertComponent.new(title: t(".title.in_progress"), state: :info, heading_level: 'h2') do |c|
       - c.body do
-        %p= t(".#{batch.operation}.in_progress.text_success", count: @batch.total_count, progress_count: @batch.progress_count)
+        %p= t(".#{batch.operation}.in_progress.text_success", count: @batch.total_count, success_count: @batch.success_count)
 
         %p
           = link_to t('.link_text'), instructeur_procedure_path(@procedure, statut: params["statut"]), data: { action: 'turbo-poll#refresh' }

--- a/app/models/batch_operation.rb
+++ b/app/models/batch_operation.rb
@@ -128,10 +128,6 @@ class BatchOperation < ApplicationRecord
     dossier_operations.size
   end
 
-  def progress_count
-    dossier_operations.pending.size
-  end
-
   def success_count
     dossier_operations.success.size
   end

--- a/spec/components/dossiers/batch_alert_component_spec.rb
+++ b/spec/components/dossiers/batch_alert_component_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       it { is_expected.to have_selector('.fr-alert--info') }
       it { is_expected.to have_text("Une action de masse est en cours") }
       it { is_expected.to have_text("1/2 dossiers ont été archivés") }
+      it { is_expected.to have_text("Cette opération a été lancée par #{instructeur.email}, il y a moins d'une minute") }
     end
 
     context 'finished and success' do


### PR DESCRIPTION
Suite au bug remonté ici -> https://secure.helpscout.net/conversation/2238470576/2029077?folderId=1653799

On ne corrige pas le bug mais on corrige et ajoute des infos dans l'alerte des batchs : 
- correction du compteur des batchs en cours
- ajout de qui a créé le batch et quand

**APRES**
<img width="1396" alt="Capture d’écran 2023-05-11 à 16 16 06" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/7cf5c6ee-0d1e-4b00-9e05-25aaf5deddc2">

**AVANT**
<img width="1408" alt="Capture d’écran 2023-05-11 à 17 19 39" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/dfddd18b-a2e5-4ded-9248-df67b57ff8c6">


