### PR TITLE
Corrige le routage si option "autre" sélectionnée

### DIFF
--- a/app/components/procedure/one_groupe_management_component.rb
+++ b/app/components/procedure/one_groupe_management_component.rb
@@ -60,6 +60,6 @@ class Procedure::OneGroupeManagementComponent < ApplicationComponent
     return [] if targeted_champ.is_a?(Logic::Empty)
     targeted_champ
       .options(@revision.types_de_champ_public)
-      .map { |tdc| [tdc.first, constant(tdc.first).to_json] }
+      .map { |(label, value)| [label, constant(value).to_json] }
   end
 end

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -40,7 +40,7 @@ module Administrateurs
 
       tdc = @procedure.active_revision.routable_types_de_champ.find { |tdc| tdc.stable_id == stable_id }
 
-      tdc_options = tdc.options["drop_down_options"].reject(&:empty?)
+      tdc_options = tdc.drop_down_options.reject(&:empty?)
 
       tdc_options.each do |option_label|
         gi = @procedure.groupe_instructeurs.find_by({ label: option_label }) || @procedure.groupe_instructeurs

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -43,9 +43,19 @@ module Administrateurs
       tdc_options = tdc.drop_down_options.reject(&:empty?)
 
       tdc_options.each do |option_label|
-        gi = @procedure.groupe_instructeurs.find_by({ label: option_label }) || @procedure.groupe_instructeurs
-          .create({ label: option_label, instructeurs: [current_administrateur.instructeur] })
-        gi.update(routing_rule: ds_eq(champ_value(stable_id), constant(gi.label)))
+        routing_rule = ds_eq(champ_value(stable_id), constant(option_label))
+        @procedure
+          .groupe_instructeurs
+          .find_or_create_by(label: option_label)
+          .update(instructeurs: [current_administrateur.instructeur], routing_rule:)
+      end
+
+      if tdc.drop_down_other?
+        routing_rule = ds_eq(champ_value(stable_id), constant(Champs::DropDownListChamp::OTHER))
+        @procedure
+          .groupe_instructeurs
+          .find_or_create_by(label: 'Autre')
+          .update(instructeurs: [current_administrateur.instructeur], routing_rule:)
       end
 
       @procedure.toggle_routing

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -117,7 +117,8 @@ class GroupeInstructeur < ApplicationRecord
 
   def routing_rule_matches_tdc?
     routing_tdc = procedure.active_revision.types_de_champ.find_by(stable_id: routing_rule.left.stable_id)
-    routing_rule.right.value.in?(routing_tdc.options['drop_down_options'])
+    options = routing_tdc.options_with_drop_down_other
+    routing_rule.right.value.in?(options)
   end
 
   serialize :routing_rule, LogicSerializer

--- a/app/models/logic/champ_value.rb
+++ b/app/models/logic/champ_value.rb
@@ -31,7 +31,7 @@ class Logic::ChampValue < Logic::Term
     targeted_champ = champ(champs)
 
     return nil if !targeted_champ.visible?
-    return nil if targeted_champ.blank?
+    return nil if targeted_champ.blank? & !targeted_champ.drop_down_other?
 
     # on dépense 22ms ici, à cause du map, mais on doit pouvoir passer par un champ type
     case targeted_champ.type

--- a/app/models/logic/constant.rb
+++ b/app/models/logic/constant.rb
@@ -17,6 +17,8 @@ class Logic::Constant < Logic::Term
       I18n.t('utils.yes')
     when FalseClass
       I18n.t('utils.no')
+    when Champs::DropDownListChamp::OTHER
+      'Autre'
     else
       @value.to_s
     end

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -517,6 +517,14 @@ class TypeDeChamp < ApplicationRecord
     (drop_down_list_options - drop_down_list_disabled_options).reject(&:empty?)
   end
 
+  def options_with_drop_down_other
+    if drop_down_other?
+      drop_down_options + [Champs::DropDownListChamp::OTHER]
+    else
+      drop_down_options
+    end
+  end
+
   def layer_enabled?(layer)
     options && options[layer] && options[layer] != '0'
   end

--- a/lib/tasks/deployment/20230728085422_update_routing_rule_for_groups_routing_from_drop_down_other.rake
+++ b/lib/tasks/deployment/20230728085422_update_routing_rule_for_groups_routing_from_drop_down_other.rake
@@ -1,0 +1,23 @@
+namespace :after_party do
+  desc 'Deployment task: update_routing_rule_for_groups_routing_from_drop_down_other'
+  task update_routing_rule_for_groups_routing_from_drop_down_other: :environment do
+    puts "Running deploy task 'update_routing_rule_for_groups_routing_from_drop_down_other'"
+
+    # Put your task implementation HERE.
+    include Logic
+
+    GroupeInstructeur
+      .joins(:procedure)
+      .where(procedures: { routing_enabled: true })
+      .in_batches do |groupe_instructeurs|
+        groupe_instructeurs
+          .filter { |gi| gi.routing_rule.present? && gi.routing_rule.right.value == 'Autre' }
+          .each { |gi| gi.update(routing_rule: ds_eq(gi.routing_rule.left, constant('__other__'))) }
+      end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
- Cette PR permet de router des dossiers vers les groupes d'instructeurs correspondant à l'option `Autre` du type de champ dédié au routage.
- Dans ce cas, la routing rule a pour valeur `__other__` (`Champs::DropDownListChamp::OTHER`)
- Cependant, pour ne pas perturber les administrateurs, on affiche `Autre` a la place de `__other__` dans la liste des groupes d'instructeurs qui mentionnent les règles de routage.
- Il y a une after_party pour mettre à jour la règle de routage des quelques groupes concernés (une vingtaine). La valeur passe de `Autre` à `__other__`