### PR TITLE
ETQ usager je peux corriger l'identité de mon dossier qui a pu être rempli sans qu'elle soit complète

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -103,7 +103,11 @@ module Users
         @dossier.update!(autorisation_donnees: true, identity_updated_at: Time.zone.now)
         flash.notice = t('.identity_saved')
 
-        redirect_to brouillon_dossier_path(@dossier)
+        if dossier.en_construction?
+          redirect_to demande_dossier_path(@dossier)
+        else
+          redirect_to brouillon_dossier_path(@dossier)
+        end
       else
         flash.now.alert = @dossier.individual.errors.full_messages
         render :identite
@@ -432,8 +436,10 @@ module Users
     def ensure_dossier_can_be_filled
       if !dossier.autorisation_donnees
         if dossier.procedure.for_individual
+          flash.alert = t('users.dossiers.fill_identity.individual')
           redirect_to identite_dossier_path(dossier)
         else
+          flash.alert = t('users.dossiers.fill_identity.siret')
           redirect_to siret_dossier_path(dossier)
         end
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -750,6 +750,9 @@ en:
       no_access: "You do not have access to this file"
       no_longer_editable: "Your file can no longer be edited"
       en_construction_submitted: "The modifications have already been submitted"
+      fill_identity:
+        individual: Complete the identity of the applicant to continue.
+        siret: Complete the identification of the establishment to continue.
       create_commentaire:
         message_send: "Your message has been sent to the instructor in charge of your file."
       cloned_success: "Your file has been duplicated. Please review it then you can submit it"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -760,6 +760,9 @@ fr:
       no_access: "Vous n’avez pas accès à ce dossier"
       no_longer_editable: "Votre dossier ne peut plus être modifié"
       en_construction_submitted: "Les modifications ont déjà été déposées"
+      fill_identity:
+        individual: Complétez l’identité du déposant du dossier pour poursuivre.
+        siret: Complétez l’identification de l’établissement pour poursuivre.
       create_commentaire:
         message_send: "Votre message a bien été envoyé à l’instructeur en charge de votre dossier."
       cloned_success: "Votre dossier a bien été dupliqué. Vous pouvez maintenant le vérifier, l’adapter puis le déposer."

--- a/lib/tasks/deployment/20230707121855_force_dossiers_to_fill_missing_individual.rake
+++ b/lib/tasks/deployment/20230707121855_force_dossiers_to_fill_missing_individual.rake
@@ -1,0 +1,27 @@
+namespace :after_party do
+  desc 'Deployment task: force_dossiers_to_fill_missing_individual'
+  task force_dossiers_to_fill_missing_individual: :environment do
+    puts "Running deploy task 'force_dossiers_to_fill_missing_individual'"
+
+    # Corrige 11 dossiers qui ont profité d'un bug les 25-26 avril 2023 pour être créés avec des noms vides
+    # et qui empêche de terminer le dossier.
+    # Les dossiers seront repasses manuellement en construction et les usagers informés par la messagerie
+    # pour que tout l'historique soit loggué et que les instructeurs soient aussi prévenus.
+    dossiers = Dossier.joins(:individual)
+      .where(individual: { nom: nil })
+      .state_en_construction_ou_instruction
+      .includes(:procedure)
+
+    dossiers.find_each do |dossier|
+      rake_puts "Dossier id=#{dossier.id} procedure_id=#{dossier.procedure.id} procedure=#{dossier.procedure.libelle}"
+
+      dossier.autorisation_donnees = false
+      dossier.save!(validate: false)
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
Les 25-26 avril, 11 dossiers ont profité d'un bug pour être soumis sans le `nom` du demandeur. Son absence empêche le traitement du dossier (y compris sur une démarche déclarative).
Le plan est de repasser les dossiers en construction de les contacter manuellement par messagerie. Ici on change le flag des dossiers pour les forcer à repasser par cette étape de remplissage d'identité.

On en profite pour améliorer l'UX quand on est forcé de repasser par la page identité.