### PR TITLE
fix(instructeurs self management): make instructeurs self management for routed procedures

### DIFF
--- a/lib/tasks/deployment/20230601121416_fix_instructeurs_self_management_for_routed_procedures.rake
+++ b/lib/tasks/deployment/20230601121416_fix_instructeurs_self_management_for_routed_procedures.rake
@@ -1,0 +1,17 @@
+namespace :after_party do
+  desc 'Deployment task: fix_instructeurs_self_management_for_routed_procedures'
+  task fix_instructeurs_self_management_for_routed_procedures: :environment do
+    puts "Running deploy task 'fix_instructeurs_self_management_for_routed_procedures'"
+
+    # Put your task implementation HERE.
+    Procedure.with_discarded
+      .where(routing_enabled: true)
+      .where(instructeurs_self_management_enabled: [nil, false])
+      .update_all(instructeurs_self_management_enabled: true)
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
Dans la PR nouvelle UX pour le routage https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/8940 on a touché à l'autogestion des instructeurs en l'activant / désactivant en même temps que le routage mais on a oublié de rattraper les données.
Ce qui fait qu'on a actuellement 1346 procédures routées, avec l'autogestion des instructeurs désactivée et inactivable. L'impact est que les instructeurs ne peuvent ajouter/enlever des instructeurs