### PR TITLE
[fix] Selecteur de filtres pour instructeurs - le champ est invisible

### DIFF
--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -310,23 +310,6 @@ ul.dropdown-items {
     width: 340px;
   }
 
-  label {
-    width: 100px;
-    display: inline-block;
-    margin-bottom: 2 * $default-spacer;
-  }
-
-  input:not(.fr-btn) {
-    width: 200px;
-    display: inline-block;
-    background-color: $light-grey;
-    border: 1px solid $border-grey;
-   }
-
-  [disabled] {
-    display: none;
-  }
-
   ul {
     list-style: none;
   }

--- a/app/components/dossiers/instructeur_filter_component/instructeur_filter_component.html.haml
+++ b/app/components/dossiers/instructeur_filter_component/instructeur_filter_component.html.haml
@@ -1,13 +1,15 @@
 = form_tag add_filter_instructeur_procedure_path(procedure), method: :post, class: 'dropdown-form large', id: 'filter-component', data: { turbo: true, controller: 'autosubmit' } do
-  = label_tag :field,  t('.column')
-  = select_tag :field, options_for_select(filterable_fields_for_select, field_id), include_blank: field_id.nil?
-  %input.hidden{ type: 'submit', formaction: update_filter_instructeur_procedure_path(procedure), data: { autosubmit_target: 'submitter' } }
-  %br
-  = label_tag :value, t('.value'), for: 'value'
+  .fr-select-group
+    = label_tag :field,  t('.column'), class: 'fr-label fr-m-0'
+    = select_tag :field, options_for_select(filterable_fields_for_select, field_id), include_blank: field_id.nil?, class: 'fr-select'
+
+    %input.hidden{ type: 'submit', formaction: update_filter_instructeur_procedure_path(procedure), data: { autosubmit_target: 'submitter' } }
+
+  = label_tag :value, t('.value'), for: 'value', class: 'fr-label'
   - if field_type == :enum
-    = select_tag :value, options_for_select(options_for_select_of_field), id: 'value', name: 'value', data: { no_autosubmit: true }
+    = select_tag :value, options_for_select(options_for_select_of_field), id: 'value', name: 'value', class: 'fr-select', data: { no_autosubmit: true }
   - else
-    %input#value{ type: field_type, name: :value, maxlength: ProcedurePresentation::FILTERS_VALUE_MAX_LENGTH, disabled: field_id.nil? ? true : false, data: { no_autosubmit: true } }
+    %input#value.fr-input{ type: field_type, name: :value, disabled: field_id.nil? ? true : false, data: { no_autosubmit: true } }
 
   = hidden_field_tag :statut, statut
   = submit_tag t('.add_filter'), class: 'fr-btn fr-btn--secondary fr-mt-2w'

--- a/app/components/dossiers/instructeur_filter_component/instructeur_filter_component.html.haml
+++ b/app/components/dossiers/instructeur_filter_component/instructeur_filter_component.html.haml
@@ -9,7 +9,7 @@
   - if field_type == :enum
     = select_tag :value, options_for_select(options_for_select_of_field), id: 'value', name: 'value', class: 'fr-select', data: { no_autosubmit: true }
   - else
-    %input#value.fr-input{ type: field_type, name: :value, disabled: field_id.nil? ? true : false, data: { no_autosubmit: true } }
+    %input#value.fr-input{ type: field_type, name: :value, maxlength: ProcedurePresentation::FILTERS_VALUE_MAX_LENGTH, disabled: field_id.nil? ? true : false, data: { no_autosubmit: true } }
 
   = hidden_field_tag :statut, statut
   = submit_tag t('.add_filter'), class: 'fr-btn fr-btn--secondary fr-mt-2w'


### PR DESCRIPTION
Avec la MAJ du DSFR, le champ pour selectionner un filtre est devenu invisible. Il fallait retirer le css specifique et ajouter les classes du DSFR.

**AVANT**
<img width="375" alt="Capture d’écran 2023-09-06 à 12 43 00" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/93e2df7d-3c7d-43c5-ac64-5a6b09f58def">

**APRES**
<img width="412" alt="Capture d’écran 2023-09-06 à 12 37 54" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/04ad9bce-08c8-413a-b14f-885ae983c7f2">
<img width="400" alt="Capture d’écran 2023-09-06 à 12 38 03" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/9622d7dd-b688-46a8-bae0-0caed7adbddc">



