### PR TITLE
ETQ usager je peux joindre une pièce justificative audio en .m4a, .aac, .wav 

### DIFF
--- a/config/initializers/authorized_content_types.rb
+++ b/config/initializers/authorized_content_types.rb
@@ -12,6 +12,10 @@ AUTHORIZED_CONTENT_TYPES = [
   'image/vnd.dwg', # multimedia x 137 auto desk
   'audio/mpeg', # multimedia x 26
   'video/x-ms-wm', # multimedia x 15 video microsoft ?
+  'audio/mp4', # audio .mp4, .m4a
+  'audio/x-m4a', # audio .m4a
+  'audio/aac', # audio .aac
+  'audio/x-wav', # audio .wav
 
   # application / program
   'application/json', # program x 6653577


### PR DESCRIPTION
Closes #9082

testé avec plusieurs fichiers, et sous firefox, chrome, safari et ios