### PR TITLE
[refonte usager] Tableau de bord - rendre recherche complémentaire avec filtre par procédure

### DIFF
--- a/app/components/dossiers/user_procedure_filter_component/user_procedure_filter_component.html.haml
+++ b/app/components/dossiers/user_procedure_filter_component/user_procedure_filter_component.html.haml
@@ -1,4 +1,5 @@
 = form_with(url: dossiers_path, method: :get, data: { controller: 'autosubmit' } ) do |f|
+  = f.hidden_field :q, value: params[:q], id: nil
   = f.label :procedure_id, t('.procedure.label'), class: 'sr-only'
   .fr-input-group
     = f.select :procedure_id, options_for_select(@procedures_for_select, params[:procedure_id]), { prompt: t('.procedures.prompt') }, class: 'fr-select'

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -5,7 +5,7 @@ module Users
 
     layout 'procedure_context', only: [:identite, :update_identite, :siret, :update_siret]
 
-    ACTIONS_ALLOWED_TO_ANY_USER = [:index, :recherche, :new, :transferer_all]
+    ACTIONS_ALLOWED_TO_ANY_USER = [:index, :new, :transferer_all]
     ACTIONS_ALLOWED_TO_OWNER_OR_INVITE = [:show, :destroy, :demande, :messagerie, :brouillon, :submit_brouillon, :submit_en_construction, :modifier, :modifier_legacy, :update, :create_commentaire, :papertrail, :restore, :champ]
 
     before_action :ensure_ownership!, except: ACTIONS_ALLOWED_TO_ANY_USER + ACTIONS_ALLOWED_TO_OWNER_OR_INVITE
@@ -340,28 +340,6 @@ module Users
         redirect_to dossiers_path
       else
         flash.alert = t('users.dossiers.ask_deletion.undergoingreview')
-        redirect_to dossiers_path
-      end
-    end
-
-    def recherche
-      @procedures_for_select = nil
-
-      @search_terms = params[:q]
-      return redirect_to dossiers_path if @search_terms.blank?
-
-      @dossiers = DossierSearchService.matching_dossiers_for_user(@search_terms, current_user).page(page)
-
-      if @dossiers.present?
-        # we need the page condition when accessing page n with n>1 when the page has only 1 result
-        # in order to avoid an unpleasant redirection when changing page
-        if @dossiers.count == 1 && page == 1
-          redirect_to url_for_dossier(@dossiers.first)
-        else
-          render :index
-        end
-      else
-        flash.alert = "Vous n’avez pas de dossiers contenant « #{@search_terms} »."
         redirect_to dossiers_path
       end
     end

--- a/app/services/dossier_search_service.rb
+++ b/app/services/dossier_search_service.rb
@@ -10,7 +10,7 @@ class DossierSearchService
 
   def self.matching_dossiers_for_user(search_terms, user)
     dossier_by_exact_id_for_user(search_terms, user)
-      .presence || dossier_by_full_text_for_user(search_terms, Dossier.where(id: user.dossiers.ids + user.dossiers_invites.ids))
+      .presence || dossier_by_full_text_for_user(search_terms, Dossier.includes(:procedure).where(id: user.dossiers.ids + user.dossiers_invites.ids))
   end
 
   private
@@ -38,7 +38,7 @@ class DossierSearchService
 
   def self.dossier_by_full_text_for_user(search_terms, dossiers)
     ts_vector = "to_tsvector('french', search_terms)"
-    ts_query = "to_tsquery('french', #{Dossier.connection.quote(to_tsquery(search_terms))})"
+    ts_query = "to_tsquery('french', #{Dossier.includes(:procedure).connection.quote(to_tsquery(search_terms))})"
 
     dossiers
       .visible_by_user
@@ -49,9 +49,9 @@ class DossierSearchService
   def self.dossier_by_exact_id_for_user(search_terms, user)
     id = search_terms.to_i
     if id != 0 && id_compatible?(id) # Sometimes user is searching dossiers with a big number (ex: SIRET), ActiveRecord can't deal with them and throws ActiveModel::RangeError. id_compatible? prevents this.
-      Dossier.where(id: user.dossiers.visible_by_user.where(id: id) + user.dossiers_invites.visible_by_user.where(id: id)).distinct
+      Dossier.includes(:procedure).where(id: user.dossiers.visible_by_user.where(id: id) + user.dossiers_invites.visible_by_user.where(id: id)).distinct
     else
