### PR TITLE
Usager: corrige un texte sur la configuration de firewall en cas d'erreur de pjs

### DIFF
--- a/app/javascript/shared/activestorage/auto-upload.ts
+++ b/app/javascript/shared/activestorage/auto-upload.ts
@@ -84,7 +84,8 @@ export class AutoUpload {
       return {
         title:
           'Le fichier n’a pas pu être envoyé. Vérifiez votre connexion à Internet, puis ré-essayez. Vérifiez aussi que le pare-feu de votre appareil ou votre réseau autorise l’envoi de fichier vers ' +
-          window.location.host,
+          window.location.host +
+          ' et static.demarches-simplifiees.fr.',
         retry: true
       };
     } else if (error.code == ERROR_CODE_READ) {


### PR DESCRIPTION
voir ce [retour](https://secure.helpscout.net/conversation/2341368692/2038390/) .

> le message d'erreur est erroné : il indiquait qu'il fallait autoriser 'www.demarches-simplifiees.fr' sur notre pare-feu mais c'est insuffisant, il a fallu autoriser « *.demarches-simplifiees.fr » (* = n'importe quel nom, plus particulièrement dans votre cas 'static').

Le fix est pas joli ni multi instance, mais j'ai pas trouvé comment faire mieux proprement et ça ne devrait pas faire plus de mal.