### PR TITLE
chore(coldwired): update to 0.11

### DIFF
--- a/app/components/attachment/edit_component.rb
+++ b/app/components/attachment/edit_component.rb
@@ -73,7 +73,7 @@ class Attachment::EditComponent < ApplicationComponent
       aria: { describedby: champ&.describedby_id },
       data: {
         auto_attach_url:,
-        turbo_force: true
+        turbo_force: :server
       }.merge(has_file_size_validator? ? { max_file_size: } : {})
         .merge(user_can_replace? ? { replace_attachment_target: "input" } : {})
     }.merge(has_content_type_validator? ? { accept: accept_content_type } : {})

--- a/app/components/profile/api_token_component/api_token_component.html.haml
+++ b/app/components/profile/api_token_component/api_token_component.html.haml
@@ -45,7 +45,7 @@
       = t('.action_choice')
     - @api_token.allowed_procedures.each do |procedure|
       = f.hidden_field :allowed_procedure_ids, value: procedure.id, multiple: true, id: dom_id(procedure, :allowed_procedure)
-    .flex.justify-between.align-center{ 'data-turbo-force': true }
+    .flex.justify-between.align-center{ 'data-turbo-force': :server }
       = f.select :allowed_procedure_ids, procedures_to_allow_options, {prompt: t('.prompt_choose_procedure')}, { class: 'no-margin width-66 small', name: "api_token[allowed_procedure_ids][]" }
       = f.button type: :submit, class: "fr-btn fr-btn--secondary" do
         = t('.add')

