### PR TITLE
ajoute nom et prénom de l'EI

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -1131,6 +1131,8 @@ class Dossier < ApplicationRecord
       ]
     else
       columns << ['Entreprise raison sociale', etablissement&.entreprise_raison_sociale]
+      columns << ["Entreprise nom de l'EI", etablissement&.entreprise_nom]
+      columns << ["Entreprise prénom de l'EI", etablissement&.entreprise_prenom]
     end
 
     columns += [

--- a/app/models/procedure_presentation.rb
+++ b/app/models/procedure_presentation.rb
@@ -78,6 +78,8 @@ class ProcedurePresentation < ApplicationRecord
         field_hash('etablissement', 'entreprise_forme_juridique', type: :text),
         field_hash('etablissement', 'entreprise_nom_commercial', type: :text),
         field_hash('etablissement', 'entreprise_raison_sociale', type: :text),
+        field_hash('etablissement', 'entreprise_nom', type: :text),
+        field_hash('etablissement', 'entreprise_prenom', type: :text),
         field_hash('etablissement', 'entreprise_siret_siege_social', type: :text),
         field_hash('etablissement', 'entreprise_date_creation', type: :date)
       )

--- a/config/locales/models/procedure_presentation/en.yml
+++ b/config/locales/models/procedure_presentation/en.yml
@@ -35,6 +35,8 @@ en:
             entreprise_forme_juridique: Forme juridique
             entreprise_nom_commercial: Commercial name
             entreprise_raison_sociale: Raison sociale
+            entreprise_nom: Last name of contractor
+            entreprise_prenom: First name of contractor
             entreprise_siret_siege_social: SIRET siège social
             entreprise_date_creation: Creation date
             siret: SIRET

--- a/config/locales/models/procedure_presentation/fr.yml
+++ b/config/locales/models/procedure_presentation/fr.yml
@@ -35,6 +35,8 @@ fr:
             entreprise_forme_juridique: Forme juridique
             entreprise_nom_commercial: Nom commercial
             entreprise_raison_sociale: Raison sociale
+            entreprise_nom: Nom de l'entrepreneur individuel
+            entreprise_prenom: Prénom de l'entrepreneur individuel
             entreprise_siret_siege_social: SIRET siège social
             entreprise_date_creation: Date de création
             siret: SIRET

--- a/spec/models/procedure_presentation_spec.rb
+++ b/spec/models/procedure_presentation_spec.rb
@@ -78,6 +78,8 @@ describe ProcedurePresentation do
           { "label" => 'Forme juridique', "table" => 'etablissement', "column" => 'entreprise_forme_juridique', 'classname' => '', 'virtual' => false, 'type' => :text, "scope" => '' },
           { "label" => 'Nom commercial', "table" => 'etablissement', "column" => 'entreprise_nom_commercial', 'classname' => '', 'virtual' => false, 'type' => :text, "scope" => '' },
           { "label" => 'Raison sociale', "table" => 'etablissement', "column" => 'entreprise_raison_sociale', 'classname' => '', 'virtual' => false, 'type' => :text, "scope" => '' },
+          { "label" => "Nom de l'entrepreneur individuel", "table" => 'etablissement', "column" => 'entreprise_nom', 'classname' => '', 'virtual' => false, 'type' => :text, "scope" => '' },
+          { "label" => "Prénom de l'entrepreneur individuel", "table" => 'etablissement', "column" => 'entreprise_prenom', 'classname' => '', 'virtual' => false, 'type' => :text, "scope" => '' },
           { "label" => 'SIRET siège social', "table" => 'etablissement', "column" => 'entreprise_siret_siege_social', 'classname' => '', 'virtual' => false, 'type' => :text, "scope" => '' },
           { "label" => 'Date de création', "table" => 'etablissement', "column" => 'entreprise_date_creation', 'classname' => '', 'virtual' => false, 'type' => :date, "scope" => '' },
           { "label" => 'SIRET', "table" => 'etablissement', "column" => 'siret', 'classname' => '', 'virtual' => false, 'type' => :text, "scope" => '' },

--- a/spec/services/procedure_export_service_spec.rb
+++ b/spec/services/procedure_export_service_spec.rb
@@ -150,6 +150,8 @@ describe ProcedureExportService do
         [
           "ID",
           "Email",
+          "Entreprise nom de l'EI",
+          "Entreprise prénom de l'EI",
           "Entreprise raison sociale",
           "Archivé",
           "État du dossier",


### PR DESCRIPTION
Depuis la v3 d'api entreprise, on peut lire sur le [guide de migration](https://entreprise.api.gouv.fr/developpeurs/guide-migration)
> Suppression du champ raison_sociale pour les personnes physiques en V.3 : par abus de langage, on parle de raison sociale ou dénomination pour les personnes physiques, or leur nom d’entreprise correspond toujours au nom de famille et au prénom, précédés ou suivis de la mention “entrepreneur individuel” ou “EI”.

Cette PR ajoute 2 colonnes à l'export des dossiers : `Entreprise Nom de l'EI` et `Entreprise Prénom de l'EI`
Sur la page instructeur, dans la personnalisation du tableau de la page d'une procédure, on peut désormais ajouter les champs : `Nom de l'entrepreneur individuel` et `Prénom de l'entrepreneur individuel`

close #9204 