### PR TITLE
tech(expiration.dossiers): evite d'envoyer tous les mails d'expiration d'un coup

### DIFF
--- a/app/jobs/cron/expired_dossiers_brouillon_deletion_job.rb
+++ b/app/jobs/cron/expired_dossiers_brouillon_deletion_job.rb
@@ -1,0 +1,7 @@
+class Cron::ExpiredDossiersBrouillonDeletionJob < Cron::CronJob
+  self.schedule_expression = "every day at 10 pm"
+
+  def perform(*args)
+    ExpiredDossiersDeletionService.process_expired_dossiers_brouillon
+  end
+end

--- a/app/jobs/cron/expired_dossiers_brouillon_deletion_job.rb
+++ b/app/jobs/cron/expired_dossiers_brouillon_deletion_job.rb
@@ -2,6 +2,6 @@ class Cron::ExpiredDossiersBrouillonDeletionJob < Cron::CronJob
   self.schedule_expression = "every day at 10 pm"
 
   def perform(*args)
-    ExpiredDossiersDeletionService.process_expired_dossiers_brouillon
+    ExpiredDossiersDeletionService.new.process_expired_dossiers_brouillon
   end
 end

--- a/app/jobs/cron/expired_dossiers_deletion_job.rb
+++ b/app/jobs/cron/expired_dossiers_deletion_job.rb
@@ -1,9 +1,0 @@
-class Cron::ExpiredDossiersDeletionJob < Cron::CronJob
-  self.schedule_expression = "every day at 7 am"
-
-  def perform(*args)
-    ExpiredDossiersDeletionService.process_expired_dossiers_brouillon
-    ExpiredDossiersDeletionService.process_expired_dossiers_en_construction
-    ExpiredDossiersDeletionService.process_expired_dossiers_termine
-  end
-end

--- a/app/jobs/cron/expired_dossiers_en_construction_deletion_job.rb
+++ b/app/jobs/cron/expired_dossiers_en_construction_deletion_job.rb
@@ -1,0 +1,7 @@
+class Cron::ExpiredDossiersEnConstructionDeletionJob < Cron::CronJob
+  self.schedule_expression = "every day at 3 pm"
+
+  def perform(*args)
+    ExpiredDossiersDeletionService.process_expired_dossiers_en_construction
+  end
+end

--- a/app/jobs/cron/expired_dossiers_en_construction_deletion_job.rb
+++ b/app/jobs/cron/expired_dossiers_en_construction_deletion_job.rb
@@ -2,6 +2,6 @@ class Cron::ExpiredDossiersEnConstructionDeletionJob < Cron::CronJob
   self.schedule_expression = "every day at 3 pm"
 
   def perform(*args)
-    ExpiredDossiersDeletionService.process_expired_dossiers_en_construction
+    ExpiredDossiersDeletionService.new.process_expired_dossiers_en_construction
   end
 end

--- a/app/jobs/cron/expired_dossiers_termine_deletion_job.rb
+++ b/app/jobs/cron/expired_dossiers_termine_deletion_job.rb
@@ -2,6 +2,6 @@ class Cron::ExpiredDossiersTermineDeletionJob < Cron::CronJob
   self.schedule_expression = "every day at 7 am"
 
   def perform(*args)
-    ExpiredDossiersDeletionService.process_expired_dossiers_termine
+    ExpiredDossiersDeletionService.new.process_expired_dossiers_termine
   end
 end

--- a/app/jobs/cron/expired_dossiers_termine_deletion_job.rb
+++ b/app/jobs/cron/expired_dossiers_termine_deletion_job.rb
@@ -1,0 +1,7 @@
+class Cron::ExpiredDossiersTermineDeletionJob < Cron::CronJob
+  self.schedule_expression = "every day at 7 am"
+
+  def perform(*args)
+    ExpiredDossiersDeletionService.process_expired_dossiers_termine
+  end
+end

--- a/app/jobs/cron/weekly_overview_job.rb
+++ b/app/jobs/cron/weekly_overview_job.rb
@@ -1,16 +1,13 @@
 class Cron::WeeklyOverviewJob < Cron::CronJob
-  self.schedule_expression = "every monday at 7 am"
+  self.schedule_expression = "every monday at 4 am"
 
   def perform
     # Feature flipped to avoid mails in staging due to unprocessed dossier
     return unless Rails.application.config.ds_weekly_overview
 
     Instructeur.find_each do |instructeur|
-      # NOTE: it's not exactly accurate because rate limit is not shared between jobs processes
-      Dolist::API.sleep_until_limit_reset if Dolist::API.near_rate_limit?
-
       # mailer won't send anything if overview if empty
-      InstructeurMailer.last_week_overview(instructeur)&.deliver_later
+      InstructeurMailer.last_week_overview(instructeur)&.deliver_later(wait: rand(0..3.hours))
     end
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -7,6 +7,8 @@ class ApplicationMailer < ActionMailer::Base
   default from: "#{APPLICATION_NAME} <#{CONTACT_EMAIL}>"
   layout 'mailer'
 
