### PR TITLE
ETQ administateur je peux filtrer les groupes d'instructeurs à configurer

### DIFF
--- a/app/components/procedure/groupes_management_component.rb
+++ b/app/components/procedure/groupes_management_component.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class Procedure::GroupesManagementComponent < ApplicationComponent
-  def initialize(procedure:, groupe_instructeurs:, query:)
+  def initialize(procedure:, groupe_instructeurs:, query:, to_configure_filter:)
     @procedure = procedure
     @groupe_instructeurs = groupe_instructeurs
     @query = query
     @total = groupe_instructeurs.total_count
+    @to_configure_filter = to_configure_filter
   end
 
   def table_header

--- a/app/components/procedure/groupes_management_component/groupes_management_component.html.haml
+++ b/app/components/procedure/groupes_management_component/groupes_management_component.html.haml
@@ -23,6 +23,8 @@
                   %p.fr-badge.fr-badge--info.fr-badge--sm.fr-ml-1w inactif
                 - elsif gi.routing_to_configure?
                   %p.fr-badge.fr-badge--warning.fr-badge--sm.fr-ml-1w à configurer
+                - elsif gi.non_unic_rule?
+                  %p.fr-badge.fr-badge--warning.fr-badge--sm.fr-ml-1w règle déjà attribuée à #{gi.groups_with_same_rule}
 
               %span.fr-mr-1w
                 #{gi.dossiers.visible_by_administration.size}

--- a/app/components/procedure/groupes_management_component/groupes_management_component.html.haml
+++ b/app/components/procedure/groupes_management_component/groupes_management_component.html.haml
@@ -24,9 +24,9 @@
                   %span= gi.label
                 - if gi.closed
                   %p.fr-badge.fr-badge--info.fr-badge--sm.fr-ml-1w inactif
-                - elsif gi.routing_to_configure?
-                  %p.fr-badge.fr-badge--warning.fr-badge--sm.fr-ml-1w à configurer
-                - elsif gi.non_unic_rule?
+                - elsif gi.invalid_rule?
+                  %p.fr-badge.fr-badge--warning.fr-badge--sm.fr-ml-1w règle invalide
+                - elsif gi.non_unique_rule?
                   %p.fr-badge.fr-badge--warning.fr-badge--sm.fr-ml-1w règle déjà attribuée à #{gi.groups_with_same_rule}
 
               %span.fr-mr-1w

--- a/app/components/procedure/groupes_management_component/groupes_management_component.html.haml
+++ b/app/components/procedure/groupes_management_component/groupes_management_component.html.haml
@@ -1,7 +1,10 @@
 - content_for(:title, 'Groupes')
 %h1 Gestion des groupes
 
-= render Procedure::GroupesSearchComponent.new(procedure: @procedure, query: @query, to_configure_count: @procedure.groupe_instructeurs.filter(&:routing_to_configure?).count)
+= render Procedure::GroupesSearchComponent.new(procedure: @procedure,
+  query: @query,
+  to_configure_count: @procedure.groupe_instructeurs.filter(&:routing_to_configure?).count,
+  to_configure_filter: @to_configure_filter)
 
 .fr-table.fr-table--no-caption.fr-table--layout-fixed.fr-mt-2w
   %table

--- a/app/components/procedure/groupes_search_component.rb
+++ b/app/components/procedure/groupes_search_component.rb
@@ -1,5 +1,14 @@
 class Procedure::GroupesSearchComponent < ApplicationComponent
-  def initialize(procedure:, query:, to_configure_count:)
-    @procedure, @query, @to_configure_count = procedure, query, to_configure_count
+  def initialize(procedure:, query:, to_configure_count:, to_configure_filter:)
+    @procedure = procedure
+    @query = query
+    @to_configure_count = to_configure_count
+    @to_configure_filter = to_configure_filter
+  end
+
+  private
+
+  def show_to_configure?
+    @to_configure_count > 0
   end
 end

--- a/app/components/procedure/groupes_search_component/groupes_search_component.fr.yml
+++ b/app/components/procedure/groupes_search_component/groupes_search_component.fr.yml
@@ -1,0 +1,5 @@
+---
+fr:
+  to_configure_filter:
+    one: "Filtrer %{count} groupe à configurer"
+    other: "Filtrer les %{count} groupes à configurer"

