### PR TITLE
Amélioration SVA/SVR: supporte le scénario d'un dossier terminé et repassé en instruction

### DIFF
--- a/app/components/instructeurs/sva_svr_decision_badge_component/sva_svr_decision_badge_component.en.yml
+++ b/app/components/instructeurs/sva_svr_decision_badge_component/sva_svr_decision_badge_component.en.yml
@@ -1,7 +1,10 @@
 ---
  en:
-  no_sva: Submitted before SVA
-  no_svr: Submitted before SVR
+  manual_decision: Manual instruction
+  manual_decision_title: The file must be processed by an instructor, either because it was submitted before the %{decision} configuration, or because it has been returned to the instruction stage.
+  depose_before_configuration: Submitted before %{decision}
+  depose_before_configuration_title: This file was submitted before the %{decision} configuration.
+  previously_termine_title: The file has been returned to the instruction stage. It must now be processed by an instructor.
   in_days:
     zero: Today
     one: Tomorrow

--- a/app/components/instructeurs/sva_svr_decision_badge_component/sva_svr_decision_badge_component.fr.yml
+++ b/app/components/instructeurs/sva_svr_decision_badge_component/sva_svr_decision_badge_component.fr.yml
@@ -1,7 +1,10 @@
 ---
   fr:
-    no_sva: Déposé avant SVA
-    no_svr: Déposé avant SVR
+    manual_decision: Instruction manuelle
+    manual_decision_title: Le dossier doit être traité par un instructeur, soit car il a été déposé avant la configuration %{decision}, soit car il a été repassé en instruction.
+    depose_before_configuration: Déposé avant %{decision}
+    depose_before_configuration_title: Ce dossier a été déposé avant la configuration %{decision}.
+    previously_termine_title: Le dossier a été repassé en instruction. Il doit être traité par un instructeur.
     in_days:
       zero: Aujourd’hui
       one: Demain

--- a/app/components/instructeurs/sva_svr_decision_badge_component/sva_svr_decision_badge_component.html.haml
+++ b/app/components/instructeurs/sva_svr_decision_badge_component/sva_svr_decision_badge_component.html.haml
@@ -1,11 +1,14 @@
-- if without_date?
-  %span.fr-badge.fr-badge--sm
-    = t(sva? ? '.no_sva' : '.no_svr')
-- else
-  %span{ class: classes, title: title }
-    - if with_label.present?
-      = label_for_badge
-    - if pending_correction?
-      = t('.remaining_days_after_correction', count: days_count)
-    - else
-      = t('.in_days', count: days_count)
+%span{ class: classes, title: title }
+  - if with_label.present?
+    = label_for_badge
+
+  - if previously_termine?
+    = t('.manual_decision')
+  - elsif depose_before_configuration?
+    = t('.depose_before_configuration', decision: human_decision)
+  - elsif without_date? # generic case without SVA/SVR date, when we have a projection
+    = t('.manual_decision')
+  - elsif pending_correction?
+    = t('.remaining_days_after_correction', count: days_count)
+  - else
+    = t('.in_days', count: days_count)

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -942,6 +942,7 @@ class Dossier < ApplicationRecord
       .processed_at
     attestation&.destroy
 
+    self.sva_svr_decision_on = nil
     self.motivation = nil
     self.justificatif_motivation.purge_later
 
@@ -1087,6 +1088,10 @@ class Dossier < ApplicationRecord
     elsif will_save_change_to_sva_svr_decision_on?
       save! # we always want the most up to date decision when there is a pending correction
     end
+  end
+
+  def previously_termine?
+    traitements.termine.exists?
   end
 
   def remove_titres_identite!

