### PR TITLE
Notifier par mail les admin de services sans siret

### DIFF
--- a/app/mailers/administrateur_mailer.rb
+++ b/app/mailers/administrateur_mailer.rb
@@ -22,6 +22,14 @@ class AdministrateurMailer < ApplicationMailer
       reply_to: CONTACT_EMAIL)
   end
 
+  def notify_service_without_siret(user_email)
+    @subject = "Siret manquant sur un de vos services"
+
+    mail(to: user_email,
+      subject: @subject,
+      reply_to: CONTACT_EMAIL)
+  end
+
   def api_token_expiration(user, tokens)
     @subject = "Renouvellement de jeton d'API nécessaire"
     @tokens = tokens

--- a/app/views/administrateur_mailer/notify_service_without_siret.haml
+++ b/app/views/administrateur_mailer/notify_service_without_siret.haml
@@ -1,0 +1,16 @@
+- content_for(:title, "Service avec Siret manquant")
+
+%p
+  Bonjour,
+
+%p
+  Vous êtes administrateur sur la plateforme
+  = APPLICATION_NAME
+  et au moins un de vos services n'a pas son siret renseigné.
+
+%p
+  Afin d'éviter tout dysfonctionnement sur la plateforme, nous vous invitons à le remplir au plus vite à cette adresse :
+  = link_to admin_procedures_url, admin_procedures_url
+
+= render partial: "layouts/mailers/signature"
+

--- a/lib/tasks/clean_services.rake
+++ b/lib/tasks/clean_services.rake
@@ -1,0 +1,21 @@
+namespace :service do
+  desc 'remove service without procedure'
+  task remove_orphans: :environment do
+    puts "Destroying services without procedure..."
+    Service.joins('LEFT OUTER JOIN "procedures" ON "procedures"."service_id" = "services"."id"')
+      .where(procedures: { id: nil })
+      .destroy_all
+    puts "Services without procedure destroyed"
+  end
+
+  desc 'email admins with published procedures with service without siret'
+  task email_no_siret: :environment do
+    admins = Administrateur.joins(:administrateurs_procedures).where(administrateurs_procedures: { procedure: Procedure.publiees.joins(:service).where(service: { siret: nil }) })
+    progress = ProgressReport.new(admins.count)
+
+    admins.each do |admin|
+      AdministrateurMailer.notify_service_without_siret(admin.email).deliver
+      progress.inc
+    end
+  end
+end

--- a/spec/lib/tasks/clean_services_spec.rb
+++ b/spec/lib/tasks/clean_services_spec.rb
@@ -1,0 +1,49 @@
+describe 'service tasks' do
+  let(:rake_task) { Rake::Task[task] }
+  subject { rake_task.invoke }
+  after(:each) do
+    rake_task.reenable
+  end
+
+  describe 'service:remove_orphans' do
+    let(:task) { 'service:remove_orphans' }
+    let(:service) { create(:service) }
+    let(:procedure) { create(:procedure, :with_service) }
+    let(:service_with_procedure) { procedure.service }
+    it 'remove orphans' do
+      service
+      service_with_procedure
+
+      subject
+
+      expect(Service.find_by(id: service.id)).to be_nil
+      expect(Service.find_by(id: service_with_procedure.id)).to eq service_with_procedure
+    end
+  end
+
+  describe 'service:notify_no_siret' do
+    let(:task) { 'service:email_no_siret' }
+    let!(:procedure_without_siret_service) { create(:procedure, :published, service: service, administrateur: administrateur) }
+    let(:administrateur) { create(:administrateur) }
+    let(:service) do
+      s = build(:service, siret: nil, administrateur: administrateur)
+      s.save(validate: false)
+      s
+    end
+    let!(:procedure_with_siret_service) { create(:procedure, :published, service: siret_service, administrateur: administrateur_with_siret_service) }
+    let(:siret_service) { create(:service, administrateur: administrateur_with_siret_service) }
+    let(:administrateur_with_siret_service) { create(:administrateur) }
+
+    it 'emails admins with published procedures with services without siret' do
+      message = double("message")
+      allow(message).to receive(:deliver)
+      allow(AdministrateurMailer).to receive(:notify_service_without_siret).with(administrateur.email).and_return(message)
+      allow(AdministrateurMailer).to receive(:notify_service_without_siret).with(administrateur_with_siret_service.email).and_return(message)
+
+      subject
+
+      expect(AdministrateurMailer).to have_received(:notify_service_without_siret).with(administrateur.email).once
+      expect(AdministrateurMailer).not_to have_received(:notify_service_without_siret).with(administrateur_with_siret_service.email)
+    end
+  end
+end

--- a/spec/mailers/administrateur_mailer_spec.rb
+++ b/spec/mailers/administrateur_mailer_spec.rb
@@ -22,4 +22,11 @@ RSpec.describe AdministrateurMailer, type: :mailer do
       it { expect(subject[BalancerDeliveryMethod::FORCE_DELIVERY_METHOD_HEADER]&.value).to eq(forced_delivery_method.to_s) }
     end
   end
+
+  describe '.notify_service_without_siret' do
+    subject { described_class.notify_service_without_siret(admin_email) }
+    it { expect(subject.to).to eq([admin_email]) }
+    it { expect(subject.subject).to eq("Siret manquant sur un de vos services") }
+    it { expect(subject.body).to include("un de vos services n'a pas son siret renseigné") }
+  end
 end


### PR DESCRIPTION
close #9502 
Cette PR crée 2 tâches : 

- `service:remove_orphans` qui supprime tous les services sans procédure
- `service:email_no_siret` qui envoie un mail aux administrateurs de procédures publiées qui ont des services sans siret

Voici le mail envoyé

![2023-09-27-111524_746x686_scrot](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/1111966/fc3fc518-e501-42e1-89d3-5c6e5873e119)
