### PR TITLE
Correction : pas d'erreur lors de la suppression d'un type de champ si déjà supprimé 

### DIFF
--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -74,7 +74,7 @@ module Administrateurs
     def destroy
       coordinate, type_de_champ = draft.coordinate_and_tdc(params[:stable_id])
 
-      if coordinate.used_by_routing_rules?
+      if coordinate&.used_by_routing_rules?
         errors = "« #{type_de_champ.libelle} » est utilisé pour le routage, vous ne pouvez pas le supprimer."
         @morphed = [champ_component_from(coordinate, focused: false, errors:)]
         flash.alert = errors


### PR DESCRIPTION
Quand un administrateur tente de supprimer un type de champ, parfois on ne retrouve pas le coordinate (si la requête est faite deux fois et que le type de champ est déjà supprimé je crois).
Pour ce cas j'ajoute un `&` pour ne pas appeler la méthode sur `nil`

Voir https://demarches-simplifiees.sentry.io/issues/4099856034