### PR TITLE
ETQ Opérateur, je voudrais que les erreurs dans Sentry soient liées à la version de l'application

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -287,7 +287,8 @@ class ApplicationController < ActionController::Base
       enabled: sentry[:enabled],
       environment: sentry[:environment],
       browser: { modern: BrowserSupport.supported?(browser) },
-      user: sentry_user
+      user: sentry_user,
+      release: SentryRelease.current
     }
   end
 

--- a/app/javascript/shared/track/sentry.ts
+++ b/app/javascript/shared/track/sentry.ts
@@ -2,13 +2,14 @@ import * as Sentry from '@sentry/browser';
 import { getConfig } from '@utils';
 
 const {
-  sentry: { key, enabled, user, environment, browser }
+  sentry: { key, enabled, user, environment, browser, release }
 } = getConfig();
 
 // We need to check for key presence here as we do not have a dsn for browser yet
 if (enabled && key) {
   Sentry.init({
     dsn: key,
+    release: release ?? undefined,
     environment,
     tracesSampleRate: 0.1,
     ignoreErrors: [

--- a/app/javascript/shared/utils.ts
+++ b/app/javascript/shared/utils.ts
@@ -32,7 +32,8 @@ const Gon = z
         enabled: z.boolean().default(false),
         environment: z.string().optional(),
         user: z.object({ id: z.string() }).default({ id: '' }),
-        browser: z.object({ modern: z.boolean() }).default({ modern: false })
+        browser: z.object({ modern: z.boolean() }).default({ modern: false }),
+        release: z.string().nullish()
       })
       .default({}),
     crisp: z

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,8 +1,21 @@
+class SentryRelease
+  @@current = nil
+
+  def self.current
+    @@current ||= begin
+      version = Rails.root.join('version')
+      version.readable? ? version.read.strip : ''
+    end
+    @@current.presence
+  end
+end
+
 Sentry.init do |config|
   secrets = Rails.application.secrets.sentry
 
   config.dsn = secrets[:enabled] ? secrets[:rails_client_key] : nil
   config.send_default_pii = false
+  config.release = SentryRelease.current
   config.environment = secrets[:environment] || Rails.env
   config.enabled_environments = ['production', secrets[:environment].presence].compact
   config.breadcrumbs_logger = [:active_support_logger]


### PR DESCRIPTION
On passe par le fichier `version` à la racine du projet