### PR TITLE
fix spec (% 10000 and assert_performed_jobs)

### DIFF
--- a/spec/services/procedure_archive_service_spec.rb
+++ b/spec/services/procedure_archive_service_spec.rb
@@ -36,7 +36,7 @@ describe ProcedureArchiveService do
             "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/",
             "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/pieces_justificatives/",
             "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/pieces_justificatives/attestation-dossier--05-03-2021-00-00-#{dossier.attestation.pdf.id % 10000}.pdf",
-            "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/export-#{dossier.id}-05-03-2021-00-00-#{dossier.id}.pdf"
+            "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/export-#{dossier.id}-05-03-2021-00-00-#{dossier.id % 10000}.pdf"
           ]
           expect(files.map(&:filename)).to match_array(structure)
         end
@@ -56,7 +56,7 @@ describe ProcedureArchiveService do
             "#{service.send(:zip_root_folder, archive)}/-LISTE-DES-FICHIERS-EN-ERREURS.txt",
             "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/",
             "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/pieces_justificatives/",
-            "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/export-#{dossier.id}-05-03-2021-00-00-#{dossier.id}.pdf"
+            "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/export-#{dossier.id}-05-03-2021-00-00-#{dossier.id % 10000}.pdf"
           ]
           expect(files.map(&:filename)).to match_array(structure)
         end
@@ -104,7 +104,7 @@ describe ProcedureArchiveService do
               "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/",
               "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/export-dossier-05-03-2020-00-00-1.pdf",
               "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/pieces_justificatives/",
-              "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/export-#{dossier.id}-05-03-2021-00-00-#{dossier.id}.pdf"
+              "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/export-#{dossier.id}-05-03-2021-00-00-#{dossier.id % 10000}.pdf"
             ]
             expect(zip_entries.map(&:filename)).to match_array(structure)
             zip_entries.map do |entry|
@@ -137,9 +137,9 @@ describe ProcedureArchiveService do
             "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/",
             "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/pieces_justificatives/",
             "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/pieces_justificatives/attestation-dossier--05-03-2020-00-00-#{dossier.attestation.pdf.id % 10000}.pdf",
-            "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/export-#{dossier.id}-05-03-2020-00-00-#{dossier.id}.pdf",
+            "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier.id}/export-#{dossier.id}-05-03-2020-00-00-#{dossier.id % 10000}.pdf",
             "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier_2020.id}/",
-            "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier_2020.id}/export-#{dossier_2020.id}-05-03-2020-00-00-#{dossier_2020.id}.pdf",
+            "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier_2020.id}/export-#{dossier_2020.id}-05-03-2020-00-00-#{dossier_2020.id % 10000}.pdf",
             "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier_2020.id}/pieces_justificatives/",
             "#{service.send(:zip_root_folder, archive)}/dossier-#{dossier_2020.id}/pieces_justificatives/attestation-dossier--05-03-2020-00-00-#{dossier_2020.attestation.pdf.id % 10000}.pdf"
           ]

--- a/spec/system/instructeurs/instruction_spec.rb
+++ b/spec/system/instructeurs/instruction_spec.rb
@@ -107,11 +107,12 @@ describe 'Instructing a dossier:', js: true do
   end
 
   scenario 'A instructeur can request an export' do
-    log_in(instructeur.email, password)
+    assert_performed_jobs 1 do
+      log_in(instructeur.email, password)
+    end
 
     click_on procedure.libelle
     test_statut_bar(a_suivre: 1, tous_les_dossiers: 1)
-    assert_performed_jobs 1
 
     click_on "Télécharger un dossier"
     within(:css, '.dossiers-export') do
@@ -121,8 +122,9 @@ describe 'Instructing a dossier:', js: true do
     expect(page).to have_text('Nous générons cet export.')
     click_on "Télécharger un dossier"
     expect(page).to have_text('Un export au format .csv est en train d’être généré')
-    perform_enqueued_jobs(only: ExportJob)
-    assert_performed_jobs 2
+    assert_performed_jobs 2 do
+      perform_enqueued_jobs(only: ExportJob)
+    end
     page.driver.browser.navigate.refresh
 
     click_on "Télécharger un dossier"


### PR DESCRIPTION
reprise de la PR https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/9251 de @seb-by-ouidou

> corrige plusieurs tests qui ne testent pas ce qu'ils devraient
> ils passent au vert lorsqu'ils sont lancés seuls, mais sont rouges lorsqu'ils sont lancés avec tous les tests

réponse de @tchak  https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/9251#issuecomment-1611128724
> Merci pour la contribution !
> Serait-il possible d'avoir une explication sur le changement` dossier.id % 10000` ? Nous n'arrivons pas à le comprendre.

commentaire de @seb-by-ouidou https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/9251#issuecomment-1611175660
> cela vient de la method
> 
> self.timestamped_filename(attachment) dans laquelle se trouve
> id = attachment.id % 10000
> 
> donc si vous lancez le test 1 fois, pas de pb car vous aurez un id < 10000
> 
> mais si vous lancez les tests de nombreuses fois consecutives, alors les id vont augmenter. Une fois que vous depassez 10000, alors le test passait au rouge avant ma contribution. En mettant % 10000 , il reste vert

[`self.timestamped_filename(attachment)`  dans `app/lib/active_storage/downloadable_file.rb`](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/blob/main/app/lib/active_storage/downloadable_file.rb#L50C2-L50C2)

-------------------

> L'ADULLACT a mandaté le prestataire **Ouidou** pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que **Ouidou** nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @seb-by-ouidou pourra interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

 --------------------
> `trackingAdullactContrib` 
