### PR TITLE
fix(carte): no autosave on champ carte

### DIFF
--- a/app/components/editable_champ/editable_champ_component.rb
+++ b/app/components/editable_champ/editable_champ_component.rb
@@ -30,7 +30,7 @@ class EditableChamp::EditableChampComponent < ApplicationComponent
   end
 
   def stimulus_controller
-    if !@champ.block? && @champ.fillable?
+    if autosave_enabled?
       # This is an editable champ. Lets find what controllers it might need.
       controllers = ['autosave']
 
@@ -44,5 +44,9 @@ class EditableChamp::EditableChampComponent < ApplicationComponent
     else
       {}
     end
+  end
+
+  def autosave_enabled?
+    !@champ.carte? && !@champ.block? && @champ.fillable?
   end
 end

--- a/app/javascript/components/MapEditor/hooks.ts
+++ b/app/javascript/components/MapEditor/hooks.ts
@@ -29,6 +29,12 @@ export function useFeatureCollection(
   const [featureCollection, setFeatureCollection] = useState(
     initialFeatureCollection
   );
+  const refreshFeatureList = useCallback<() => void>(() => {
+    httpRequest(url)
+      .turbo()
+      .catch(() => null);
+  }, [url]);
+
   const updateFeatureCollection = useCallback<
     (callback: (features: Feature[]) => Feature[]) => void
   >(
@@ -37,11 +43,9 @@ export function useFeatureCollection(
         type: 'FeatureCollection',
         features: callback(features)
       }));
-      httpRequest(url)
-        .turbo()
-        .catch(() => null);
+      refreshFeatureList();
     },
-    [url, setFeatureCollection]
+    [refreshFeatureList, setFeatureCollection]
   );
 
   const addFeatures = useCallback(
@@ -153,13 +157,15 @@ export function useFeatureCollection(
         if (newFeatures.length > 0) {
           addFeatures(newFeatures, external);
           updateFeatureCollection((features) => [...features, ...newFeatures]);
+        } else {
+          refreshFeatureList();
         }
       } catch (error) {
         console.error(error);
         onError('Le polygone dessiné n’est pas valide.');
       }
     },
-    [url, updateFeatureCollection, addFeatures, onError]
+    [url, refreshFeatureList, updateFeatureCollection, addFeatures, onError]
   );
 
   const deleteFeatures = useCallback<DeleteFeatures>(

--- a/app/javascript/controllers/geo_area_controller.tsx
+++ b/app/javascript/controllers/geo_area_controller.tsx
@@ -19,7 +19,7 @@ export class GeoAreaController extends ApplicationController {
   }
 
   onInput() {
-    this.debounce(this.updateDescription, 200);
+    this.debounce(this.updateDescription, 500);
   }
 
   private updateDescription(): void {

--- a/spec/components/editable_champ/editable_champ_component_spec.rb
+++ b/spec/components/editable_champ/editable_champ_component_spec.rb
@@ -21,6 +21,12 @@ describe EditableChamp::EditableChampComponent, type: :component do
       it { expect(subject).to eq(nil) }
     end
 
+    context 'when a carte champ' do
+      let(:champ) { create(:champ_carte, dossier: dossier) }
+
+      it { expect(subject).to eq(nil) }
+    end
+
     context 'when a private champ' do
       let(:champ) { create(:champ, dossier: dossier, private: true) }
 


### PR DESCRIPTION
Actuellement, l'autosave des champs carte se déclenche lors de l'édition des descriptions des points. Cela provoque des effets secondaires bizarres. L'autosave n'est pas nécessaire sur ce champ car il a sa propre implémentation de l'autosave en React.