### PR TITLE
Tech: étale un peu dans le temps certains envois massifs d'emails

### DIFF
--- a/app/jobs/cron/weekly_overview_job.rb
+++ b/app/jobs/cron/weekly_overview_job.rb
@@ -10,7 +10,7 @@ class Cron::WeeklyOverviewJob < Cron::CronJob
       Dolist::API.sleep_until_limit_reset if Dolist::API.near_rate_limit?
 
       # mailer won't send anything if overview if empty
-      InstructeurMailer.last_week_overview(instructeur)&.deliver_later
+      InstructeurMailer.last_week_overview(instructeur)&.deliver_later(wait: rand(0..3.hours))
     end
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -7,6 +7,8 @@ class ApplicationMailer < ActionMailer::Base
   default from: "#{APPLICATION_NAME} <#{CONTACT_EMAIL}>"
   layout 'mailer'
 
+  before_action -> { Sentry.set_tags(mailer: mailer_name, action: action_name) }
+
   # Attach the procedure logo to the email (if any).
   # Returns the attachment url.
   def attach_logo(procedure)

--- a/app/services/expired_dossiers_deletion_service.rb
+++ b/app/services/expired_dossiers_deletion_service.rb
@@ -1,4 +1,6 @@
 class ExpiredDossiersDeletionService
+  SPREAD_DURATION = 3.hours
+
   def self.process_expired_dossiers_brouillon
     send_brouillon_expiration_notices
     delete_expired_brouillons_and_notify
@@ -27,7 +29,7 @@ class ExpiredDossiersDeletionService
       DossierMailer.notify_brouillon_near_deletion(
         dossiers,
         email
-      ).deliver_later
+      ).deliver_later(wait: rand(0..SPREAD_DURATION))
     end
   end
 
@@ -55,7 +57,7 @@ class ExpiredDossiersDeletionService
       DossierMailer.notify_brouillon_deletion(
         dossiers_hash,
         email
-      ).deliver_later
+      ).deliver_later(wait: rand(0..SPREAD_DURATION))
     end
   end
 
@@ -76,10 +78,10 @@ class ExpiredDossiersDeletionService
     dossiers_close_to_expiration.in_batches.update_all(close_to_expiration_flag => Time.zone.now)
 
     user_notifications.each do |(email, dossiers)|
-      DossierMailer.notify_near_deletion_to_user(dossiers, email).deliver_later
+      DossierMailer.notify_near_deletion_to_user(dossiers, email).deliver_later(wait: rand(0..SPREAD_DURATION))
     end
     administration_notifications.each do |(email, dossiers)|
-      DossierMailer.notify_near_deletion_to_administration(dossiers, email).deliver_later
+      DossierMailer.notify_near_deletion_to_administration(dossiers, email).deliver_later(wait: rand(0..SPREAD_DURATION))
     end
   end
 
@@ -101,7 +103,7 @@ class ExpiredDossiersDeletionService
         DossierMailer.notify_automatic_deletion_to_user(
           DeletedDossier.where(dossier_id: dossier_ids).to_a,
           email
-        ).deliver_later
+        ).deliver_later(wait: rand(0..SPREAD_DURATION))
       end
     end
     administration_notifications.each do |(email, dossier_ids)|
@@ -110,7 +112,7 @@ class ExpiredDossiersDeletionService
         DossierMailer.notify_automatic_deletion_to_administration(
           DeletedDossier.where(dossier_id: dossier_ids).to_a,
           email
-        ).deliver_later
+        ).deliver_later(wait: rand(0..SPREAD_DURATION))
       end
     end
   end


### PR DESCRIPTION
Pour éviter de trop taper le rate limiting et potentiellement de perdre des emails ou dégrader leur délivérabilité, on étale dans le temps de nouveaux mailers qui envoient des milliers d'emails d'un coup