### PR TITLE
ETQ usager corrige une erreur d'affichage du dossier lorsque le groupe instructeur du dossier a des informations de contact

### DIFF
--- a/app/models/contact_information.rb
+++ b/app/models/contact_information.rb
@@ -9,6 +9,10 @@ class ContactInformation < ApplicationRecord
   validates :adresse, presence: { message: 'doit être renseignée' }, allow_nil: false
   validates :groupe_instructeur, presence: { message: 'doit être renseigné' }, allow_nil: false
 
+  def pretty_nom
+    nom
+  end
+
   def telephone_url
     if telephone.present?
       "tel:#{telephone.gsub(/[[:blank:]]/, '')}"

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -25,6 +25,10 @@ class Service < ApplicationRecord
   validates :adresse, presence: { message: 'doit être renseignée' }, allow_nil: false
   validates :administrateur, presence: { message: 'doit être renseigné' }, allow_nil: false
 
+  def pretty_nom
+    "#{nom}, #{organisme}"
+  end
+
   def clone_and_assign_to_administrateur(administrateur)
     service_cloned = self.dup
     service_cloned.administrateur = administrateur

--- a/app/views/layouts/mailers/_service_footer.html.haml
+++ b/app/views/layouts/mailers/_service_footer.html.haml
@@ -5,6 +5,7 @@
     = succeed '.' do
       = link_to t('.file_messagerie'), messagerie_dossier_url(dossier), target: '_blank', rel: 'noopener'
 
+- service = dossier&.service || dossier.procedure.service
 - if service.present?
   %table{ width: "100%", border: "0", cellspacing: "0", cellpadding: "0", style: "cursor:auto;color:#55575d;font-family:Helvetica, Arial, sans-serif;font-size:11px;line-height:22px;text-align:left;" }
     %tr
@@ -13,7 +14,6 @@
           %strong
             = t('.procedure_management')
           = service.nom
-          = service.organisme
           = service.adresse
       %td{ width: "50%", valign: "top" }
         %p

--- a/app/views/users/_procedure_footer.html.haml
+++ b/app/views/users/_procedure_footer.html.haml
@@ -7,7 +7,7 @@
           - if service.present?
             %h3.fr-footer__top-cat= I18n.t('users.procedure_footer.managed_by.header')
             .fr-footer__top-link.fr-pb-2w
-              %span{ lang: :fr }= "#{service.nom}, #{service.organisme},"
+              %span{ lang: :fr }= service.pretty_nom
               %div{ lang: :fr }
                 = render SimpleFormatComponent.new(service.adresse, class_names_map: {paragraph: 'fr-footer__content-desc'})
           %h3.fr-footer__top-cat= I18n.t('users.procedure_footer.contact.header')


### PR DESCRIPTION
Cette PR corrige des bugs lorsqu'un groupe instructeur a des informations de contact (erreur 500 à l'affichage du pied de page pour l'utilisateur, et pour l'envoi de mails de notifs)