### PR TITLE
Correctif: utilise le template d'email de notification par défaut quand la démarche n'a pas personnalisé le sien

### DIFF
--- a/app/models/concerns/mail_template_concern.rb
+++ b/app/models/concerns/mail_template_concern.rb
@@ -34,12 +34,12 @@ module MailTemplateConcern
     before_save :update_rich_body
   end
 
-  module ClassMethods
+  class_methods do
     def default_for_procedure(procedure)
       template_name = default_template_name_for_procedure(procedure)
       rich_body = ActionController::Base.render template: template_name
       trix_rich_body = rich_body.gsub(/(?<!^|[.-])(?<!<\/strong>)\n/, '')
-      new(subject: const_get(:DEFAULT_SUBJECT), rich_body: trix_rich_body, procedure: procedure)
+      new(subject: const_get(:DEFAULT_SUBJECT), body: trix_rich_body, rich_body: trix_rich_body, procedure: procedure)
     end
 
     def default_template_name_for_procedure(procedure)

--- a/app/models/concerns/mail_template_concern.rb
+++ b/app/models/concerns/mail_template_concern.rb
@@ -38,7 +38,7 @@ module MailTemplateConcern
     def default_for_procedure(procedure)
       template_name = default_template_name_for_procedure(procedure)
       rich_body = ActionController::Base.render template: template_name
-      trix_rich_body = rich_body.gsub(/(?<!^|[.-])(?<!<\/strong>)\n/, '')
+      trix_rich_body = rich_body.gsub(/(?<!^|[.-])(?<!<\/strong>)\n/, ' ')
       new(subject: const_get(:DEFAULT_SUBJECT), body: trix_rich_body, rich_body: trix_rich_body, procedure: procedure)
     end
 

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -1019,7 +1019,7 @@ describe Procedure do
 
         procedure.reset_draft_revision!
 
-        expect { published_tdc.reload }.not_to raise_error(ActiveRecord::RecordNotFound)
+        expect { published_tdc.reload }.not_to raise_error
         expect { draft_tdc.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end


### PR DESCRIPTION
Fix aussi bien l'envoi de mail que le preview admin, sans template personnalisé.

J'ai pas compris l'historique avec les 2 `body` / `rich_body`, (j'ai l'impression que `body` pourrait être supprimé maintenant que la migration vers trix a été faite.)

## APRES (exemple avec mail de dépôt en construction)
<img width="622" alt="Capture d’écran 2023-07-05 à 23 21 43" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/2daf33e2-3b90-479e-898c-8be06acf4560">


<img width="417" alt="Capture d’écran 2023-07-05 à 23 22 54" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/6e8d7429-6b10-426f-889c-d5864555f970">

## AVANT

<img width="620" alt="Capture d’écran 2023-07-05 à 18 45 48" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/92aeb0d9-ca9f-48cd-8ae3-d8178f3db604">
<img width="417" alt="Capture d’écran 2023-07-05 à 23 23 29" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/1f1cd770-2bfd-43e6-8173-5c7a70085d0f">

