### PR TITLE
[instructeur] Mettre en avant les démarches closes avec des dossiers à traiter

### DIFF
--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -21,7 +21,7 @@ module Instructeurs
       @procedures = all_procedures.order(closed_at: :desc, unpublished_at: :desc, published_at: :desc, created_at: :desc)
       publiees_or_closes_with_dossiers_en_cours = all_procedures.publiees.or(all_procedures.closes.where(dossiers: { id: dossiers.en_cours.ids }))
       @procedures_en_cours = publiees_or_closes_with_dossiers_en_cours.order(published_at: :desc).page(params[:page]).per(ITEMS_PER_PAGE)
-      closes_with_no_dossier_en_cours = all_procedures.closes.excluding(all_procedures.closes.where(dossiers: { id: dossiers.en_cours.pluck(:id) }))
+      closes_with_no_dossier_en_cours = all_procedures.closes.excluding(all_procedures.closes.where(dossiers: { id: dossiers.en_cours.ids }))
       @procedures_closes = closes_with_no_dossier_en_cours.order(created_at: :desc).page(params[:page]).per(ITEMS_PER_PAGE)
       @procedures_draft = all_procedures.brouillons.order(created_at: :desc).page(params[:page]).per(ITEMS_PER_PAGE)
       @procedures_en_cours_count = publiees_or_closes_with_dossiers_en_cours.count

--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -19,7 +19,7 @@ module Instructeurs
         .where(procedures: { hidden_at: nil })
 
       @procedures = all_procedures.order(closed_at: :desc, unpublished_at: :desc, published_at: :desc, created_at: :desc)
-      publiees_or_closes_with_dossiers_en_cours = all_procedures.publiees.or(all_procedures.closes.where(dossiers: { id: dossiers.en_cours.pluck(:id) }))
+      publiees_or_closes_with_dossiers_en_cours = all_procedures.publiees.or(all_procedures.closes.where(dossiers: { id: dossiers.en_cours.ids }))
       @procedures_en_cours = publiees_or_closes_with_dossiers_en_cours.order(published_at: :desc).page(params[:page]).per(ITEMS_PER_PAGE)
       closes_with_no_dossier_en_cours = all_procedures.closes.excluding(all_procedures.closes.where(dossiers: { id: dossiers.en_cours.pluck(:id) }))
       @procedures_closes = closes_with_no_dossier_en_cours.order(created_at: :desc).page(params[:page]).per(ITEMS_PER_PAGE)

--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -12,18 +12,22 @@ module Instructeurs
         .kept
         .with_attached_logo
         .includes(:defaut_groupe_instructeur)
-
-      @procedures = all_procedures.order(closed_at: :desc, unpublished_at: :desc, published_at: :desc, created_at: :desc)
-      @procedures_publiees = all_procedures.publiees.order(published_at: :desc).page(params[:page]).per(ITEMS_PER_PAGE)
-      @procedures_draft = all_procedures.brouillons.order(created_at: :desc).page(params[:page]).per(ITEMS_PER_PAGE)
-      @procedures_closed = all_procedures.closes.order(created_at: :desc).page(params[:page]).per(ITEMS_PER_PAGE)
-      @procedures_publiees_count = all_procedures.publiees.count
-      @procedures_draft_count = all_procedures.brouillons.count
-      @procedures_closed_count = all_procedures.closes.count
+        .includes(:dossiers)
 
       dossiers = current_instructeur.dossiers
         .joins(groupe_instructeur: :procedure)
         .where(procedures: { hidden_at: nil })
