### PR TITLE
Correction (2e essai) : désactive le routage de procédures clonées ou l'admin n'était pas aussi admin de la procédure parente

### DIFF
--- a/lib/tasks/deployment/20230921132123_unroute_cloned_procedures_from_diffent_admin.rake
+++ b/lib/tasks/deployment/20230921132123_unroute_cloned_procedures_from_diffent_admin.rake
@@ -8,7 +8,9 @@ namespace :after_party do
       .with_discarded
       .where(routing_enabled: true)
       .filter { |p| p.groupe_instructeurs.active.count == 1 }
-      .update_all(routing_enabled: false)
+      .each do |p|
+        p.update!(routing_enabled: false)
+      end
 
     # Update task as completed.  If you remove the line below, the task will
     # run with every deploy (or every time you call after_party:run).


### PR DESCRIPTION
Une première PR (https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/9504) contenait une after party qui a échoué (`update_all` appelé sur un array).
-> nouvelle after-party pour corriger les données