### PR TITLE
Ajout d'un cron pour maintenir le nombre de pjs en cours de migration entre 0 et 200K

### DIFF
--- a/app/jobs/cron/pjs_migration_cron_job.rb
+++ b/app/jobs/cron/pjs_migration_cron_job.rb
@@ -1,0 +1,26 @@
+class Cron::PjsMigrationCronJob < Cron::CronJob
+  self.schedule_expression = "every 15 minutes"
+
+  def perform(*args)
+    # avoid reschedule enqueued jobs
+    # but ignore fail jobs
+    return if migration_jobs.count > 100
+
+    blobs = ActiveStorage::Blob
+      .where.not("key LIKE '%/%'")
+      .limit(200_000)
+
+    blobs.in_batches { |batch| batch.ids.each { |id| PjsMigrationJob.perform_later(id) } }
+  end
+
+  def self.schedulable?
+    ENV.fetch("MIGRATE_PJS", "enabled") == "enabled"
+  end
+
+  private
+
+  def migration_jobs
+    Delayed::Job
+      .where(queue: 'pj_migration_jobs')
+  end
+end


### PR DESCRIPTION
le cron est activé avec la variable d'env `MIGRATE_PJS`.

Nous sommes en train de changer le noms des pjs afin de faciliter le travail de sauvegarde.
Nous mettons à la file un job par migration.
Les performances de la base de données se dégradent si on insert plus de ~ 400k job de migration.

On utilise donc un cron qui compte le nombre de job de migration restant toutes les 15 minutes, et s'il n'y en a plus, réinsert 200k jobs.

On se garde une marge de 100 jobs résidents au cas ou il y aurait des erreurs (502 bad gateway ...).