### PR TITLE
ETQ Usager: fix dépot en construction après qu'un champ d'une répétition a été ajouté/modifié par une révision

### DIFF
--- a/app/models/concerns/dossier_clone_concern.rb
+++ b/app/models/concerns/dossier_clone_concern.rb
@@ -145,11 +145,11 @@ module DossierCloneConcern
   end
 
   def apply_diff(diff)
-    champs_index = (champs + diff[:added]).index_by(&:stable_id_with_row)
+    champs_index = (champs_public_all + diff[:added]).index_by(&:stable_id_with_row)
 
     diff[:added].each do |champ|
       if champ.child?
-        champ.update_columns(dossier_id: id, parent_id: champs_index[champ.parent.stable_id_with_row].id)
+        champ.update_columns(dossier_id: id, parent_id: champs_index.fetch(champ.parent.stable_id_with_row).id)
       else
         champ.update_column(:dossier_id, id)
       end
@@ -157,13 +157,13 @@ module DossierCloneConcern
 
     champs_to_remove = []
     diff[:updated].each do |champ|
-      old_champ = champs_index[champ.stable_id_with_row]
+      old_champ = champs_index.fetch(champ.stable_id_with_row)
       champs_to_remove << old_champ
 
       if champ.child?
         # we need to do that in order to avoid a foreign key constraint
         old_champ.update(row_id: nil)
-        champ.update_columns(dossier_id: id, parent_id: champs_index[champ.parent.stable_id_with_row].id)
+        champ.update_columns(dossier_id: id, parent_id: champs_index.fetch(champ.parent.stable_id_with_row).id)
       else
         champ.update_column(:dossier_id, id)
       end

--- a/app/models/concerns/dossier_rebase_concern.rb
+++ b/app/models/concerns/dossier_rebase_concern.rb
@@ -129,10 +129,10 @@ module DossierRebaseConcern
       champs.filter { _1.stable_id == parent_stable_id }.each do |champ_repetition|
         if champ_repetition.champs.present?
           champ_repetition.champs.map(&:row_id).uniq.each do |row_id|
-            create_champ(target_coordinate, champ_repetition, row_id:)
+            champs << create_champ(target_coordinate, champ_repetition, row_id:)
           end
         elsif champ_repetition.mandatory?
-          create_champ(target_coordinate, champ_repetition, row_id: ULID.generate)
+          champs << create_champ(target_coordinate, champ_repetition, row_id: ULID.generate)
         end
       end
     else
@@ -141,10 +141,10 @@ module DossierRebaseConcern
   end
 
   def create_champ(target_coordinate, parent, row_id: nil)
-    champ = target_coordinate
+    target_coordinate
       .type_de_champ
       .build_champ(rebased_at: Time.zone.now, row_id:)
-    parent.champs << champ
+      .tap { parent.champs << _1 }
   end
 
   def purge_piece_justificative_file(champ)


### PR DESCRIPTION
Après le rebase, on génère le diff origine/fork avec `champs_public_all` ; or le merge se fait en se basant sur `champs`. `champs` avait déjà été loadé par le rebase, et ne contenait pas toutes les valeurs mises à jour par le rebase. Plutôt que faire un reload, on peut unifier en utilisant `champs_public_all` partout au niveau du fork.

https://demarches-simplifiees.sentry.io/issues/4228424336/events/c3479391f8ab438d9e4d58a513066b32/

La différence avec un champ non répété, c'est que le code du rebase associe le champ sur le parent et pas sur la relation `champs` du dossier : https://github.com/demarches-simplifiees/demarches-simplifiees.fr/blob/862318ffddfddf81af77254811b3b11564be9ca1/app/models/concerns/dossier_rebase_concern.rb#L143-L148

C'est ce que je corrige dans le second commit. Cependant pour bien faire il faudrait gérer la récursivité des blocs répétables, et je suis pas sûr qu'il faille ça s'embarquer là-dedans