### PR TITLE
Ameliore le wording des personnes impliquées

### DIFF
--- a/app/views/instructeurs/dossiers/personnes_impliquees.html.haml
+++ b/app/views/instructeurs/dossiers/personnes_impliquees.html.haml
@@ -12,7 +12,7 @@
 
   = render partial: 'instructeurs/dossiers/personnes_impliquees_block', locals: { emails_collection: @avis_emails, title: "Personnes à qui un avis a été demandé", blank: "Aucun avis n’a été demandé" }
 
-  = render partial: 'instructeurs/dossiers/personnes_impliquees_block', locals: { emails_collection: @invites_emails, title: "Personnes invitées à consulter ce dossier", blank: "Aucune personne n’a été invitée à consulter ce dossier" }
+  = render partial: 'instructeurs/dossiers/personnes_impliquees_block', locals: { emails_collection: @invites_emails, title: "Personnes invitées par l'usager à modifier ce dossier", blank: "Aucune personne n’a été invitée par l'usager à modifier ce dossier" }
 
   = render partial: 'instructeurs/dossiers/decisions_rendues_block', locals: { traitements: @dossier.traitements }
 


### PR DESCRIPTION
close #9331 

Cette PR ameliore le wording en tant qu'instructeur pour les personnes impliquées, et notamment les personnes invitées par l'usager à modifier le dossier.
