### PR TITLE
ETQ usager/instructeur: fix date de modification du dossier

### DIFF
--- a/app/components/dossiers/champ_row_show_component.rb
+++ b/app/components/dossiers/champ_row_show_component.rb
@@ -2,6 +2,7 @@ class Dossiers::ChampRowShowComponent < ApplicationComponent
   include ChampHelper
   include DossierHelper
   include ApplicationHelper
+
   def initialize(champs:, demande_seen_at:, profile:, repetition:)
     @repetition = repetition
     @champs = champs
@@ -11,11 +12,20 @@ class Dossiers::ChampRowShowComponent < ApplicationComponent
 
   def updated_after_deposer?(champ)
     return false if champ.dossier.depose_at.blank?
+
     champ.updated_at > champ.dossier.depose_at
   end
 
   def number_with_html_delimiter(num)
     # we are using the span delimiter that doesn't insert spaces when copying and pasting the number
     number_with_delimiter(num, delimiter: tag.span(class: 'numbers-delimiter'))
+  end
+
+  def blank_key(champ)
+    key = ".blank"
+    key += "_optional" if @profile == "usager"
+    key += "_attachment" if champ.type_de_champ.piece_justificative?
+
+    key
   end
 end

--- a/app/components/dossiers/champ_row_show_component/champ_row_show_component.en.yml
+++ b/app/components/dossiers/champ_row_show_component/champ_row_show_component.en.yml
@@ -1,4 +1,6 @@
 ---
 en:
-  blank: "blank (optional)"
-  blank_attachment: "document not supplied (optional)"
+  blank: "empty"
+  blank_attachment: "document not supplied"
+  blank_optional: "empty (optional)"
+  blank_optional_attachment: "document not supplied (optional)"

--- a/app/components/dossiers/champ_row_show_component/champ_row_show_component.en.yml
+++ b/app/components/dossiers/champ_row_show_component/champ_row_show_component.en.yml
@@ -1,3 +1,4 @@
 ---
 en:
   blank: "blank (optional)"
+  blank_attachment: "document not supplied (optional)"

--- a/app/components/dossiers/champ_row_show_component/champ_row_show_component.fr.yml
+++ b/app/components/dossiers/champ_row_show_component/champ_row_show_component.fr.yml
@@ -1,4 +1,6 @@
 ---
 fr:
-  blank: "non saisi (facultatif)"
-  blank_attachment: "pièce justificative non saisie (facultative)"
+  blank: "non saisi"
+  blank_attachment: "pièce justificative non saisie"
+  blank_optional: "non saisi (facultatif)"
+  blank_optional_attachment: "pièce justificative non saisie (facultative)"

--- a/app/components/dossiers/champ_row_show_component/champ_row_show_component.fr.yml
+++ b/app/components/dossiers/champ_row_show_component/champ_row_show_component.fr.yml
@@ -1,3 +1,4 @@
 ---
 fr:
   blank: "non saisi (facultatif)"
+  blank_attachment: "pièce justificative non saisie (facultative)"

--- a/app/components/dossiers/champ_row_show_component/champ_row_show_component.html.haml
+++ b/app/components/dossiers/champ_row_show_component/champ_row_show_component.html.haml
@@ -17,7 +17,7 @@
       - if champ.blank?
         .champ-content.fr-text-mention--grey{ class: [highlight_if_unseen_class(@demande_seen_at, champ.updated_at), champ.type_champ] }
           %p
-            %em= t(champ.type_de_champ.piece_justificative? ? '.blank_attachment' : '.blank')
+            %em= t(blank_key(champ))
       - else
         .champ-content{ class: [highlight_if_unseen_class(@demande_seen_at, champ.updated_at), champ.type_champ] }
           - case champ.type_champ

--- a/app/components/dossiers/champ_row_show_component/champ_row_show_component.html.haml
+++ b/app/components/dossiers/champ_row_show_component/champ_row_show_component.html.haml
@@ -14,10 +14,10 @@
             %span{ class: highlight_if_unseen_class(@demande_seen_at, champ.updated_at) }
               = t(:updated_at, scope: [:views, :shared, :dossiers, :form], datetime: try_format_datetime(champ.updated_at))
 
-      - if champ.blank? && ![TypeDeChamp.type_champs.fetch(:piece_justificative), TypeDeChamp.type_champs.fetch(:titre_identite)].include?(champ.type_champ)
+      - if champ.blank?
         .champ-content.fr-text-mention--grey{ class: [highlight_if_unseen_class(@demande_seen_at, champ.updated_at), champ.type_champ] }
           %p
-            %em= t('.blank')
+            %em= t(champ.type_de_champ.piece_justificative? ? '.blank_attachment' : '.blank')
       - else
         .champ-content{ class: [highlight_if_unseen_class(@demande_seen_at, champ.updated_at), champ.type_champ] }
           - case champ.type_champ

--- a/app/models/champs/piece_justificative_champ.rb
+++ b/app/models/champs/piece_justificative_champ.rb
@@ -43,6 +43,10 @@ class Champs::PieceJustificativeChamp < Champ
     mandatory? && !piece_justificative_file.attached?
   end
 
+  def blank?
+    piece_justificative_file.blank?
+  end
+
   def for_export
     piece_justificative_file.map { _1.filename.to_s }.join(', ')
   end

--- a/app/models/champs/titre_identite_champ.rb
+++ b/app/models/champs/titre_identite_champ.rb
@@ -37,6 +37,10 @@ class Champs::TitreIdentiteChamp < Champ
     mandatory? && !piece_justificative_file.attached?
   end
 
+  def blank?
+    piece_justificative_file.blank?
+  end
+
   def for_export
     piece_justificative_file.attached? ? "présent" : "absent"
   end

