### PR TITLE
tech(smtp): passe du relai SMTP de SendInBlue vers le relai SMTP Brevo

### DIFF
--- a/config/initializers/sendinblue.rb
+++ b/config/initializers/sendinblue.rb
@@ -10,8 +10,8 @@ if ENV.key?('SENDINBLUE_BALANCING_VALUE')
     ActionMailer::Base.sendinblue_settings = {
       user_name: Rails.application.secrets.sendinblue[:username],
       password: Rails.application.secrets.sendinblue[:smtp_key],
-      address: 'smtp-relay.sendinblue.com',
-      domain: 'smtp-relay.sendinblue.com',
+      address: 'smtp-relay.brevo.com',
+      domain: 'smtp-relay.brevo.com',
       port: '587',
       authentication: :cram_md5
     }


### PR DESCRIPTION
Un des fournisseurs de DS a changé de nom, on met juste à jour ce changement de nom qui impact l'infrastructure