### PR TITLE
[instructeur] je veux pouvoir filtrer les dossiers "en construction" sans avoir ceux "en attente de corrections"

### DIFF
--- a/app/models/procedure_presentation.rb
+++ b/app/models/procedure_presentation.rb
@@ -209,6 +209,8 @@ class ProcedurePresentation < ApplicationRecord
           dossiers.filter_by_datetimes(column, dates)
         elsif field['column'] == "state" && values.include?("pending_correction")
           dossiers.joins(:corrections).where(corrections: DossierCorrection.pending)
+        elsif field['column'] == "state" && values.include?("en_construction")
+          dossiers.where("dossiers.#{column} IN (?)", values).includes(:corrections).where.not(corrections: DossierCorrection.pending)
         else
           dossiers.where("dossiers.#{column} IN (?)", values)
         end

--- a/spec/models/procedure_presentation_spec.rb
+++ b/spec/models/procedure_presentation_spec.rb
@@ -565,6 +565,21 @@ describe ProcedurePresentation do
           is_expected.to contain_exactly(kept_dossier.id, other_kept_dossier.id)
         end
       end
+
+      context 'with en_construction state filters' do
+        let(:filter) do
+          [
+            { 'table' => 'self', 'column' => 'state', 'value' => 'en_construction' }
+          ]
+        end
+
+        let!(:en_construction) { create(:dossier, :en_construction, procedure: procedure) }
+        let!(:en_construction_with_correction) { create(:dossier, :en_construction, procedure: procedure) }
+        let!(:correction) { create(:dossier_correction, dossier: en_construction_with_correction) }
+        it 'excludes dossier en construction with pending correction' do
+          is_expected.to contain_exactly(en_construction.id)
+        end
+      end
     end
 
     context 'for type_de_champ table' do


### PR DESCRIPTION
closes #9483 

Suite à une demande du fond vert, il y a un besoin de pouvoir filtrer les dossiers en construction sans avoir les dossiers en attente de correction. Cette PR répond bien au besoin exprimé, mais ce n'est peut-être pas assez explicite en l'état à cause du double statut ("en correction" et "en attente") et il faudrait réfléchir plus tard à une autre solution (ou dès maintenant ?)
On pourrait par exemple résoudre cette problematique de double statut en retirant le badge "en correction" lorsque le dossier est "en attente" dans l'interface. (suggestion d' @E-L-T 👌)
<img width="1409" alt="Capture d’écran 2023-09-26 à 17 01 17" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/cd6b070f-7ed7-47a5-85c7-c66eca50a937">
<img width="1407" alt="Capture d’écran 2023-09-26 à 17 01 03" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/6296c056-bc28-4501-b151-c615ecbe7111">

