### PR TITLE
Précise le contenu du total des dossiers pour les instructeurs

### DIFF
--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -37,7 +37,10 @@
         = t('views.instructeurs.dossiers.tab_explainations.traites_html', archives_path: instructeur_archives_path(@procedure))
     - if @statut == 'tous'
       %p
-        = t('views.instructeurs.dossiers.tab_explainations.tous')
+        - if @procedure.routing_enabled?
+          = t('views.instructeurs.dossiers.tab_explainations.tous_with_routing')
+        - else
+          = t('views.instructeurs.dossiers.tab_explainations.tous')
     - if @statut == 'supprimes_recemment'
       %p
         = t('views.instructeurs.dossiers.tab_explainations.supprimes_recemment').html_safe

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -357,7 +357,8 @@ en:
           a_suivre: No instructor is assigned to follow up on these files. Be the first !
           suivis: The folders that are in this tab are only those that you follow. You can exchange with the requester until you can accept them, refuse them or classify them without follow-up.
           traites_html: "The files in this tab are finished: they have been accepted, refused or closed without follow-up. You can <a href=%{archives_path}>download</a> the zip archives of finished files and their attachments."
-          tous: All the files that have been submitted on this approach, regardless of the status.
+          tous: All the files that have been submitted on this approach, included files to be follow and files followed by you or other instructors.
+          tous_with_routing: All the files that have been submitted on this approach, and assigned to your instructors groups.
           supprimes_recemment: All files not <strong>archive</strong>, <strong>completed</strong> and <strong>deleted by the instructors</strong> on this approach.
           archives: "The files in this tab are archived: you can no longer reply to them, and requesters can no longer modify them."
           expirant: Records will not expire prior to the data retention period.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -357,7 +357,8 @@ fr:
           a_suivre: Aucun instructeur n’est affecté au suivi de ces dossiers. Soyez le premier !
           suivis: Les dossiers qui sont dans cet onglet sont uniquement ceux que vous suivez. Vous pouvez échanger avec le demandeur jusqu’à pouvoir les accepter, les refuser ou les classer sans suite.
           traites_html: "Les dossiers dans cet onglet sont terminés : ils ont été acceptés, refusés ou classés sans suite. Vous pouvez <a href=%{archives_path}>télécharger</a> les archives au format zip des dossiers terminés et leurs pièces jointes."
-          tous: Tous les dossiers qui ont été déposés sur cette démarche, quel que soit le statut.
+          tous: Tous les dossiers déposés sur cette démarche, qu'ils soient à suivre, suivis par vous ou suivis par d'autres instructeurs.
+          tous_with_routing: Tous les dossiers déposés sur cette démarche et attribués aux groupes d'instructeurs dont vous faites partie.
           supprimes_recemment: Tous les dossiers <strong>non archivés</strong>, <strong>terminés</strong> et <strong>supprimés par les instructeurs</strong> sur cette démarche
           archives:  "Les dossiers de cet onglet sont archivés : vous ne pouvez plus y répondre, et les demandeurs ne peuvent plus les modifier."
           expirant: Les dossiers n’expireront pas avant la période de conservation des données.


### PR DESCRIPTION
Mise à jour du wording dans l'index des dossiers ETQ instructeur, dans l'onglet "total".
Pour rappel : 
- "a suivre" = dossiers suivis par personne
- "suivis" = suivis que par moi
- "total" inclut les dossiers à suivre, les dossiers suivis par moi ET par les autres instructeurs.