### PR TITLE
ETQ admin je peux conditionner sur un champ département

### DIFF
--- a/app/models/logic/champ_value.rb
+++ b/app/models/logic/champ_value.rb
@@ -5,7 +5,8 @@ class Logic::ChampValue < Logic::Term
     :integer_number,
     :decimal_number,
     :drop_down_list,
-    :multiple_drop_down_list
+    :multiple_drop_down_list,
+    :departements
   )
 
   CHAMP_VALUE_TYPE = {
@@ -60,7 +61,7 @@ class Logic::ChampValue < Logic::Term
       CHAMP_VALUE_TYPE.fetch(:boolean)
     when MANAGED_TYPE_DE_CHAMP.fetch(:integer_number), MANAGED_TYPE_DE_CHAMP.fetch(:decimal_number)
       CHAMP_VALUE_TYPE.fetch(:number)
-    when MANAGED_TYPE_DE_CHAMP.fetch(:drop_down_list)
+    when MANAGED_TYPE_DE_CHAMP.fetch(:drop_down_list), MANAGED_TYPE_DE_CHAMP.fetch(:departements)
       CHAMP_VALUE_TYPE.fetch(:enum)
     when MANAGED_TYPE_DE_CHAMP.fetch(:multiple_drop_down_list)
       CHAMP_VALUE_TYPE.fetch(:enums)
@@ -94,11 +95,15 @@ class Logic::ChampValue < Logic::Term
 
   def options(type_de_champs)
     tdc = type_de_champ(type_de_champs)
-    opts = tdc.drop_down_list_enabled_non_empty_options.map { |option| [option, option] }
-    if tdc.drop_down_other?
-      opts + [["Autre", Champs::DropDownListChamp::OTHER]]
+    if tdc.departement?
+      APIGeoService.departements.map { ["#{_1[:code]} – #{_1[:name]}", _1[:code]] }
     else
-      opts
+      opts = tdc.drop_down_list_enabled_non_empty_options.map { |option| [option, option] }
+      if tdc.drop_down_other?
+        opts + [["Autre", Champs::DropDownListChamp::OTHER]]
+      else
+        opts
+      end
     end
   end
 

--- a/spec/components/types_de_champ_editor/conditions_component_spec.rb
+++ b/spec/components/types_de_champ_editor/conditions_component_spec.rb
@@ -80,6 +80,18 @@ describe TypesDeChampEditor::ConditionsComponent, type: :component do
             expect(page).to have_select('type_de_champ[condition_form][rows][][value]', options: ['Sélectionner', 'val1', 'val2', 'val3'])
           end
         end
+
+        context 'departements' do
+          let(:departements) { create(:type_de_champ_departements) }
+          let(:upper_tdcs) { [departements] }
+          let(:condition) { empty_operator(champ_value(departements.stable_id), constant(true)) }
+          let(:departement_options) { APIGeoService.departements.map { "#{_1[:code]} – #{_1[:name]}" } }
+
+          it do
+            expect(page).to have_select('type_de_champ[condition_form][rows][][operator_name]', with_options: ['Est'])
+            expect(page).to have_select('type_de_champ[condition_form][rows][][value]', options: (['Sélectionner'] + departement_options))
+          end
+        end
       end
 
       context 'and 2 conditions' do

--- a/spec/models/logic/champ_value_spec.rb
+++ b/spec/models/logic/champ_value_spec.rb
@@ -95,6 +95,13 @@ describe Logic::ChampValue do
     end
   end
 
+  context 'departement tdc' do
+    let(:champ) { create(:champ_departements, value: '02') }
+
+    it { expect(champ_value(champ.stable_id).type([champ.type_de_champ])).to eq(:enum) }
+    it { is_expected.to eq('02') }
+  end
+
   context 'region tdc' do
     let(:champ) { create(:champ_regions, value: 'La Réunion') }
 


### PR DESCRIPTION
closes #9508 

ETQ admin, dans l'éditeur de types de champ, je peux créer une condition à partir de la valeur d'un champ département, avec l'opérateur "Est" ou "N'est pas".

Par exemple : 

![Screenshot from 2023-09-21 21-24-42](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/29131404/ce530913-d8f8-4cc6-9bfd-f98683371897)
