### PR TITLE
[fix] Vider les champs invalides pour permettre de cloner une procedure

### DIFF
--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -169,7 +169,7 @@ module Administrateurs
       new_procedure = procedure.clone(current_administrateur, cloned_from_library?)
 
       if new_procedure.valid?
-        flash.notice = 'Démarche clonée, pensez a vérifier la Présentation et choisir le service a laquelle cette procédure est associé.'
+        flash.notice = 'Démarche clonée. Pensez à vérifier la présentation et choisir le service à laquelle cette démarche est associée.'
         redirect_to admin_procedure_path(id: new_procedure.id)
       else
         if cloned_from_library?

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -576,8 +576,13 @@ class Procedure < ApplicationRecord
     procedure.service = nil
 
     transaction do
-      procedure.save
+      if !procedure.valid?
+        procedure.errors.attribute_names.each do |attribute|
+          procedure.send("#{attribute}=", nil)
+        end
+      end
 
+      procedure.save
       move_new_children_to_new_parent_coordinate(procedure.draft_revision)
     end
 

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -575,14 +575,15 @@ class Procedure < ApplicationRecord
     procedure.replaced_by_procedure = nil
     procedure.service = nil
 
-    transaction do
-      if !procedure.valid?
-        procedure.errors.attribute_names.each do |attribute|
-          procedure.send("#{attribute}=", nil)
-        end
+    if !procedure.valid?
+      procedure.errors.attribute_names.each do |attribute|
+        next if [:notice, :deliberation, :logo].exclude?(attribute)
+        procedure.public_send("#{attribute}=", nil)
       end
+    end
 
-      procedure.save
+    transaction do
+      procedure.save!
       move_new_children_to_new_parent_coordinate(procedure.draft_revision)
     end
 

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -548,7 +548,7 @@ describe Administrateurs::ProceduresController, type: :controller do
         expect(Procedure.last.cloned_from_library).to be_falsey
         expect(Procedure.last.notice.attached?).to be_truthy
         expect(Procedure.last.deliberation.attached?).to be_truthy
-        expect(flash[:notice]).to have_content 'Démarche clonée, pensez a vérifier la Présentation et choisir le service a laquelle cette procédure est associé.'
+        expect(flash[:notice]).to have_content 'Démarche clonée. Pensez à vérifier la présentation et choisir le service à laquelle cette démarche est associée.'
       end
 
       context 'when the procedure is cloned from the library' do
@@ -569,7 +569,7 @@ describe Administrateurs::ProceduresController, type: :controller do
 
       it 'creates a new procedure and redirect to it' do
         expect(response).to redirect_to admin_procedure_path(id: Procedure.last.id)
-        expect(flash[:notice]).to have_content 'Démarche clonée, pensez a vérifier la Présentation et choisir le service a laquelle cette procédure est associé.'
+        expect(flash[:notice]).to have_content 'Démarche clonée. Pensez à vérifier la présentation et choisir le service à laquelle cette démarche est associée.'
       end
     end
 
@@ -601,7 +601,7 @@ describe Administrateurs::ProceduresController, type: :controller do
         expect(response).to redirect_to admin_procedure_path(id: Procedure.last.id)
         expect(Procedure.last.notice.attached?).to be_falsey
         expect(Procedure.last.deliberation.attached?).to be_falsey
-        expect(flash[:notice]).to have_content 'Démarche clonée, pensez a vérifier la Présentation et choisir le service a laquelle cette procédure est associé.'
+        expect(flash[:notice]).to have_content 'Démarche clonée. Pensez à vérifier la présentation et choisir le service à laquelle cette démarche est associée.'
       end
     end
   end


### PR DESCRIPTION
closes #8807 
On ne peut pas cloner une demarche quand l'original contient une notice ou une déclaration dans un format qui n'est plus supporté par les nouvelles démarches. On résolue ce pb en vidant les champs invalides avant de cloner la demarche.