### PR TITLE
Correction : lorsqu'un dossier est cloné, il est toujours rebasé

### DIFF
--- a/app/models/concerns/dossier_clone_concern.rb
+++ b/app/models/concerns/dossier_clone_concern.rb
@@ -107,9 +107,7 @@ module DossierCloneConcern
     transaction do
       cloned_dossier.save!(validate: !fork)
 
-      if fork
-        cloned_dossier.rebase!
-      end
+      cloned_dossier.rebase!
     end
 
     if fork

--- a/spec/models/concern/dossier_clone_concern_spec.rb
+++ b/spec/models/concern/dossier_clone_concern_spec.rb
@@ -272,6 +272,7 @@ RSpec.describe DossierCloneConcern do
     context 'with new revision' do
       let(:added_champ) { forked_dossier.champs.find { _1.libelle == "Un nouveau champ text" } }
       let(:removed_champ) { dossier.champs.find { _1.stable_id == 99 } }
+      let(:new_dossier) { dossier.clone }
 
       before do
         procedure.draft_revision.add_type_de_champ({
@@ -284,6 +285,7 @@ RSpec.describe DossierCloneConcern do
 
       it {
         expect(dossier.revision_id).to eq(procedure.revisions.first.id)
+        expect(new_dossier.revision_id).to eq(procedure.published_revision.id)
         expect(forked_dossier.revision_id).to eq(procedure.published_revision_id)
         is_expected.to eq(added: [added_champ], updated: [], removed: [removed_champ])
       }


### PR DESCRIPTION
closes #9492 