### PR TITLE
poc(gems): utilise selenium-webdriver gem plutot que webdrivers qui est actuellement cassé

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,7 +110,6 @@ group :test do
   gem 'shoulda-matchers', require: false
   gem 'timecop'
   gem 'vcr'
-  gem 'webdrivers'
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -425,7 +425,7 @@ GEM
       rake
     mini_magick (4.11.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.2)
+    mini_portile2 (2.8.4)
     minitest (5.18.1)
     msgpack (1.4.2)
     multi_json (1.15.0)
@@ -770,10 +770,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webfinger (1.2.0)
       activesupport
       httpclient (>= 2.4)
@@ -933,7 +929,6 @@ DEPENDENCIES
   vite_rails
   warden
   web-console
-  webdrivers
   webmock
   zipline
   zxcvbn-ruby


### PR DESCRIPTION
…. cf: https://github.com/SplitTime/OpenSplitTime/pull/1100