-      Dossier.none
+      Dossier.includes(:procedure).none
     end
   end
 

--- a/app/views/users/dossiers/_dossiers_list.html.haml
+++ b/app/views/users/dossiers/_dossiers_list.html.haml
@@ -94,7 +94,7 @@
 
 
 - else
-  - if filter.filter_params.present?
+  - if filter.present?
     .blank-tab
       %h2.empty-text= t('views.users.dossiers.dossiers_list.no_result_title')
       %p.empty-text-details
@@ -102,6 +102,13 @@
         %br
         = link_to t('views.users.dossiers.dossiers_list.no_result_reset_filter'), dossiers_path(statut: statut), class: 'fr-btn fr-btn--sm fr-mt-2w'
 
+  - elsif search
+    .blank-tab
+      %h2.empty-text= t('views.users.dossiers.dossiers_list.no_result_title')
+      %p.empty-text-details
+        = t('views.users.dossiers.dossiers_list.no_result_text_with_search')
+        %br
+        = link_to t('views.users.dossiers.dossiers_list.no_result_reset_search'), dossiers_path(), class: 'fr-btn fr-btn--sm fr-mt-2w'
   - else
     .blank-tab
       %h2.empty-text= t('views.users.dossiers.dossiers_list.no_result_title')

--- a/app/views/users/dossiers/index.html.haml
+++ b/app/views/users/dossiers/index.html.haml
@@ -14,7 +14,8 @@
       - if current_user.dossiers.count > 2 || current_user.dossiers_invites.count > 2
         .fr-col
           #search-2.fr-search-bar
-            = form_tag recherche_dossiers_path, method: :get, :role => "search", class: "flex width-100 fr-mb-5w" do
+            = form_tag dossiers_path, method: :get, :role => "search", class: "flex width-100 fr-mb-5w" do
+              = hidden_field_tag :procedure_id, params[:procedure_id]
               = label_tag "q", t('views.users.dossiers.search.search_file'), class: 'fr-label'
               = text_field_tag "q", "#{@search_terms if @search_terms.present?}", placeholder: t('views.users.dossiers.search.search_file'), class: "fr-input"
               %button.fr-btn.fr-btn--sm
@@ -71,7 +72,7 @@
 .fr-container
   .fr-grid-row.fr-grid-row--center
     .fr-col-xl-10
-      - if @statut == "en-cours"
+      - if @statut == "en-cours" && @search_terms.blank?
         - if @first_brouillon_recently_updated.present?
           = render Dsfr::CalloutComponent.new(title: t('users.dossiers.header.callout.first_brouillon_recently_updated_title'), heading_level: 'h2') do |c|
             - c.with_body do
@@ -80,8 +81,11 @@
               = link_to t('users.dossiers.header.callout.first_brouillon_recently_updated_button'), url_for_dossier(@first_brouillon_recently_updated), class: 'fr-btn'
 
       - if @search_terms.present?
-        %h2.page-title Résultat de la recherche pour « #{@search_terms} »
-        = render partial: "dossiers_list", locals: { dossiers: @dossiers }
+        %h2.page-title
+          = t('views.users.dossiers.search.result_term_title', search_terms: @search_terms)
+          - if @procedure_id.present?
+            = t('views.users.dossiers.search.result_procedure_title', procedure_libelle: @procedures_for_select.rassoc(@procedure_id.to_i).first)
+        = render partial: "dossiers_list", locals: { dossiers: @dossiers_visibles, filter: nil, search: true }
 
       - else
         = render Dossiers::UserFilterComponent.new(statut: @statut, filter: @filter, procedure_id: @procedure_id )
@@ -90,4 +94,4 @@
           -# /!\ in this context, @dossiers is a collection of DeletedDossier not Dossier
           = render partial: "deleted_dossiers_list", locals: { deleted_dossiers: @dossiers }
         - else
-          = render partial: "dossiers_list", locals: { dossiers: @dossiers, filter: @filter, statut: @statut }
+          = render partial: "dossiers_list", locals: { dossiers: @dossiers, filter: @filter, statut: @statut, search: false }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -456,6 +456,8 @@ en:
         search:
           search_file: Search a file (File number, keywords)
           simple: Search
