### PR TITLE
ETQ dev je ne veux plus de requêtes infinies sur /csp

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -53,7 +53,7 @@ Rails.application.config.content_security_policy do |policy|
 
     # CSP are not enforced in development (see content_security_policy_report_only in development.rb)
     # However we notify a random local URL, to see breakage in the DevTools when adding a new external resource.
-    policy.report_uri "http://#{ENV.fetch('APP_HOST')}/csp/"
+    policy.report_uri CSP_REPORT_URI if CSP_REPORT_URI.present?
 
   elsif Rails.env.test?
     # Disallow all connections to external domains during tests


### PR DESCRIPTION
On a pas de route /csp, donc les navigateurs font des requêtes en boucles, et ça empêche de se connecter proprement à des break points ruby comme binding.pry

A la place on fait comme en prod avec une constante/var d'env si définie

