### PR TITLE
ETQ instructeur: uniformise le wording "informé" sur les actions d'instruction et de correction

### DIFF
--- a/app/components/instructeurs/en_construction_menu_component/en_construction_menu_component.html.haml
+++ b/app/components/instructeurs/en_construction_menu_component/en_construction_menu_component.html.haml
@@ -8,7 +8,7 @@
         %span.fr-icon.fr-icon-draft-line.fr-text-default--info.fr-mt-1v{ "aria-hidden": "true" }
         .dropdown-description
           %h4= t('.revert_en_construction')
-          L’usager sera notifié qu’il peut modifier son dossier
+          L’usager sera informé qu’il peut modifier son dossier
 
   - menu.with_item do
     = link_to('#', onclick: "DS.showMotivation(event, 'pending_correction');", role: 'menuitem') do
@@ -16,7 +16,7 @@
 
       .dropdown-description
         %h4= t('.request_correction')
-        L’usager sera notifié que des modifications sont attendues
+        L’usager sera informé que des modifications sont attendues
 
   - menu.with_item(class: "inactive form-inside fr-pt-1v") do
     = render partial: 'instructeurs/dossiers/instruction_button_motivation', locals: { dossier:,


### PR DESCRIPTION
Je n'avais pas répercuté le changement de wording notifié => informé dans mon refacto sur ce component que j'avais fait en //