--- a/app/components/procedure/groupes_search_component/groupes_search_component.html.haml
+++ b/app/components/procedure/groupes_search_component/groupes_search_component.html.haml
@@ -5,5 +5,17 @@
     = text_field_tag :q, @query, class: 'fr-input', type: 'search', autocomplete: 'off', placeholder: 'Rechercher par nom'
     %button.fr-btn{ title: "Rechercher" } Rechercher
 
-- if @to_configure_count > 0
-  %span #{ @to_configure_count } à configurer
+- if show_to_configure?
+  .flex.align-baseline
+    %ul.fr-btns-group.fr-btns-group--sm
+      - if @query.present?
+        %li= link_to "Réinialiser la recherche",
+          admin_procedure_groupe_instructeurs_path(@procedure),
+          class: 'fr-btn fr-btn--tertiary-no-outline'
+      - else
+        = form_with(url: admin_procedure_groupe_instructeurs_path(@procedure),
+          method: :get,
+          data: { controller: 'autosubmit' }) do |f|
+          .fr-checkbox-group.fr-ml-2w.fr-py-1w
+            = f.check_box :filter, checked: @filter_value
+            = f.label :filter, "#{ @to_configure_count } à configurer"

--- a/app/components/procedure/groupes_search_component/groupes_search_component.html.haml
+++ b/app/components/procedure/groupes_search_component/groupes_search_component.html.haml
@@ -1,25 +1,20 @@
-= form_for admin_procedure_groupe_instructeurs_path(@procedure),
-  method: :get do
+= form_with(url: admin_procedure_groupe_instructeurs_path(@procedure),
+  method: :get) do
   #header-search.fr-search-bar.fr-mb-2w{ role: "search" }
     = label_tag :q, 'Rechercher par nom', class: 'fr-label'
     = text_field_tag :q, @query, class: 'fr-input', type: 'search', autocomplete: 'off', placeholder: 'Rechercher par nom'
     %button.fr-btn{ title: "Rechercher" } Rechercher
+  - if @query.present?
+    = link_to "Réinitialiser la recherche",
+      admin_procedure_groupe_instructeurs_path(@procedure),
+      class: 'fr-link'
+  - if show_to_configure?
+    .flex.align-baseline
+      %ul.fr-btns-group.fr-btns-group--sm
+        %li.fr-checkbox-group.fr-ml-1w.fr-py-1w
+          .title.font-weight-bold.fr-mb-1w
+            %span.fr-icon-filter-fill.fr-icon--sm.fr-mr-1w{ 'aria-hidden': 'true' }
+              Filtre
 
-- if show_to_configure?
-  .flex.align-baseline
-    %ul.fr-btns-group.fr-btns-group--sm
-      - if @query.present?
-        %li= link_to "Réinialiser la recherche",
-          admin_procedure_groupe_instructeurs_path(@procedure),
-          class: 'fr-btn fr-btn--tertiary-no-outline'
-      - else
-        = form_with(url: admin_procedure_groupe_instructeurs_path(@procedure),
-          method: :get,
-          data: { controller: 'autosubmit' }) do |f|
-          .fr-checkbox-group.fr-ml-1w.fr-py-1w
-            .title.font-weight-bold.fr-mb-1w
-              %span.fr-icon-filter-fill.fr-icon--sm.fr-mr-1w{ 'aria-hidden': 'true' }
-                Filtre
-
-            = f.check_box :filter, checked: @filter_value
-            = f.label :filter, t('.to_configure_filter', count: @to_configure_count)
+          = check_box_tag :filter, '1', @to_configure_filter, data: { controller: 'autosubmit' }
+          = label_tag :filter, t('.to_configure_filter', count: @to_configure_count)

--- a/app/components/procedure/groupes_search_component/groupes_search_component.html.haml
+++ b/app/components/procedure/groupes_search_component/groupes_search_component.html.haml
@@ -16,6 +16,10 @@
         = form_with(url: admin_procedure_groupe_instructeurs_path(@procedure),
           method: :get,
           data: { controller: 'autosubmit' }) do |f|
-          .fr-checkbox-group.fr-ml-2w.fr-py-1w
+          .fr-checkbox-group.fr-ml-1w.fr-py-1w
+            .title.font-weight-bold.fr-mb-1w
+              %span.fr-icon-filter-fill.fr-icon--sm.fr-mr-1w{ 'aria-hidden': 'true' }
+                Filtre
+
             = f.check_box :filter, checked: @filter_value
