### PR TITLE
Correctif : exclut les dossiers en brouillon de la recherche (etq instructeur)

### DIFF
--- a/app/controllers/recherche_controller.rb
+++ b/app/controllers/recherche_controller.rb
@@ -35,7 +35,7 @@ class RechercheController < ApplicationController
     # to make it simpler we only do it if the @search_terms is an id
     return if !DossierSearchService.id_compatible?(@search_terms)
 
-    dossier_instructeur_searched_for = Dossier.find_by(id: @search_terms)
+    dossier_instructeur_searched_for = Dossier.state_not_brouillon.find_by(id: @search_terms)
 
     return if dossier_instructeur_searched_for.nil?
     return if current_instructeur&.groupe_instructeur_ids&.include?(dossier_instructeur_searched_for.groupe_instructeur_id)

--- a/spec/controllers/recherche_controller_spec.rb
+++ b/spec/controllers/recherche_controller_spec.rb
@@ -78,6 +78,20 @@ describe RechercheController, type: :controller do
         end
       end
 
+      context 'when dossier is brouillon without groupe instructeur' do
+        let(:dossier2) { create(:dossier, :brouillon, procedure: procedure) }
+        let(:query) { dossier2.id }
+        before { dossier2.update(groupe_instructeur_id: nil) }
+
+        it { is_expected.to have_http_status(200) }
+
+        it 'does not return the dossier' do
+          subject
+          expect(assigns(:projected_dossiers).count).to eq(0)
+          expect(assigns(:dossier_not_in_instructor_group)).to eq(nil)
+        end
+      end
+
       context 'when instructeur is attached to the procedure but is not in the instructor group of the dossier' do
         let!(:gi_p1_1) { GroupeInstructeur.create(label: 'groupe 1', procedure: procedure) }
         let!(:gi_p1_2) { GroupeInstructeur.create(label: 'groupe 2', procedure: procedure) }


### PR DESCRIPTION
Lorsqu'un instructeur faisait une recherche par id d'un dossier encore en brouillon (donc sans groupe instructeurs) on avait une erreur 500.

cf https://demarches-simplifiees.sentry.io/issues/4275606696/?project=1429550&query=is%3Aunresolved&referrer=issue-stream&stream_index=2
