### PR TITLE
Tech : mise à jour du routage sans callback

### DIFF
--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -48,7 +48,8 @@ module Administrateurs
         gi.update(routing_rule: ds_eq(champ_value(stable_id), constant(gi.label)))
       end
 
-      defaut = @procedure.defaut_groupe_instructeur.tap(&:toggle_routing)
+      @procedure.toggle_routing
+      defaut = @procedure.defaut_groupe_instructeur
 
       if !tdc_options.include?(defaut.label)
         new_defaut = @procedure.reload.groupe_instructeurs_but_defaut.first
@@ -67,7 +68,8 @@ module Administrateurs
         new_label = procedure.defaut_groupe_instructeur.label + ' bis'
         procedure.groupe_instructeurs
           .create({ label: new_label, instructeurs: [current_administrateur.instructeur] })
-          .tap(&:toggle_routing)
+
+        procedure.toggle_routing
 
         redirect_to admin_procedure_groupe_instructeurs_path(procedure)
       elsif params[:choice][:state] == 'routage_simple'
@@ -101,7 +103,7 @@ module Administrateurs
         .new({ instructeurs: [current_administrateur.instructeur] }.merge(groupe_instructeur_params))
 
       if @groupe_instructeur.save
-        @groupe_instructeur.toggle_routing
+        procedure.toggle_routing
         routing_notice = " et le routage a été activé" if procedure.groupe_instructeurs.active.size == 2
         redirect_to admin_procedure_groupe_instructeur_path(procedure, @groupe_instructeur),
           notice: "Le groupe d’instructeurs « #{@groupe_instructeur.label} » a été créé#{routing_notice}."
@@ -119,7 +121,7 @@ module Administrateurs
       @groupe_instructeur = groupe_instructeur
 
       if @groupe_instructeur.update(groupe_instructeur_params)
-        @groupe_instructeur.toggle_routing
+        procedure.toggle_routing
         redirect_to admin_procedure_groupe_instructeur_path(procedure, groupe_instructeur),
           notice: "Le nom est à présent « #{@groupe_instructeur.label} »."
       else
@@ -164,7 +166,7 @@ module Administrateurs
       else
         @groupe_instructeur.destroy!
         if procedure.groupe_instructeurs.active.one?
