### PR TITLE
ETQ operateur, je peux piloter le niveau de log à partir de la variable DS_LOG_LEVEL

### DIFF
--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -215,3 +215,7 @@ POSTGIS_EXTENSION_DISABLED=""
 REDIS_CACHE_URL=""
 REDIS_CACHE_SSL="enabled"
 REDIS_CACHE_SSL_VERIFY_NONE="enabled"
+
+# Setup log level, info if nil
+# can be debug, info, warn, error, fatal, and unknown
+DS_LOG_LEVEL='info'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,7 +52,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = ENV["DS_ENV"] == "staging" ? :debug : :info
+  config.log_level = ENV["DS_LOG_LEVEL"].presence&.to_sym || :info
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]


### PR DESCRIPTION
Avant le niveau de log était piloté par la variable environnement "DS_ENV".
si DS_ENV == "staging" alors le niveau était degug sinon info.

Maintenant, on peut directement mettre un des niveau dans la variable DS_LOG_LEVEL, les niveaux disponibles sont:
debug, info, warn, error, fatal, and unknown

le défaut est info.