### PR TITLE
ETQ Instructeur, je voudrais pouvoir créer des listes avec une numérotation personnalisée et sur plusieurs lignes

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -150,7 +150,7 @@ linters:
     properties: {}
 
   PseudoElement:
-    enabled: true
+    enabled: false # otherwise rules on ::marker fails
 
   # To enable later
   QualifyingElement:

--- a/app/assets/stylesheets/dsfr.scss
+++ b/app/assets/stylesheets/dsfr.scss
@@ -1,5 +1,15 @@
 @import "colors";
 
+// overwrite DSFR style for SimpleFormatComponent, some user use markdown with
+// ordered list having paragraph between list item
+.fr-ol-content--override {
+  list-style-type: decimal;
+
+  li::marker {
+    content: inherit;
+  }
+}
+
 // override default transparent background on inputs & font-size to 16px by default
 input,
 textarea,

--- a/app/components/simple_format_component.rb
+++ b/app/components/simple_format_component.rb
@@ -51,7 +51,7 @@ class SimpleFormatComponent < ApplicationComponent
     end.join.lstrip
 
     @renderer = Redcarpet::Markdown.new(
-      Redcarpet::BareRenderer.new(class_names_map:),
+      Redcarpet::BareRenderer.new(class_names_map: { list: 'fr-ol-content--override' }),
       REDCARPET_EXTENSIONS.merge(autolink: @allow_a)
     )
   end

--- a/app/lib/redcarpet/bare_renderer.rb
+++ b/app/lib/redcarpet/bare_renderer.rb
@@ -10,7 +10,14 @@ module Redcarpet
     end
 
     def list_item(content, list_type)
-      content_tag(:li, content.strip.gsub(/<\/?p>/, ''), {}, false)
+      item_number = content.match(/\[value:(\d+)\]/)
+      text = content.strip
+        .gsub(/<\/?p>/, '')
+        .gsub(/\[value:\d+\]/, '')
+        .gsub(/\n/, '<br>')
+      attributes = item_number.present? ? { value: item_number[1] } : {}
+
+      content_tag(:li, text, attributes, false)
     end
 
     def paragraph(text)

--- a/spec/components/simple_format_component_spec.rb
+++ b/spec/components/simple_format_component_spec.rb
@@ -47,11 +47,59 @@ TEXT
       <<~TEXT
         1. 1er paragraphe
         2. paragraphe
+        4. 4eme paragraphe
       TEXT
     end
 
     it { expect(page).to have_selector("ol", count: 1) }
-    it { expect(page).to have_selector("li", count: 2) }
+    it { expect(page).to have_selector("li", count: 3) }
+    it { expect(page.native.inner_html).to match('value="1"') }
+    it { expect(page.native.inner_html).to match('value="4"') }
+  end
+
+  context 'multi line lists' do
+    let(:text) do
+      <<~TEXT
+        Lorsque nous souhaitons envoyer ce message :
+
+        1. Premier point de la recette
+        Commentaire 1
+        2. Deuxième point de la recette
+          Commentaire 2
+
+        4. Troisième point de la recette
+        Commentaire 3
+
+        trois nouveaux paragraphes
+        sur plusieures
+        lignes
+
+        - 1er point de la recette
+        * 2eme point de la recette
+        avec des détailles
+        + 3eme point de la recette
+        beaucoup
+        de détails
+
+        conclusion
+      TEXT
+    end
+
+    it { expect(page).to have_selector("ol", count: 1) }
+    it { expect(page).to have_selector("ul", count: 1) }
+    it { expect(page).to have_selector("li", count: 6) }
+    it { expect(page).to have_selector("p", count: 5) }
+  end
+
+  context 'strong' do
+    let(:text) do
+      <<~TEXT
+        1er paragraphe **fort** un_mot_pas_italic
+      TEXT
+    end
+
+    it { expect(page).to have_selector("strong", count: 1) }
+    it { expect(page).not_to have_selector("em") }
   end
 
   context 'auto-link' do


### PR DESCRIPTION
Cela corrige le problème au niveau du HTML en utilisant la technique : https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li#ordered_list_with_a_custom_value

Mais le rendu est toujours incorrect. Je suppose qu'il y a un bug de CSS dans DSFR qui est trop agressif dans les styles des listes ? Si @mfo ou @colinux vous avez une idée je suis preneur :)