### PR TITLE
[design] Changement de couleurs pour les bagdes de statuts des dossiers

### DIFF
--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -79,11 +79,12 @@ module DossierHelper
 
   def status_badge(state, alignment_class = '')
     status_text = dossier_display_state(state, lower: true)
-    if [Dossier.states.fetch(:en_instruction), Dossier.states.fetch(:accepte)].include?(state)
-      tag.span(status_text, class: "fr-badge fr-badge--sm #{class_badge_state(state)} #{alignment_class}", role: 'status')
-    else
-      tag.span(status_text, class: "fr-badge fr-badge--sm #{class_badge_state(state)} fr-badge--no-icon #{alignment_class}", role: 'status')
-    end
+      tag.span status_text, role: 'status', class: class_names(
+        'fr-badge fr-badge--sm' => true,
+        'fr-badge--no-icon' => [Dossier.states.fetch(:en_instruction), Dossier.states.fetch(:accepte)].include?(state),
+        class_badge_state(state) => true,
+        alignment_class => true
+      )
   end
 
   def deletion_reason_badge(reason)

--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -79,12 +79,12 @@ module DossierHelper
 
   def status_badge(state, alignment_class = '')
     status_text = dossier_display_state(state, lower: true)
-      tag.span status_text, role: 'status', class: class_names(
-        'fr-badge fr-badge--sm' => true,
-        'fr-badge--no-icon' => [Dossier.states.fetch(:en_instruction), Dossier.states.fetch(:accepte)].include?(state),
-        class_badge_state(state) => true,
-        alignment_class => true
-      )
+    tag.span status_text, role: 'status', class: class_names(
+      'fr-badge fr-badge--sm' => true,
+      'fr-badge--no-icon' => [Dossier.states.fetch(:en_instruction), Dossier.states.fetch(:accepte)].include?(state),
+      class_badge_state(state) => true,
+      alignment_class => true
+    )
   end
 
   def deletion_reason_badge(reason)

--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -62,14 +62,14 @@ module DossierHelper
 
   def class_badge_state(state)
     case state
-    when Dossier.states.fetch(:en_construction), Dossier.states.fetch(:en_instruction)
-      'fr-badge--info'
+    when Dossier.states.fetch(:en_construction)
+      'fr-badge--purple-glycine'
+    when Dossier.states.fetch(:en_instruction)
+      'fr-badge--new'
     when Dossier.states.fetch(:accepte)
       'fr-badge--success'
-    when Dossier.states.fetch(:refuse)
+    when Dossier.states.fetch(:refuse), Dossier.states.fetch(:sans_suite)
       'fr-badge--warning'
-    when Dossier.states.fetch(:sans_suite)
-      'fr-badge--new'
     when Dossier.states.fetch(:brouillon)
       ''
     else
@@ -79,7 +79,11 @@ module DossierHelper
 
   def status_badge(state, alignment_class = '')
     status_text = dossier_display_state(state, lower: true)
-    tag.span(status_text, class: "fr-badge fr-badge--sm #{class_badge_state(state)} fr-badge--no-icon #{alignment_class}", role: 'status')
+    if [Dossier.states.fetch(:en_instruction), Dossier.states.fetch(:accepte)].include?(state)
+      tag.span(status_text, class: "fr-badge fr-badge--sm #{class_badge_state(state)} #{alignment_class}", role: 'status')
+    else
+      tag.span(status_text, class: "fr-badge fr-badge--sm #{class_badge_state(state)} fr-badge--no-icon #{alignment_class}", role: 'status')
+    end
   end
 
   def deletion_reason_badge(reason)


### PR DESCRIPTION
En travaillant sur le SVA/SVR qui entraine l'apparition de nouveaux badges de couleurs, ça semblait un bon moment pour harmoniser les couleurs des badges en accord avec les recommandations d'Olivier.

**APRES**
<img width="399" alt="Capture d’écran 2023-06-08 à 11 41 53" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/7a45c5c1-a0c8-47ad-a1f0-d9b243be61bf">

**AVANT**
<img width="293" alt="Capture d’écran 2023-06-08 à 12 03 17" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/6eafe13a-229b-4db7-a5d8-b825687c146c">

