### PR TITLE
ETQ instructeur je vois un badge d'alerte quand le dossier a été réaffecté

### DIFF
--- a/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.html.haml
+++ b/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.html.haml
@@ -18,6 +18,8 @@
             = render partial: "shared/champs/carte/show", locals: { champ: champ }
           - when TypeDeChamp.type_champs.fetch(:dossier_link)
             = render partial: "shared/champs/dossier_link/show", locals: { champ: champ }
+          - when TypeDeChamp.type_champs.fetch(:drop_down_list)
+            = render partial: "shared/champs/drop_down_list/show", locals: { champ: champ }
           - when TypeDeChamp.type_champs.fetch(:multiple_drop_down_list)
             = render partial: "shared/champs/multiple_drop_down_list/show", locals: { champ: champ }
           - when TypeDeChamp.type_champs.fetch(:piece_justificative), TypeDeChamp.type_champs.fetch(:titre_identite)

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -84,6 +84,7 @@ class Champ < ApplicationRecord
   delegate :to_typed_id, :to_typed_id_for_query, to: :type_de_champ, prefix: true
 
   delegate :revision, to: :dossier, prefix: true
+  delegate :used_by_routing_rules?, to: :type_de_champ
 
   scope :updated_since?, -> (date) { where('champs.updated_at > ?', date) }
   scope :public_only, -> { where(private: false) }

--- a/app/views/shared/champs/drop_down_list/_show.html.haml
+++ b/app/views/shared/champs/drop_down_list/_show.html.haml
@@ -1,0 +1,6 @@
+- if champ.used_by_routing_rules? && champ.dossier.forced_groupe_instructeur
+  %p
+    %span= champ.value
+    %span.fr-badge.fr-badge--warning.fr-badge--sm dossier réaffecté au groupe « #{champ.dossier.groupe_instructeur.label} »
+- else
+  %p= champ.value


### PR DESCRIPTION
Dans l'onglet demande, ajout d'un badge warning au niveau du champ utilisé pour le routage si le dossier a été réaffecté manuellement.

**Desktop**

![Screenshot from 2023-07-31 14-37-48](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/29131404/35bc35f9-77f8-4708-9d6f-dc5738cfb7f0)


**Mobile**

![Screenshot from 2023-07-31 14-37-29](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/29131404/ae427be7-bc6f-4392-a673-5d635f819345)

