### PR TITLE
ETQ usager, fix position du spinner pour les champs conditionnels

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -514,7 +514,7 @@
     }
   }
 
-  fieldset ~ .spinner {
+  fieldset + .spinner {
     position: relative;
     top: -($default-fields-spacer / 2);
   }

--- a/app/components/editable_champ/siret_component/siret_component.html.haml
+++ b/app/components/editable_champ/siret_component/siret_component.html.haml
@@ -1,5 +1,4 @@
 = @form.text_field(:value, input_opts(id: @champ.input_id, aria: { describedby: @champ.describedby_id }, placeholder: t(".placeholder"), data: { controller: 'turbo-input', turbo_input_load_on_connect_value: @champ.prefilled? && @champ.value.present? && @champ.etablissement.blank?, turbo_input_url_value: champs_siret_path(@champ.id) }, required: @champ.required?, pattern: "[0-9]{14}", title: t(".title"), class: "width-33-desktop", maxlength: 14))
-.spinner.right.hidden
 .siret-info{ id: dom_id(@champ, :siret_info) }
   - if @champ.etablissement.present?
     = render EditableChamp::EtablissementTitreComponent.new(etablissement: @champ.etablissement)

--- a/app/javascript/controllers/autosave_controller.ts
+++ b/app/javascript/controllers/autosave_controller.ts
@@ -124,12 +124,12 @@ export class AutosaveController extends ApplicationController {
   private showSpinner(champElement: Element) {
     this.#spinnerTimeoutId = setTimeout(() => {
       // do not do anything if there is already a spinner for this champ, like SIRET champ
-      if (!champElement.querySelector('.spinner')) {
+      if (!champElement.nextElementSibling?.classList.contains('spinner')) {
         const spinner = document.createElement('div');
         spinner.classList.add('spinner', 'spinner-removable');
         spinner.setAttribute('aria-live', 'live');
         spinner.setAttribute('aria-label', 'Chargement en cours…');
-        champElement.appendChild(spinner);
+        champElement.insertAdjacentElement('afterend', spinner);
       }
     }, AUTOSAVE_CONDITIONAL_SPINNER_DEBOUNCE_DELAY);
   }

--- a/app/views/shared/dossiers/_update_champs.turbo_stream.haml
+++ b/app/views/shared/dossiers/_update_champs.turbo_stream.haml
@@ -11,8 +11,8 @@
       = turbo_stream.update champ.labelledby_id do
         = render EditableChamp::ChampLabelContentComponent.new champ:, form:
 
-= turbo_stream.remove_all(".editable-champ .spinner-removable")
-= turbo_stream.hide_all(".editable-champ .spinner")
+= turbo_stream.remove_all(".editable-champ + .spinner-removable")
+= turbo_stream.hide_all(".editable-champ + .spinner")
 
 - if dossier.present?
   = turbo_stream.replace_all '.dossier-edit-sticky-footer' do


### PR DESCRIPTION
Changements depuis le passage des inputs au dsfr

## Loader pour Conditionnel
![Capture d’écran 2023-09-05 à 18 37 06](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/ab24e77c-dc7c-4832-a6b8-7c5e3c642e1f)
![Capture d’écran 2023-09-05 à 18 36 56](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/d5f7c717-5a60-4030-835b-f55a546612e3)


## Loader pour champ SIRET
Il n'était plus bien cablé depuis au moins 1 an, et ça coûtait trop cher de le remettre. J'ai donc enlevé le peu qu'il restait.


