### PR TITLE
chore(dev): use overmind instead of foreman

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 
-if ! command -v foreman &> /dev/null
+if ! command -v overmind &> /dev/null
 then
-  echo "Installing foreman..."
-  gem install foreman
+  echo "You need to install overmind. https://github.com/DarthSim/overmind#installation"
 fi
 
-foreman start -f Procfile.dev "$@"
+OVERMIND_SKIP_ENV=true overmind start -f Procfile.dev "$@"


### PR DESCRIPTION
* `forman` n'est plus maintenu
* le support de `.env` dans `forman` est pété (j'ai pérdu une bonne heur avec ça aujourd'hui)