### PR TITLE
ETQ usager/instructeur: augmente le contraste entre libellés et réponses sur la page de la demande

### DIFF
--- a/app/assets/stylesheets/demande.scss
+++ b/app/assets/stylesheets/demande.scss
@@ -2,34 +2,23 @@
 @import "constants";
 
 .dossier-show {
-  &-instructeur {
-    @media (min-width: 48em) {
-      .champ-row {
-        display: flex;
-      }
-
-      .champ-label {
-        flex: 3;
-        margin-right: 1rem;
-      }
-
-      .champ-content {
-        flex: 4;
-      }
-    }
-  }
-
   .champ-row {
     padding: 0.5rem 1rem;
   }
 
   .champ-label {
-    font-weight: 600;
     margin-bottom: 0;
+    font-size: 0.8rem;
+    font-weight: 300;
   }
 
   .champ-content {
     padding: 0 0 0.5rem;
+    font-weight: 600;
+
+    a {
+      font-weight: normal;
+    }
 
     p {
       padding: 0;
@@ -39,6 +28,11 @@
     ul {
       margin-block-start: 0;
     }
+  }
+
+  .champ-blank {
+    font-weight: normal;
+    font-style: italic;
   }
 
   .champ-updated {

--- a/app/assets/stylesheets/demande.scss
+++ b/app/assets/stylesheets/demande.scss
@@ -2,30 +2,34 @@
 @import "constants";
 
 .dossier-show {
-  .champ-row {
+  &-instructeur {
     @media (min-width: 48em) {
-      display: flex;
-    }
+      .champ-row {
+        display: flex;
+      }
 
+      .champ-label {
+        flex: 3;
+        margin-right: 1rem;
+      }
+
+      .champ-content {
+        flex: 4;
+      }
+    }
+  }
+
+  .champ-row {
     padding: 0.5rem 1rem;
   }
 
   .champ-label {
     font-weight: 600;
     margin-bottom: 0;
-
-    @media (min-width: 48em) {
-      flex: 3;
-      margin-right: 1rem;
-    }
   }
 
   .champ-content {
     padding: 0 0 0.5rem;
-
-    @media (min-width: 48em) {
-      flex: 4;
-    }
 
     p {
       padding: 0;

--- a/app/components/dossiers/row_show_component.html.haml
+++ b/app/components/dossiers/row_show_component.html.haml
@@ -1,17 +1,16 @@
 .champ-row
-  %p.champ-label= "#{label} :"
+  %p.champ-label
+    = "#{label} :"
+    - if updated_at.present?
+      %span.fr-ml-3v.champ-updated{ class: badge_updated_class }
+        = t(:updated_at, scope: [:views, :shared, :dossiers, :form], datetime: helpers.try_format_datetime(updated_at, format: :veryshort))
 
   - if blank?
     .champ-content.fr-text-mention--grey{ class: content_class }
       - if usager?
-        %p
-          %em= blank
+        %p.champ-blank= blank
 
   - else
-    .champ-content{ class: content_class }
-      - if updated_at.present?
-        %p.fr-mb-1v.fr-ml-3v.champ-updated
-          %span{ class: badge_updated_class }
-            = t(:updated_at, scope: [:views, :shared, :dossiers, :form], datetime: helpers.try_format_datetime(updated_at, format: :veryshort))
 
+    .champ-content{ class: content_class }
       = value

--- a/app/views/shared/dossiers/_demande.html.haml
+++ b/app/views/shared/dossiers/_demande.html.haml
@@ -4,7 +4,7 @@
 
 .fr-container.counter-start-header-section.dossier-show{ class: class_names("dossier-show-instructeur" => profile =="instructeur") }
   .fr-grid-row.fr-grid-row--center
-    .fr-col-12{ class: class_names("fr-col-xl-10" => profile == "usager") }
+    .fr-col-12.fr-col-xl-8
       %h2.fr-h6.fr-background-alt--grey.fr-mb-0
         .flex-grow.fr-py-3v.fr-px-2w= t('views.shared.dossiers.demande.en_construction')
 

--- a/app/views/shared/dossiers/_demande.html.haml
+++ b/app/views/shared/dossiers/_demande.html.haml
@@ -2,9 +2,9 @@
   - content_for(:notice_info) do
     = render partial: "shared/dossiers/france_connect_informations_notice", locals: { user_information: dossier.france_connect_information }
 
-.fr-container.counter-start-header-section.dossier-show
+.fr-container.counter-start-header-section.dossier-show{ class: class_names("dossier-show-instructeur" => profile =="instructeur") }
   .fr-grid-row.fr-grid-row--center
-    .fr-col-12
+    .fr-col-12{ class: class_names("fr-col-xl-10" => profile == "usager") }
       %h2.fr-h6.fr-background-alt--grey.fr-mb-0
         .flex-grow.fr-py-3v.fr-px-2w= t('views.shared.dossiers.demande.en_construction')
 

--- a/app/views/shared/dossiers/_identite_entreprise.html.haml
+++ b/app/views/shared/dossiers/_identite_entreprise.html.haml
@@ -175,7 +175,8 @@
               %p= try_format_date(etablissement.association_date_declaration)
 
   - unless local_assigns[:short_identity]
-    %p.text-center
-      = link_to "➡ Autres informations sur l’organisme sur « annuaire-entreprises.data.gouv.fr » (ex: fiche d’immatriculation RNCS)",
-        annuaire_link(etablissement.siret),
-        **external_link_attributes
+    .champ-row
+      %p
+        = link_to "➡ Autres informations sur l’organisme sur « annuaire-entreprises.data.gouv.fr »",
+          annuaire_link(etablissement.siret),
+          **external_link_attributes

--- a/app/views/users/dossiers/demande.html.haml
+++ b/app/views/users/dossiers/demande.html.haml
@@ -17,5 +17,7 @@
 
   - if !@dossier.read_only?
     .fr-container.fr-mt-2w
-      %p= link_to t('views.users.dossiers.demande.edit_dossier'), modifier_dossier_path(@dossier), class: 'fr-btn fr-btn-sm',
-        title: "Modifier mon dossier tant qu'il n'est pas passé en instruction"
+      .fr-grid-row
+        .fr-col-xl-10.fr-col-offset-xl-1
+          %p= link_to t('views.users.dossiers.demande.edit_dossier'), modifier_dossier_path(@dossier), class: 'fr-btn fr-btn-sm',
+            title: "Modifier mon dossier tant qu'il n'est pas passé en instruction"

--- a/app/views/users/dossiers/demande.html.haml
+++ b/app/views/users/dossiers/demande.html.haml
@@ -18,6 +18,6 @@
   - if !@dossier.read_only?
     .fr-container.fr-mt-2w
       .fr-grid-row
-        .fr-col-xl-10.fr-col-offset-xl-1
+        .fr-col-xl-8.fr-col-offset-xl-2
           %p= link_to t('views.users.dossiers.demande.edit_dossier'), modifier_dossier_path(@dossier), class: 'fr-btn fr-btn-sm',
             title: "Modifier mon dossier tant qu'il n'est pas passé en instruction"

--- a/app/views/users/dossiers/demande.html.haml
+++ b/app/views/users/dossiers/demande.html.haml
@@ -20,4 +20,4 @@
       .fr-grid-row
         .fr-col-xl-8.fr-col-offset-xl-2
           %p= link_to t('views.users.dossiers.demande.edit_dossier'), modifier_dossier_path(@dossier), class: 'fr-btn fr-btn-sm',
-            title: "Modifier mon dossier tant qu'il n'est pas passé en instruction"
+            title: t('views.users.dossiers.demande.edit_dossier_title')

--- a/app/views/users/dossiers/show/_header.html.haml
+++ b/app/views/users/dossiers/show/_header.html.haml
@@ -17,8 +17,8 @@
       .header-actions
         = render partial: 'invites/dropdown', locals: { dossier: dossier, morphing: false }
         - if dossier.can_be_updated_by_user? && !current_page?(modifier_dossier_path(dossier))
-          = link_to t('views.users.dossiers.show.header.edit_dossier'), modifier_dossier_path(dossier), class: 'fr-btn fr-btn-sm',
-            title: t('views.users.dossiers.show.header.edit_dossier_title')
+          = link_to t('views.users.dossiers.demande.edit_dossier'), modifier_dossier_path(dossier), class: 'fr-btn fr-btn-sm',
+            title: t('views.users.dossiers.demande.edit_dossier_title')
         = render(partial: 'users/dossiers/show/print_dossier', locals: { dossier: dossier })
 
     %nav.tabs

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -423,8 +423,6 @@ en:
           submit_dossier: Submit an other file
         show:
           header:
-            edit_dossier: Edit my file
-            edit_dossier_title: "Edit my file - You can modify your file as long as it has not been sent for processing"
             summary: "Summary"
             request: "Request"
             mailbox: "Mailbox"
@@ -454,7 +452,8 @@ en:
         messagerie:
           mailbox: "The mailbox allows you to contact the instructor in charge of your file."
         demande:
-          edit_dossier: "Edit file"
+          edit_dossier: Edit file
+          edit_dossier_title: "Edit my file - You can modify your file as long as it has not been sent for processing"
         search:
           search_file: Search a file (File number, keywords)
           simple: Search

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -425,8 +425,6 @@ fr:
           submit_dossier: Déposer un autre dossier
         show:
           header:
-            edit_dossier: Modifier mon dossier
-            edit_dossier_title: "Modifier mon dossier - Vous pouvez modifier votre dossier tant qu’il n’est pas passé en instruction"
             summary: "Résumé"
             request: "Demande"
             mailbox: "Messagerie"
@@ -456,7 +454,8 @@ fr:
         messagerie:
           mailbox: "La messagerie vous permet de contacter l’instructeur en charge de votre dossier."
         demande:
-          edit_dossier: "Modifier le dossier"
+          edit_dossier: Modifier le dossier
+          edit_dossier_title: "Modifier mon dossier - Vous pouvez modifier votre dossier tant qu’il n’est pas passé en instruction"
         search:
           search_file: Rechercher un dossier (N° de dossier, mots-clés)
           simple: Rechercher

--- a/spec/system/users/dossier_shared_examples.rb
+++ b/spec/system/users/dossier_shared_examples.rb
@@ -6,7 +6,7 @@ RSpec.shared_examples 'the user can edit the submitted demande' do
     click_on 'Demande'
 
     expect(page).to have_current_path(demande_dossier_path(dossier))
-    click_on 'Modifier le dossier'
+    click_on 'Modifier le dossier', match: :first
 
     expect(page).to have_current_path(modifier_dossier_path(dossier))
     fill_in('Texte obligatoire', with: 'Nouveau texte')


### PR DESCRIPTION
Après moult discussions et retours instructeurs, on met largement en valeur les réponses (les valeurs). C'est très utile pour les instructeurs, mais aussi pour les usagers en relecture de leur dossier.

A discuter pour plus tard: proposer en option une variante 2 colonnes que préfèrent les instructeurs avancés.

## INSTRUCTEURS
![demande-by-lisa](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/355d0f69-ccd2-4ee0-89f8-52e65d561162)



![demande-by-lisa-badges](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/4254998d-476b-468a-8922-edb1c86f853b)


## Variante plebescitée par certains instructeurs avancés

![demande-2cols-regular-space-around](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/57d6d731-e880-4b6a-9598-89f5972b2ef7)
