### PR TITLE
Correctif: force le rebase du dossier origin en construction avant merge du fork

### DIFF
--- a/app/models/concerns/dossier_clone_concern.rb
+++ b/app/models/concerns/dossier_clone_concern.rb
@@ -64,11 +64,11 @@ module DossierCloneConcern
     return false if invalid? || editing_fork.invalid?
     return false if revision_id > editing_fork.revision_id
 
-    diff = make_diff(editing_fork)
-
     transaction do
+      rebase!(force: true)
+      diff = make_diff(editing_fork)
       apply_diff(diff)
-      update(revision_id: editing_fork.revision_id, last_champ_updated_at: Time.zone.now)
+      touch(:last_champ_updated_at)
       assign_to_groupe_instructeur(editing_fork.groupe_instructeur)
     end
     reload

--- a/app/models/concerns/dossier_rebase_concern.rb
+++ b/app/models/concerns/dossier_rebase_concern.rb
@@ -1,8 +1,8 @@
 module DossierRebaseConcern
   extend ActiveSupport::Concern
 
-  def rebase!
-    if can_rebase?
+  def rebase!(force: false)
+    if force || can_rebase?
       transaction do
         rebase
       end

--- a/lib/tasks/deployment/20230512155606_fix_champs_after_merge.rake
+++ b/lib/tasks/deployment/20230512155606_fix_champs_after_merge.rake
@@ -1,0 +1,38 @@
+namespace :after_party do
+  desc 'Deployment task: fix_champs_after_merge'
+  task fix_champs_after_merge: :environment do
+    puts "Running deploy task 'fix_champs_after_merge'"
+
+    dossiers = Dossier.where('updated_at > ?', 2.days.ago).pluck(:id, :revision_id)
+    champs = Champ.where(dossier_id: dossiers.map(&:first)).pluck(:dossier_id, :type_de_champ_id)
+    champs_by_dossier_id = champs.group_by(&:first).transform_values { _1.map(&:second) }
+    revisions_by_type_de_champ_id = ProcedureRevisionTypeDeChamp
+      .where(type_de_champ_id: champs.map(&:second))
+      .pluck(:type_de_champ_id, :revision_id)
+      .group_by(&:first).transform_values { _1.map(&:second) }
+
+    bad_dossiers = dossiers.filter do |(id, revision_id)|
+      champs_by_dossier_id[id].any? do |type_de_champ_id|
+        revision_ids = revisions_by_type_de_champ_id[type_de_champ_id] || []
+        !revision_id.in?(revision_ids)
+      end
+    end
+
+    Dossier
+      .where(id: bad_dossiers.map(&:first))
+      .includes(champs: { type_de_champ: :revisions })
+      .find_each do |dossier|
+        bad_champs = dossier.champs.filter { !dossier.revision_id.in?(_1.type_de_champ.revisions.ids) }
+        bad_champs.each do |champ|
+          type_de_champ = dossier.revision.types_de_champ.find { _1.stable_id == champ.stable_id }
+          puts "Updating champ #{champ.id} on dossier #{dossier.id} from #{champ.type_de_champ_id} to type_de_champ #{type_de_champ.id}"
+          champ.update_column(:type_de_champ_id, type_de_champ.id)
+        end
+      end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
Fix la désynchro entre la révision d'un type de champ et la révision du dossier après validation des modifications en construction.