### PR TITLE
ETQ exploitant je veux faire remonter les contacts Dolist en erreur dans sentry

### DIFF
--- a/app/lib/dolist/api.rb
+++ b/app/lib/dolist/api.rb
@@ -156,7 +156,7 @@ module Dolist
 
       if fields.empty?
         Sentry.with_scope do |scope|
-          scope.set_extra(:email, email_address)
+          scope.set_extra(:contact, email_address)
           Sentry.capture_message("Dolist::API: contact not found")
         end
 


### PR DESCRIPTION
On a une config Sentry qui filtre les champs /email/, hors on a dit que pour cette erreur là on les veut
