### PR TITLE
Fix datetime_champ validation with negative time zone

### DIFF
--- a/app/models/champs/datetime_champ.rb
+++ b/app/models/champs/datetime_champ.rb
@@ -44,6 +44,6 @@ class Champs::DatetimeChamp < Champ
   end
 
   def valid_iso8601?
-    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}\+\d{2}:\d{2})?$/.match?(value)
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}[\+\-]\d{2}:\d{2})?$/.match?(value)
   end
 end

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -949,7 +949,7 @@ describe Instructeurs::DossiersController, type: :controller do
         expect(champ_multiple_drop_down_list.value).to eq('["val1","val2"]')
         expect(champ_linked_drop_down_list.primary_value).to eq('primary')
         expect(champ_linked_drop_down_list.secondary_value).to eq('secondary')
-        expect(champ_datetime.value).to eq('2019-12-21T13:17:00+01:00')
+        expect(champ_datetime.value).to eq(Time.zone.parse('2019-12-21T13:17:00').iso8601)
         expect(champ_repetition.champs.first.value).to eq('text')
         expect(champ_drop_down_list.value).to eq('other value')
         expect(dossier.reload.last_champ_private_updated_at).to eq(now)

--- a/spec/jobs/migrations/batch_update_datetime_values_job_spec.rb
+++ b/spec/jobs/migrations/batch_update_datetime_values_job_spec.rb
@@ -4,24 +4,26 @@ describe Migrations::BatchUpdateDatetimeValuesJob, type: :job do
   end
 
   context "when the value is a valid ISO8601 date" do
-    let!(:datetime_champ) { build(:champ_datetime, value: "2023-01-10T00:00:00+01:00") }
+    let!(:value) { Time.zone.parse('10/01/2023 13:30').iso8601 }
+    let!(:datetime_champ) { build(:champ_datetime, value: value) }
 
     subject { described_class.perform_now([datetime_champ.id]) }
 
     it "keeps the existing value" do
       subject
-      expect(datetime_champ.reload.value).to eq("2023-01-10T00:00:00+01:00")
+      expect(datetime_champ.reload.value).to eq(value)
     end
   end
 
   context "when the value is a date convertible to IS8061" do
-    let!(:datetime_champ) { build(:champ_datetime, value: "2023-01-10") }
+    let!(:value) { "2023-01-10" }
+    let!(:datetime_champ) { build(:champ_datetime, value: value) }
 
     subject { described_class.perform_now([datetime_champ.id]) }
 
     it "updates the value to ISO8601" do
       subject
-      expect(datetime_champ.reload.value).to eq("2023-01-10T00:00:00+01:00")
+      expect(datetime_champ.reload.value).to eq(Time.zone.parse(value).iso8601)
     end
   end
 

--- a/spec/models/champ_spec.rb
+++ b/spec/models/champ_spec.rb
@@ -99,13 +99,13 @@ describe Champ do
     context 'when the value is sent by a modern browser' do
       let(:value) { '2017-12-31 10:23' }
 
-      it { expect(champ.value).to eq("2017-12-31T10:23:00+01:00") }
+      it { expect(champ.value).to eq(Time.zone.parse("2017-12-31T10:23:00").iso8601) }
     end
 
     context 'when the value is sent by a old browser' do
       let(:value) { '31/12/2018 09:26' }
 
-      it { expect(champ.value).to eq("2018-12-31T09:26:00+01:00") }
+      it { expect(champ.value).to eq(Time.zone.parse("2018-12-31T09:26:00").iso8601) }
     end
   end
 

--- a/spec/models/champs/datetime_champ_spec.rb
+++ b/spec/models/champs/datetime_champ_spec.rb
@@ -29,19 +29,19 @@ describe Champs::DatetimeChamp do
     it 'preserves if ISO8601' do
       champ = champ_with_value("2023-12-21T03:20")
       champ.save
-      expect(champ.reload.value).to eq("2023-12-21T03:20:00+01:00")
+      expect(champ.reload.value).to eq(Time.zone.parse("2023-12-21T03:20:00").iso8601)
     end
 
     it 'converts to ISO8601 if form format' do
       champ = champ_with_value("{3=>21, 2=>12, 1=>2023, 4=>3, 5=>20}")
       champ.save
-      expect(champ.reload.value).to eq("2023-12-21T03:20:00+01:00")
+      expect(champ.reload.value).to eq(Time.zone.parse("2023-12-21T03:20:00").iso8601)
     end
 
     it 'converts to ISO8601 if old browser form format' do
       champ = champ_with_value("21/12/2023 03:20")
       champ.save
-      expect(champ.reload.value).to eq("2023-12-21T03:20:00+01:00")
+      expect(champ.reload.value).to eq(Time.zone.parse("2023-12-21T03:20:00").iso8601)
     end
   end
 

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -54,7 +54,7 @@ describe 'The user' do
     expect(champ_value_for('text')).to eq('super texte')
     expect(champ_value_for('textarea')).to eq('super textarea')
     expect(champ_value_for('date')).to eq('2012-12-12')
-    expect(champ_value_for('datetime')).to eq('2023-01-06T07:05:00+01:00')
+    expect(champ_value_for('datetime')).to eq(Time.zone.parse('2023-01-06T07:05:00').iso8601)
     expect(champ_value_for('number')).to eq('42')
     expect(champ_value_for('decimal_number')).to eq('17')
     expect(champ_value_for('integer_number')).to eq('12')


### PR DESCRIPTION
Petites corrections pour prendre en compte la timezone de la Polynésie qui est -10 ;-)
==> correction de la regex 
==> Dans les tests, à  vous de me dire si l'utilisation de parse suffit ou si certains préfèreraient une valeur plus en dur qui prendrait en compte la time zone en cours genre '2023-01-10T00:00" + Timezone 