### PR TITLE
fix(admin): replaced a hard-coded value in mailer/activate_before_expiration template

### DIFF
--- a/app/mailers/administrateur_mailer.rb
+++ b/app/mailers/administrateur_mailer.rb
@@ -4,6 +4,7 @@ class AdministrateurMailer < ApplicationMailer
 
   def activate_before_expiration(user, reset_password_token)
     @user = user
+    @author_name = BizDev.full_name(administration_id)
     @reset_password_token = reset_password_token
     @expiration_date = @user.reset_password_sent_at + Devise.reset_password_within
     @subject = "N'oubliez pas d’activer votre compte administrateur"

--- a/app/views/administrateur_mailer/activate_before_expiration.haml
+++ b/app/views/administrateur_mailer/activate_before_expiration.haml
@@ -15,4 +15,4 @@
   Nous restons à votre disposition si vous avez besoin d’accompagnement.
 
 %p
-  = render partial: "layouts/mailers/bizdev_signature", locals: { author_name: "Benjamin Doberset" }
+  = render partial: "layouts/mailers/bizdev_signature", locals: { author_name: @author_name }


### PR DESCRIPTION
Closes #9393 

## Résumé

ETQ Adminsitrateur, le mail "N'oubliez pas d’activer votre compte administrateur" 
à une signature (prénom, nom) codée en dur

## Actuellement

[app/views/administrateur_mailer/activate_before_expiration.haml](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/blob/main/app/views/administrateur_mailer/activate_before_expiration.haml#L18)
```ruby
  = render partial: "layouts/mailers/bizdev_signature", locals: { author_name: "PrénomCodéEnDur NomCodéEnDur" }
```


## Correctif proposé

Comportement identique au mail  _"Activez votre compte administrateur"_

[app/views/administration_mailer/invite_admin.html.haml](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/blob/main/app/views/administration_mailer/invite_admin.html.haml#L24)
```ruby
  = render partial: "layouts/mailers/bizdev_signature", locals: { author_name: @author_name }
```

  --------------------
> `trackingAdullactContrib`   `trackingAdullactBugReport`