--- a/spec/components/instructeurs/sva_svr_decision_badge_component_spec.rb
+++ b/spec/components/instructeurs/sva_svr_decision_badge_component_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+RSpec.describe Instructeurs::SVASVRDecisionBadgeComponent, type: :component do
+  let(:procedure) { create(:procedure, sva_svr: { decision: :sva, period: 10, unit: :days, resume: :continue }) }
+  let(:with_label) { false }
+
+  before do
+    travel_to DateTime.new(2023, 9, 1)
+  end
+
+  context 'with dossier object' do
+    subject do
+      render_inline(described_class.new(projection_or_dossier: dossier, procedure:, with_label:))
+    end
+
+    let(:title) { subject.at_css("span")["title"] }
+
+    context 'dossier en instruction' do
+      let(:dossier) { create(:dossier, :en_instruction, procedure:, sva_svr_decision_on: Date.new(2023, 9, 5)) }
+      it { expect(subject).to have_text("dans 4 jours") }
+      it { expect(title).to have_text("sera automatiquement traité le 05/09/2023") }
+
+      context 'with label' do
+        let(:with_label) { true }
+        it { expect(subject.text.delete("\n")).to have_text("SVA : dans 4 jours") }
+      end
+    end
+
+    context 'without sva date' do
+      let(:dossier) { create(:dossier, :en_instruction, procedure:) }
+
+      context 'dossier depose before configuration' do
+        it { expect(subject).to have_text("Déposé avant SVA") }
+        it { expect(title).to have_text("avant la configuration SVA") }
+      end
+
+      context 'dossier previously terminated' do
+        before {
+          create(:traitement, :accepte, dossier:)
+        }
+
+        it { expect(subject).to have_text("Instruction manuelle") }
+        it { expect(title).to have_text("repassé en instruction") }
+      end
+    end
+
+    context 'pending corrections' do
+      let(:dossier) { create(:dossier, :en_construction, procedure:, depose_at: Time.current, sva_svr_decision_on: Date.new(2023, 9, 5)) }
+
+      before do
+        create(:dossier_correction, dossier:)
+      end
+
+      it { expect(subject).to have_text("4 j. après correction") }
+    end
+  end
+
+  context 'with projection object' do
+    subject do
+      render_inline(described_class.new(projection_or_dossier: projection, procedure:, with_label:))
+    end
+
+    context 'dossier en instruction' do
+      let(:projection) { DossierProjectionService::DossierProjection.new(dossier_id: 12, state: :en_instruction, sva_svr_decision_on: Date.new(2023, 9, 5)) }
+
+      it { expect(subject).to have_text("dans 4 jours") }
+    end
+
+    context 'dossier without sva decision date' do
+      let(:projection) { DossierProjectionService::DossierProjection.new(dossier_id: 12, state: :en_instruction) }
+
+      it { expect(subject).to have_text("Instruction manuelle") }
+    end
+  end
+end

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1494,7 +1494,7 @@ describe Dossier, type: :model do
   end
 
   describe '#repasser_en_instruction!' do
-    let(:dossier) { create(:dossier, :refuse, :with_attestation, :with_justificatif, archived: true, termine_close_to_expiration_notice_sent_at: Time.zone.now) }
+    let(:dossier) { create(:dossier, :refuse, :with_attestation, :with_justificatif, archived: true, termine_close_to_expiration_notice_sent_at: Time.zone.now, sva_svr_decision_on: 1.day.ago) }
     let!(:instructeur) { create(:instructeur) }
     let(:last_operation) { dossier.dossier_operation_logs.last }
 
@@ -1512,6 +1512,7 @@ describe Dossier, type: :model do
     it { expect(dossier.motivation).to be_nil }
     it { expect(dossier.justificatif_motivation.attached?).to be_falsey }
     it { expect(dossier.attestation).to be_nil }
+    it { expect(dossier.sva_svr_decision_on).to be_nil }
     it { expect(dossier.termine_close_to_expiration_notice_sent_at).to be_nil }
     it { expect(last_operation.operation).to eq('repasser_en_instruction') }
     it { expect(last_operation.data['author']['email']).to eq(instructeur.email) }


### PR DESCRIPTION
On précise qu'il faut instruire manuellement le dossier ; l'attribut title précise encore un peu plus le contexte

![Capture d’écran 2023-09-04 à 16 12 00](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/27f9e313-0140-4087-bf7d-c3b7540a220b)

NB: sur la liste des dossiers, on a un objet `DossierProjection` à la place de l'objet complet `Dossier`, donc on ne peut pas savoir s'il s'agit d'un dossier déposé avant SVA ou d'un dossier repassé en instruction. On affiche alors un message plus générique :

![Capture d’écran 2023-09-04 à 16 15 16](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/cade1de2-b13f-4026-b955-d873183eecc1)
