### PR TITLE
8588 search engine footer optimization

### DIFF
--- a/app/views/users/dossiers/index.html.haml
+++ b/app/views/users/dossiers/index.html.haml
@@ -10,10 +10,10 @@
   .container
     %h1.page-title.fr-h2= t('views.users.dossiers.index.dossiers')
     - if current_user.dossiers.count > 2
-      #search-2.fr-search-bar.fr-search-bar--lg{ role: "search", "aria-label": t('views.users.dossiers.search.search_file') }
+      #search-2.fr-search-bar.fr-search-bar--lg
         = form_tag recherche_dossiers_path, method: :get, :role => "search", class: "flex width-100 fr-mb-5w" do
           = label_tag "q", t('views.users.dossiers.search.search_file'), class: 'fr-label'
-          = text_field_tag "q", "#{@search_terms if @search_terms.present?}", placeholder: t('views.users.dossiers.search.search_file'), class: "fr-input"
+          = text_field_tag "q", "#{@search_terms if @search_terms.present?}", placeholder: t('views.users.dossiers.search.placeholder'), class: "fr-input"
           %button.fr-btn
             = t('views.users.dossiers.search.simple')
 

--- a/app/views/users/dossiers/index.html.haml
+++ b/app/views/users/dossiers/index.html.haml
@@ -13,7 +13,7 @@
       #search-2.fr-search-bar.fr-search-bar--lg
         = form_tag recherche_dossiers_path, method: :get, :role => "search", class: "flex width-100 fr-mb-5w" do
           = label_tag "q", t('views.users.dossiers.search.search_file'), class: 'fr-label'
-          = text_field_tag "q", "#{@search_terms if @search_terms.present?}", placeholder: t('views.users.dossiers.search.placeholder'), class: "fr-input"
+          = text_field_tag "q", "#{@search_terms if @search_terms.present?}", placeholder: t('views.users.dossiers.search.search_file'), class: "fr-input"
           %button.fr-btn
             = t('views.users.dossiers.search.simple')
 

--- a/app/views/users/dossiers/transferer.html.haml
+++ b/app/views/users/dossiers/transferer.html.haml
@@ -18,3 +18,5 @@
 
         = f.hidden_field :dossier, value: @dossier.id
         = f.submit t('.submit'), class: 'fr-btn'
+- content_for :footer do
+  = render partial: 'users/dossiers/index_footer'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -448,7 +448,6 @@ en:
         demande:
           edit_dossier: "Edit file"
         search:
-          placeholder: File number, keywords
           search_file: Search a file (File number, keywords)
           simple: Search
         secondary_menu: Secondary menu

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -448,7 +448,8 @@ en:
         demande:
           edit_dossier: "Edit file"
         search:
-          search_file: Search a file
+          placeholder: File number, keywords
+          search_file: Search a file (File number, keywords)
           simple: Search
         secondary_menu: Secondary menu
         index:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -449,7 +449,6 @@ fr:
         demande:
           edit_dossier: "Modifier le dossier"
         search:
-          placeholder: N° de dossier, mots-clés
           search_file: Rechercher un dossier (N° de dossier, mots-clés)
           simple: Rechercher
         secondary_menu: Menu secondaire

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -449,7 +449,8 @@ fr:
         demande:
           edit_dossier: "Modifier le dossier"
         search:
-          search_file: Rechercher un dossier
+          placeholder: N° de dossier, mots-clés
+          search_file: Rechercher un dossier (N° de dossier, mots-clés)
           simple: Rechercher
         secondary_menu: Menu secondaire
         index:


### PR DESCRIPTION
Closes [#8588](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/8588)

<img width="1332" alt="Capture d’écran 2023-05-26 à 12 33 20" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/49035942/aa176308-3323-4a88-924a-f76c5270d561">
<img width="402" alt="Capture d’écran 2023-05-26 à 12 33 29" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/49035942/ed59ba74-b165-400a-b413-68ed45550bea">

Footer page de transfert de dossier : 

<img width="966" alt="Capture d’écran 2023-05-26 à 16 43 04" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/49035942/f1850fbb-5e71-4b4a-96fa-918d1e100441">
