### PR TITLE
ETQ admin, dans les personnes impliquées, je vois la liste des instructeurs suivants le dossier triée par ordre d'envoi

### DIFF
--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -85,7 +85,8 @@ module Instructeurs
     end
 
     def personnes_impliquees
-      @following_instructeurs_emails = dossier.followers_instructeurs.map(&:email)
+      # sort following_instructeurs (last follower on top) for the API of Agence de l'Eau Loire-Bretagne
+      @following_instructeurs_emails = dossier.followers_instructeurs.joins(:follows).merge(Follow.order(id: :desc)).map(&:email)
       previous_followers = dossier.previous_followers_instructeurs - dossier.followers_instructeurs
       @previous_following_instructeurs_emails = previous_followers.map(&:email)
       @avis_emails = dossier.experts.map(&:email)


### PR DESCRIPTION
L'agence de l'eau Loire-Bretagne utilise une API qui met en lien DS avec leur outil de gestion. Leur système se base sur l'ordre d'affichage des instructeurs qui suivent le dossier dans l'onglet personnes impliquées : le dossier est fléché vers l'instructeur situé 
en tête de liste.
Jusqu'à présent notre requête affichait les instructeurs dans un ordre pouvant être différent selon les démarches.
Là on fait en sorte d'afficher en haut de liste les derniers instructeurs à qui le dossier a été envoyé.
Ce mode de fonctionnement ne me parait pas idéal, mais ça ne nous coûte pas grand chose.

Voir sur HS : https://secure.helpscout.net/conversation/2286597564/2033751/