### PR TITLE
Correction : désactive le routage des procédures clonées si l'admin n'est pas aussi admin de la procédure parente

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -495,6 +495,7 @@ class Procedure < ApplicationRecord
       procedure.encrypted_api_particulier_token = nil
       procedure.opendata = true
       procedure.api_particulier_scopes = []
+      procedure.routing_enabled = false
     else
       procedure.administrateurs = administrateurs
     end

--- a/lib/tasks/deployment/20230921132123_unroute_cloned_procedures_from_diffent_admin.rake
+++ b/lib/tasks/deployment/20230921132123_unroute_cloned_procedures_from_diffent_admin.rake
@@ -1,0 +1,18 @@
+namespace :after_party do
+  desc 'Deployment task: unroute_cloned_procedures_from_diffent_admin'
+  task unroute_cloned_procedures_from_diffent_admin: :environment do
+    puts "Running deploy task 'unroute_cloned_procedures_from_diffent_admin'"
+
+    # Put your task implementation HERE.
+    Procedure
+      .with_discarded
+      .where(routing_enabled: true)
+      .filter { |p| p.groupe_instructeurs.active.count == 1 }
+      .update_all(routing_enabled: false)
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -747,6 +747,10 @@ describe Procedure do
         expect(subject.api_particulier_scopes).to be_empty
       end
 
+      it 'should not route the procedure' do
+        expect(subject.routing_enabled).to eq(false)
+      end
+
       it 'should have a default groupe instructeur' do
         expect(subject.groupe_instructeurs.size).to eq(1)
         expect(subject.groupe_instructeurs.first.label).to eq(GroupeInstructeur::DEFAUT_LABEL)


### PR DESCRIPTION
Jusqu'à présent, lors du clonage d'une procédure routée, si l'admin n'est pas aussi admin de la procédure parente, on ne copie pas les groupes d'instructeurs.
Or, depuis la mep de cette PR https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/9244 le 10 juillet, le routage n'est plus mis à jour depuis un callback dans le modèle `GroupeInstructeur` mais directement dans les contrôleurs.
Ce qui a fait qu'à partir de cette date, les procédures clonées à partir d'une procedure routée avaient bien un seul groupe d'instructeurs mais le champ `routing_enabled` à true.
A priori pas d'impact fonctionnel.
-> un commit pour corriger et un pour rattraper les données