### PR TITLE
wip(autocomplete): autocomplete from url

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.8.4)
+    addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     administrate (0.18.0)
       actionpack (>= 5.0)
@@ -103,13 +103,10 @@ GEM
     anchored (1.1.0)
     ast (2.4.2)
     attr_required (1.0.1)
-    axe-core-api (4.2.1)
-      capybara
+    axe-core-api (4.8.0)
       dumb_delegator
-      selenium-webdriver
       virtus
-      watir
-    axe-core-rspec (4.2.1)
+    axe-core-rspec (4.8.0)
       axe-core-api
       dumb_delegator
       virtus
@@ -487,7 +484,7 @@ GEM
       pry (>= 0.13, < 0.15)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
-    public_suffix (5.0.1)
+    public_suffix (5.0.3)
     puma (6.3.1)
       nio4r (~> 2.0)
     pundit (2.2.0)
@@ -576,7 +573,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.2.5)
+    rexml (3.2.6)
     rodf (1.1.1)
       builder (>= 3.0)
       dry-inflector (~> 0.1)
@@ -666,7 +663,7 @@ GEM
     selectize-rails (0.12.6)
     selenium-devtools (0.114.0)
       selenium-webdriver (~> 4.2)
-    selenium-webdriver (4.10.0)
+    selenium-webdriver (4.13.1)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -763,9 +760,6 @@ GEM
       zeitwerk (~> 2.2)
     warden (1.2.9)
       rack (>= 2.0.9)
-    watir (6.19.1)
-      regexp_parser (>= 1.2, < 3)
-      selenium-webdriver (>= 3.142.7)
     web-console (4.1.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -778,7 +772,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    websocket (1.2.9)
+    websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)

--- a/app/components/dsfr/combobox_component.rb
+++ b/app/components/dsfr/combobox_component.rb
@@ -1,9 +1,9 @@
 class Dsfr::ComboboxComponent < ApplicationComponent
-  def initialize(form: nil, options:, selected: nil, allows_custom_value: false, **html_options)
-    @form, @options, @selected, @allows_custom_value, @html_options = form, options, selected, allows_custom_value, html_options
+  def initialize(form: nil, options: nil, url: nil, selected: nil, allows_custom_value: false, **html_options)
+    @form, @options, @url, @selected, @allows_custom_value, @html_options = form, options, url, selected, allows_custom_value, html_options
   end
 
-  attr_reader :form, :options, :selected, :allows_custom_value
+  attr_reader :form, :options, :url, :selected, :allows_custom_value
 
   private
 
@@ -22,7 +22,7 @@ class Dsfr::ComboboxComponent < ApplicationComponent
       spellcheck: 'false',
       id: input_id,
       class: input_class,
-      value: input_value,
+      role: 'combobox',
       'aria-expanded': 'false',
       'aria-describedby': @html_options[:describedby]
     }.compact
@@ -36,8 +36,22 @@ class Dsfr::ComboboxComponent < ApplicationComponent
     "#{@html_options[:class].presence || ''} fr-select"
   end
 
-  def input_value
-    selected.present? ? options_with_values.find { _1.last == selected }&.first : nil
+  def selected_option_label_input_value
+    if selected.is_a?(Array) && selected.size == 2
+      selected.first
+    elsif options.present?
+      selected.present? ? options_with_values.find { _1.last == selected }&.first : nil
+    else
+      selected
+    end
+  end
+
+  def selected_option_value_input_value
+    if selected.is_a?(Array) && selected.size == 2
+      selected.last
+    else
+      selected
+    end
   end
 
   def list_id
@@ -45,10 +59,12 @@ class Dsfr::ComboboxComponent < ApplicationComponent
   end
 
   def options_with_values
+    return [] if url.present?
     options.map { _1.is_a?(Array) ? _1 : [_1, _1] }
   end
 
   def options_json
+    return nil if url.present?
     options_with_values.map { |(label, value)| { label:, value: } }.to_json
   end
 

--- a/app/components/dsfr/combobox_component/combobox_component.html.haml
+++ b/app/components/dsfr/combobox_component/combobox_component.html.haml
@@ -1,13 +1,14 @@
 .fr-ds-combobox{ data: { controller: 'combobox', allows_custom_value: allows_custom_value } }
   .fr-ds-combobox-input
-    %input{ **html_input_options }
+    %input{ value: selected_option_label_input_value, **html_input_options }
   - if form
-    = form.hidden_field name, value: selected, form: form_id
+    = form.hidden_field name, value: selected_option_value_input_value, form: form_id
   - else
-    %input{ type: 'hidden', name:, value: selected, form: form_id }
+    %input{ type: 'hidden', name:, value: selected_option_value_input_value, form: form_id }
   .fr-menu
-    %ul.fr-menu__list.hidden{ role: 'listbox', hidden: true, id: list_id, data: { turbo_force: :browser, options: options_json, selected:, hints: hints_json } }
+    %ul.fr-menu__list.hidden{ role: 'listbox', hidden: true, id: list_id, data: { turbo_force: :browser, options: options_json, url:, hints: hints_json }.compact }
   .sr-only{ aria: { live: 'polite', atomic: 'true' }, data: { turbo_force: :browser } }
   %template
     %li.fr-menu__item{ role: 'option' }
       %slot{ name: 'label' }
+  = content

--- a/app/components/editable_champ/address_component.rb
+++ b/app/components/editable_champ/address_component.rb
@@ -1,2 +1,2 @@
-class EditableChamp::AddressComponent < EditableChamp::ComboSearchComponent
+class EditableChamp::AddressComponent < EditableChamp::EditableChampBaseComponent
 end

