### PR TITLE
fix(archive): ne réessaye de construire une archive périmée

### DIFF
--- a/app/jobs/archive_creation_job.rb
+++ b/app/jobs/archive_creation_job.rb
@@ -1,4 +1,6 @@
 class ArchiveCreationJob < ApplicationJob
+  discard_on ActiveRecord::RecordNotFound
+
   queue_as :archives
 
   def max_run_time


### PR DESCRIPTION
la queue des archives est remplie de job avec l'erreur 
`Error while trying to deserialize arguments: Couldn't find Archive with 'id'=xxx`

ces jobs sont réessayer 25 fois.

Cette pr les supprime.