### PR TITLE
[Design] Harmonisation des espaces du sub header pour les differents profils

### DIFF
--- a/app/assets/stylesheets/dossier_edit.scss
+++ b/app/assets/stylesheets/dossier_edit.scss
@@ -4,7 +4,7 @@
 $dossier-actions-bar-border-width: 1px;
 
 .dossier-header {
-  .container {
+  .fr-container {
     padding-bottom: $default-padding;
   }
 

--- a/app/assets/stylesheets/procedure_show.scss
+++ b/app/assets/stylesheets/procedure_show.scss
@@ -9,12 +9,6 @@
 }
 
 #procedure-show {
-  h1 {
-    color: $black;
-    font-size: 22px;
-    margin-bottom: 1 * $default-padding;
-  }
-
   .titre-dossiers {
     text-align: center;
   }

--- a/app/assets/stylesheets/sub_header.scss
+++ b/app/assets/stylesheets/sub_header.scss
@@ -7,7 +7,7 @@
   margin-bottom: $sub-header-bottom-margin;
   border-bottom: 1px solid $border-grey;
 
-  .container {
+  .fr-container {
     margin-bottom: -1px;
   }
 

--- a/app/assets/stylesheets/tabs.scss
+++ b/app/assets/stylesheets/tabs.scss
@@ -4,6 +4,7 @@
 .tabs {
   ul {
     margin-bottom: 0;
+    padding: 0;
   }
 
   li {

--- a/app/views/administrateurs/procedures/apercu.html.haml
+++ b/app/views/administrateurs/procedures/apercu.html.haml
@@ -1,5 +1,5 @@
 .dossiers-headers.sub-header
-  .container
+  .fr-container
     %h1.page-title Prévisualisation de la démarche «&nbsp;#{@dossier.procedure.libelle}&nbsp;»
 
     %nav.tabs

--- a/app/views/experts/avis/_header.html.haml
+++ b/app/views/experts/avis/_header.html.haml
@@ -1,5 +1,5 @@
 .sub-header
-  .container
+  .fr-container
     .flex.justify-between
       %nav.fr-breadcrumb{ "aria-label" => "vous êtes ici :", role: "navigation" }
         %button.fr-breadcrumb__button{ "aria-controls" => "breadcrumb-1", "aria-expanded" => "false" } Voir le fil d’Ariane

--- a/app/views/experts/avis/procedure.html.haml
+++ b/app/views/experts/avis/procedure.html.haml
@@ -3,13 +3,13 @@
 
 #procedure-show
   .sub-header
-    .container.flex
+    .fr-container.flex
 
       .procedure-logo{ style: "background-image: url(#{@procedure.logo_url})",
         role: 'img', 'aria-label': "logo de la démarche #{@procedure.libelle}" }
 
       .procedure-header
-        %h1= procedure_libelle @procedure
+        %h1.fr-h3= procedure_libelle @procedure
 
         %nav.tabs
           %ul
@@ -24,7 +24,7 @@
               active: @statut == Instructeurs::AvisController::DONNES_STATUS,
               badge: @avis_donnes.count)
 
-.container
+.fr-container
   - if @avis.present?
     %table.table.dossiers-table.hoverable
       %thead

--- a/app/views/instructeurs/dossiers/_header.html.haml
+++ b/app/views/instructeurs/dossiers/_header.html.haml
@@ -9,7 +9,7 @@
   = render partial: 'instructeurs/dossiers/header_top', locals: { dossier: }
   = render partial: 'instructeurs/dossiers/header_bottom', locals: { dossier: }
 
-.container
+.fr-container
   .print-header
     = dossier.procedure.libelle.truncate_words(10)
     >

--- a/app/views/instructeurs/dossiers/_header_bottom.html.haml
+++ b/app/views/instructeurs/dossiers/_header_bottom.html.haml
@@ -1,4 +1,4 @@
-#header-bottom.container
+#header-bottom.fr-container
   %nav.tabs
     %ul
       - notifications_summary = current_instructeur.notifications_for_dossier(dossier)

--- a/app/views/instructeurs/dossiers/_header_top.html.haml
+++ b/app/views/instructeurs/dossiers/_header_top.html.haml
@@ -1,7 +1,7 @@
-#header-top.container
+#header-top.fr-container
   .flex.fr-mb-3w
     %div
-      %h1.fr-h2.fr-mb-1w
+      %h1.fr-h3.fr-mb-1w
         = "Dossier nº #{dossier.id}"
 
         = status_badge(dossier.state, 'super')

--- a/app/views/instructeurs/procedures/_header.html.haml
+++ b/app/views/instructeurs/procedures/_header.html.haml
@@ -1,6 +1,6 @@
 .procedure-header
   .flex.clipboard-container
-    %h1
+    %h1.fr-h3
       = "#{procedure_libelle procedure} - n°#{procedure.id}"
     = render Dsfr::CopyButtonComponent.new(title: t('instructeurs.procedures.index.copy_link_button'), text: commencer_url(procedure.path))
   = link_to t('instructeurs.dossiers.header.banner.notification_management'), email_notifications_instructeur_procedure_path(procedure), class: 'header-link'

--- a/app/views/instructeurs/procedures/deleted_dossiers.html.haml
+++ b/app/views/instructeurs/procedures/deleted_dossiers.html.haml
@@ -2,7 +2,7 @@
 
 #procedure-show
   .sub-header
-    .container.flex
+    .fr-container.flex
 
       .procedure-logo{ style: "background-image: url(#{@procedure.logo_url})",
         role: 'img', 'aria-label': "logo de la démarche #{@procedure.libelle}" }
@@ -13,7 +13,7 @@
         - if @can_download_dossiers
           = render Dossiers::ExportComponent.new(procedure: @procedure, exports: @exports, export_url: method(:download_export_instructeur_procedure_path))
 
-    .container.flex= render partial: "tabs", locals: { procedure: @procedure,
+    .fr-container.flex= render partial: "tabs", locals: { procedure: @procedure,
         statut: @statut,
         a_suivre_count: @a_suivre_count,
         suivis_count: @suivis_count,
@@ -25,7 +25,7 @@
         has_en_cours_notifications: @has_en_cours_notifications,
         has_termine_notifications: @has_termine_notifications }
 
-  .container
+  .fr-container
     %h1.titre-dossiers Dossiers supprimés
     %details
       %summary Les dossiers ont été supprimés. Vous ne pouvez plus les récupérer depuis Démarches Simplifiées.

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -2,7 +2,7 @@
 
 #procedure-show
   .sub-header
-    .container.flex
+    .fr-container.flex
 
       .procedure-logo{ style: "background-image: url(#{@procedure.logo_url})",
         role: 'img', 'aria-label': "logo de la démarche #{@procedure.libelle}" }
@@ -13,7 +13,7 @@
         - if @can_download_dossiers
           = render Dossiers::ExportComponent.new(procedure: @procedure, exports: @exports, export_url: method(:download_export_instructeur_procedure_path))
 
-    .container.flex= render partial: "tabs", locals: { procedure: @procedure,
+    .fr-container.flex= render partial: "tabs", locals: { procedure: @procedure,
         statut: @statut,
         a_suivre_count: @counts[:a_suivre],
         suivis_count: @counts[:suivis],
@@ -25,7 +25,7 @@
         has_en_cours_notifications: @has_en_cours_notifications,
         has_termine_notifications: @has_termine_notifications }
 
-  .container.fr-highlight
+  .fr-container.fr-highlight
     - if @statut == 'a-suivre'
       %p
         = t('views.instructeurs.dossiers.tab_explainations.a_suivre')

--- a/app/views/users/dossiers/brouillon.html.haml
+++ b/app/views/users/dossiers/brouillon.html.haml
@@ -6,7 +6,7 @@
 
 .dossier-container
   .dossier-header.sub-header
-    .container
+    .fr-container
       = render partial: "shared/dossiers/header", locals: { dossier: @dossier }
 
   = render partial: "shared/dossiers/edit", locals: { dossier: @dossier }

--- a/app/views/users/dossiers/index.html.haml
+++ b/app/views/users/dossiers/index.html.haml
@@ -7,7 +7,7 @@
   = render partial: "users/dossiers/index_footer"
 
 .dossiers-headers.sub-header
-  .container
+  .fr-container
     %h1.page-title.fr-h2= t('views.users.dossiers.index.dossiers')
     - if current_user.dossiers.count > 2
       #search-2.fr-search-bar.fr-search-bar--lg

--- a/app/views/users/dossiers/show/_header.html.haml
+++ b/app/views/users/dossiers/show/_header.html.haml
@@ -1,5 +1,5 @@
 .sub-header
-  .container
+  .fr-container
     %h1
       = dossier.procedure.libelle
       = status_badge(dossier.state, 'super')


### PR DESCRIPTION
Un petit fix pour 
- harmoniser les largeurs du container du sub-header
- Utiliser une classe du DSFR pour une meilleur gestion du titre (l'interlignage était très grand sur le h1)


### USAGER

**APRES**
<img width="1302" alt="Capture d’écran 2023-06-29 à 15 04 19" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/5cfa5f16-554c-47c1-9256-9757912f1be0">
<img width="1268" alt="Capture d’écran 2023-06-29 à 15 03 46" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/db44a37f-0ff5-4702-b496-41f183a04d6d">

**AVANT**
<img width="1302" alt="Capture d’écran 2023-06-29 à 15 11 34" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/3576a894-68e9-4021-91ec-d05ca3ee054a">

<img width="1263" alt="Capture d’écran 2023-06-29 à 15 11 24" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/b1d7ce01-1d73-4abd-866a-a3fce8b86f78">

### INSTRUCTEUR

**APRES**
<img width="1265" alt="Capture d’écran 2023-06-29 à 15 06 07" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/8749483d-919a-4f3d-8686-5a06fa79bf63">
<img width="1272" alt="Capture d’écran 2023-06-29 à 15 06 24" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/26dce046-5993-4099-8b6f-c2ab83240c06">

**AVANT**
<img width="1260" alt="Capture d’écran 2023-06-29 à 15 12 02" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/4b2aeb73-ff93-4cdd-b07a-ffebe378cf7b">
<img width="1292" alt="Capture d’écran 2023-06-29 à 15 11 50" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/857d4601-27e3-4492-8b9a-b3811dfd8bb5">