--- a/app/views/shared/champs/piece_justificative/_show.html.haml
+++ b/app/views/shared/champs/piece_justificative/_show.html.haml
@@ -1,8 +1,4 @@
-- pj = champ.piece_justificative_file
-- if pj.attached?
-  .fr-downloads-group
-    %ul
-      - pj.attachments.each do |attachment|
-        %li= render Attachment::ShowComponent.new(attachment:, new_tab: true)
-- else
-  Pièce justificative non fournie
+.fr-downloads-group
+  %ul
+    - champ.piece_justificative_file.attachments.each do |attachment|
+      %li= render Attachment::ShowComponent.new(attachment:, new_tab: true)

--- a/app/views/shared/dossiers/_infos_generales.html.haml
+++ b/app/views/shared/dossiers/_infos_generales.html.haml
@@ -1,5 +1,5 @@
-%div
-  %p.fr-my-2w.fr-px-4v
+.fr-px-2w
+  %p.fr-my-2w
     = t(:submitted_at, scope: [:views, :shared, :dossiers, :form], datetime: l(dossier.depose_at))
     %br
     - if dossier.last_champ_updated_at.present? && dossier.last_champ_updated_at > dossier.depose_at
@@ -7,22 +7,23 @@
 
 
   - if dossier.justificatif_motivation.attached?
-    .fr-my-4v.fr-px-4v
+    -# download component already has margin bottom
+    %div
       %p.champ-label Justificatif :
-      .champ-content.fr-text-action-high--grey
+      .champ-content
         .action
           = render Attachment::ShowComponent.new(attachment: dossier.justificatif_motivation.attachment)
 
   - if dossier.motivation.present?
-    .fr-my-4v.fr-px-4v
+    .fr-mb-2w
       %p.champ-label Motivation :
-      .champ-content.fr-text-action-high--grey
+      .champ-content
         .action
           = dossier.motivation
 
   - if dossier.attestation.present?
-    .fr-my-4v.fr-px-4v
+    .fr-mb-2w
       %p.champ-label Attestation :
-      .champ-content.fr-text-action-high--grey
+      .champ-content
         .action
           = link_to('Voir l’attestation', attestation_instructeur_dossier_path(dossier.procedure, dossier), target: '_blank', rel: 'noopener')

--- a/app/views/shared/dossiers/_infos_generales.html.haml
+++ b/app/views/shared/dossiers/_infos_generales.html.haml
@@ -2,8 +2,8 @@
   %p.fr-my-2w.fr-px-4v
     = t(:submitted_at, scope: [:views, :shared, :dossiers, :form], datetime: l(dossier.depose_at))
     %br
-    - if dossier.updated_at != dossier.depose_at
-      = t(:updated_at, scope: [:views, :shared, :dossiers, :form], datetime: l(dossier.updated_at))
+    - if dossier.last_champ_updated_at.present? && dossier.last_champ_updated_at > dossier.depose_at
+      = t(:updated_at, scope: [:views, :shared, :dossiers, :form], datetime: l(dossier.last_champ_updated_at))
 
 
   - if dossier.justificatif_motivation.attached?

--- a/spec/views/shared/dossiers/_champs.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_champs.html.haml_spec.rb
@@ -1,14 +1,18 @@
 describe 'shared/dossiers/champs', type: :view do
   let(:instructeur) { create(:instructeur) }
   let(:demande_seen_at) { nil }
+  let(:profile) { "instructeur" }
 
   before do
     view.extend DossierHelper
     view.extend DossierLinkHelper
-    allow(view).to receive(:current_instructeur).and_return(instructeur)
+
+    if profile == "instructeur"
+      allow(view).to receive(:current_instructeur).and_return(instructeur)
+    end
   end
 
-  subject { render 'shared/dossiers/champs', champs: champs, dossier: dossier, demande_seen_at: demande_seen_at, profile: nil }
+  subject { render 'shared/dossiers/champs', champs:, dossier:, demande_seen_at:, profile: }
 
   context "there are some champs" do
     let(:dossier) { create(:dossier) }
@@ -108,7 +112,25 @@ describe 'shared/dossiers/champs', type: :view do
     let(:champ) { create(:champ_dossier_link, dossier: dossier, value: nil) }
     let(:champs) { [champ] }
 
-    it { is_expected.to include("non saisi (facultatif)") }
+    it { is_expected.to include("non saisi") }
+
+    context 'when profile is usager' do
+      let(:profile) { "usager" }
+      it { is_expected.to include("non saisi (facultatif)") }
+    end
+  end
+
+  context "with a piece justificative without value" do
+    let(:dossier) { create(:dossier) }
+    let(:champ) { create(:champ_without_piece_justificative, dossier:) }
+    let(:champs) { [champ] }
+
+    it { is_expected.to include("pièce justificative non saisie") }
+
+    context 'when profile is usager' do
+      let(:profile) { "usager" }
+      it { is_expected.to include("pièce justificative non saisie (facultative)") }
+    end
   end
 
   context "with seen_at" do


### PR DESCRIPTION
- La date de re-dépot d'un dossier est déterminée par `last_champ_updated_at` qui est mise à jour [lors du merge du fork](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/blob/f5bd1292189e2aa3984d110044299e443b2c5ac1/app/models/concerns/dossier_clone_concern.rb#L71)

- plus de mention "facultatif" pour le profile instructeur

- J'embarque aussi des améliorations visuelles mineures (marges…) et homogénéise les styles des messages _PJ non fournie_ et _non saisi_)

<img width="829" alt="Capture d’écran 2023-06-27 à 17 47 15" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/4af1fde9-accd-43a9-8ac1-d5aa155975b8">


<img width="832" alt="Capture d’écran 2023-06-27 à 17 44 37" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/6d566424-940e-4ae8-8256-cffc8040e02c">

