### PR TITLE
[Refonte page accueil demarche] Ajout du détail sur le temps d'estimation

### DIFF
--- a/app/views/shared/_procedure_description.html.haml
+++ b/app/views/shared/_procedure_description.html.haml
@@ -29,13 +29,23 @@
   .fr-accordions-group
     %section.fr-accordion
       %h2.fr-accordion__title
-        %button.fr-accordion__btn{ "aria-controls" => "accordion-114", "aria-expanded" => "true" } Quel est l’objet de cette démarche ?
+        %button.fr-accordion__btn{ "aria-controls" => "accordion-114", "aria-expanded" => "true" }
+          = t('activerecord.attributes.procedure.description')
       #accordion-114.fr-collapse.js_description
         = h render SimpleFormatComponent.new(procedure.description, allow_a: true)
 
     - if procedure.description_target_audience.present?
       %section.fr-accordion
         %h2.fr-accordion__title
-          %button.fr-accordion__btn{ "aria-controls" => "accordion-115", "aria-expanded" => "false" } À qui s’adresse la démarche ?
+          %button.fr-accordion__btn{ "aria-controls" => "accordion-115", "aria-expanded" => "false" }
+            = t('activerecord.attributes.procedure.description_target_audience')
         #accordion-115.fr-collapse.js_description_target_audience
           = h render SimpleFormatComponent.new(procedure.description_target_audience, allow_a: true)
+
+    - if procedure.persisted? && procedure.estimated_duration_visible?
+      %section.fr-accordion
+        %h2.fr-accordion__title
+          %button.fr-accordion__btn{ "aria-controls" => "accordion-116", "aria-expanded" => "false" }
+            = t('shared.procedure_description.estimated_fill_duration_title')
+        #accordion-116.fr-collapse.js_description_target_audience
+          = t('shared.procedure_description.estimated_fill_duration_detail', estimated_minutes: estimated_fill_duration_minutes(procedure))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -820,3 +820,5 @@ en:
         weekly_distribution_details: "in the last 6 months"
     procedure_description:
       estimated_fill_duration: "Estimated fill time: %{estimated_minutes} mn"
+      estimated_fill_duration_title: What is the procedure estimated fill time ?
+      estimated_fill_duration_detail: "The fill time is etimated to %{estimated_minutes} min. This period may vary depending on the options you choose"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -871,3 +871,5 @@ fr:
         weekly_distribution_details: "au cours des 6 derniers mois"
     procedure_description:
       estimated_fill_duration: "Temps de remplissage estimé : %{estimated_minutes} mn"
+      estimated_fill_duration_title: Quelle est la durée de remplissage de la démarche ?
+      estimated_fill_duration_detail: "La durée de remplissage est estimée à %{estimated_minutes} min. Ce délai peut varier selon les options que vous choisirez."


### PR DESCRIPTION
closes #9065 

<img width="854" alt="Capture d’écran 2023-06-01 à 11 15 37" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/dc33f647-5322-46a0-97cf-569a161fcf29">
