### PR TITLE
feat(DB): ignore migrated_champ_routage_columns

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -56,6 +56,8 @@ class Dossier < ApplicationRecord
   include DossierSearchableConcern
   include DossierSectionsConcern
 
+  self.ignored_columns += [:migrated_champ_routage]
+
   enum state: {
     brouillon:       'brouillon',
     en_construction: 'en_construction',

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -69,7 +69,14 @@ class Procedure < ApplicationRecord
 
   include Discard::Model
   self.discard_column = :hidden_at
-  self.ignored_columns += [:direction, :durees_conservation_required, :cerfa_flag, :test_started_at, :lien_demarche]
+  self.ignored_columns += [
+    :direction,
+    :durees_conservation_required,
+    :cerfa_flag,
+    :test_started_at,
+    :lien_demarche,
+    :migrated_champ_routage
+  ]
 
   default_scope -> { kept }
 

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -13,6 +13,7 @@
 #
 class ProcedureRevision < ApplicationRecord
   self.implicit_order_column = :created_at
+  self.ignored_columns += [:migrated_champ_routage]
   belongs_to :procedure, -> { with_discarded }, inverse_of: :revisions, optional: false
   belongs_to :dossier_submitted_message, inverse_of: :revisions, optional: true, dependent: :destroy
 


### PR DESCRIPTION
Première étape avant de supprimer les colonnes `migrated_champ_routage` des tables `dossiers`, `procedures` et `procedure_revisions`, dans le cadre de l'usage des strong migrations (voir  https://github.com/ankane/strong_migrations#removing-a-column)  