### PR TITLE
fix(revision): backfill missing published_at on published revisions

### DIFF
--- a/lib/tasks/deployment/20230516152457_fix_procedure_revision_publiee_without_published_at.rake
+++ b/lib/tasks/deployment/20230516152457_fix_procedure_revision_publiee_without_published_at.rake
@@ -1,0 +1,18 @@
+namespace :after_party do
+  desc 'Deployment task: fix_procedure_revision_publiee_without_published_at'
+  task fix_procedure_revision_publiee_without_published_at: :environment do
+    puts "Running deploy task 'fix_procedure_revision_publiee_without_published_at'"
+
+    Procedure.unscoped.publiees_ou_closes.includes(:published_revision).find_each do |procedure| # rubocop:disable DS/Unscoped
+      next unless procedure.published_revision.published_at.nil?
+
+      rake_puts "Found Procedure##{procedure.id}, set published_at on published revision ##{procedure.published_revision.id}: #{procedure.published_at}"
+      procedure.published_revision.update!(published_at: procedure.published_at)
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
log en dev : 

```
Found Procedure#42365, set published_at on published revision #82224: 2023-04-26 16:33:43 +0200
Found Procedure#47500, set published_at on published revision #92901: 2021-11-25 14:05:35 +0100
Found Procedure#58088, set published_at on published revision #74111: 2022-08-31 11:29:39 +0200
Found Procedure#59361, set published_at on published revision #76175: 2022-09-06 11:09:20 +0200
Found Procedure#59362, set published_at on published revision #76176: 2023-04-11 08:48:43 +0200
Found Procedure#59363, set published_at on published revision #76177: 2022-07-06 08:05:23 +0200
Found Procedure#59783, set published_at on published revision #76824: 2022-05-25 11:20:17 +0200
Found Procedure#60603, set published_at on published revision #78250: 2022-06-03 15:17:21 +0200
Found Procedure#68743, set published_at on published revision #96016: 2023-01-12 17:20:00 +0100
Found Procedure#69549, set published_at on published revision #94217: 2023-02-01 17:27:09 +0100
Found Procedure#70245, set published_at on published revision #97080: 2023-03-01 09:47:16 +0100
Found Procedure#73153, set published_at on published revision #100776: 2023-04-03 14:46:15 +0200
Found Procedure#73522, set published_at on published revision #102121: 2023-04-11 17:04:11 +0200
Found Procedure#75191, set published_at on published revision #104746: 2023-05-11 15:43:58 +0200
Found Procedure#75192, set published_at on published revision #104747: 2023-05-11 15:45:16 +0200
Found Procedure#75193, set published_at on published revision #104748: 2023-05-11 15:40:13 +0200
Found Procedure#75194, set published_at on published revision #104754: 2023-05-12 09:04:35 +0200
Found Procedure#75208, set published_at on published revision #104759: 2023-05-12 08:46:51 +0200
Found Procedure#75227, set published_at on published revision #104752: 2023-05-12 09:25:24 +0200
Found Procedure#75250, set published_at on published revision #104750: 2023-05-12 11:53:22 +0200
```