### PR TITLE
rend plus actionnable message d'erreur

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -596,7 +596,7 @@ module Users
     end
 
     def forbidden!
-      flash[:alert] = t('users.dossiers.no_access')
+      flash[:alert] = t('users.dossiers.no_access_html', email: current_user.email)
       redirect_to root_path
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -756,7 +756,7 @@ en:
   users:
     dossiers:
       test_procedure: "This file is submitted on a test procedure. Any modification of the procedure by the administrator (addition of a field, publication of the procedure, etc.) will result in the removal of the file."
-      no_access: "You do not have access to this file"
+      no_access_html: "You do not have access to this file.<br>Check that you were signed in as <b>%{email}</b> to fill this procedure.<br>If not, please log off"
       no_longer_editable: "Your file can no longer be edited"
       en_construction_submitted: "The modifications have already been submitted"
       fill_identity:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -759,7 +759,7 @@ fr:
   users:
     dossiers:
       test_procedure: "Ce dossier est déposé sur une démarche en test. Toute modification de la démarche par l’administrateur (ajout d’un champ, publication de la démarche...) entraînera sa suppression."
-      no_access: "Vous n’avez pas accès à ce dossier"
+      no_access_html: "Vous n’avez pas accès à ce dossier.<br>Vérifiez que votre adresse email de connexion <b>%{email}</b> est bien celle utilisée pour remplir cette démarche.<br> Si ce n'est pas le cas, déconnectez-vous"
       no_longer_editable: "Votre dossier ne peut plus être modifié"
       en_construction_submitted: "Les modifications ont déjà été déposées"
       fill_identity:

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -25,7 +25,7 @@ describe Users::DossiersController, type: :controller do
     before { @controller.send(ensure_authorized) }
 
     it { expect(@controller).to have_received(:redirect_to).with(root_path) }
-    it { expect(flash.alert).to eq("Vous n’avez pas accès à ce dossier") }
+    it { expect(flash.alert).to include("Vous n’avez pas accès à ce dossier") }
   end
 
   describe '#ensure_ownership!' do
@@ -35,28 +35,41 @@ describe Users::DossiersController, type: :controller do
 
     before do
       @controller.params = @controller.params.merge(dossier_id: asked_dossier.id)
-      expect(@controller).to receive(:current_user).and_return(user)
       allow(@controller).to receive(:redirect_to)
     end
 
     context 'when a user asks for their own dossier' do
+      before do
+        expect(@controller).to receive(:current_user).and_return(user)
+      end
+
       let(:asked_dossier) { create(:dossier, user: user) }
 
       it_behaves_like 'does not redirect nor flash'
     end
 
     context 'when a user asks for another dossier' do
+      before do
+        expect(@controller).to receive(:current_user).twice.and_return(user)
+      end
+
       it_behaves_like 'redirects and flashes'
     end
 
     context 'when an invite asks for a dossier where they were invited' do
-      before { create(:invite, dossier: asked_dossier, user: user) }
+      before do
+        expect(@controller).to receive(:current_user).twice.and_return(user)
+        create(:invite, dossier: asked_dossier, user: user)
+      end
 
       it_behaves_like 'redirects and flashes'
     end
 
     context 'when an invite asks for another dossier' do
-      before { create(:invite, dossier: create(:dossier), user: user) }
+      before do
+        expect(@controller).to receive(:current_user).twice.and_return(user)
+        create(:invite, dossier: create(:dossier), user: user)
+      end
 
       it_behaves_like 'redirects and flashes'
     end
@@ -69,28 +82,41 @@ describe Users::DossiersController, type: :controller do
 
     before do
       @controller.params = @controller.params.merge(dossier_id: asked_dossier.id)
-      expect(@controller).to receive(:current_user).and_return(user)
       allow(@controller).to receive(:redirect_to)
     end
 
     context 'when a user asks for their own dossier' do
+      before do
+        expect(@controller).to receive(:current_user).and_return(user)
+      end
+
       let(:asked_dossier) { create(:dossier, user: user) }
 
       it_behaves_like 'does not redirect nor flash'
     end
 
     context 'when a user asks for another dossier' do
+      before do
+        expect(@controller).to receive(:current_user).twice.and_return(user)
+      end
+
       it_behaves_like 'redirects and flashes'
     end
 
     context 'when an invite asks for a dossier where they were invited' do
-      before { create(:invite, dossier: asked_dossier, user: user) }
+      before do
+        expect(@controller).to receive(:current_user).and_return(user)
+        create(:invite, dossier: asked_dossier, user: user)
+      end
 
       it_behaves_like 'does not redirect nor flash'
     end
 
     context 'when an invite asks for another dossier' do
-      before { create(:invite, dossier: create(:dossier), user: user) }
+      before do
+        expect(@controller).to receive(:current_user).twice.and_return(user)
+        create(:invite, dossier: create(:dossier), user: user)
+      end
 
       it_behaves_like 'redirects and flashes'
     end
@@ -431,7 +457,7 @@ describe Users::DossiersController, type: :controller do
         before { subject }
 
         it { expect(response).to redirect_to(root_path) }
-        it { expect(flash.alert).to eq("Vous n’avez pas accès à ce dossier") }
+        it { expect(flash.alert).to include("Vous n’avez pas accès à ce dossier") }
       end
     end
 


### PR DESCRIPTION
close #9062 

Cette PR améliore le message d'erreur lorsqu'un utilisateur tente d'accéder à un dossier qui ne lui appartient pas, en le rendant plus actionnable.

## Avant la PR : 

<img width="974" alt="Capture d’écran 2023-07-19 à 11 39 22" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/1111966/262563f9-7371-4f3f-9410-068977227b9d">

## Après la PR 

<img width="1076" alt="Capture d’écran 2023-07-19 à 11 39 52" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/1111966/db722631-a83b-48c7-9154-3dc8711243eb">
