### PR TITLE
ETQ Admin je peux importer des instructeurs depuis la page d'un groupe

### DIFF
--- a/app/components/procedure/groupes_ajout_component/groupes_ajout_component.html.haml
+++ b/app/components/procedure/groupes_ajout_component/groupes_ajout_component.html.haml
@@ -2,8 +2,7 @@
 %h1 Ajout de groupes d'instructeurs
 
 = render partial: 'administrateurs/groupe_instructeurs/import_export',
-    locals: { procedure: @procedure,
-    groupe_instructeurs: @groupe_instructeurs }
+    locals: { procedure: @procedure }
 
 %section
   = form_for :groupe_instructeur,

--- a/app/components/procedure/instructeurs_management_component/instructeurs_management_component.html.haml
+++ b/app/components/procedure/instructeurs_management_component/instructeurs_management_component.html.haml
@@ -2,8 +2,7 @@
 %h1 Gestion des instructeurs
 
 = render partial: 'administrateurs/groupe_instructeurs/import_export',
-    locals: { procedure: @procedure,
-    groupe_instructeurs: @procedure.groupe_instructeurs }
+    locals: { procedure: @procedure }
 
 = render partial: 'administrateurs/groupe_instructeurs/instructeurs',
     locals: { procedure: @procedure,

--- a/app/components/procedure/one_groupe_management_component.rb
+++ b/app/components/procedure/one_groupe_management_component.rb
@@ -4,7 +4,7 @@ class Procedure::OneGroupeManagementComponent < ApplicationComponent
   def initialize(revision:, groupe_instructeur:)
     @revision = revision
     @groupe_instructeur = groupe_instructeur
-    @procedure_id = revision.procedure_id
+    @procedure = revision.procedure
   end
 
   private

--- a/app/components/procedure/one_groupe_management_component/one_groupe_management_component.html.haml
+++ b/app/components/procedure/one_groupe_management_component/one_groupe_management_component.html.haml
@@ -1,8 +1,11 @@
 %div{ id: dom_id(@groupe_instructeur, :routing) }
   %h1 Paramètres du groupe
 
+  = render partial: 'administrateurs/groupe_instructeurs/import_export',
+      locals: { procedure: @procedure }
+
   = form_for @groupe_instructeur,
-    url: admin_procedure_groupe_instructeur_path(@procedure_id, @groupe_instructeur),
+    url: admin_procedure_groupe_instructeur_path(@procedure, @groupe_instructeur),
     method: :patch do |f|
     = f.label :label, 'Nom du groupe', class: 'fr-label fr-mb-1w'
     .flex
@@ -10,7 +13,7 @@
       = f.button 'Renommer', class: 'fr-btn fr-btn--secondary'
 
   = form_for @groupe_instructeur,
-    url: admin_procedure_groupe_instructeur_update_state_path(@procedure_id, @groupe_instructeur),
+    url: admin_procedure_groupe_instructeur_update_state_path(@procedure, @groupe_instructeur),
     method: :patch,
     data: { turbo: true, controller: 'autosubmit' } do |f|
     .fr-checkbox-group.fr-my-3w
@@ -19,7 +22,7 @@
         Groupe inactif
         %span.fr-hint-text Si cette option est activée, les usagers ne pourront plus sélectionner ce groupe d’instructeurs
 
-  = form_tag admin_procedure_routing_rules_path(@procedure_id),
+  = form_tag admin_procedure_routing_rules_path(@procedure),
     method: :post,
     data: { controller: 'autosave' },
     class: 'fr-mb-3w' do
@@ -41,18 +44,18 @@
     .fr-hint-text
       %span Si vous ne trouvez pas l'option correspondant à votre groupe, veuillez l'ajouter dans le champ dédié au
       %span
-        = link_to 'routage', champs_admin_procedure_path(@procedure_id)
+        = link_to 'routage', champs_admin_procedure_path(@procedure)
 
   .flex.fr-btns-group--sm.fr-btns-group--inline.fr-btns-group--icon-right
     - if @groupe_instructeur.can_delete?
       %p= t('.delete')
-      = button_to admin_procedure_groupe_instructeur_path(@procedure_id, @groupe_instructeur),
+      = button_to admin_procedure_groupe_instructeur_path(@procedure, @groupe_instructeur),
       class: 'fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-delete-line',
       method: :delete,
       data: { confirm: t('.delete_confirmation', group_name: @groupe_instructeur.label) } do
         Supprimer
     - else
-      = button_to reaffecter_dossiers_admin_procedure_groupe_instructeur_path(@procedure_id, @groupe_instructeur),
+      = button_to reaffecter_dossiers_admin_procedure_groupe_instructeur_path(@procedure, @groupe_instructeur),
       class: 'fr-btn fr-btn--tertiary fr-icon-folder-2-line',
       title: t('.move_files_confirmation'),
       method: :get do

--- a/app/views/administrateurs/groupe_instructeurs/_import_export.html.haml
+++ b/app/views/administrateurs/groupe_instructeurs/_import_export.html.haml
@@ -1,4 +1,4 @@
-- key = @procedure.groupe_instructeurs.one? ? 'instructeurs' : 'groupes'
+- key = procedure.groupe_instructeurs.one? ? 'instructeurs' : 'groupes'
 %section.fr-accordion.fr-mb-3w
   %h3.fr-accordion__title
     %button.fr-accordion__btn{ "aria-controls" => "accordion-106", "aria-expanded" => "false" }
@@ -10,7 +10,7 @@
         = t(".csv_import.#{key}.notice_1_html", csv_max_size: number_to_human_size(csv_max_size))
       %p.notice
         = t(".csv_import.#{key}.notice_2")
-      = form_tag import_admin_procedure_groupe_instructeurs_path(@procedure), method: :post, multipart: true, class: "mt-4 form flex justify-between align-center" do
+      = form_tag import_admin_procedure_groupe_instructeurs_path(procedure), method: :post, multipart: true, class: "mt-4 form flex justify-between align-center" do
         = file_field_tag :csv_file, required: true, accept: 'text/csv', size: "1"
         = submit_tag t('.csv_import.import_file'), class: 'fr-btn fr-btn--secondary', data: { disable_with: "Envoi...", confirm: t('.csv_import.import_file_alert') }
     - else
@@ -18,11 +18,11 @@
         = t(".csv_import.#{key}.title")
       %p.notice
         = t('.csv_import.import_file_procedure_not_published')
-    - if groupe_instructeurs.many?
+    - if procedure.groupe_instructeurs.many?
       .flex.justify-between.align-center.mt-4
         %div
-          = t(".existing_groupe", count: groupe_instructeurs.total_count)
+          = t(".existing_groupe", count: procedure.groupe_instructeurs.count)
         = button_to "Exporter au format CSV",
-          export_groupe_instructeurs_admin_procedure_groupe_instructeurs_path(@procedure, format: :csv),
+          export_groupe_instructeurs_admin_procedure_groupe_instructeurs_path(procedure, format: :csv),
           method: :get,
           class: 'fr-btn fr-btn--secondary'

--- a/config/locales/views/administrateurs/groupe_instructeurs/fr.yml
+++ b/config/locales/views/administrateurs/groupe_instructeurs/fr.yml
@@ -37,12 +37,12 @@ fr:
           import_file_procedure_not_published: L’import par fichier CSV est disponible une fois la démarche publiée
           groupes:
             title: Import / Export en masse
-            notice_1_html: Pour l’import, votre fichier csv doit comporter 2 colonnes (Groupe, Email) et être séparé par des virgules (<a href=/csv/fr/import-groupe-test.csv>exemple de fichier</a>). Le poids du fichier doit être inférieur %{csv_max_size}.
-            notice_2: L’import n’écrase pas les groupes existants. Il permet uniquement d'en ajouter. Pour supprimer un groupe, allez dans la page dédiée et cliquez sur le bouton « Supprimer ».
+            notice_1_html: Pour l’import, votre fichier csv doit comporter 2 colonnes (Groupe, Email) et être séparé par des virgules (<a href=/csv/fr/import-groupe-test.csv>exemple de fichier</a>). Le poids du fichier doit être inférieur à %{csv_max_size}.
+            notice_2: L’import n’écrase pas les groupes et instructeurs existants. Il permet uniquement d'en ajouter.
           instructeurs:
             title: Import en masse
-            notice_1_html: Pour l’import, le fichier csv doit comporter 1 seule colonne (Email) avec une adresse email d'instructeur par ligne (<a href=/csv/import-instructeurs-test.csv>exemple de fichier</a>). Le poids du fichier doit être inférieur %{csv_max_size}.
-            notice_2: L’import n’écrase pas les instructeurs existants. Il permet uniquement d'en ajouter. Pour supprimer un instructeur, cliquez sur le bouton « Retirer ».
+            notice_1_html: Pour l’import, le fichier csv doit comporter 1 seule colonne (Email) avec une adresse email d’instructeur par ligne (<a href=/csv/import-instructeurs-test.csv>exemple de fichier</a>). Le poids du fichier doit être inférieur à %{csv_max_size}.
+            notice_2: L’import n’écrase pas les instructeurs existants. Il permet uniquement d'en ajouter.
         existing_groupe:
           one: "%{count} groupe existe"
           other: "%{count} groupes existent"


### PR DESCRIPTION
- Le composant import / export d'instructeurs/groupes d'instructeurs étaient présent à deux endroits : dans la page "Instructeurs" d'une procédure non routée et dans la page "Ajout de groupes" d'une procédure routée.
Suite à un retour utilisateur qui ne trouvait plus où importer des instructeurs dans le cas d'une procédure routée, on ajoute ce composant dans la page de chaque groupe.

![Screenshot from 2023-06-12 16-51-36](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/29131404/99c8233e-2479-4b36-b399-75cc0f853da1)


- Petite modif en passant dans la partial `import_export.html.haml` : utiliser `procedure.groupe_instructeurs` plutôt que `paginated_groupe_instructeurs` car on n'a pas besoin de la pagination dans cette partial 