+  before_action -> { Sentry.set_tags(mailer: mailer_name, action: action_name) }
+
   # Attach the procedure logo to the email (if any).
   # Returns the attachment url.
   def attach_logo(procedure)

--- a/app/services/mail_rate_limiter.rb
+++ b/app/services/mail_rate_limiter.rb
@@ -23,10 +23,10 @@ class MailRateLimiter
   end
 
   def current_window_expired?
-    @current_window[:started_at] + @window <= Time.zone.now.utc
+    (@current_window[:started_at] + @window).past?
   end
 
   def current_window_full?
-    @current_window[:sent] == @limit
+    @current_window[:sent] >= @limit
   end
 end

--- a/app/services/mail_rate_limiter.rb
+++ b/app/services/mail_rate_limiter.rb
@@ -1,0 +1,32 @@
+class MailRateLimiter
+  attr_reader :delay, :current_window
+
+  def send_with_delay(mail)
+    if current_window_full?
+      @delay += @window
+    end
+    if current_window_full? || current_window_expired?
+      @current_window = { started_at: Time.current, sent: 0 }
+    end
+    @current_window[:sent] += 1
+
+    mail.deliver_later(wait: delay)
+  end
+
+  private
+
+  def initialize(limit:, window:)
+    @limit = limit
+    @window = window
+    @current_window = { started_at: Time.current, sent: 0 }
+    @delay = 0
+  end
+
+  def current_window_expired?
+    @current_window[:started_at] + @window <= Time.zone.now.utc
+  end
+
+  def current_window_full?
+    @current_window[:sent] == @limit
+  end
+end

--- a/db/migrate/20230623160831_add_index_to_parent_dossier_id.rb
+++ b/db/migrate/20230623160831_add_index_to_parent_dossier_id.rb
@@ -1,0 +1,7 @@
+class AddIndexToParentDossierId < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :dossiers, :parent_dossier_id, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_21_161733) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_23_160831) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -416,6 +416,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_21_161733) do
     t.index ["editing_fork_origin_id"], name: "index_dossiers_on_editing_fork_origin_id"
     t.index ["groupe_instructeur_id"], name: "index_dossiers_on_groupe_instructeur_id"
     t.index ["hidden_at"], name: "index_dossiers_on_hidden_at"
+    t.index ["parent_dossier_id"], name: "index_dossiers_on_parent_dossier_id"
     t.index ["prefill_token"], name: "index_dossiers_on_prefill_token", unique: true
     t.index ["revision_id"], name: "index_dossiers_on_revision_id"
     t.index ["state"], name: "index_dossiers_on_state"

--- a/spec/lib/mail_rate_limiter_spec.rb
+++ b/spec/lib/mail_rate_limiter_spec.rb
@@ -1,0 +1,26 @@
+describe MailRateLimiter do
+  describe 'hits limits' do
+    let(:limit) { 10 }
+    let(:window) { 2.seconds }
+    let(:rate_limiter) { MailRateLimiter.new(limit:, window:) }
+    let(:mail) { DossierMailer.notify_automatic_deletion_to_user([], 'tartampion@france.fr') }
+
+    it 'decreases current_window[:limit]' do
+      expect { rate_limiter.send_with_delay(mail) }.to change { rate_limiter.current_window[:sent] }.by(1)
+    end
+
+    it 'increases the delay by window when it reaches the max number of call' do
+      expect do
+        (limit + 1).times { rate_limiter.send_with_delay(mail) }
+      end.to change { rate_limiter.delay }.by(window)
+    end
+
+    it 'renews current_window when it expires' do
+      rate_limiter.send_with_delay(mail)
+      Timecop.travel(window + 1.second) do
+        rate_limiter.send_with_delay(mail)
+        expect(rate_limiter.current_window[:sent]).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/lib/mail_rate_limiter_spec.rb
+++ b/spec/lib/mail_rate_limiter_spec.rb
@@ -17,7 +17,7 @@ describe MailRateLimiter do
 
     it 'renews current_window when it expires' do
       rate_limiter.send_with_delay(mail)
-      Timecop.travel(window + 1.second) do
+      travel_to(Time.current + window + 1.second) do
         rate_limiter.send_with_delay(mail)
         expect(rate_limiter.current_window[:sent]).to eq(1)
       end


### PR DESCRIPTION
en résumé : 
- on espace la suppression des dossiers : en brouillon a 22h, en construction a 14h, termine a 7h.
- il manquait un index, ce qui fait que la suppression etait super lente
- on ajoute un "rate limiter", car on a 95 ou 75k (j'ai plus le chiffre en tete) de dossier en attente de suppression, on va pas peter le rate limit