### PR TITLE
Tech (seo): disallow /super_admins/

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,3 +4,4 @@
 User-agent: *
 Disallow: /commencer*
 Disallow: /rails/
+Disallow: /super_admins/


### PR DESCRIPTION
c'est parfois la première url remontée dans le moteur de recherche, pas pratique pour un user normal