-          procedure.defaut_groupe_instructeur.toggle_routing
+          procedure.toggle_routing
           procedure.defaut_groupe_instructeur.update!(
             routing_rule: nil,
             label: GroupeInstructeur::DEFAUT_LABEL,

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -78,7 +78,7 @@ module Administrateurs
     def destroy_all_groups_but_defaut
       reaffecter_all_dossiers_to_defaut_groupe
       procedure.groupe_instructeurs_but_defaut.each(&:destroy!)
-      procedure.update!(routing_enabled: false, instructeurs_self_management_enabled: false)
+      procedure.update!(routing_enabled: false)
       procedure.defaut_groupe_instructeur.update!(
         routing_rule: nil,
         label: GroupeInstructeur::DEFAUT_LABEL,

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -100,6 +100,7 @@ module Administrateurs
         .new({ instructeurs: [current_administrateur.instructeur] }.merge(groupe_instructeur_params))
 
       if @groupe_instructeur.save
+        @groupe_instructeur.toggle_routing
         routing_notice = " et le routage a été activé" if procedure.groupe_instructeurs.active.size == 2
         redirect_to admin_procedure_groupe_instructeur_path(procedure, @groupe_instructeur),
           notice: "Le groupe d’instructeurs « #{@groupe_instructeur.label} » a été créé#{routing_notice}."
@@ -117,6 +118,7 @@ module Administrateurs
       @groupe_instructeur = groupe_instructeur
 
       if @groupe_instructeur.update(groupe_instructeur_params)
+        @groupe_instructeur.toggle_routing
         redirect_to admin_procedure_groupe_instructeur_path(procedure, groupe_instructeur),
           notice: "Le nom est à présent « #{@groupe_instructeur.label} »."
       else

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -67,6 +67,7 @@ module Administrateurs
         new_label = procedure.defaut_groupe_instructeur.label + ' bis'
         procedure.groupe_instructeurs
           .create({ label: new_label, instructeurs: [current_administrateur.instructeur] })
+          .tap(&:toggle_routing)
 
         redirect_to admin_procedure_groupe_instructeurs_path(procedure)
       elsif params[:choice][:state] == 'routage_simple'

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -43,7 +43,7 @@ module Administrateurs
       tdc_options = tdc.options["drop_down_options"].reject(&:empty?)
 
       tdc_options.each do |option_label|
-        gi = procedure.groupe_instructeurs.find_by({ label: option_label }) || procedure.groupe_instructeurs
+        gi = @procedure.groupe_instructeurs.find_by({ label: option_label }) || @procedure.groupe_instructeurs
           .create({ label: option_label, instructeurs: [current_administrateur.instructeur] })
         gi.update(routing_rule: ds_eq(champ_value(stable_id), constant(gi.label)))
       end
@@ -59,7 +59,7 @@ module Administrateurs
       end
 
       flash.notice = 'Les groupes instructeurs ont été ajoutés'
-      redirect_to admin_procedure_groupe_instructeurs_path(procedure)
+      redirect_to admin_procedure_groupe_instructeurs_path(@procedure)
     end
 
     def wizard

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -163,10 +163,7 @@ module Administrateurs
       else
         @groupe_instructeur.destroy!
         if procedure.groupe_instructeurs.active.one?
-          procedure.update!(
-            routing_enabled: false,
-            instructeurs_self_management_enabled: false
-          )
+          procedure.defaut_groupe_instructeur.toggle_routing
           procedure.defaut_groupe_instructeur.update!(
             routing_rule: nil,
             label: GroupeInstructeur::DEFAUT_LABEL,

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -48,7 +48,7 @@ module Administrateurs
         gi.update(routing_rule: ds_eq(champ_value(stable_id), constant(gi.label)))
       end
 
-      defaut = @procedure.defaut_groupe_instructeur
+      defaut = @procedure.defaut_groupe_instructeur.tap(&:toggle_routing)
 
       if !tdc_options.include?(defaut.label)
         new_defaut = @procedure.reload.groupe_instructeurs_but_defaut.first

--- a/app/graphql/mutations/groupe_instructeur_creer.rb
+++ b/app/graphql/mutations/groupe_instructeur_creer.rb
@@ -26,7 +26,7 @@ module Mutations
         .build(label: groupe_instructeur.label, closed: groupe_instructeur.closed, instructeurs: [current_administrateur.instructeur].compact)
 
       if groupe_instructeur.save
-        groupe_instructeur.toggle_routing
+        groupe_instructeur.procedure.toggle_routing
 
         # ugly hack to keep retro compatibility
         # do not judge

--- a/app/graphql/mutations/groupe_instructeur_creer.rb
+++ b/app/graphql/mutations/groupe_instructeur_creer.rb
@@ -26,6 +26,7 @@ module Mutations
         .build(label: groupe_instructeur.label, closed: groupe_instructeur.closed, instructeurs: [current_administrateur.instructeur].compact)
 
       if groupe_instructeur.save
+        groupe_instructeur.toggle_routing
 
         # ugly hack to keep retro compatibility
         # do not judge

--- a/app/graphql/mutations/groupe_instructeur_modifier.rb
+++ b/app/graphql/mutations/groupe_instructeur_modifier.rb
@@ -11,7 +11,7 @@ module Mutations
 
     def resolve(groupe_instructeur:, label: nil, closed: nil)
       if groupe_instructeur.update({ label:, closed: }.compact)
-        groupe_instructeur.toggle_routing
+        groupe_instructeur.procedure.toggle_routing
 
         # ugly hack to keep retro compatibility
         # do not judge

--- a/app/graphql/mutations/groupe_instructeur_modifier.rb
+++ b/app/graphql/mutations/groupe_instructeur_modifier.rb
@@ -11,6 +11,7 @@ module Mutations
 
     def resolve(groupe_instructeur:, label: nil, closed: nil)
       if groupe_instructeur.update({ label:, closed: }.compact)
+        groupe_instructeur.toggle_routing
 
         # ugly hack to keep retro compatibility
         # do not judge

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -93,16 +93,16 @@ class GroupeInstructeur < ApplicationRecord
     procedure.groupe_instructeurs - [self]
   end
 
+  def toggle_routing
+    procedure.update!(routing_enabled: procedure.groupe_instructeurs.active.many?)
+    procedure.update!(instructeurs_self_management_enabled: true) if procedure.routing_enabled?
+  end
+
   private
 
   def routing_rule_matches_tdc?
     routing_tdc = procedure.active_revision.types_de_champ.find_by(stable_id: routing_rule.left.stable_id)
     routing_rule.right.value.in?(routing_tdc.options['drop_down_options'])
-  end
-
-  def toggle_routing
-    procedure.update!(routing_enabled: procedure.groupe_instructeurs.active.many?)
-    procedure.update!(instructeurs_self_management_enabled: true) if procedure.routing_enabled?
   end
 
   serialize :routing_rule, LogicSerializer

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -93,10 +93,6 @@ class GroupeInstructeur < ApplicationRecord
     procedure.groupe_instructeurs - [self]
   end
 
-  def toggle_routing
-    procedure.update!(routing_enabled: procedure.groupe_instructeurs.active.many?)
-  end
-
   private
 
   def routing_rule_matches_tdc?

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -34,7 +34,6 @@ class GroupeInstructeur < ApplicationRecord
   end
 
   before_validation -> { label&.strip! }
-  after_save :toggle_routing
 
   scope :without_group, -> (group) { where.not(id: group) }
   scope :for_api_v2, -> { includes(procedure: [:administrateurs]) }

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -95,7 +95,6 @@ class GroupeInstructeur < ApplicationRecord
 
   def toggle_routing
     procedure.update!(routing_enabled: procedure.groupe_instructeurs.active.many?)
-    procedure.update!(instructeurs_self_management_enabled: true) if procedure.routing_enabled?
   end
 
   private

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -714,6 +714,10 @@ class Procedure < ApplicationRecord
     revisions.size - 2
   end
 
+  def instructeurs_self_management?
+    routing_enabled? || instructeurs_self_management_enabled?
+  end
+
   def defaut_groupe_instructeur_for_new_dossier
     if !routing_enabled? || feature_enabled?(:procedure_routage_api)
       defaut_groupe_instructeur

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -966,6 +966,10 @@ class Procedure < ApplicationRecord
     active_revision.types_de_champ_public.where.not(condition: nil).filter(&:piece_justificative?)
   end
 
+  def toggle_routing
+    update!(routing_enabled: self.groupe_instructeurs.active.many?)
+  end
+
   private
 
   def validate_auto_archive_on_in_the_future

--- a/app/services/instructeurs_import_service.rb
+++ b/app/services/instructeurs_import_service.rb
@@ -16,7 +16,7 @@ class InstructeursImportService
     if missing_labels.present?
       created_at = Time.zone.now
       GroupeInstructeur.create!(missing_labels.map { |label| { procedure_id: procedure.id, label:, created_at:, updated_at: created_at } })
-      procedure.defaut_groupe_instructeur.toggle_routing
+      procedure.toggle_routing
     end
 
     emails_in_groupe = groupes_emails

--- a/app/services/instructeurs_import_service.rb
+++ b/app/services/instructeurs_import_service.rb
@@ -16,6 +16,7 @@ class InstructeursImportService
     if missing_labels.present?
       created_at = Time.zone.now
       GroupeInstructeur.create!(missing_labels.map { |label| { procedure_id: procedure.id, label:, created_at:, updated_at: created_at } })
+      procedure.defaut_groupe_instructeur.toggle_routing
     end
 
     emails_in_groupe = groupes_emails

--- a/app/views/instructeurs/procedures/_header.html.haml
+++ b/app/views/instructeurs/procedures/_header.html.haml
@@ -7,7 +7,7 @@
   |
   = link_to t('instructeurs.dossiers.header.banner.statistics'), stats_instructeur_procedure_path(procedure), class: 'header-link'
 
-  - if procedure.instructeurs_self_management_enabled?
+  - if procedure.instructeurs_self_management?
     |
     - if can_manage_groupe_instructeurs?(procedure)
       = link_to t('instructeurs.dossiers.header.banner.instructeurs'), admin_procedure_groupe_instructeurs_path(procedure), class: 'header-link'

--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -726,4 +726,25 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
       expect(procedure3.routing_enabled).to be_truthy
     end
   end
+
+  describe '#wizard' do
+    let!(:procedure4) do
+      create(:procedure,
+             types_de_champ_public: [
+               { type: :drop_down_list, libelle: 'Votre ville', options: ['Paris', 'Lyon', 'Marseille'] },
+               { type: :text, libelle: 'Un champ texte' }
+             ],
+             administrateurs: [admin])
+    end
+
+    let!(:drop_down_tdc) { procedure4.draft_revision.types_de_champ.first }
+
+    before { patch :wizard, params: { procedure_id: procedure4.id, choice: { state: 'routage_custom' } } }
+
+    it do
+      expect(response).to redirect_to(admin_procedure_groupe_instructeurs_path(procedure4))
+      expect(procedure4.groupe_instructeurs.pluck(:label)).to match_array(['défaut', 'défaut bis'])
+      expect(procedure4.reload.routing_enabled).to be_truthy
+    end
+  end
 end

--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -723,6 +723,7 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
       expect(flash.notice).to eq 'Les groupes instructeurs ont été ajoutés'
       expect(procedure3.groupe_instructeurs.pluck(:label)).to match_array(['Paris', 'Lyon', 'Marseille'])
       expect(procedure3.reload.defaut_groupe_instructeur.routing_rule).to eq(ds_eq(champ_value(drop_down_tdc.stable_id), constant('Lyon')))
+      expect(procedure3.routing_enabled).to be_truthy
     end
   end
 end

--- a/spec/controllers/administrateurs/routing_controller_spec.rb
+++ b/spec/controllers/administrateurs/routing_controller_spec.rb
@@ -5,7 +5,7 @@ describe Administrateurs::RoutingController, type: :controller do
 
   describe '#update targeted champ' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :drop_down_list, libelle: 'Votre ville', options: ['Paris', 'Lyon', 'Marseille'] }, { type: :text, libelle: 'Un champ texte' }]) }
