### PR TITLE
fix: display close when procedure depubliee

### DIFF
--- a/app/views/administrateurs/procedures/_procedures_list.html.haml
+++ b/app/views/administrateurs/procedures/_procedures_list.html.haml
@@ -55,11 +55,11 @@
 
       .text-right
         %p.fr-mb-0.width-max-content N° #{number_with_html_delimiter(procedure.id)}
-        - if procedure.close?
+        - if procedure.close? || procedure.depubliee?
           %span.fr-badge.fr-badge--sm.fr-badge--warning
             = t('closed', scope: [:layouts, :breadcrumb])
 
-        - elsif procedure.locked?
+        - elsif procedure.publiee?
           %span.fr-badge.fr-badge--sm.fr-badge--success
             = t('published', scope: [:layouts, :breadcrumb])
 


### PR DESCRIPTION
Bug remonté : une procédure dépubliée est indiquée dans l'interface d'admin comme publiée.
Cette PR affiche une procédure dépubliée comme close.