### PR TITLE
ETQ dev fix création des foreign keys de la création de la table `dossier_corrections` 

### DIFF
--- a/db/migrate/20230228134859_create_dossier_corrections.rb
+++ b/db/migrate/20230228134859_create_dossier_corrections.rb
@@ -3,8 +3,10 @@ class CreateDossierCorrections < ActiveRecord::Migration[6.1]
 
   def change
     create_table :dossier_corrections do |t|
-      t.references :dossier, null: false, foreign_key: true
-      t.references :commentaire, foreign_key: true
+      # foreign keys are added in a later migration
+      # see https://github.com/fatkodima/online_migrations#adding-multiple-foreign-keys
+      t.references :dossier, null: false, foreign_key: false
+      t.references :commentaire, foreign_key: false
       t.datetime :resolved_at, precision: 6
 
       t.timestamps

--- a/db/migrate/20230228134900_add_foreign_keys_to_dossier_corrections.rb
+++ b/db/migrate/20230228134900_add_foreign_keys_to_dossier_corrections.rb
@@ -1,0 +1,11 @@
+class AddForeignKeysToDossierCorrections < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_foreign_key :dossier_corrections, :dossiers, column: :dossier_id, validate: false
+    validate_foreign_key :dossier_corrections, :dossiers
+
+    add_foreign_key :dossier_corrections, :commentaires, column: :commentaire_id, validate: false
+    validate_foreign_key :dossier_corrections, :commentaires
+  end
+end


### PR DESCRIPTION
C'est unsafe de créer une table avec 2 foreign keys, il vaut mieux les faire dans des migrations séparées pour pas se prendre un lock timeout

Cf https://github.com/fatkodima/online_migrations#adding-multiple-foreign-keys
et https://github.com/ankane/strong_migrations/issues/187