+          result_term_title: Search result for « %{search_terms} »
+          result_procedure_title: and procedure « %{procedure_libelle} »
         secondary_menu: Secondary menu
         index:
           dossiers: "My files"
@@ -463,6 +465,8 @@ en:
           n_dossier: "File n."
           no_result_title: No files
           no_result_text_html: "To fill a procedure, contact your administration asking for the procedure link. <br> It should look like %{app_base}/commencer/xxx."
+          no_result_text_with_search: found with search terms
+          no_result_reset_search: Reset search
           no_result_text_with_filter: found with selected filters
           no_result_reset_filter: Reset filters
           procedure_closed: This procedure has been closed, you will not be able to submit a file again from the procedure link, contact your administration for more information.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -459,6 +459,9 @@ fr:
         search:
           search_file: Rechercher un dossier (N° de dossier, mots-clés)
           simple: Rechercher
+          result: Résultat de la recherche pour « %{search_terms} »
+          result_term_title: Résultat de la recherche pour « %{search_terms} »
+          result_procedure_title: et pour la procédure « %{procedure_libelle} »
         secondary_menu: Menu secondaire
         index:
           dossiers: "Mes dossiers"
@@ -466,6 +469,8 @@ fr:
           n_dossier: "dossier Nº "
           no_result_title: Aucun dossier
           no_result_text_html: "Pour remplir une démarche, contactez votre administration en lui demandant le lien de la démarche. <br> Celui ci doit ressembler à %{app_base}/commencer/xxx."
+          no_result_text_with_search: ne correspond aux termes recherchés
+          no_result_reset_search: Réinitialiser la recherche
           no_result_text_with_filter: ne correspond aux filtres sélectionnés
           no_result_reset_filter: Réinitialiser les filtres
           procedure_closed: Cette démarche a été clôturée, vous ne pourrez pas redéposer de dossier à partir du lien de la démarche, contactez votre administration pour plus d’information.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -459,7 +459,6 @@ fr:
         search:
           search_file: Rechercher un dossier (N° de dossier, mots-clés)
           simple: Rechercher
-          result: Résultat de la recherche pour « %{search_terms} »
           result_term_title: Résultat de la recherche pour « %{search_terms} »
           result_procedure_title: et pour la procédure « %{procedure_libelle} »
         secondary_menu: Menu secondaire

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -331,7 +331,6 @@ Rails.application.routes.draw do
 
       collection do
         get 'transferer', to: 'dossiers#transferer_all'
-        get 'recherche'
         resources :transfers, only: [:create, :update, :destroy]
       end
     end

--- a/spec/system/users/invite_spec.rb
+++ b/spec/system/users/invite_spec.rb
@@ -164,16 +164,18 @@ describe 'Invitations' do
         visit dossiers_path
       end
 
-      it "can search by id and it redirects to the dossier page" do
+      it "can search by id and it displays the dossier" do
         page.find_by_id('q').set(dossier.id)
         find('.fr-search-bar .fr-btn').click
-        expect(current_path).to eq(dossier_path(dossier))
+        expect(current_path).to eq(dossiers_path)
+        expect(page).to have_link(dossier.procedure.libelle)
       end
 
-      it "can search something inside the dossier and it redirects to the dossier page" do
+      it "can search something inside the dossier and it displays the dossier" do
         page.find_by_id('q').set(dossier_2.champs_public.first.value)
         find('.fr-search-bar .fr-btn').click
-        expect(current_path).to eq(dossier_path(dossier_2))
+        expect(current_path).to eq(dossiers_path)
+        expect(page).to have_link(dossier.procedure.libelle)
       end
     end
   end


### PR DESCRIPTION
Suite à la mise en place du filtre par procédure sur le dashboard usager #9338 , on a souhaité la rendre compatible avec la barre de recherche - pour pouvoir filtrer selon les 2 critères et non l'un après l'autre.

En faisant ça, on a simplifié le fonctionnement de la recherche qui faisait avant des redirections sur la page d'un dossier s'il n'y avait qu'un seul résultat de recherche.


![image](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/59873b61-dea6-40e9-9023-0556f0f2fe36)

![image](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/d4d3bc03-0920-4e07-98c4-c5f0184e01ab)

![image](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/1e7feebf-c901-40aa-92ae-0891c359c505)