-            = f.label :filter, "#{ @to_configure_count } à configurer"
+            = f.label :filter, t('.to_configure_filter', count: @to_configure_count)

--- a/app/components/procedure/one_groupe_management_component/one_groupe_management_component.html.haml
+++ b/app/components/procedure/one_groupe_management_component/one_groupe_management_component.html.haml
@@ -33,6 +33,8 @@
       %p.fr-mb-1w.fr-mr-2w Routage
       - if @groupe_instructeur.routing_to_configure?
         %p.fr-mb-1w.fr-badge.fr-badge--warning.fr-badge--sm à configurer
+      - elsif @groupe_instructeur.non_unic_rule?
+        %p.fr-mb-1w.fr-badge.fr-badge--warning.fr-badge--sm règle déjà attribuée à #{@groupe_instructeur.groups_with_same_rule}
 
     .flex.align-baseline.fr-mb-1w
       .fr-mr-2w.no-wrap si le champ

--- a/app/components/procedure/one_groupe_management_component/one_groupe_management_component.html.haml
+++ b/app/components/procedure/one_groupe_management_component/one_groupe_management_component.html.haml
@@ -31,9 +31,9 @@
 
     .flex
       %p.fr-mb-1w.fr-mr-2w Routage
-      - if @groupe_instructeur.routing_to_configure?
-        %p.fr-mb-1w.fr-badge.fr-badge--warning.fr-badge--sm à configurer
-      - elsif @groupe_instructeur.non_unic_rule?
+      - if @groupe_instructeur.invalid_rule?
+        %p.fr-mb-1w.fr-badge.fr-badge--warning.fr-badge--sm règle invalide
+      - elsif @groupe_instructeur.non_unique_rule?
         %p.fr-mb-1w.fr-badge.fr-badge--warning.fr-badge--sm règle déjà attribuée à #{@groupe_instructeur.groups_with_same_rule}
 
     .flex.align-baseline.fr-mb-1w

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -389,15 +389,12 @@ module Administrateurs
         procedure
           .groupe_instructeurs
           .where('unaccent(label) ILIKE unaccent(?)', "%#{query}%")
-
-      elsif params[:filter] == '1'
-        Kaminari.paginate_array(
-          procedure
-          .groupe_instructeurs
-          .filter(&:routing_to_configure?)
-        )
       else
         procedure.groupe_instructeurs
+      end
+
+      if params[:filter] == '1'
+        groupes = Kaminari.paginate_array(groupes.filter(&:routing_to_configure?))
       end
 
       groupes

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -389,6 +389,13 @@ module Administrateurs
         procedure
           .groupe_instructeurs
           .where('unaccent(label) ILIKE unaccent(?)', "%#{query}%")
+
+      elsif params[:filter] == '1'
+        Kaminari.paginate_array(
+          procedure
+          .groupe_instructeurs
+          .filter(&:routing_to_configure?)
+        )
       else
         procedure.groupe_instructeurs
       end

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -86,14 +86,18 @@ class GroupeInstructeur < ApplicationRecord
   end
 
   def routing_to_configure?
+    invalid_rule? || non_unique_rule?
+  end
+
+  def invalid_rule?
     rule = routing_rule
     return true if !(rule.is_a?(Logic::Eq) && rule.left.is_a?(Logic::ChampValue) && rule.right.is_a?(Logic::Constant))
     return true if !routing_rule_matches_tdc?
   end
 
-  def non_unic_rule?
-    return false if routing_to_configure?
-    routing_rule.in?((procedure.groupe_instructeurs - [self]).map(&:routing_rule))
+  def non_unique_rule?
+    return false if invalid_rule?
+    routing_rule.in?(other_groupe_instructeurs.map(&:routing_rule))
   end
 
   def groups_with_same_rule

--- a/app/models/routing_engine.rb
+++ b/app/models/routing_engine.rb
@@ -2,7 +2,7 @@ module RoutingEngine
   def self.compute(dossier)
     return if dossier.forced_groupe_instructeur
 
-    matching_groupe = dossier.procedure.groupe_instructeurs.active.reject(&:routing_to_configure?).find do |gi|
+    matching_groupe = dossier.procedure.groupe_instructeurs.active.reject(&:invalid_rule?).find do |gi|
       gi.routing_rule&.compute(dossier.champs)
     end
     matching_groupe ||= dossier.procedure.defaut_groupe_instructeur

