### PR TITLE
changed(brevo): use env vars for smtp relay address and port.

### DIFF
--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -122,6 +122,10 @@ MATOMO_IFRAME_URL="https://matomo.example.org/index.php?module=CoreAdminHome&act
 # DOLIST_NO_REPLY_EMAIL=""
 # DOLIST_API_KEY=""
 
+# SMTP Provider: SIB (Brevo)
+# SENDINBLUE_SMTP_ADDRESS=""
+# SENDINBLUE_SMTP_PORT=""
+
 # Ratio of emails sent using SendInBlue
 # When present, N % of emails will be sent using SendInBlue
 # (and the others using the default SMTP provider)

--- a/config/initializers/sendinblue.rb
+++ b/config/initializers/sendinblue.rb
@@ -10,9 +10,9 @@ if ENV.key?('SENDINBLUE_BALANCING_VALUE')
     ActionMailer::Base.sendinblue_settings = {
       user_name: Rails.application.secrets.sendinblue[:username],
       password: Rails.application.secrets.sendinblue[:smtp_key],
-      address: 'smtp-relay.brevo.com',
+      address: ENV.fetch("SENDINBLUE_SMTP_ADDRESS", "smtp-relay.brevo.com"),
       domain: 'smtp-relay.brevo.com',
-      port: '587',
+      port: ENV.fetch("SENDINBLUE_SMTP_PORT", "587"),
       authentication: :cram_md5
     }
   end


### PR DESCRIPTION
Utilise une variable d'env pour l'adresse et le port du relay SMTP brevo. Cela va être utilisé pour traverser un proxy en interne avant d'accéder au relay smtp pour mieux tracer les erreurs de sorties de mail.