### PR TITLE
Tech: log technique de la destruction de dossiers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,6 +25,7 @@ class ApplicationController < ActionController::Base
 
   before_action do
     Current.request_id = request.uuid
+    Current.user = current_user
   end
 
   def staging_authenticate

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1934,6 +1934,17 @@ describe Dossier, type: :model do
       expect { dossier.procedure.reset! }.not_to raise_error
       expect { dossier.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
+
+    it "call logger with context" do
+      json_message = nil
+
+      allow(Rails.logger).to receive(:info) { json_message ||= _1 }
+      dossier.destroy
+
+      expect(JSON.parse(json_message)).to a_hash_including(
+        { message: "Dossier destroyed", dossier_id: dossier.id, procedure_id: procedure.id }.stringify_keys
+      )
+    end
   end
 
   describe "#spreadsheet_columns" do


### PR DESCRIPTION
produit une entrée de log logstash avec contexte en json du type :

```json
{
  "message":"Dossier destroyed",
  "dossier_id":2676,
  "procedure_id":2376,
  "request_id":"d1fd8731-9f29-489e-8785-90aeb3638185",
  "user_id":456948,
  "controller":"/app/controllers/administrateurs/procedures_controller.rb:286:in `publish'",
  "caller":"/app/models/procedure.rb:395:in `block in publish_or_reopen!'"
}
```

J'ai fait au plus simple, on parfois on n'aurait qu'un controller et trace approximative, mais on devrait pouvoir les retrouver facilement avec ça.

Extrait kibana : (ici nommé par `ds_dossier_id` mais finalement ce sera bien `dossier_id`)
![Capture d’écran 2023-09-05 à 18 15 49](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/ea5a6d96-da42-403d-aa17-f3e824e8d661)



Closes #9229 


