### PR TITLE
Correction : rejoue le routing engine apres ajout des règles de routage sur une procédure clonée

### DIFF
--- a/lib/tasks/deployment/20230613114744_replay_routing_engine_for_a_cloned_procedure.rake
+++ b/lib/tasks/deployment/20230613114744_replay_routing_engine_for_a_cloned_procedure.rake
@@ -1,0 +1,25 @@
+namespace :after_party do
+  desc 'Deployment task: replay_routing_engine_for_a_cloned_procedure'
+  task replay_routing_engine_for_a_cloned_procedure: :environment do
+    puts "Running deploy task 'replay_routing_engine_for_a_cloned_procedure'"
+
+    # Put your task implementation HERE.
+    dossiers = Procedure
+      .find(76266)
+      .dossiers
+      .en_construction
+
+    progress = ProgressReport.new(dossiers.count)
+
+    dossiers.find_each do |dossier|
+      RoutingEngine.compute(dossier)
+      progress.inc
+    end
+    progress.finish
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
La démarche 76266 a été clonée à partir d'une démarche routée, puis publiée. Ses groupes d'instructeurs n'ont pas de règle de routage (le process de clonage n'a pas encore été modifié pour copier les règles de routage). Tous les dossiers ont donc été affectés au groupe d'instructeurs par défaut.
J'ai ajouté les règles de routage depuis l'interface admin. Depuis, les nouveaux dossiers sont correctement routés.
Maintenant, il faut re-router les 1683 dossiers attribués au groupe par défaut.
C'est ce que fait cette tâche rake qui rejoue le RoutingEngine pour chaque dossier