--- a/app/javascript/controllers/turbo_controller.ts
+++ b/app/javascript/controllers/turbo_controller.ts
@@ -36,7 +36,6 @@ export class TurboController extends ApplicationController {
       element: document.body,
       schema: {
         forceAttribute: 'data-turbo-force',
-        permanentAttribute: 'data-turbo-permanent',
         focusGroupAttribute: 'data-turbo-focus-group',
         focusDirectionAttribute: 'data-turbo-focus-direction',
         hiddenClassName: 'hidden'

--- a/app/views/administrateurs/procedure_administrateurs/_add_admin_form.html.haml
+++ b/app/views/administrateurs/procedure_administrateurs/_add_admin_form.html.haml
@@ -1,7 +1,7 @@
 = form_for procedure.administrateurs.new(user: User.new),
   url: { controller: 'procedure_administrateurs' },
   html: { class: 'form', id: "new_administrateur"  },
-  data: { turbo: true, turbo_force: true } do |f|
+  data: { turbo: true, turbo_force: :server } do |f|
   = f.label :email do
     Ajouter un administrateur
   %p.notice Renseignez l’email d’un administrateur déjà enregistré sur #{APPLICATION_NAME} pour lui permettre de modifier « #{procedure.libelle} ».

--- a/app/views/administrateurs/procedures/administrateurs.html.haml
+++ b/app/views/administrateurs/procedures/administrateurs.html.haml
@@ -8,7 +8,7 @@
       = hidden_field_tag 'from_publication_date', @filter.from_publication_date if @filter.from_publication_date.present?
 
       = f.label 'email', 'Recercher des administrateurs par email', class: 'fr-label'
-      = f.search_field 'email', size: 40, class: 'fr-input', data: { turbo_force: true }
+      = f.search_field 'email', size: 40, class: 'fr-input', data: { turbo_force: :server }
     .actions= link_to 'Voir la liste des démarches', all_admin_procedures_path(@filter.params), class: 'fr-btn fr-btn--secondary'
   .fr-table.fr-table--bordered
     %table#all-admins

--- a/app/views/administrateurs/procedures/all.html.haml
+++ b/app/views/administrateurs/procedures/all.html.haml
@@ -10,7 +10,7 @@
       = hidden_field_tag 'from_publication_date', @filter.from_publication_date if @filter.from_publication_date.present?
 
       = f.label :libelle, 'Rechercher des démarches par libellé', class: 'fr-label'
-      = f.search_field 'libelle', size: 30, class: 'fr-input', data: { turbo_force: true }
+      = f.search_field 'libelle', size: 30, class: 'fr-input', data: { turbo_force: :server }
     .actions
       .link.fr-mx-1w= link_to 'Voir les administrateurs', administrateurs_admin_procedures_path(@filter.params), class: 'fr-btn fr-btn--secondary'
       .link.fr-mx-1w{ "data-turbo": "false" }= link_to 'Exporter les résultats', all_admin_procedures_path(@filter.params.merge(format: :xlsx)), class: 'fr-btn fr-btn--secondary'

--- a/app/views/france_connect/particulier/_password_confirmation.html.haml
+++ b/app/views/france_connect/particulier/_password_confirmation.html.haml
@@ -3,7 +3,7 @@
   %br
   = t('.fill_in_password')
 
-= form_tag france_connect_particulier_merge_with_existing_account_path, data: { turbo: true, turbo_force: true }, class: 'mt-2 form fconnect-form' do
+= form_tag france_connect_particulier_merge_with_existing_account_path, data: { turbo: true, turbo_force: :server }, class: 'mt-2 form fconnect-form' do
   = hidden_field_tag :merge_token, merge_token
   = hidden_field_tag :email, email
   = label_tag :password, t('views.registrations.new.password_label', min_length: 8)

--- a/app/views/instructeurs/dossiers/_instruction_button.html.haml
+++ b/app/views/instructeurs/dossiers/_instruction_button.html.haml
@@ -1,5 +1,5 @@
 - if dossier.en_instruction?
-  = render Dropdown::MenuComponent.new(wrapper: :div, wrapper_options: { data: {'turbo-force': true} }, button_options: { class: [button_or_label_class(dossier)]}, role: dossier.en_instruction? ? :region : :menu) do |menu|
+  = render Dropdown::MenuComponent.new(wrapper: :div, wrapper_options: { data: { turbo_force: :server } }, button_options: { class: [button_or_label_class(dossier)]}, role: dossier.en_instruction? ? :region : :menu) do |menu|
     - menu.with_button_inner_html do
       Instruire le dossier
 

--- a/app/views/invites/_form.html.haml
+++ b/app/views/invites/_form.html.haml
@@ -17,7 +17,7 @@
     %p= t('views.invites.form.invite_to_edit_line1')
     %p= t('views.invites.form.invite_to_edit_line2')
 
-  = form_tag dossier_invites_path(dossier), data: { turbo: true, turbo_force: true }, method: :post, class: 'form' do
+  = form_tag dossier_invites_path(dossier), data: { turbo: true, turbo_force: :server }, method: :post, class: 'form' do
     .row
       .col
         %span

--- a/app/views/layouts/all.html.haml
+++ b/app/views/layouts/all.html.haml
@@ -79,7 +79,7 @@
                       Tags
                   .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
                     %div
-                      = f.search_field :tags, placeholder: 'Choisissez un tag', list: 'tags_list', class: 'fr-input', data: { no_autosubmit: 'input', turbo_force: true }, multiple: true
+                      = f.search_field :tags, placeholder: 'Choisissez un tag', list: 'tags_list', class: 'fr-input', data: { no_autosubmit: 'input', turbo_force: :server }, multiple: true
                       %datalist#tags_list
                         - Procedure.tags.each do |tag|
                           %option{ value: tag }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "@coldwired/actions": "^0.10.0",
-    "@coldwired/turbo-stream": "^0.10.0",
+    "@coldwired/actions": "^0.11.0",
+    "@coldwired/turbo-stream": "^0.11.0",
     "@coldwired/utils": "^0.10.0",
     "@gouvfr/dsfr": "^1.7.2",
     "@graphiql/plugin-explorer": "^0.1.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1150,21 +1150,21 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
-"@coldwired/actions@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@coldwired/actions/-/actions-0.10.0.tgz#8ce75a132e6ba7917337b4cc366ff59d725b4c75"
-  integrity sha512-EFXUnYRL2uWJe9LrBW5F6L874VX1aKrvKQ3uLTa7rmGmd91PksXzIY0ZDrBJ9pWAdQQywfiGxUkyerIDR4e4jg==
+"@coldwired/actions@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@coldwired/actions/-/actions-0.11.0.tgz#b50f833074ff4cd0b80afe022efb9c44b048b21a"
+  integrity sha512-IIF1fCCPWRywUfF1nG0QvOzjqKZWKBoniyS2qEJbejpE5FB17eohLIG4GZpkxFtzW+yb96ASRcqAFYcmMEjmYQ==
   dependencies:
     "@coldwired/utils" "^0.10.0"
     morphdom "^2.7.0"
     tiny-invariant "^1.3.1"
 
-"@coldwired/turbo-stream@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@coldwired/turbo-stream/-/turbo-stream-0.10.0.tgz#1e8fa6512691ec65c9f5152f62d5a1daef9b08c9"
-  integrity sha512-6WZ9DB2L/E8vBSWVbr//VMawQFU15cj1DBO8YY+ktcnUmRR90D6yy7yfq65g7xSd6qIOJo4sQ3vvCVr9U4enRw==
+"@coldwired/turbo-stream@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@coldwired/turbo-stream/-/turbo-stream-0.11.0.tgz#fef5338cf95c5e331aa229c5edda92383bc6a05d"
+  integrity sha512-Ty1xvjBzqp9dXZfibH6mYTgESmccxe6utG9wZbla+GcsibgCDJJ7NWQEs13RNUhVeCeSRyDL8Ho//UpwqFUEHg==
   dependencies:
-    "@coldwired/actions" "^0.10.0"
+    "@coldwired/actions" "^0.11.0"
     "@coldwired/utils" "^0.10.0"
     tiny-invariant "^1.3.1"
 


### PR DESCRIPTION
Prérequis pour le travaille sur le `autocomplete`.

J'ai voulu faire le malin et réutiliser l'attribut `data-turbo-permanent`. Mauvaise idée – la scementique n'est pas exactement la même entre `turbo` et `coldwired`. Ça fout la merde. Donc je rend `data-turbo-force` configurable.

Avant :
Priorité pour le HTML du serveur `data-turbo-force`
Priorité pour le HTML du navigateur `data-turbo-permanent`

Après :
Priorité pour le HTML du serveur `data-turbo-force="server"`
Priorité pour le HTML du navigateur `data-turbo-force="browser"`

https://github.com/tchak/coldwired/commit/bf71bde4562c6365c5fd1a353d289e5b61d9c1a3