### PR TITLE
Tech: supprime la colonne dossier_corrections#kind

### DIFF
--- a/app/models/dossier_correction.rb
+++ b/app/models/dossier_correction.rb
@@ -14,8 +14,6 @@ class DossierCorrection < ApplicationRecord
   belongs_to :dossier
   belongs_to :commentaire
 
-  self.ignored_columns += ['kind']
-
   validates_associated :commentaire
 
   scope :pending, -> { where(resolved_at: nil) }

--- a/db/migrate/20230713163641_remove_dossier_corrections_kind.rb
+++ b/db/migrate/20230713163641_remove_dossier_corrections_kind.rb
@@ -1,0 +1,7 @@
+class RemoveDossierCorrectionsKind < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      remove_column :dossier_corrections, :kind, :string, default: 'incorrect', null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_19_112020) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_18_113920) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -336,7 +336,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_19_112020) do
     t.bigint "dossier_id", null: false
     t.datetime "resolved_at", precision: 6
     t.datetime "updated_at", precision: 6, null: false
-    t.string "kind", default: "correction", null: false
     t.string "reason", default: "incorrect", null: false
     t.index ["commentaire_id"], name: "index_dossier_corrections_on_commentaire_id"
     t.index ["dossier_id"], name: "index_dossier_corrections_on_dossier_id"


### PR DESCRIPTION
Suite et fin d'un renommage de colonne fait dans
https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/9310

Cette colonne `kind` avait été remplacée par `reason` 