### PR TITLE
correctif(notifications): ETQ usager, j'aimerais que les notifications soient fiable

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -186,11 +186,9 @@ module Users
         @dossier.passer_en_construction!
         @dossier.process_declarative!
         @dossier.process_sva_svr!
-        NotificationMailer.send_en_construction_notification(@dossier).deliver_later
         @dossier.groupe_instructeur.instructeurs.with_instant_email_dossier_notifications.each do |instructeur|
           DossierMailer.notify_new_dossier_depose_to_instructeur(@dossier, instructeur.email).deliver_later
         end
-
         redirect_to merci_dossier_path(@dossier)
       else
         flash.now.alert = errors

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -6,12 +6,8 @@
 # The subject and body of a Notification can be customized by each demarche.
 #
 class NotificationMailer < ApplicationMailer
-  include ActionView::Helpers::SanitizeHelper
-  include ActionView::Helpers::TextHelper
-
   before_action :set_dossier
   before_action :set_services_publics_plus, only: :send_notification
-  after_action :create_commentaire_for_notification
 
   helper ServiceHelper
   helper MailerHelper
@@ -22,11 +18,9 @@ class NotificationMailer < ApplicationMailer
   def send_notification
     @service = @dossier.procedure.service
     @logo_url = attach_logo(@dossier.procedure)
-    @rendered_template = sanitize(@body, scrubber: Sanitizers::MailScrubber.new)
     attachments[@attachment[:filename]] = @attachment[:content] if @attachment.present?
-
     I18n.with_locale(@dossier.user_locale) do
-      mail(subject: Nokogiri::HTML.parse(@subject).text, to: @email, template_name: 'send_notification')
+      mail(subject: @subject, to: @email, template_name: 'send_notification')
     end
   end
 
@@ -69,19 +63,15 @@ class NotificationMailer < ApplicationMailer
       mail.perform_deliveries = false
     else
       I18n.with_locale(@dossier.user_locale) do
-        mail_template = @dossier.procedure.mail_template_for(params[:state])
+        mail_template = @dossier.mail_template_for_state
+        mail_template_presenter = MailTemplatePresenterService.new(@dossier)
 
         @email = @dossier.user_email_for(:notification)
-        @subject = truncate(mail_template.subject_for_dossier(@dossier), length: 100)
-        @body = mail_template.body_for_dossier(@dossier)
+        @rendered_template = mail_template_presenter.safe_body
+        @subject = mail_template_presenter.safe_subject
         @actions = mail_template.actions_for_dossier(@dossier)
         @attachment = mail_template.attachment_for_dossier(@dossier)
       end
     end
-  end
-
-  def create_commentaire_for_notification
-    body = ["<p>[#{@subject}]</p>", @body].join('')
-    CommentaireService.create!(CONTACT_EMAIL, @dossier, body: body)
   end
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -81,7 +81,7 @@ class NotificationMailer < ApplicationMailer
   end
 
   def create_commentaire_for_notification
-    body = ["[#{@subject}]", @body].join("<br><br>")
+    body = ["<p>[#{@subject}]</p>", @body].join('')
     CommentaireService.create!(CONTACT_EMAIL, @dossier, body: body)
   end
 end

--- a/app/models/mails/closed_mail.rb
+++ b/app/models/mails/closed_mail.rb
@@ -10,6 +10,7 @@
 #  procedure_id :integer
 #
 module Mails
+  # accepte
   class ClosedMail < ApplicationRecord
     include MailTemplateConcern
 

--- a/app/models/mails/initiated_mail.rb
+++ b/app/models/mails/initiated_mail.rb
@@ -10,6 +10,7 @@
 #  procedure_id :integer
 #
 module Mails
+  # en_construction
   class InitiatedMail < ApplicationRecord
     include MailTemplateConcern
 

--- a/app/models/mails/received_mail.rb
+++ b/app/models/mails/received_mail.rb
@@ -10,6 +10,7 @@
 #  procedure_id :integer
 #
 module Mails
+  # en_instruction
   class ReceivedMail < ApplicationRecord
     include MailTemplateConcern
 

--- a/app/models/mails/refused_mail.rb
+++ b/app/models/mails/refused_mail.rb
@@ -10,6 +10,7 @@
 #  procedure_id :integer
 #
 module Mails
+  # refuse
   class RefusedMail < ApplicationRecord
     include MailTemplateConcern
 

--- a/app/models/mails/without_continuation_mail.rb
+++ b/app/models/mails/without_continuation_mail.rb
@@ -10,6 +10,7 @@
 #  procedure_id :integer
 #
 module Mails
+  # classe_sans_suite
   class WithoutContinuationMail < ApplicationRecord
     include MailTemplateConcern
 

--- a/app/services/mail_template_presenter_service.rb
+++ b/app/services/mail_template_presenter_service.rb
@@ -1,0 +1,24 @@
+class MailTemplatePresenterService
+  include ActionView::Helpers::SanitizeHelper
+  include ActionView::Helpers::TextHelper
+
+  delegate :mail_template_for_state, to: :@dossier
+
+  def self.create_commentaire_for_state(dossier)
+    service = new(dossier)
+    body = ["<p>[#{service.safe_subject}]</p>", service.safe_body].join('')
+    CommentaireService.create!(CONTACT_EMAIL, dossier, body: body)
+  end
+
+  def safe_body
+    sanitize(mail_template_for_state.body_for_dossier(@dossier), scrubber: Sanitizers::MailScrubber.new)
+  end
+
+  def safe_subject
+    Nokogiri::HTML.parse(truncate(mail_template_for_state.subject_for_dossier(@dossier), length: 100)).text
+  end
+
+  def initialize(dossier)
+    @dossier = dossier
+  end
+end

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -300,6 +300,10 @@ describe Instructeurs::DossiersController, type: :controller do
 
           subject
         end
