### PR TITLE
send service siret as recipient

### DIFF
--- a/app/lib/api_entreprise/api.rb
+++ b/app/lib/api_entreprise/api.rb
@@ -91,6 +91,10 @@ class APIEntreprise::API
 
   private
 
+  def recipient
+    @procedure&.service && @procedure.service.siret.presence || ENV.fetch('API_ENTREPRISE_DEFAULT_SIRET')
+  end
+
   def call_with_siret(resource_name, siret_or_siren, user_id: nil)
     url = make_url(resource_name, siret_or_siren)
 
@@ -157,7 +161,7 @@ class APIEntreprise::API
   def base_params
     {
       context: APPLICATION_NAME,
-      recipient: ENV.fetch('API_ENTREPRISE_DEFAULT_SIRET'),
+      recipient: recipient,
       non_diffusables: true
     }
   end

--- a/spec/lib/api_entreprise/api_spec.rb
+++ b/spec/lib/api_entreprise/api_spec.rb
@@ -81,6 +81,26 @@ describe APIEntreprise::API do
           expect(WebMock).to have_requested(:get, /https:\/\/entreprise.api.gouv.fr\/v3\/insee\/sirene\/unites_legales\/#{siren}/)
         end
       end
+
+      context 'with a service without siret' do
+        let(:procedure) { create(:procedure, :with_service) }
+        let(:dinum_siret) { "13002526500013" }
+        it 'send default recipient' do
+          ENV["API_ENTREPRISE_DEFAULT_SIRET"] = dinum_siret
+          procedure.service.siret = nil
+          procedure.service.save(validate: false)
+          subject
+          expect(WebMock).to have_requested(:get, /https:\/\/entreprise.api.gouv.fr\/v3\/insee\/sirene\/unites_legales\/#{siren}/).with(query: hash_including({ recipient: dinum_siret }))
+        end
+      end
+
+      context 'with a service with siret' do
+        let(:procedure) { create(:procedure, :with_service) }
+        it 'send default recipient' do
+          subject
+          expect(WebMock).to have_requested(:get, /https:\/\/entreprise.api.gouv.fr\/v3\/insee\/sirene\/unites_legales\/#{siren}/).with(query: hash_including({ recipient: procedure.service.siret }))
+        end
+      end
     end
   end
 


### PR DESCRIPTION
close #9242

Si le siret du service de la procédure est renseigné, alors il est envoyé comme `recipient`dans l'appel api entreprise.