### PR TITLE
API: expose les 2 dates utilisées par le SVA

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -1349,6 +1349,11 @@ type Dossier {
   datePassageEnInstruction: ISO8601DateTime
 
   """
+  Date prévisionnelle de décision automatique par le SVA/SVR.
+  """
+  datePrevisionnelleDecisionSVASVR: ISO8601Date
+
+  """
   Date de la suppression par l’administration.
   """
   dateSuppressionParAdministration: ISO8601DateTime
@@ -1362,6 +1367,11 @@ type Dossier {
   Date du dernier traitement.
   """
   dateTraitement: ISO8601DateTime
+
+  """
+  Date du traitement automatique par le SVA/SVR.
+  """
+  dateTraitementSVASVR: ISO8601DateTime
   demandeur: Demandeur!
   demarche: DemarcheDescriptor!
 

--- a/app/graphql/types/dossier_type.rb
+++ b/app/graphql/types/dossier_type.rb
@@ -32,6 +32,9 @@ module Types
 
     field :date_derniere_correction_en_attente, GraphQL::Types::ISO8601DateTime, "Date de la dernière demande de correction qui n’a pas encore été traitée par l’usager.", null: true
 
+    field :date_previsionnelle_decision_sva_svr, GraphQL::Types::ISO8601Date, "Date prévisionnelle de décision automatique par le SVA/SVR.", null: true, method: :sva_svr_decision_on
+    field :date_traitement_sva_svr, GraphQL::Types::ISO8601DateTime, "Date du traitement automatique par le SVA/SVR.", null: true, method: :sva_svr_decision_triggered_at
+
     field :archived, Boolean, null: false
 
     field :connection_usager, ConnectionUsager, null: false

--- a/spec/graphql/dossier_spec.rb
+++ b/spec/graphql/dossier_spec.rb
@@ -257,6 +257,28 @@ RSpec.describe Types::DossierType, type: :graphql do
     }
   end
 
+  describe 'dossier on sva procedure' do
+    let(:procedure) { create(:procedure, :sva) }
+    let(:query) { DOSSIER_WITH_SVA_QUERY }
+    let(:variables) { { number: dossier.id } }
+
+    context 'dossier en_instruction' do
+      let(:dossier) { create(:dossier, :en_instruction, procedure:, sva_svr_decision_on: 3.days.from_now.to_date) }
+
+      it {
+        expect(data[:dossier][:datePrevisionnelleDecisionSVASVR]).not_to be_nil
+      }
+    end
+
+    context 'dossier accepte' do
+      let(:dossier) { create(:dossier, :accepte, procedure:, sva_svr_decision_triggered_at: 24.hours.ago) }
+
+      it {
+        expect(data[:dossier][:dateTraitementSVASVR]).not_to be_nil
+      }
+    end
+  end
+
   DOSSIER_QUERY = <<-GRAPHQL
   query($number: Int!) {
     dossier(number: $number) {
@@ -436,6 +458,15 @@ RSpec.describe Types::DossierType, type: :graphql do
           dateResolution
         }
       }
+    }
+  }
+  GRAPHQL
+
+  DOSSIER_WITH_SVA_QUERY = <<-GRAPHQL
+  query($number: Int!) {
+    dossier(number: $number) {
+      datePrevisionnelleDecisionSVASVR
+      dateTraitementSVASVR
     }
   }
   GRAPHQL


### PR DESCRIPTION
~~⚠️ @tchak je ne sais pas si c'est normal, graphql ne  réutilise pas la config des inflectors pour la camélisation ? (`datePrevisionnelleDecisionSva` aurait dû être `datePrevisionnelleDecisionSVA` par exemple)~~