### PR TITLE
ETQ admin je veux voir les erreurs lorsque la (re-)publication échoue

### DIFF
--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -282,8 +282,6 @@ module Administrateurs
           if @procedure.publish_or_reopen!(current_administrateur)
             @procedure.publish_revision!
             flash.notice = "Démarche publiée"
-          else
-            flash.alert = @procedure.errors.full_messages
           end
         else
           @procedure.publish_revision!
@@ -291,8 +289,6 @@ module Administrateurs
         end
       elsif @procedure.publish_or_reopen!(current_administrateur)
         flash.notice = "Démarche publiée"
-      else
-        flash.alert = @procedure.errors.full_messages
       end
 
       if params[:old_procedure].present? && @procedure.errors.empty?
@@ -305,6 +301,9 @@ module Administrateurs
       end
 
       redirect_to admin_procedure_path(@procedure)
+    rescue ActiveRecord::RecordInvalid
+      flash.alert = @procedure.errors.full_messages
+      redirect_to admin_procedure_publication_path(@procedure)
     end
 
     def reset_draft


### PR DESCRIPTION
On renvoyait une 500 ou 422 qui n'informait pas les admins de l'erreur, ce qui déclenchait un passage par le support

https://demarches-simplifiees.sentry.io/issues/4244674755/