### PR TITLE
Ajoute un lien dans le menu d'export vers la doc sur les macros

### DIFF
--- a/app/assets/stylesheets/menu_component.scss
+++ b/app/assets/stylesheets/menu_component.scss
@@ -1,0 +1,10 @@
+@import "colors";
+
+.menu-component-header {
+  color: $dark-grey;
+  font-size: 12px;
+
+  a {
+    text-decoration: underline;
+  }
+}

--- a/app/components/dossiers/export_component.rb
+++ b/app/components/dossiers/export_component.rb
@@ -1,4 +1,6 @@
 class Dossiers::ExportComponent < ApplicationComponent
+  include ApplicationHelper
+
   def initialize(procedure:, exports:, statut: nil, count: nil, class_btn: nil, export_url: nil)
     @procedure = procedure
     @exports = exports

--- a/app/components/dossiers/export_component/export_component.en.yml
+++ b/app/components/dossiers/export_component/export_component.en.yml
@@ -12,3 +12,6 @@ en:
   download:
     one: Download a file
     other: Download %{count} files
+  macros_doc:
+    title: "Macros documentation"
+    url: "https://doc.demarches-simplifiees.fr/pour-aller-plus-loin/exports-et-macros"

--- a/app/components/dossiers/export_component/export_component.fr.yml
+++ b/app/components/dossiers/export_component/export_component.fr.yml
@@ -12,3 +12,6 @@ fr:
   download:
     one: Télécharger un dossier
     other: Télécharger %{count} dossiers
+  macros_doc:
+    title: "documentation sur les macros"
+    url: "https://doc.demarches-simplifiees.fr/pour-aller-plus-loin/exports-et-macros"

--- a/app/components/dossiers/export_component/export_component.html.haml
+++ b/app/components/dossiers/export_component/export_component.html.haml
@@ -1,4 +1,12 @@
 = render Dropdown::MenuComponent.new(wrapper: :span, button_options: { class: ['fr-btn--sm', @class_btn.present? ? @class_btn : 'fr-btn--secondary']}, menu_options: { id: @count.nil? ? "download_menu" : "download_all_menu", class: ['dropdown-export'] }) do |menu|
+  - menu.with_menu_header_html do
+    %p.menu-component-header.fr-px-2w.fr-pt-2w.fr-mb-0
+      %span.fr-icon-info-line{ aria: { hidden: true } }
+        Des macros ? Lisez la
+        = link_to('doc', t('.macros_doc.url'),
+          title: t('.macros_doc.title'),
+          **external_link_attributes)
+
   - menu.with_button_inner_html do
     = @count.nil? ? t(".download_all") : t(".download", count: @count)
   - exports.each do |item|

--- a/app/components/dropdown/menu_component.rb
+++ b/app/components/dropdown/menu_component.rb
@@ -1,5 +1,6 @@
 class Dropdown::MenuComponent < ApplicationComponent
   renders_one :button_inner_html
+  renders_one :menu_header_html
   # beware, items elements like button_to/link_to must include role: 'menuitem' for aria reason
   renders_many :items, -> (options = {}, &block) do
     tag.li(**options.merge(role: 'none'), &block)

--- a/app/components/dropdown/menu_component/menu_component.html.haml
+++ b/app/components/dropdown/menu_component/menu_component.html.haml
@@ -3,6 +3,7 @@
     = button_inner_html
 
   %div{ data: { menu_button_target: 'menu' }, id: menu_id, 'aria-labelledby': button_id, role: menu_role, 'tab-index': -1, class: menu_class_names }
+    = menu_header_html
 
     -# the dropdown can be a menu with a list of item
     - if items?


### PR DESCRIPTION
Ajoute un lien vers la doc concernant les macros excel

![Screenshot 2023-06-08 at 11-25-45 une bien belle procédure · demarches-simplifiees fr](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/907405/6ad92e44-4f58-4e02-9b64-984880a59dec)

la doc: https://doc.demarches-simplifiees.fr/pour-aller-plus-loin/exports-et-macros

resolve #9125 