+
+        it 'creates a commentaire' do
+          expect { subject }.to change { Commentaire.count }.by(1)
+        end
       end
 
       context 'refusal with a justificatif' do

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe NotificationMailer, type: :mailer do
   end
 
   describe 'send_en_instruction_notification' do
-    let(:dossier) { create(:dossier, :en_construction, :with_individual, :with_service, user: user, procedure: procedure) }
+    let(:dossier) { create(:dossier, :en_instruction, :with_individual, :with_service, user: user, procedure: procedure) }
     let(:email_template) { create(:received_mail, subject: 'Email subject', body: 'Your dossier was processed. Thanks.') }
 
     before do
@@ -42,15 +42,6 @@ RSpec.describe NotificationMailer, type: :mailer do
     end
 
     subject(:mail) { described_class.send_en_instruction_notification(dossier) }
-
-    it 'creates a commentaire in the messagerie' do
-      expect { subject.deliver_now }.to change { Commentaire.count }.by(1)
-      expect(subject.perform_deliveries).to be_truthy
-
-      commentaire = Commentaire.last
-      expect(commentaire.body).to include(email_template.subject_for_dossier(dossier), email_template.body_for_dossier(dossier))
-      expect(commentaire.dossier).to eq(dossier)
-    end
 
     it 'renders the template' do
       expect(mail.subject).to eq('Email subject')
@@ -92,32 +83,9 @@ RSpec.describe NotificationMailer, type: :mailer do
     end
   end
 
-  describe 'send_accepte_notification' do
-    let(:dossier) { create(:dossier, :en_instruction, :with_individual, :with_service, user: user, procedure: procedure) }
-    let(:email_template) { create(:closed_mail, subject: 'Email subject', body: 'Your dossier was accepted. Thanks.') }
-
-    before do
-      dossier.procedure.closed_mail = email_template
-    end
-
-    subject(:mail) { described_class.send_accepte_notification(dossier) }
-
-    context 'when dossier user is deleted' do
-      before do
-        dossier.user.delete_and_keep_track_dossiers_also_delete_user(administrateur)
-        dossier.reload
-      end
-
-      it 'should not send notification' do
-        expect { subject.deliver_now }.not_to change { Commentaire.count }
-        expect(subject.perform_deliveries).to be_falsey
-      end
-    end
-  end
-
   describe 'subject length' do
     let(:procedure) { create(:simple_procedure, libelle: "My super long title " + ("xo " * 100)) }
-    let(:dossier) { create(:dossier, :en_instruction, :with_individual, :with_service, user: user, procedure: procedure) }
+    let(:dossier) { create(:dossier, :accepte, :with_individual, :with_service, user: user, procedure: procedure) }
     let(:email_template) { create(:closed_mail, subject:, body: 'Your dossier was accepted. Thanks.') }
 
     before do
@@ -141,10 +109,10 @@ RSpec.describe NotificationMailer, type: :mailer do
   describe 'subject with apostrophe' do
     let(:procedure) { create(:simple_procedure, libelle: "Mon titre avec l'apostrophe") }
     let(:dossier) { create(:dossier, :en_instruction, :with_individual, :with_service, user: user, procedure: procedure) }
-    let(:email_template) { create(:closed_mail, subject:, body: 'Your dossier was accepted. Thanks.') }
+    let(:email_template) { create(:received_mail, subject:, body: 'Your dossier was accepted. Thanks.') }
 
     before do
-      dossier.procedure.closed_mail = email_template
+      dossier.procedure.received_mail = email_template
     end
 
     subject(:mail) { described_class.send_accepte_notification(dossier) }

--- a/spec/models/concern/dossier_rebase_concern_spec.rb
+++ b/spec/models/concern/dossier_rebase_concern_spec.rb
@@ -265,7 +265,7 @@ describe DossierRebaseConcern do
       ]
     end
     let(:types_de_champ_private) { [{ type: :text, stable_id: 11 }] }
-    let(:dossier) { create(:dossier, procedure: procedure) }
+    let(:dossier) { create(:dossier, :with_entreprise, procedure: procedure) }
     let(:types_de_champ) { procedure.active_revision.types_de_champ }
 
     let(:text_type_de_champ) { types_de_champ.find { _1.stable_id == 1 } }


### PR DESCRIPTION
hs: https://secure.helpscout.net/conversation/2282297626/2033291/

on a plusieurs problèmes liés aux commentaires générés automatiquement.
1. quand les mails retry, ça crée a nouveau le commentaire
2. il semblerait que certains message ne soit jms crée [j'imagine que le mail plante avant]

bref, l'idée c'est de découpler mail/commentaire pour eviter les probs (le contre coup c'est une requete sql de plus sur les actions d'instruction)

En explorant le code autour de ça j'ai deux questions : 
* la transition `repasser_en_instruction` utilise le `DossierMailer` qui n'a pas de logique de creation de commentaire. La logique voudrait qu'on remette le commentaire de passage en instruction ds la messagerie. Qu'en pensez-vous ?
* la transition `repasser_en_construction` ne declenche aucune notif (ni mail, ni commentaire), ce qui me semble etonnant. La logique voudrait qu'on remette les deux (mail et commentaire). Qu'en pensez-vous ?