### PR TITLE
Tech : déplace une validation sur le groupe d'instructeurs défaut du controleur au modèle

### DIFF
--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -147,20 +147,13 @@ module Administrateurs
     def update_state
       @groupe_instructeur = procedure.groupe_instructeurs.find(params[:groupe_instructeur_id])
 
-      if closed_params? && @groupe_instructeur.id == procedure.defaut_groupe_instructeur.id
-        redirect_to admin_procedure_groupe_instructeur_path(procedure, @groupe_instructeur),
-          alert: "Il est impossible de désactiver le groupe d’instructeurs par défaut."
-      elsif @groupe_instructeur.update(closed: params[:closed])
+      if @groupe_instructeur.update(closed: params[:closed])
         state_for_notice = @groupe_instructeur.closed ? 'désactivé' : 'activé'
         redirect_to admin_procedure_groupe_instructeur_path(procedure, @groupe_instructeur),
           notice: "Le groupe #{@groupe_instructeur.label} est #{state_for_notice}."
       else
-        @procedure = procedure
-        @instructeurs = paginated_instructeurs
-        @available_instructeur_emails = available_instructeur_emails
-
-        flash.now[:alert] = @groupe_instructeur.errors.full_messages
-        render :show
+        redirect_to admin_procedure_groupe_instructeur_path(procedure, @groupe_instructeur),
+          alert: @groupe_instructeur.errors.messages_for(:closed).to_sentence
       end
     end
 

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -16,7 +16,8 @@ class GroupeInstructeur < ApplicationRecord
 
   validates :label, presence: true, allow_nil: false
   validates :label, uniqueness: { scope: :procedure }
-  validates :closed, acceptance: { accept: [false] }, if: -> do
+  validates :closed, acceptance: { accept: [false], message: I18n.t('.activerecord.errors.models.groupe_instructeur.defaut') }, if: -> { (self == procedure.defaut_groupe_instructeur) }
+  validates :closed, acceptance: { accept: [false], message: 'Il doit y avoir au moins un groupe d’instructeurs actif sur chaque démarche' }, if: -> do
     if closed
       (other_groupe_instructeurs.map(&:closed) + [closed]).all?
     else

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -16,14 +16,7 @@ class GroupeInstructeur < ApplicationRecord
 
   validates :label, presence: true, allow_nil: false
   validates :label, uniqueness: { scope: :procedure }
-  validates :closed, acceptance: { accept: [false], message: I18n.t('.activerecord.errors.models.groupe_instructeur.defaut') }, if: -> { (self == procedure.defaut_groupe_instructeur) }
-  validates :closed, acceptance: { accept: [false], message: 'Il doit y avoir au moins un groupe d’instructeurs actif sur chaque démarche' }, if: -> do
-    if closed
-      (other_groupe_instructeurs.map(&:closed) + [closed]).all?
-    else
-      false
-    end
-  end
+  validates :closed, acceptance: { accept: [false] }, if: -> { (self == procedure.defaut_groupe_instructeur) }
 
   before_validation -> { label&.strip! }
 

--- a/config/locales/models/groupe_instructeur/fr.yml
+++ b/config/locales/models/groupe_instructeur/fr.yml
@@ -15,4 +15,4 @@ fr:
               format: "Le libellé %{message}"
             closed:
               format: "%{message}"
-              accepted: Il doit y avoir au moins un groupe d’instructeurs actif sur chaque démarche
+              accepted: Il est impossible de désactiver le groupe d’instructeurs par défaut.

--- a/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
@@ -639,9 +639,9 @@ describe API::V2::GraphqlController do
         let(:variables) { { input: { groupeInstructeurId: dossier.groupe_instructeur.to_typed_id, closed: true } } }
 
         context 'with multiple groupes' do
-          before do
-            create(:groupe_instructeur, procedure: procedure)
-          end
+          let!(:defaut_groupe_instructeur) { create(:groupe_instructeur, procedure: procedure) }
+
+          before { procedure.update(defaut_groupe_instructeur_id: defaut_groupe_instructeur.id) }
 
           it {
             expect(gql_errors).to be_nil
@@ -656,10 +656,11 @@ describe API::V2::GraphqlController do
           let(:types_de_champ_public) { [{ type: :drop_down_list }] }
           let(:groupe_instructeur) { procedure.groupe_instructeurs.first }
           let(:routing_champ) { procedure.active_revision.types_de_champ.first }
+          let!(:defaut_groupe_instructeur) { create(:groupe_instructeur, procedure: procedure) }
 
           before do
             groupe_instructeur.update(routing_rule: ds_eq(champ_value(routing_champ.stable_id), constant(groupe_instructeur.label)))
-            create(:groupe_instructeur, procedure: procedure)
+            procedure.update(defaut_groupe_instructeur_id: defaut_groupe_instructeur.id)
             Flipper.enable(:groupe_instructeur_api_hack, procedure)
           end
 
@@ -675,7 +676,7 @@ describe API::V2::GraphqlController do
         context 'validation error' do
           it {
             expect(gql_errors).to be_nil
-            expect(gql_data[:groupeInstructeurModifier][:errors].first[:message]).to eq('Il doit y avoir au moins un groupe d’instructeurs actif sur chaque démarche')
+            expect(gql_data[:groupeInstructeurModifier][:errors].first[:message]).to eq('Il est impossible de désactiver le groupe d’instructeurs par défaut.')
           }
         end
       end

--- a/spec/models/groupe_instructeur_spec.rb
+++ b/spec/models/groupe_instructeur_spec.rb
@@ -99,14 +99,15 @@ describe GroupeInstructeur, type: :model do
   end
 
   describe "active group validations" do
-    context "there is at least one active groupe instructeur" do
-      let(:gi_active) { procedure.defaut_groupe_instructeur }
-      let(:gi_closed) { create(:groupe_instructeur, procedure:) }
-      before do
-        gi_active
-        gi_closed.update(closed: true)
-      end
+    let(:gi_active) { procedure.defaut_groupe_instructeur }
+    let(:gi_closed) { create(:groupe_instructeur, procedure:) }
 
+    before do
+      gi_active
+      gi_closed.update(closed: true)
+    end
+
+    context "there is one active groupe instructeur" do
       it "closed is valid when there is one other active groupe" do
         expect(gi_active).to be_valid
         expect(gi_closed).to be_valid
@@ -114,6 +115,15 @@ describe GroupeInstructeur, type: :model do
 
       it "closed is invalid when there is no active groupe" do
         gi_active.closed = true
+        expect(gi_active).not_to be_valid
+      end
+    end
+
+    context "there are many active groupes instructeurs" do
+      let!(:second_gi_active) { create(:groupe_instructeur, procedure:) }
+
+      it "closed is invalid for defaut groupe instructeur even if many active groupes" do
+        gi_active.update(closed: true)
         expect(gi_active).not_to be_valid
       end
     end


### PR DESCRIPTION
PR de refacto : 
- La validation qui empêche de désactiver le groupe d'instructeurs défaut passe du controleur au modèle.
- L'autre validation, qui vérifie qu'il y a au moins un groupe actif, est enlevée, parce que c'est un doublon de la précédente