### PR TITLE
Fix (demande): pas d'erreur lorsque l'entreprie n'a pas de SIRET associé au siège social

### DIFF
--- a/app/views/shared/dossiers/_identite_entreprise.html.haml
+++ b/app/views/shared/dossiers/_identite_entreprise.html.haml
@@ -28,7 +28,7 @@
 
 
       - unless local_assigns[:short_identity]
-        - if etablissement.siret != etablissement.entreprise.siret_siege_social
+        - if etablissement.entreprise.siret_siege_social.present? && etablissement.siret != etablissement.entreprise.siret_siege_social
           = render Dossiers::RowShowComponent.new(label: "SIRET du siège social") do |c|
             - c.with_value do
               %p

--- a/spec/views/shared/dossiers/_identite_entreprise.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_identite_entreprise.html.haml_spec.rb
@@ -56,5 +56,35 @@ describe 'shared/dossiers/identite_entreprise', type: :view do
         expect(rendered).to include("9 001")
       end
     end
+
+    context 'siret siege social' do
+      let(:etablissement) { create(:etablissement, siret: "12345678900001", entreprise_siret_siege_social: siret_siege_social) }
+
+      context 'when siege social has same siret' do
+        let(:siret_siege_social) { "12345678900001" }
+
+        it 'does not duplicate siret' do
+          expect(subject).to include("123 456 789 00001").once
+        end
+      end
+
+      context 'when siege social is different' do
+        let(:siret_siege_social) { "98765432100001" }
+
+        it 'shows both sirets' do
+          expect(subject).to include("123 456 789 00001")
+          expect(subject).to include("SIRET du siège social")
+          expect(subject).to include("987 654 321 00001")
+        end
+      end
+
+      context 'when siege social has no siret' do
+        let(:siret_siege_social) { nil }
+
+        it 'does not duplicate siret' do
+          expect(subject).not_to include("SIRET du siège social")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
https://demarches-simplifiees.sentry.io/issues/4305281008/