### PR TITLE
ETQ usager le formulaire est aéré grâce au bon markup du DSFR

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -27,7 +27,7 @@
 
   .section-2 {
     margin-top: 1.5rem;
-    padding-top: 1rem;
+    padding-top: 2rem;
     border-top: 2px solid var(--border-default-grey);
   }
 
@@ -42,6 +42,11 @@
   .section-6 {
     margin-top: 1.5rem;
     margin-bottom: 1rem;
+  }
+
+  // Keep only bottom margin in nested (consecutive) header sections, ie. first legend for a same level
+  .fr-fieldset > .fr-fieldset__legend + .fr-fieldset__element > .fr-fieldset:first-of-type .header-section {
+    margin-top: 0 !important;
   }
 
   legend {

--- a/app/components/dsfr/input_errorable.rb
+++ b/app/components/dsfr/input_errorable.rb
@@ -11,12 +11,14 @@ module Dsfr
       def dsfr_group_classname
         if dsfr_champ_container == :fieldset
           'fr-fieldset'
-        else
+        elsif dsfr_input_classname.present? # non fillable element
           "#{dsfr_input_classname}-group"
         end
       end
 
       def input_group_error_class_names
+        return {} if dsfr_group_classname.nil?
+
         {
           "#{dsfr_group_classname}--error" => errors_on_attribute?,
           "#{dsfr_group_classname}--valid" => !errors_on_attribute? && errors_on_another_attribute?

--- a/app/components/editable_champ/section_component.rb
+++ b/app/components/editable_champ/section_component.rb
@@ -8,11 +8,11 @@ class EditableChamp::SectionComponent < ApplicationComponent
   end
 
   def render_within_fieldset?
-    first_champ_is_an_header_section? && any_champ_fillable?
+    first_champ_is_an_header_section?
   end
 
   def header_section
-    return @nodes.first if @nodes.first.is_a?(Champs::HeaderSectionChamp)
+    @nodes.first if @nodes.first.is_a?(Champs::HeaderSectionChamp)
   end
 
   def splitted_tail
@@ -28,13 +28,6 @@ class EditableChamp::SectionComponent < ApplicationComponent
 
   def tag_for_depth
     "h#{header_section.level + 1}"
-  end
-
-  # if two headers follows each others [h1, [h2, c]]
-  # the first one must not be contained in fieldset
-  # so we make the tree not fillable
-  def fillable?
-    false
   end
 
   def split_section_champ(node)
@@ -54,9 +47,5 @@ class EditableChamp::SectionComponent < ApplicationComponent
 
   def first_champ_is_an_header_section?
     header_section.present?
-  end
-
-  def any_champ_fillable?
-    tail.any? { _1&.fillable? }
   end
 end

--- a/app/components/editable_champ/section_component/section_component.html.haml
+++ b/app/components/editable_champ/section_component/section_component.html.haml
@@ -1,19 +1,24 @@
 - if render_within_fieldset?
-  = tag.fieldset(class: "reset-#{tag_for_depth} fr-m-0 fr-p-0") do
-    = tag.legend do
-      = render EditableChamp::HeaderSectionComponent.new(champ: header_section)
+  .fr-fieldset__element{ class: class_names("fr-my-0" => render_within_fieldset?) }
+    %fieldset.fr-fieldset.fr-my-0{ class: "reset-#{tag_for_depth}" }
+      %legend.fr-fieldset__legend
+        = render EditableChamp::HeaderSectionComponent.new(champ: header_section)
+      - splitted_tail.each do |section, champ|
+        - if section.present?
+          = render section
+        - else
+          = fields_for champ.input_name, champ do |form|
+            .fr-fieldset__element
+              = render EditableChamp::EditableChampComponent.new form:, champ:
+- else
+  %fieldset.fr-fieldset.fr-my-0
+    - if header_section
+      %legend.fr-fieldset__legend.fr-my-0{ class: "reset-#{tag_for_depth}" }
+        = render EditableChamp::HeaderSectionComponent.new(champ: header_section)
     - splitted_tail.each do |section, champ|
       - if section.present?
         = render section
       - else
         = fields_for champ.input_name, champ do |form|
-          = render EditableChamp::EditableChampComponent.new form: ,champ:
-- else
-  - if header_section
-    %div{ class: "reset-#{tag_for_depth}" }= render EditableChamp::HeaderSectionComponent.new(champ: header_section)
-  - splitted_tail.each do |section, champ|
-    - if section.present?
-      = render section
-    - else
-      = fields_for champ.input_name, champ do |form|
-        = render EditableChamp::EditableChampComponent.new form: ,champ:
+          .fr-fieldset__element
+            = render EditableChamp::EditableChampComponent.new form:, champ:


### PR DESCRIPTION
L'espacement vertical du form n'est pas bon car il manque le niveau de hiéarchie `fr-fieldset > fr-fieldset-element` autour de chaque champ.

Le markup du dsfr attendu est toujours : 

```haml
%fieldset.fr-fieldset
  %legend.fr-fieldset--legend
     # la légende
  %div.fr-fieldset-element
    # - un champ (par ex `.fr-input-group`)
    # - ou un nouveau %fieldset.fr-fieldset et on recommence
```

Autrement dit, **tous** les enfants d'un fieldset doivent être un `fr-fieldset-element` (ou sa `legend`). C'est d'ailleurs lui qui assure l'espacement vertical.

Chaque (sous-)section a son propre `fieldset` avec sa légende (le libellé de la section); ils sont donc imbriqués.

Questions et remarques pour @mfo , je sais qu'il y a eu beaucoup d'allers retours : 
- ce n'est plus une arborcesence "flat" : y avait-t'il une raison pour ne pas imbriquer des fieldset ?
- les sections n'étaient déjà plus collapsibles (il reste d'ailleurs un peu de code mort)
- les sections vides à cause de champs conditionnel s'affichaient aussi (là aussi du code mort, peut-être depuis que les titres de sections sont conditionnés ?)
- théoriquement on améliore encore l'accessibilité grâce aux fieldsets, à confirmer
- l'espacement entre les niveaux de titres consécutifs est mieux maitrisé
- un test s'assure qu'on a la bonne hiérarchie

TODO (plus tard) : 
- [ ] Conditionnel sur section entière ; aussi actuellement on masque le titre de section, mais la legend n'est pas hidden donc occupe de la place

## APRES (sur 3)

![Capture d’écran 2023-09-27 à 16 57 46](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/1b330ba0-f171-4613-919e-e59f98a1c32a)
![tous les champs](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/f44e42f5-f2b8-4132-b91a-0a3b5872c9a6)


![Capture d’écran 2023-09-27 à 18 59 30](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/b2fce71e-fbe2-4a7a-88d7-658b5b2c15c4)


## AVANT 
![Capture d’écran 2023-09-27 à 18 57 05](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/02334666-7865-427a-a381-65b64adb89ed)
![Capture d’écran 2023-09-27 à 18 56 51](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/ba367304-918e-4fab-9e29-5bc1c1207198)
![Capture d’écran 2023-09-27 à 18 59 50](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/f796720c-0364-49ad-8511-8493622375ec)


