### PR TITLE
Affiche l'email du demandeur dans l'attestation de dépôt

### DIFF
--- a/app/views/users/dossiers/papertrail.pdf.prawn
+++ b/app/views/users/dossiers/papertrail.pdf.prawn
@@ -49,6 +49,7 @@ prawn_document(margin: [top_margin, right_margin, bottom_margin, left_margin], p
         pdf.fill_color grey
         pdf.text "#{Individual.human_attribute_name(:prenom)} : #{@dossier.individual.prenom}", size: 10, character_spacing: -0.2, align: :justify
         pdf.text "#{Individual.human_attribute_name(:nom)} :  #{@dossier.individual.nom.upcase}", size: 10, character_spacing: -0.2, align: :justify
+        pdf.text "#{User.human_attribute_name(:email)} :  #{@dossier.user.email}", size: 10, character_spacing: -0.2, align: :justify
       end
     end
 


### PR DESCRIPTION
close #9330 

Avec cette PR, l'adresse email de l'usager est inscrite dans l'attestation de dépôt dans la section *Identité du demandeur*