### PR TITLE
ETQ usager je peux modifier un dossier en_construction qui contient des champs en erreur

### DIFF
--- a/app/models/concerns/dossier_clone_concern.rb
+++ b/app/models/concerns/dossier_clone_concern.rb
@@ -106,7 +106,7 @@ module DossierCloneConcern
     end
 
     transaction do
-      cloned_dossier.save!
+      cloned_dossier.save!(validate: !fork)
 
       if fork
         cloned_dossier.rebase!


### PR DESCRIPTION
Contexte : un dossier en construction a un champ invalide, par exemple une option qui n'est pas dans la liste attendue. (Ça ne devrait pas arriver, mais ça arrive).

Avant cette PR, le dossier ne pouvait pas être forké car le fork était considéré invalide et ça provoque une erreur https://demarches-simplifiees.sentry.io/issues/4154045845/
Avec cette PR, le dossier peut être forké, et c'est même l'occasion de corriger sur le fork en brouillon.


NB: j'ai désactivé de la validation que pour les forks, pas pour les clones "classiques"