--- a/app/views/administrateurs/groupe_instructeurs/index.html.haml
+++ b/app/views/administrateurs/groupe_instructeurs/index.html.haml
@@ -11,4 +11,7 @@
       available_instructeur_emails: @available_instructeur_emails,
       disabled_as_super_admin: administrateur_as_manager?)
   - else
-    = render Procedure::GroupesManagementComponent.new(procedure: @procedure, groupe_instructeurs: @groupes_instructeurs, query: params[:q])
+    = render Procedure::GroupesManagementComponent.new(procedure: @procedure,
+      groupe_instructeurs: @groupes_instructeurs,
+      query: params[:q],
+      to_configure_filter: params[:filter].present?)

--- a/spec/components/procedures/one_group_management_component_spec.rb
+++ b/spec/components/procedures/one_group_management_component_spec.rb
@@ -23,7 +23,7 @@ describe Procedure::OneGroupeManagementComponent, type: :component do
         procedure.reload
         subject
       end
-      it { expect(page).to have_text('à configurer') }
+      it { expect(page).to have_text('règle invalide') }
     end
   end
 end

--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -66,7 +66,7 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
 
       it do
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include('à configurer')
+        expect(response.body).to include('règle invalide')
       end
     end
 
@@ -81,7 +81,7 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
 
       it do
         expect(response).to have_http_status(:ok)
-        expect(response.body).not_to include('à configurer')
+        expect(response.body).not_to include('règle invalide')
       end
     end
 
@@ -96,7 +96,7 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
 
       it do
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include('à configurer')
+        expect(response.body).to include('règle invalide')
       end
     end
   end

--- a/spec/system/routing/rules_full_scenario_spec.rb
+++ b/spec/system/routing/rules_full_scenario_spec.rb
@@ -36,7 +36,7 @@ describe 'The routing with rules', js: true do
 
     expect(page).to have_text('Gestion des groupes')
     expect(page).to have_text('3 groupes')
-    expect(page).not_to have_text('À configurer')
+    expect(page).not_to have_text('à configurer')
 
     click_on 'littéraire'
     expect(page).to have_select("targeted_champ", selected: "Spécialité")
@@ -56,7 +56,7 @@ describe 'The routing with rules', js: true do
     click_on 'Continuer'
 
     expect(page).to have_text('Gestion des groupes')
-    expect(page).to have_text('à configurer')
+    expect(page).to have_text('règle invalide')
 
     # update defaut groupe
     click_on 'défaut'

--- a/spec/system/routing/rules_full_scenario_spec.rb
+++ b/spec/system/routing/rules_full_scenario_spec.rb
@@ -49,13 +49,14 @@ describe 'The routing with rules', js: true do
     expect(page).to have_select("value", selected: "scientifique")
   end
 
-  scenario 'Routage personnalisé' do
+  scenario 'Routage avancé' do
     steps_to_routing_configuration
 
     choose('Avancé', allow_label_click: true)
     click_on 'Continuer'
 
     expect(page).to have_text('Gestion des groupes')
+    expect(page).to have_text('à configurer')
 
     # update defaut groupe
     click_on 'défaut'
@@ -113,7 +114,14 @@ describe 'The routing with rules', js: true do
     click_on 'littéraire'
 
     within('.target') { select('Spécialité') }
+    within('.value') { select('scientifique') }
+
+    expect(page).to have_text('règle déjà attribuée à scientifique')
+
+    within('.target') { select('Spécialité') }
     within('.value') { select('littéraire') }
+
+    expect(page).not_to have_text('règle déjà attribuée à scientifique')
 
     procedure.groupe_instructeurs.where(closed: false).each { |gi| wait_until { gi.reload.routing_rule.present? } }
 


### PR DESCRIPTION
- Ajoute un warning si deux groupes ont la même règle de routage
- Ajouter un filtre pour afficher uniquement les groupes à configurer

AVANT

![Screenshot from 2023-06-09 15-21-35](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/29131404/3c69678c-5005-4c09-8629-1438c17653b1)


APRÈS

![Screenshot from 2023-06-16 15-46-37](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/29131404/f0e5b15c-ff1f-495b-8900-879294a82848)



APRÈS

![Screenshot from 2023-06-16 15-47-03](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/29131404/19573729-820f-4494-b685-d0e93482e236)


