### PR TITLE
[bug] fix de la barre de recherche pour les dossiers invités

### DIFF
--- a/app/services/dossier_search_service.rb
+++ b/app/services/dossier_search_service.rb
@@ -10,7 +10,7 @@ class DossierSearchService
 
   def self.matching_dossiers_for_user(search_terms, user)
     dossier_by_exact_id_for_user(search_terms, user)
-      .presence || dossier_by_full_text_for_user(search_terms, user.dossiers).presence || dossier_by_full_text_for_user(search_terms, user.dossiers_invites)
+      .presence || dossier_by_full_text_for_user(search_terms, Dossier.where(id: user.dossiers.ids + user.dossiers_invites.ids))
   end
 
   private

--- a/app/services/dossier_search_service.rb
+++ b/app/services/dossier_search_service.rb
@@ -10,7 +10,7 @@ class DossierSearchService
 
   def self.matching_dossiers_for_user(search_terms, user)
     dossier_by_exact_id_for_user(search_terms, user)
-      .presence || dossier_by_full_text_for_user(search_terms, user.dossiers).presence || dossier_by_full_text_for_user(search_terms, user.dossiers_invites).presence
+      .presence || dossier_by_full_text_for_user(search_terms, user.dossiers).presence || dossier_by_full_text_for_user(search_terms, user.dossiers_invites)
   end
 
   private

--- a/app/services/dossier_search_service.rb
+++ b/app/services/dossier_search_service.rb
@@ -10,7 +10,7 @@ class DossierSearchService
 
   def self.matching_dossiers_for_user(search_terms, user)
     dossier_by_exact_id_for_user(search_terms, user)
-      .presence || dossier_by_full_text_for_user(search_terms, user.dossiers) || dossier_by_full_text_for_user(search_terms, user.dossiers_invites)
+      .presence || dossier_by_full_text_for_user(search_terms, user.dossiers).presence || dossier_by_full_text_for_user(search_terms, user.dossiers_invites).presence
   end
 
   private

--- a/app/views/users/dossiers/index.html.haml
+++ b/app/views/users/dossiers/index.html.haml
@@ -9,7 +9,7 @@
 .dossiers-headers.sub-header
   .fr-container
     %h1.page-title.fr-h2= t('views.users.dossiers.index.dossiers')
-    - if current_user.dossiers.count > 2
+    - if current_user.dossiers.count > 2 || current_user.dossiers_invites.count > 2
       #search-2.fr-search-bar.fr-search-bar--lg
         = form_tag recherche_dossiers_path, method: :get, :role => "search", class: "flex width-100 fr-mb-5w" do
           = label_tag "q", t('views.users.dossiers.search.search_file'), class: 'fr-label'

--- a/spec/system/users/invite_spec.rb
+++ b/spec/system/users/invite_spec.rb
@@ -139,6 +139,45 @@ describe 'Invitations' do
     end
   end
 
+  describe 'recherche' do
+    context "when user has one invited dossier" do
+      let!(:dossier) { create(:dossier, :with_individual, :en_construction, user: owner, procedure: procedure) }
+      let!(:invite) { create(:invite, user: invited_user, dossier: dossier) }
+      before do
+        navigate_to_invited_dossier(invite)
+        visit dossiers_path
+      end
+
+      it "does not have access to search bar" do
+        expect(page).not_to have_selector('#q')
+      end
+    end
+
+    context "when user has multiple invited dossiers" do
+      let(:dossier) { create(:dossier, :with_individual, :en_construction, user: owner, procedure: procedure) }
+      let!(:dossier_2) { create(:dossier, :with_individual, :with_populated_champs, :en_construction, user: owner, procedure: procedure) }
+      let!(:invite_2) { create(:invite, user: invited_user, dossier: dossier_2) }
+      let!(:dossier_3) { create(:dossier, :with_individual, :en_construction, user: owner, procedure: procedure) }
+      let!(:invite_3) { create(:invite, user: invited_user, dossier: dossier_3) }
+      before do
+        navigate_to_invited_dossier(invite)
+        visit dossiers_path
+      end
+
+      it "can search by id and it redirects to the dossier page" do
+        page.find_by_id('q').set(dossier.id)
+        find('.fr-search-bar .fr-btn').click
+        expect(current_path).to eq(dossier_path(dossier))
+      end
+
+      it "can search something inside the dossier and it redirects to the dossier page" do
+        page.find_by_id('q').set(dossier_2.champs_public.first.value)
+        find('.fr-search-bar .fr-btn').click
+        expect(current_path).to eq(dossier_path(dossier_2))
+      end
+    end
+  end
+
   private
 
   def log_in(user)


### PR DESCRIPTION
- la barre de recherche s'affiche à partir de 2 dossiers mais ne prend pas en compte les dossiers invités (donc dans l'exemple ça ne s'affiche pas car la personne a un seul dossier et 59 dossiers invités)

- la recherche des dossiers invités fonctionne uniquement sur l'id mais pas sur les mots clés

https://secure.helpscout.net/conversation/2297064371/2034853?folderId=1653799