### PR TITLE
ETQ admin d'une démarche routée, je suis alerté à la publication si des groupes n'ont pas de règle de routage valide

### DIFF
--- a/app/components/procedure/revision_changes_component/revision_changes_component.fr.yml
+++ b/app/components/procedure/revision_changes_component/revision_changes_component.fr.yml
@@ -9,6 +9,7 @@ fr:
     other: "%{count} dossiers en cours de traitement portent ce champ. Les <strong>données</strong> associées avec ce champ seront <strong>supprimées</strong>."
   add_option: "ajoutés : %{items}"
   remove_option: "supprimés : %{items}"
+  invalid_routing_rules_alert: "Certains groupes d'instructeurs ont une règle de routage invalide. Veuillez mettre à jour la configuration des groupes d'instructeurs après avoir publié les modifications."
   public:
     add: Le champ « %{label} » a été ajouté.
     add_mandatory: Le champ obligatoire « %{label} » a été ajouté.

--- a/app/components/procedure/revision_changes_component/revision_changes_component.html.haml
+++ b/app/components/procedure/revision_changes_component/revision_changes_component.html.haml
@@ -148,3 +148,7 @@
   - if @private_move_changes.present?
     - list.with_item do
       = t(".private.move", count: @private_move_changes.size)
+  - if @previous_revision.procedure.groupe_instructeurs.any?(&:invalid_rule?)
+    - list.with_item do
+      .fr-alert.fr-alert--warning.fr-mt-1v
+        = t(".invalid_routing_rules_alert")

--- a/app/components/procedure/revision_changes_component/revision_changes_component.html.haml
+++ b/app/components/procedure/revision_changes_component/revision_changes_component.html.haml
@@ -74,7 +74,7 @@
           - if !total_dossiers.zero? && !change.can_rebase?
             .fr-alert.fr-alert--warning.fr-mt-1v
               %p= t('.breaking_change', count: total_dossiers)
-          - if removed.present? && change.type_de_champ.used_by_routing_rules?
+          - if (removed.present? || added.present? ) && change.type_de_champ.used_by_routing_rules?
             .fr-alert.fr-alert--warning.fr-mt-1v
               = t(".#{prefix}.update_drop_down_options_alert", label: change.label)
       - when :drop_down_other


### PR DESCRIPTION
closes #9383 
Il y avait déjà une alerte si une option du tdc utilisé pour le routage était enlevé. On alerte aussi si une option est ajoutée. Et s'il y a des groupes d'instructeurs avec règle de routage invalide.

![Screenshot from 2023-08-03 13-59-50](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/29131404/7d8746a5-055a-4912-9082-16facec4449c)
