### PR TITLE
ETQ instructeur: intègre les demandes de corrections dans les PDF

### DIFF
--- a/app/models/concerns/dossier_correctable_concern.rb
+++ b/app/models/concerns/dossier_correctable_concern.rb
@@ -4,6 +4,7 @@ module DossierCorrectableConcern
   included do
     A_CORRIGER = 'a_corriger'
     has_many :corrections, class_name: 'DossierCorrection', dependent: :destroy
+    has_many :pending_corrections, -> { DossierCorrection.pending }, class_name: 'DossierCorrection', inverse_of: :dossier
 
     scope :with_pending_corrections, -> { joins(:corrections).where(corrections: { resolved_at: nil }) }
 
@@ -18,7 +19,7 @@ module DossierCorrectableConcern
     end
 
     def may_flag_as_pending_correction?
-      return false if corrections.pending.exists?
+      return false if pending_corrections.exists?
 
       en_construction? || may_repasser_en_construction?
     end
@@ -27,15 +28,17 @@ module DossierCorrectableConcern
       # We don't want to show any alert if user is not allowed to modify the dossier
       return false unless en_construction?
 
-      corrections.pending.exists?
+      return pending_corrections.any? if pending_corrections.loaded?
+
+      pending_corrections.exists?
     end
 
     def pending_correction
-      corrections.pending.first
+      pending_corrections.first
     end
 
     def resolve_pending_correction!
-      corrections.pending.update!(resolved_at: Time.current)
+      pending_corrections.update!(resolved_at: Time.current)
     end
   end
 end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -481,6 +481,7 @@ class Dossier < ApplicationRecord
       :traitement,
       :groupe_instructeur,
       :etablissement,
+      :pending_corrections,
       procedure: [:groupe_instructeurs],
       avis: [:claimant, :expert]
     ).ordered_for_export).in_batches

--- a/app/views/dossiers/show.pdf.prawn
+++ b/app/views/dossiers/show.pdf.prawn
@@ -223,7 +223,8 @@ end
 
 def add_etat_dossier(pdf, dossier)
   pdf.pad_bottom(default_margin) do
-    pdf.text "Ce dossier est <b>#{clean_string(dossier_display_state(dossier, lower: true))}</b>.", inline_format: true
+    pending_correction = dossier.pending_correction? ? " (en attente de correction)" : nil
+    pdf.text "Ce dossier est <b>#{clean_string(dossier_display_state(dossier, lower: true))}#{pending_correction}</b>.", inline_format: true
   end
 end
 
@@ -231,9 +232,15 @@ def add_etats_dossier(pdf, dossier)
   if dossier.depose_at.present?
     format_in_2_columns(pdf, "Déposé le", try_format_date(dossier.depose_at))
   end
+
+  if dossier.pending_correction?
+    format_in_2_columns(pdf, "Correction demandée le", try_format_date(dossier.pending_correction.created_at))
+  end
+
   if dossier.en_instruction_at.present?
     format_in_2_columns(pdf, "En instruction le", try_format_date(dossier.en_instruction_at))
   end
+
   if dossier.processed_at.present?
     format_in_2_columns(pdf, "Décision le", try_format_date(dossier.processed_at))
   end


### PR DESCRIPTION
On ne mentionne que les corrections "en attente" (pas celles qui ont été résolues)

- **PDF**: précise le sous-statut "en attente de correction" + date de la dernière correction

- **Exports**: pour le moment on ne fait rien, car on ne veut plus ajouter de nouvelle colonne.

## Extrait du PDF : 
![Capture d’écran 2023-06-28 à 18 19 38](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/3192d331-3463-4efe-9d1c-d303a190d077)


