### PR TITLE
[fix] Afficher le bouton "personnaliser" en entier dans le tableau des instructeurs

### DIFF
--- a/app/assets/stylesheets/table.scss
+++ b/app/assets/stylesheets/table.scss
@@ -65,3 +65,8 @@
     }
   }
 }
+
+// Hacky css to display dropdown "customize table" for table with only 1 or 2 lines
+table.min-height-300 {
+  min-height: 300px;
+}

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -91,7 +91,7 @@
           = render batch_operation_component
 
         .fr-table.fr-table--bordered
-          %table.table.dossiers-table.hoverable
+          %table.table.dossiers-table.hoverable.min-height-300
             %thead
               %tr
                 - if batch_operation_component.render?


### PR DESCRIPTION
Lorsque le tableau des instructeurs ne comprend que 1 ou 2 lignes, le dropdown pour personnaliser le tableau est coupé. Il est utilisable mais il faut scroller, ce n'est pas très heureux comme fonctionnement.

J'ai donc ajouté un min-height en dur pour les tableaux instructeur. Ce n'est pas un super fix, mais j'ai l'impression que c'est tout de même mieux que l'existant.

**APRES**
<img width="1410" alt="Capture d’écran 2023-09-19 à 17 51 10" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/0a403c7d-d0dc-4013-b5b7-fdf2f352f0d6">

**AVANT**
<img width="1408" alt="Capture d’écran 2023-09-19 à 17 55 25" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/b89ea4a4-4b64-4771-85fe-3f67b11e289f">

