### PR TITLE
add default values for some of the config options

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -26,7 +26,7 @@ features = [
 def database_exists?
   ActiveRecord::Base.connection
   true
-rescue ActiveRecord::NoDatabaseError, PG::ConnectionBad
+rescue ActiveRecord::ConnectionNotEstablished, ActiveRecord::NoDatabaseError, PG::ConnectionBad
   false
 end
 


### PR DESCRIPTION
Si l'on veut faire tourner demarches simplifiées de manière minimale (par ex. pour precompiler les assets) on n'a pas nécessairement envie de spécifier toutes les options disponibles. Par ailleurs lorsque postgres n'est pas disponible, l'erreur levée est `ActiveRecord::ConnectionNotEstablished`