### PR TITLE
[Page accueil demarche] Ajouter la possibilité de créer sa propre liste de PJ pour les Admins

### DIFF
--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -454,6 +454,7 @@ module Administrateurs
         :libelle,
         :description,
         :description_target_audience,
+        :description_pj,
         :organisation,
         :direction,
         :lien_site_web,

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -16,6 +16,7 @@
 #  closed_at                                 :datetime
 #  declarative_with_state                    :string
 #  description                               :string
+#  description_pj                            :string
 #  description_target_audience               :string
 #  dossiers_count_computed_at                :datetime
 #  duree_conservation_dossiers_dans_ds       :integer

--- a/app/views/administrateurs/procedures/_informations.html.haml
+++ b/app/views/administrateurs/procedures/_informations.html.haml
@@ -10,6 +10,8 @@
 
 = render Dsfr::InputComponent.new(form: f, attribute: :description_target_audience, input_type: :text_area, opts: {}, required: false)
 
+= render Dsfr::InputComponent.new(form: f, attribute: :description_pj, input_type: :text_area, opts: {placeholder: t('activerecord.attributes.procedure.description_pj_placeholder')}, required: false)
+
 = f.label :logo, 'Ajouter un logo de la démarche (facultatif)', class: 'fr-label'
 = render Attachment::EditComponent.new(attached_file: @procedure.logo, view_as: :link)
 

--- a/app/views/shared/_procedure_description.html.haml
+++ b/app/views/shared/_procedure_description.html.haml
@@ -39,7 +39,15 @@
         #accordion-115.fr-collapse
           = h render SimpleFormatComponent.new(procedure.description_target_audience, allow_a: true)
 
-    - if procedure.pieces_jointes_list?
+    - if procedure.description_pj.present?
+      %section.fr-accordion.pieces_jointes
+        %h2.fr-accordion__title
+          %button.fr-accordion__btn{ "aria-controls" => "accordion-116", "aria-expanded" => "false" }
+            = t('shared.procedure_description.pieces_jointes')
+        #accordion-116.fr-collapse
+          = h render SimpleFormatComponent.new(procedure.description_pj, allow_a: true)
+
+    - elsif procedure.pieces_jointes_list?
       %section.fr-accordion.pieces_jointes
         %h2.fr-accordion__title
           %button.fr-accordion__btn{ "aria-controls" => "accordion-116", "aria-expanded" => "false" }

--- a/config/locales/models/procedure/en.yml
+++ b/config/locales/models/procedure/en.yml
@@ -9,12 +9,15 @@ en:
         hints:
           description: Describe in a few lines the context, the aim etc.
           description_target_audience: Describe in a few lines the final recipients of the process, the eligibility criteria if there are any, the prerequisites, etc.
+          description_pj: Describe the required attachments list if there is any
           lien_site_web: "Exemple: 'https://exemple.gouv.fr/ma_demarche'"
           cadre_juridique: "Exemple: 'https://www.legifrance.gouv.fr/'"
         path: Public link
         organisation: Service
         description: What is the purpose of this procedure?
         description_target_audience: Who is the procedure intended for?
+        description_pj: Required attachments list
+        description_pj_placeholder: If you leave this field blank and your form contains attachments, an automatically generated list will be displayed on the home page of your procedure.
         lien_site_web: Where will users find the link to the procedure?
         cadre_juridique: Link to the legal text
         lien_dpo: Link or email to contact the data protection officer (DPO)

--- a/config/locales/models/procedure/fr.yml
+++ b/config/locales/models/procedure/fr.yml
@@ -9,6 +9,7 @@ fr:
         hints:
           description: Décrivez en quelques lignes le contexte, la finalité, etc.
           description_target_audience: Décrivez en quelques lignes les destinataires finaux de la démarche, les critères d’éligibilité s’il y en a, les pré-requis, etc.
+          description_pj: Décrivez la liste des pièces jointes à fournir s’il y en a
           lien_site_web: "Exemple: 'https://exemple.gouv.fr/ma_demarche'"
           cadre_juridique: "Exemple: 'https://www.legifrance.gouv.fr/'"
         path: Lien public
@@ -19,6 +20,8 @@ fr:
         libelle: Titre de la démarche
         description: Quel est l’objet de la démarche ?
         description_target_audience: À qui s’adresse la démarche ?
+        description_pj: Liste des pièces jointes demandées
+        description_pj_placeholder: Si vous ne renseignez pas ce champ et que votre formulaire contient des pièces jointes, une liste générée automatiquement s'affichera dans la page d'accueil de votre démarche.
         lien_site_web: Où les usagers trouveront-ils le lien vers la démarche ?
         cadre_juridique: Lien vers le texte
         lien_dpo: Lien ou email pour contacter le Délégué à la Protection des Données (DPO)

--- a/db/migrate/20230621161733_add_pj_field_for_description_to_procedure.rb
+++ b/db/migrate/20230621161733_add_pj_field_for_description_to_procedure.rb
@@ -1,0 +1,5 @@
+class AddPjFieldForDescriptionToProcedure < ActiveRecord::Migration[7.0]
+  def change
+    add_column :procedures, :description_pj, :string
+  end
+end

--- a/spec/views/shared/_procedure_description.html.haml_spec.rb
+++ b/spec/views/shared/_procedure_description.html.haml_spec.rb
@@ -50,5 +50,12 @@ describe 'shared/_procedure_description', type: :view do
       expect(rendered).to have_text('Libelle du champ')
       expect(rendered).to have_selector('.pieces_jointes ul li', count: 2)
     end
+
+    it 'shows the manual description pieces jointes list if admin filled one' do
+      procedure.update!(description_pj: 'une description des pj manuelle')
+      subject
+      expect(rendered).to have_text('Quelles sont les pièces justificatives à fournir')
+      expect(rendered).to have_text('une description des pj manuelle')
+    end
   end
 end


### PR DESCRIPTION
Après l'ajout de la liste automatique des PJ dans la page d'accueil de la démarche - on a eu des retours d'admins qui souhaitaient pouvoir être plus précis dans la description des PJ - notamment quand il y a du conditionnel et des champs répétables. Comme on ne peut pas être aussi précis que les admins, on propose de 
- pouvoir surcharger cette liste auto par un champ manuel
- garder l'ajout automatique des PJ (si le champ est vide mais qu'il y a des PJ dans le formulaire)

**NV CHAMPS DANS LE FORMULAIRE DE DESCRIPTION DE LA DEMARCHE**
<img width="862" alt="Capture d’écran 2023-06-22 à 09 53 57" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/6af91b2f-7da9-469f-abf3-90e4996208bb">

**PAGE D'ACCUEIL DE LA DEMARCHE**
<img width="858" alt="Capture d’écran 2023-06-22 à 09 54 45" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/ef46b7e3-5c9a-465f-8eb1-ae8ba503c8ff">