+
+      @procedures = all_procedures.order(closed_at: :desc, unpublished_at: :desc, published_at: :desc, created_at: :desc)
+      publiees_or_closes_with_dossiers_en_cours = all_procedures.publiees.or(all_procedures.closes.where(dossiers: { id: dossiers.en_cours.pluck(:id) }))
+      @procedures_en_cours = publiees_or_closes_with_dossiers_en_cours.order(published_at: :desc).page(params[:page]).per(ITEMS_PER_PAGE)
+      closes_with_no_dossier_en_cours = all_procedures.closes.excluding(all_procedures.closes.where(dossiers: { id: dossiers.en_cours.pluck(:id) }))
+      @procedures_closes = closes_with_no_dossier_en_cours.order(created_at: :desc).page(params[:page]).per(ITEMS_PER_PAGE)
+      @procedures_draft = all_procedures.brouillons.order(created_at: :desc).page(params[:page]).per(ITEMS_PER_PAGE)
+      @procedures_en_cours_count = publiees_or_closes_with_dossiers_en_cours.count
+      @procedures_draft_count = all_procedures.brouillons.count
+      @procedures_closes_count = closes_with_no_dossier_en_cours.count
+
       @dossiers_count_per_procedure = dossiers.by_statut('tous').group('groupe_instructeurs.procedure_id').reorder(nil).count
       @dossiers_a_suivre_count_per_procedure = dossiers.by_statut('a-suivre').group('groupe_instructeurs.procedure_id').reorder(nil).count
       @dossiers_archived_count_per_procedure = dossiers.by_statut('archives').group('groupe_instructeurs.procedure_id').count
@@ -55,7 +59,7 @@ module Instructeurs
       @procedure_ids_en_cours_with_notifications = current_instructeur.procedure_ids_with_notifications(:en_cours)
       @procedure_ids_termines_with_notifications = current_instructeur.procedure_ids_with_notifications(:termine)
       @statut = params[:statut]
-      @statut.blank? ? @statut = 'publiees' : @statut = params[:statut]
+      @statut.blank? ? @statut = 'en-cours' : @statut = params[:statut]
     end
 
     def show

--- a/app/views/instructeurs/procedures/index.html.haml
+++ b/app/views/instructeurs/procedures/index.html.haml
@@ -12,7 +12,7 @@
         = tab_item(t('pluralize.closed', count: @procedures_closes_count), instructeur_procedures_path(statut: 'archivees'), active: @statut == 'archivees', badge: number_with_html_delimiter(@procedures_closes_count))
 
 .fr-container
-  - if @statut === "en-cours"
+  - if @statut.in? ["publiees", "en-cours"] # FIX ME: @statut === "en-cours" à partir du 1/11/2023
     = render Dsfr::CalloutComponent.new(title: nil) do |c|
       - c.with_body do
         = t(".procedure_en_cours_description")

--- a/app/views/instructeurs/procedures/index.html.haml
+++ b/app/views/instructeurs/procedures/index.html.haml
@@ -7,17 +7,26 @@
 
     %nav.tabs{ role: 'navigation', 'aria-label': t('views.users.dossiers.secondary_menu') }
       %ul
-        = tab_item(t('pluralize.published', count: @procedures_publiees_count), instructeur_procedures_path(statut: 'publiees'), active: @statut == 'publiees', badge: number_with_html_delimiter(@procedures_publiees_count))
-        = tab_item('En test', instructeur_procedures_path(statut: 'brouillons'), active: @statut == 'brouillons', badge: number_with_html_delimiter(@procedures_draft_count))
-        = tab_item(t('pluralize.closed', count: @procedures_closed_count), instructeur_procedures_path(statut: 'archivees'), active: @statut == 'archivees', badge: number_with_html_delimiter(@procedures_closed_count))
+        = tab_item(t('pluralize.en_cours', count: @procedures_en_cours_count), instructeur_procedures_path(statut: 'en-cours'), active: @statut == 'en-cours', badge: number_with_html_delimiter(@procedures_en_cours_count))
+        = tab_item(t('pluralize.en_test', count: @procedures_draft_count), instructeur_procedures_path(statut: 'brouillons'), active: @statut == 'brouillons', badge: number_with_html_delimiter(@procedures_draft_count))
+        = tab_item(t('pluralize.closed', count: @procedures_closes_count), instructeur_procedures_path(statut: 'archivees'), active: @statut == 'archivees', badge: number_with_html_delimiter(@procedures_closes_count))
 
 .fr-container
-  - if @statut === "publiees"
-    - collection = @procedures_publiees
+  - if @statut === "en-cours"
+    = render Dsfr::CalloutComponent.new(title: nil) do |c|
+      - c.with_body do
+        = t(".procedure_en_cours_description")
+    - collection = @procedures_en_cours
   - if @statut === "brouillons"
