### PR TITLE
ETQ Administrateur, je voudrais proposer de pré-remplir les annotations privées

### DIFF
--- a/app/models/concerns/dossier_prefillable_concern.rb
+++ b/app/models/concerns/dossier_prefillable_concern.rb
@@ -3,13 +3,17 @@
 module DossierPrefillableConcern
   extend ActiveSupport::Concern
 
-  def prefill!(champs_public_attributes)
-    return unless champs_public_attributes.any?
+  def prefill!(champs_attributes)
+    return unless champs_attributes.any?
 
-    attr = { prefilled: true }
-    attr[:champs_public_all_attributes] = champs_public_attributes.map { |h| h.merge(prefilled: true) }
+    attributes = { prefilled: true }
+    attributes[:champs_attributes] = champs_attributes.map { |h| h.merge(prefilled: true) }
 
-    assign_attributes(attr)
+    assign_attributes(attributes)
     save(validate: false)
+  end
+
+  def find_champs_by_stable_ids(stable_ids)
+    champs.joins(:type_de_champ).where(types_de_champ: { stable_id: stable_ids.compact.uniq })
   end
 end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -1229,12 +1229,6 @@ class Dossier < ApplicationRecord
     termine_expired_to_delete.find_each(&:purge_discarded)
   end
 
-  def find_champs_by_stable_ids(stable_ids)
-    return [] if stable_ids.compact.empty?
-
-    champs.joins(:type_de_champ).where(types_de_champ: { stable_id: stable_ids })
-  end
-
   def skip_user_notification_email?
     return true if brouillon? && procedure.declarative?
     return true if for_procedure_preview?

--- a/spec/controllers/api/public/v1/dossiers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/dossiers_controller_spec.rb
@@ -201,6 +201,6 @@ RSpec.describe API::Public::V1::DossiersController, type: :controller do
   private
 
   def find_champ_by_stable_id(dossier, stable_id)
-    dossier.champs_public.joins(:type_de_champ).find_by(types_de_champ: { stable_id: stable_id })
+    dossier.champs.joins(:type_de_champ).find_by(types_de_champ: { stable_id: stable_id })
   end
 end

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -1319,6 +1319,6 @@ describe Users::DossiersController, type: :controller do
   private
 
   def find_champ_by_stable_id(dossier, stable_id)
-    dossier.champs_public.joins(:type_de_champ).find_by(types_de_champ: { stable_id: stable_id })
+    dossier.champs.joins(:type_de_champ).find_by(types_de_champ: { stable_id: stable_id })
   end
 end

--- a/spec/models/concern/dossier_prefillable_concern_spec.rb
+++ b/spec/models/concern/dossier_prefillable_concern_spec.rb
@@ -2,9 +2,10 @@
 
 RSpec.describe DossierPrefillableConcern do
   describe '.prefill!' do
-    let(:procedure) { create(:procedure, :published, types_de_champ_public:) }
+    let(:procedure) { create(:procedure, :published, types_de_champ_public:, types_de_champ_private:) }
     let(:dossier) { create(:dossier, :brouillon, procedure: procedure) }
     let(:types_de_champ_public) { [] }
+    let(:types_de_champ_private) { [] }
 
     subject(:fill) do
       dossier.prefill!(values)
@@ -17,7 +18,7 @@ RSpec.describe DossierPrefillableConcern do
       end
     end
 
-    context 'when champs_public_attributes is empty' do
+    context 'when champs_attributes is empty' do
       let(:values) { [] }
 
       it "doesn't mark the dossier as prefilled" do
@@ -29,9 +30,11 @@ RSpec.describe DossierPrefillableConcern do
       end
     end
 
-    context 'when champs_public_attributes has values' do
+    context 'when champs_attributes has values' do
       context 'when the champs are valid' do
         let(:types_de_champ_public) { [{ type: :text }, { type: :phone }] }
+        let(:types_de_champ_private) { [{ type: :text }] }
+
         let(:type_de_champ_1) { procedure.published_revision.types_de_champ_public.first }
         let(:value_1) { "any value" }
         let(:champ_id_1) { find_champ_by_stable_id(dossier, type_de_champ_1.stable_id).id }
@@ -40,7 +43,11 @@ RSpec.describe DossierPrefillableConcern do
         let(:value_2) { "33612345678" }
         let(:champ_id_2) { find_champ_by_stable_id(dossier, type_de_champ_2.stable_id).id }
 
-        let(:values) { [{ id: champ_id_1, value: value_1 }, { id: champ_id_2, value: value_2 }] }
+        let(:type_de_champ_3) { procedure.published_revision.types_de_champ_private.first }
+        let(:value_3) { "some value" }
+        let(:champ_id_3) { find_champ_by_stable_id(dossier, type_de_champ_3.stable_id).id }
+
+        let(:values) { [{ id: champ_id_1, value: value_1 }, { id: champ_id_2, value: value_2 }, { id: champ_id_3, value: value_3 }] }
 
         it_behaves_like 'a dossier marked as prefilled'
 
@@ -51,6 +58,8 @@ RSpec.describe DossierPrefillableConcern do
           expect(dossier.champs_public.first.prefilled).to eq(true)
           expect(dossier.champs_public.last.value).to eq(value_2)
           expect(dossier.champs_public.last.prefilled).to eq(true)
+          expect(dossier.champs_private.first.value).to eq(value_3)
+          expect(dossier.champs_private.first.prefilled).to eq(true)
         end
       end
 


### PR DESCRIPTION
Retour au support. On permettait (sans le documenter) de pré-remplir les annotations privées. Ça a été cassé. Je répare et j'ajoute un test.