-    let(:gi_2) { procedure.groupe_instructeurs.create(label: 'groupe 2') }
+    let(:gi_2) { create(:groupe_instructeur, label: 'groupe 2', procedure: procedure) }
     let(:drop_down_tdc) { procedure.draft_revision.types_de_champ.first }
     let(:params) do
       {
@@ -52,7 +52,7 @@ describe Administrateurs::RoutingController, type: :controller do
 
   describe "#update_defaut_groupe_instructeur" do
     let(:procedure) { create(:procedure) }
-    let(:gi_2) { procedure.groupe_instructeurs.create(label: 'groupe 2') }
+    let(:gi_2) { create(:groupe_instructeur, label: 'groupe 2', procedure: procedure) }
     let(:params) do
       {
         procedure_id: procedure.id,

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -1193,7 +1193,8 @@ describe API::V2::GraphqlController do
         end
 
         context "should changer groupe instructeur" do
-          let!(:new_groupe_instructeur) { procedure.groupe_instructeurs.create(label: 'new groupe instructeur') }
+          let!(:new_groupe_instructeur) { create(:groupe_instructeur, label: 'new groupe instructeur', procedure: procedure) }
+
           let(:query) do
             "mutation {
             dossierChangerGroupeInstructeur(input: {

--- a/spec/controllers/instructeurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/instructeurs/groupe_instructeurs_controller_spec.rb
@@ -4,10 +4,10 @@ describe Instructeurs::GroupeInstructeursController, type: :controller do
   let(:instructeur) { create(:instructeur) }
   let(:procedure) { create(:procedure, :published) }
   let!(:gi_1_1) { procedure.defaut_groupe_instructeur }
-  let!(:gi_1_2) { procedure.groupe_instructeurs.create(label: 'groupe instructeur 2') }
+  let!(:gi_1_2) { create(:groupe_instructeur, label: 'groupe instructeur 2', procedure: procedure) }
 
   let(:procedure2) { create(:procedure, :published) }
-  let!(:gi_2_2) { procedure2.groupe_instructeurs.create(label: 'groupe instructeur 2 2') }
+  let!(:gi_2_2) { create(:groupe_instructeur, label: 'groupe instructeur 2 2', procedure: procedure2) }
 
   before do
     gi_1_2.instructeurs << instructeur

--- a/spec/controllers/instructeurs/procedures_controller_spec.rb
+++ b/spec/controllers/instructeurs/procedures_controller_spec.rb
@@ -241,8 +241,9 @@ describe Instructeurs::ProceduresController, type: :controller do
   describe "#show" do
     let(:instructeur) { create(:instructeur) }
     let!(:procedure) { create(:procedure, :expirable, instructeurs: [instructeur]) }
-    let!(:gi_2) { procedure.groupe_instructeurs.create(label: '2') }
-    let!(:gi_3) { procedure.groupe_instructeurs.create(label: '3') }
+    let!(:gi_2) { create(:groupe_instructeur, label: '2', procedure: procedure) }
+    let!(:gi_3) { create(:groupe_instructeur, label: '3', procedure: procedure) }
+
     let(:statut) { nil }
 
     subject do

--- a/spec/factories/groupe_instructeur.rb
+++ b/spec/factories/groupe_instructeur.rb
@@ -5,6 +5,10 @@ FactoryBot.define do
     label { generate(:groupe_label) }
     association :procedure
 
+    after(:create) do |groupe_instructeur, _evaluator|
+      groupe_instructeur.procedure.toggle_routing
+    end
+
     trait :default do
       label { GroupeInstructeur::DEFAUT_LABEL }
     end

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -129,7 +129,7 @@ FactoryBot.define do
 
     trait :routee do
       after(:create) do |procedure, _evaluator|
-        procedure.groupe_instructeurs.create(label: 'deuxième groupe')
+        create(:groupe_instructeur, label: 'deuxième groupe', procedure: procedure)
       end
     end
 

--- a/spec/models/concern/tags_substitution_concern_spec.rb
+++ b/spec/models/concern/tags_substitution_concern_spec.rb
@@ -78,8 +78,9 @@ describe TagsSubstitutionConcern, type: :model do
       let!(:dossier) { create(:dossier, procedure: procedure, individual: individual, etablissement: etablissement, state: state) }
       context 'and the dossier has a groupe instructeur' do
         label = 'Ville de Bordeaux'
+        let(:gi) { create(:groupe_instructeur, label: label, procedure: procedure) }
+
         before do
-          gi = procedure.groupe_instructeurs.create(label: label)
           gi.dossiers << dossier
           dossier.update(groupe_instructeur: gi)
           dossier.reload

--- a/spec/models/instructeur_spec.rb
+++ b/spec/models/instructeur_spec.rb
@@ -573,8 +573,8 @@ describe Instructeur, type: :model do
     let(:instructeur_3) { create(:instructeur) }
     let(:procedure) { create(:procedure, instructeurs: [instructeur_2, instructeur_3], procedure_expires_when_termine_enabled: true) }
     let(:gi_1) { procedure.defaut_groupe_instructeur }
-    let(:gi_2) { procedure.groupe_instructeurs.create(label: '2') }
-    let(:gi_3) { procedure.groupe_instructeurs.create(label: '3') }
+    let(:gi_2) { create(:groupe_instructeur, label: '2', procedure: procedure) }
+    let(:gi_3) { create(:groupe_instructeur, label: '3', procedure: procedure) }
 
     subject do
       instructeur_2.dossiers_count_summary([gi_1.id, gi_2.id])

--- a/spec/models/procedure_overview_spec.rb
+++ b/spec/models/procedure_overview_spec.rb
@@ -62,8 +62,8 @@ describe ProcedureOverview, type: :model do
   end
 
   describe 'with a procedure routee' do
-    let!(:gi_2) { procedure.groupe_instructeurs.create(label: 'groupe instructeur 2') }
-    let!(:gi_3) { procedure.groupe_instructeurs.create(label: 'groupe instructeur 3') }
+    let!(:gi_2) { create(:groupe_instructeur, label: 'groupe instructeur 2', procedure: procedure) }
+    let!(:gi_3) { create(:groupe_instructeur, label: 'groupe instructeur 3', procedure: procedure) }
 
     def create_dossier_in_group(g)
       create(:dossier, procedure: procedure, created_at: monday, state: Dossier.states.fetch(:en_instruction), groupe_instructeur: g)

--- a/spec/models/procedure_presentation_spec.rb
+++ b/spec/models/procedure_presentation_spec.rb
@@ -784,8 +784,8 @@ describe ProcedurePresentation do
     context 'for groupe_instructeur table' do
       let(:filter) { [{ 'table' => 'groupe_instructeur', 'column' => 'id', 'value' => procedure.defaut_groupe_instructeur.id.to_s }] }
 
-      let!(:gi_2) { procedure.groupe_instructeurs.create(label: 'gi2') }
-      let!(:gi_3) { procedure.groupe_instructeurs.create(label: 'gi3') }
+      let!(:gi_2) { create(:groupe_instructeur, label: 'gi2', procedure: procedure) }
+      let!(:gi_3) { create(:groupe_instructeur, label: 'gi3', procedure: procedure) }
 
       let!(:kept_dossier) { create(:dossier, :en_construction, procedure: procedure) }
       let!(:discarded_dossier) { create(:dossier, :en_construction, procedure: procedure, groupe_instructeur: gi_2) }

--- a/spec/services/procedure_export_service_spec.rb
+++ b/spec/services/procedure_export_service_spec.rb
@@ -119,7 +119,7 @@ describe ProcedureExportService do
       end
 
       context 'with a procedure routee' do
-        before { procedure.groupe_instructeurs.create(label: '2') }
+        before { create(:groupe_instructeur, label: '2', procedure: procedure) }
 
         let(:routee_headers) { nominal_headers.insert(nominal_headers.index('textarea'), 'Groupe instructeur') }
 


### PR DESCRIPTION
Jusqu'à présent on mettait à jour la valeur du routage avec un `after_save` sur le groupe d'instructeurs. Cela posait deux problèmes : 
- Un problème de performance lors du clonage d'une démarche routée avec un nombre important de groupes (4-5 minutes pour une démarche avec 100 groupes).
- Un problème de consistance dans le code. A la suppression d'un groupe, mise à jour du routage depuis le contrôleur / à la création ou update d'un groupe mise à jour via le callback `after_save`.

Désormais la méthode `toggle_routing` est appelée : 
- Dans le `administrateurs/groupe_instructeurs_controller.rb` dans les méthodes `create`, `update`, `import`, `destroy`, `simple_routing` et `wizard`.
- Dans les mutations de l'api lors de la création ou de la mise à jour d'un groupe