### PR TITLE
Corrige un bug de numérotation automatique sur Firefox

### DIFF
--- a/app/assets/stylesheets/sections.scss
+++ b/app/assets/stylesheets/sections.scss
@@ -1,5 +1,5 @@
 .counter-start-header-section {
-  counter-reset: h2 h3 h4 h5 h6 h7;
+  counter-reset: h2;
 
   .reset-h2 {
     counter-reset: h3;


### PR DESCRIPTION
La propriété css `counter-reset` buggue sur Firefox, ce qui fait que les numéros de sous-titres n'étaient pas réinitialisés (pour les champs de type titre de section dans le formulaire).  La PR permet de contourner le problème.

AVANT (sur Firefox)
![Screenshot from 2023-05-23 10-09-14](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/29131404/5246bfd0-b18e-45a7-8725-577de3dc3f69)

APRÈS
![Screenshot from 2023-05-23 10-09-38](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/29131404/dd438566-0159-4732-89a5-e87be875a426)