+    = render Dsfr::CalloutComponent.new(title: nil) do |c|
+      - c.with_body do
+        = t(".procedure_en_test_description")
     - collection = @procedures_draft
   - if @statut === "archivees"
-    - collection = @procedures_closed
+    = render Dsfr::CalloutComponent.new(title: nil) do |c|
+      - c.with_body do
+        = t(".procedure_close_description")
+    - collection = @procedures_closes
 
 
   - if collection.present?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -733,6 +733,9 @@ en:
     en_cours:
       one: in progress
       other: in progress
+    en_test:
+      one: in testing
+      other: in testing
     traites:
       one: finished
       other: finished
@@ -755,17 +758,17 @@ en:
       one: "%{count} file found"
       other: "%{count} files found"
     published:
-      one: Published
-      other: Published
+      one: published
+      other: published
     closed:
-      one: Closed
-      other: Closed
+      one: finished
+      other: finished
     draft:
-      one: Draft
-      other: Drafts
+      one: draft
+      other: drafts
     deleted:
-      one: Deleted
-      other: Deleted
+      one: deleted
+      other: deleted
   administrateurs:
     activate:
       new:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -745,6 +745,9 @@ fr:
     en_cours:
       one: en cours
       other: en cours
+    en_test:
+      one: en test
+      other: en test
     traites:
       one: traité
       other: traités
@@ -767,17 +770,17 @@ fr:
       one: "%{count} dossier trouvé"
       other: "%{count} dossiers trouvés"
     published:
-      one: Publiée
-      other: Publiées
+      one: publiée
+      other: publiées
     closed:
-      one: Close
-      other: Closes
+      one: terminée
+      other: terminées
     draft:
-      one: Brouillon
-      other: Brouillons
+      one: brouillon
+      other: brouillons
     deleted:
-      one: Supprimée
-      other: Supprimées
+      one: supprimée
+      other: supprimées
     procedures:
       one: Démarche
       other: Démarches

--- a/config/locales/views/instructeurs/procedures/en.yml
+++ b/config/locales/views/instructeurs/procedures/en.yml
@@ -2,6 +2,9 @@ en:
   instructeurs:
     procedures:
       index:
+        procedure_en_cours_description: The “in progress” tab groups published procedures as well as closed procedures that still have files to process.
+        procedure_en_test_description: The “in testing” tab groups unpublished procedures. Files submitted during the test phase will be automatically deleted when the procedure is modified or published.
+        procedure_close_description: The “finished” tab groups closed procedures with no more files to process.
         to_follow: to follow
         followed: followed
         processed: processed

--- a/config/locales/views/instructeurs/procedures/fr.yml
+++ b/config/locales/views/instructeurs/procedures/fr.yml
@@ -2,6 +2,9 @@ fr:
   instructeurs:
     procedures:
       index:
+        procedure_en_cours_description: L'onglet « en cours » regroupe les démarches publiées ainsi que les démarches closes ayant encore des dossiers à traiter.
+        procedure_en_test_description: L'onglet « en test » regroupe les démarches qui ne sont pas encore publiées. Les dossiers déposés pendant la phase de test seront automatiquement supprimés lors de la modification ou de la publication de la démarche.
+        procedure_close_description: L'onglet « terminée » regroupe les démarches closes n'ayant plus de dossiers à traiter.
         to_follow: à suivre
         followed: suivis
         processed: traités


### PR DESCRIPTION
closes #9334 

La pblematique : Les instructeurs ne comprennent pas qu'il y a encore des dossiers à instruire dans les procédure closes.

J'ai donc regroupé les démarches publiées et closes mais avec des dossiers en cours dans un onglet "en cours" comme suggéré par Simon. Et renommé l'onglet "close" en "terminée" pour éviter la confusion, pour les démarches closes qui n'ont plus de dossiers à traiter.
J'en ai profité pour également mettre un composant DSFR callout pour expliquer le regroupement des onglets.
<img width="1298" alt="Capture d’écran 2023-09-25 à 15 41 30" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/04368be5-638d-48e8-b338-3b732e6ee393">

