### PR TITLE
tech(active-storage.queues.purge): place les jobs de purge ds low_priority

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -58,6 +58,7 @@ module TPS
 
     # Set the queue name for the analysis jobs to 'active_storage_analysis'
     config.active_storage.queues.analysis = :active_storage_analysis
+    config.active_storage.queues.purge = :low_priority
 
     config.to_prepare do
       # Make main application helpers available in administrate


### PR DESCRIPTION
si l'expiration vient a purger beaucoup de PJ, ca peut congestionner la fil `default`