--- a/app/components/editable_champ/address_component/address_component.html.haml
+++ b/app/components/editable_champ/address_component/address_component.html.haml
@@ -1,11 +1,2 @@
-- render_parent
-
-= @form.hidden_field :value
-= @form.hidden_field :external_id
-
-= react_component("ComboAdresseSearch",
-  required: @champ.required?,
-  id: @champ.input_id,
-  describedby: @champ.describedby_id,
-  **react_combo_props,
-)
+= render Dsfr::ComboboxComponent.new form: @form, name: :value, url: data_sources_data_source_adresse_path, selected: @champ.value, id: @champ.input_id, class: 'fr-select', describedby: @champ.describedby_id do
+  = @form.hidden_field :external_id, data: { value_slot: 'value' }

--- a/app/controllers/data_sources/adresse_controller.rb
+++ b/app/controllers/data_sources/adresse_controller.rb
@@ -1,0 +1,11 @@
+class DataSources::AdresseController < ApplicationController
+  def search
+    if params[:q].present? && params[:q].length > 3
+      response = Typhoeus.get("#{API_ADRESSE_URL}/search", params: { q: params[:q], limit: 10 })
+      result = JSON.parse(response.body, symbolize_names: true)
+      render json: result[:features].map { { label: _1[:properties][:label], value: _1[:properties][:label] } }
+    else
+      render json: []
+    end
+  end
+end

--- a/app/javascript/controllers/combobox_controller.ts
+++ b/app/javascript/controllers/combobox_controller.ts
@@ -9,14 +9,16 @@ export class ComboboxController extends ApplicationController {
   #combobox?: ComboboxUI;
 
   connect() {
-    const { input, valueInput, list, item, hint } = this.getElements();
+    const { input, selectedValueInput, valueSlots, list, item, hint } =
+      this.getElements();
     const hints = JSON.parse(list.dataset.hints ?? '{}') as Record<
       string,
       string
     >;
     this.#combobox = new ComboboxUI({
       input,
-      valueInput,
+      selectedValueInput,
+      valueSlots,
       list,
       item,
       hint,
@@ -33,8 +35,11 @@ export class ComboboxController extends ApplicationController {
   private getElements() {
     const input =
       this.element.querySelector<HTMLInputElement>('input[type="text"]');
-    const valueInput = this.element.querySelector<HTMLInputElement>(
+    const selectedValueInput = this.element.querySelector<HTMLInputElement>(
       'input[type="hidden"]'
+    );
+    const valueSlots = this.element.querySelectorAll<HTMLInputElement>(
+      'input[type="hidden"][data-value-slot]'
     );
     const list = this.element.querySelector<HTMLUListElement>('[role=listbox]');
     const item = this.element.querySelector<HTMLTemplateElement>('template');
@@ -46,7 +51,7 @@ export class ComboboxController extends ApplicationController {
       'ComboboxController requires a input element'
     );
     invariant(
-      isInputElement(valueInput),
+      isInputElement(selectedValueInput),
       'ComboboxController requires a hidden input element'
     );
     invariant(
@@ -58,7 +63,7 @@ export class ComboboxController extends ApplicationController {
       'ComboboxController requires a template element'
     );
 
-    return { input, valueInput, list, item, hint };
+    return { input, selectedValueInput, valueSlots, list, item, hint };
   }
 }
 

--- a/app/javascript/shared/combobox.test.ts
+++ b/app/javascript/shared/combobox.test.ts
@@ -1,4 +1,5 @@
 import { suite, test, beforeEach, expect } from 'vitest';
+import { matchSorter } from 'match-sorter';
 
 import { Combobox, Option, State } from './combobox';
 
@@ -26,6 +27,7 @@ suite('Combobox', () => {
 
       test('open select box and select option with click', () => {
         expect(currentState.open).toBeFalsy();
+        expect(currentState.loading).toBe(null);
         expect(currentState.selection?.label).toBe('Fraises');
 
         combobox.open();
@@ -260,6 +262,34 @@ suite('Combobox', () => {
       expect(currentState.open).toBeFalsy();
       expect(currentState.selection).toBeNull();
       expect(currentState.inputValue).toEqual('toto');
+    });
+  });
+
+  suite('single select with fetcher', () => {
+    beforeEach(() => {
+      combobox = new Combobox({
+        options: (term: string) =>
+          Promise.resolve(matchSorter(options, term, { keys: ['value'] })),
+        selected: null,
+        render: (state) => {
+          currentState = state;
+        }
+      });
+      combobox.init();
+    });
+
+    test('type and get options from fetcher', async () => {
+      expect(currentState.open).toBeFalsy();
+      expect(currentState.loading).toBe(false);
+
+      const result = combobox.input('Baies');
+
+      expect(currentState.loading).toBe(true);
+      await result;
+      expect(currentState.loading).toBe(false);
+      expect(currentState.open).toBeTruthy();
+      expect(currentState.selection).toBeNull();
+      expect(currentState.options.length).toEqual(3);
     });
   });
 });

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -221,6 +221,10 @@ Rails.application.routes.draw do
     end
   end
 
+  namespace :data_sources do
+    get :adresse, to: 'adresse#search', as: :data_source_adresse
+  end
+
   #
   # Deprecated UI
   #


### PR DESCRIPTION
Cette pull request ajoute la possibilité de récupérer les options d'un select via l'API. On ajoute également la possibilité d'inclure des input hidden comme enfants du composant, avec le marqueur indiquant quelle est la valeur attendue de l'objet option. Dans le cas du "data", l'objet retourné par l'API est sérialisé en JSON.

* `data-value-slot="value"`
* `data-value-slot="label"`
* `data-value-slot="data"`