### PR TITLE
ETQ Opérateur, je ne veux pas voir de log de timeout d'API dans les log Sentry

### DIFF
--- a/app/graphql/api/v2/schema.rb
+++ b/app/graphql/api/v2/schema.rb
@@ -134,7 +134,6 @@ class API::V2::Schema < GraphQL::Schema
   class Timeout < GraphQL::Schema::Timeout
     def handle_timeout(error, query)
       error.extensions = { code: :timeout }
-      Sentry.capture_exception(error, extra: query.context.query_info)
     end
   end
 


### PR DESCRIPTION
Nous avons maintenant cette information dans lograge et c'est plus facilement exploitable