### PR TITLE
Usager: fix modif en construction lorsqu'un objet associé (geo area…) n'est pas valide

### DIFF
--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -246,7 +246,7 @@ class Champ < ApplicationRecord
     value_attributes = fork || !private? ? [:value, :value_json, :data, :external_id] : []
     relationships = fork || !private? ? [:etablissement, :geo_areas] : []
 
-    deep_clone(only: champ_attributes + value_attributes, include: relationships) do |original, kopy|
+    deep_clone(only: champ_attributes + value_attributes, include: relationships, validate: !fork) do |original, kopy|
       PiecesJustificativesService.clone_attachments(original, kopy)
     end
   end

--- a/spec/models/concern/dossier_clone_concern_spec.rb
+++ b/spec/models/concern/dossier_clone_concern_spec.rb
@@ -207,6 +207,26 @@ RSpec.describe DossierCloneConcern do
 
           # rubocop:enable Lint/BooleanSymbol
         end
+
+        context 'when associated record is invalid' do
+          let(:procedure) do
+            create(:procedure, types_de_champ_public: [
+              { type: :carte, libelle: "Carte", stable_id: 992, mandatory: true }
+            ])
+          end
+
+          before do
+            champ = dossier.champs.find { _1.stable_id == 992 }
+            geo_area = build(:geo_area, champ:, geometry: { "i'm" => "invalid" })
+            geo_area.save!(validate: false)
+          end
+
+          it 'can still fork' do
+            new_dossier.champs.load # load relation so champs are validated below
+
+            expect(new_dossier.champs.find { _1.stable_id == 992 }.geo_areas.first).not_to be_valid
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
On suit la logique du fork: on ne valide pas le dossier / les champs etc… à la création d'un fork.

fix https://demarches-simplifiees.sentry.io/issues/4327864844/
et HS https://secure.helpscout.net/conversation/2311444846/2035958?folderId=1653799