### PR TITLE
  Nettoyage du code de l'ancien système de routage (suite)

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -58,8 +58,6 @@ class Dossier < ApplicationRecord
   include DossierSearchableConcern
   include DossierSectionsConcern
 
-  self.ignored_columns += [:migrated_champ_routage]
-
   enum state: {
     brouillon:       'brouillon',
     en_construction: 'en_construction',

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -78,8 +78,7 @@ class Procedure < ApplicationRecord
     :durees_conservation_required,
     :cerfa_flag,
     :test_started_at,
-    :lien_demarche,
-    :migrated_champ_routage
+    :lien_demarche
   ]
 
   default_scope -> { kept }

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -78,7 +78,8 @@ class Procedure < ApplicationRecord
     :durees_conservation_required,
     :cerfa_flag,
     :test_started_at,
-    :lien_demarche
+    :lien_demarche,
+    :routing_criteria_name
   ]
 
   default_scope -> { kept }

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -13,7 +13,6 @@
 #
 class ProcedureRevision < ApplicationRecord
   self.implicit_order_column = :created_at
-  self.ignored_columns += [:migrated_champ_routage]
   belongs_to :procedure, -> { with_discarded }, inverse_of: :revisions, optional: false
   belongs_to :dossier_submitted_message, inverse_of: :revisions, optional: true, dependent: :destroy
 

--- a/db/migrate/20230801121131_remove_migrated_champ_routage_columns.rb
+++ b/db/migrate/20230801121131_remove_migrated_champ_routage_columns.rb
@@ -1,0 +1,7 @@
+class RemoveMigratedChampRoutageColumns < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured { remove_column :procedures, :migrated_champ_routage }
+    safety_assured { remove_column :procedure_revisions, :migrated_champ_routage }
+    safety_assured { remove_column :dossiers, :migrated_champ_routage }
+  end
+end


### PR DESCRIPTION
- Enlève les colonnes `migrated_champ_routage` de 3 tables après les avoir ignorées dans une PR précédente (https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/9237)
- Ignore la colonne `routing_criteria_name`