### PR TITLE
ETQ instructeur je peux filtrer les dossiers par avis

### DIFF
--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -314,6 +314,7 @@ module Instructeurs
       Procedure
         .with_attached_logo
         .find(procedure_id)
+        .tap { Sentry.set_tags(procedure: _1.id) }
     end
 
     def ensure_ownership!

--- a/app/models/procedure_presentation.rb
+++ b/app/models/procedure_presentation.rb
@@ -61,7 +61,7 @@ class ProcedurePresentation < ApplicationRecord
       field_hash('user', 'email', type: :text),
       field_hash('followers_instructeurs', 'email', type: :text),
       field_hash('groupe_instructeur', 'id', type: :enum),
-      field_hash('avis', 'id', type: :text)
+      field_hash('avis', 'answer', type: :text)
     )
 
     if procedure.for_individual
@@ -211,7 +211,7 @@ class ProcedurePresentation < ApplicationRecord
           .includes(:followers_instructeurs)
           .joins('INNER JOIN users instructeurs_users ON instructeurs_users.id = instructeurs.user_id')
           .filter_ilike('instructeurs_users', :email, values)
-      when 'user', 'individual'
+      when 'user', 'individual', 'avis'
         dossiers
           .includes(table)
           .filter_ilike(table, column, values)

--- a/config/locales/models/procedure_presentation/en.yml
+++ b/config/locales/models/procedure_presentation/en.yml
@@ -29,7 +29,7 @@ en:
             nom: Last name
             gender: Title
           avis:
-            id: Opinion
+            answer: Opinion
           etablissement:
             entreprise_siren: SIREN
             entreprise_forme_juridique: Forme juridique

--- a/config/locales/models/procedure_presentation/fr.yml
+++ b/config/locales/models/procedure_presentation/fr.yml
@@ -29,7 +29,7 @@ fr:
             nom: Nom
             gender: Civilité
           avis:
-            id: Avis
+            answer: Avis
           etablissement:
             entreprise_siren: SIREN
             entreprise_forme_juridique: Forme juridique

--- a/spec/models/procedure_presentation_spec.rb
+++ b/spec/models/procedure_presentation_spec.rb
@@ -73,7 +73,7 @@ describe ProcedurePresentation do
           { "label" => 'Demandeur', "table" => 'user', "column" => 'email', 'classname' => '', 'virtual' => false, 'type' => :text, "scope" => '' },
           { "label" => 'Email instructeur', "table" => 'followers_instructeurs', "column" => 'email', 'classname' => '', 'virtual' => false, 'type' => :text, "scope" => '' },
           { "label" => 'Groupe instructeur', "table" => 'groupe_instructeur', "column" => 'id', 'classname' => '', 'virtual' => false, 'type' => :enum, "scope" => '' },
-          { "label" => 'Avis', "table" => 'avis', "column" => 'id', 'classname' => '', 'virtual' => false, 'type' => :text, "scope" => '' },
+          { "label" => 'Avis', "table" => 'avis', "column" => 'answer', 'classname' => '', 'virtual' => false, 'type' => :text, "scope" => '' },
           { "label" => 'SIREN', "table" => 'etablissement', "column" => 'entreprise_siren', 'classname' => '', 'virtual' => false, 'type' => :text, "scope" => '' },
           { "label" => 'Forme juridique', "table" => 'etablissement', "column" => 'entreprise_forme_juridique', 'classname' => '', 'virtual' => false, 'type' => :text, "scope" => '' },
           { "label" => 'Nom commercial', "table" => 'etablissement', "column" => 'entreprise_nom_commercial', 'classname' => '', 'virtual' => false, 'type' => :text, "scope" => '' },
@@ -703,6 +703,19 @@ describe ProcedurePresentation do
         it 'returns every dossier that matches any of the search criteria for a given column' do
           is_expected.to contain_exactly(kept_dossier.id, other_kept_dossier.id)
         end
+      end
+    end
+
+    context 'for avis table' do
+      let(:procedure) { create(:procedure, :for_individual) }
+      let!(:kept_dossier) { create(:dossier, procedure:) }
+      let!(:discarded_dossier) { create(:dossier, procedure:) }
+      let!(:avis) { create(:avis, :with_answer, dossier: kept_dossier) }
+
+      context 'for answer column' do
+        let(:filter) { [{ 'table' => 'avis', 'column' => 'answer', 'value' => 'Pertinente' }] }
+
+        it { is_expected.to contain_exactly(kept_dossier.id) }
       end
     end
 


### PR DESCRIPTION
L'UX du filtre était implémentée (sur la colonne id), mais pas le back donc ça plantait. Je la remplace par la colonne `answer`

https://demarches-simplifiees.sentry.io/issues/4132081117/

Il restera à faire un filtre sur la colonne `question_answer` mais c'est un booléen et ça a d'autres implications