### PR TITLE
ETQ administrateur, je veux pouvoir valider des champs avec des règles simples (Regexp)

### DIFF
--- a/app/components/editable_champ/expression_reguliere_component.rb
+++ b/app/components/editable_champ/expression_reguliere_component.rb
@@ -1,0 +1,5 @@
+class EditableChamp::ExpressionReguliereComponent < EditableChamp::EditableChampBaseComponent
+  def dsfr_input_classname
+    'fr-input'
+  end
+end

--- a/app/components/editable_champ/expression_reguliere_component/expression_reguliere_component.html.haml
+++ b/app/components/editable_champ/expression_reguliere_component/expression_reguliere_component.html.haml
@@ -1,0 +1,1 @@
+= @form.text_field(:value, input_opts(id: @champ.input_id, placeholder: @champ.expression_reguliere_exemple_text, required: @champ.required?, aria: { describedby: @champ.describedby_id }))

--- a/app/components/procedure/revision_changes_component/revision_changes_component.fr.yml
+++ b/app/components/procedure/revision_changes_component/revision_changes_component.fr.yml
@@ -40,6 +40,12 @@ fr:
     update_condition: La condition du champ « %{label} » a été modifiée. La nouvelle condition est « %{to} ».
     update_character_limit: La limite de caractères du champ texte « %{label} » a été modifiée. La nouvelle limite est « %{to} ».
     remove_character_limit: La limite de caractères du champ texte « %{label} » a été supprimée.
+    remove_expression_reguliere: L’expression régulière du champ « %{label} » a été supprimée.
+    update_expression_reguliere: L’expression régulière du champ « %{label} » a été modifiée. La nouvelle expression est « %{to} ».
+    remove_expression_reguliere_exemple_text: L’exemple d’expression régulière du champ « %{label} » a été supprimé.
+    update_expression_reguliere_exemple_text: L’exemple d’expression régulière du champ « %{label} » a été modifié. Le nouvel exemple est « %{to} ».
+    remove_expression_reguliere_error_message: Le message d’erreur de l’expression régulière du champ « %{label} » a été supprimé.
+    update_expression_reguliere_error_message: Le message d’erreur de l’expression régulière du champ « %{label} » a été modifié. Le nouveau message est « %{to} ».
   private:
     add: L’annotation privée « %{label} » a été ajoutée.
     remove: L’annotation privée « %{label} » a été supprimée.

--- a/app/components/procedure/revision_changes_component/revision_changes_component.html.haml
+++ b/app/components/procedure/revision_changes_component/revision_changes_component.html.haml
@@ -141,6 +141,27 @@
         - else
           - list.with_item do
             = t(".#{prefix}.update_character_limit", label: change.label, to: change.to)
+      - when :expression_reguliere
+        - if change.to.blank?
+          - list.with_item do
+            = t(".#{prefix}.remove_expression_reguliere", label: change.label, to: change.to)
+        - else
+          - list.with_item do
+            = t(".#{prefix}.update_expression_reguliere", label: change.label, to: change.to)
+      - when :expression_reguliere_exemple_text
+        - if change.to.blank?
+          - list.with_item do
+            = t(".#{prefix}.remove_expression_reguliere_exemple_text", label: change.label, to: change.to)
+        - else
+          - list.with_item do
+            = t(".#{prefix}.update_expression_reguliere_exemple_text", label: change.label, to: change.to)
+      - when :expression_reguliere_error_message
+        - if change.to.blank?
+          - list.with_item do
+            = t(".#{prefix}.remove_expression_reguliere_error_message", label: change.label, to: change.to)
+        - else
+          - list.with_item do
+            = t(".#{prefix}.update_expression_reguliere_error_message", label: change.label, to: change.to)
 
   - if @public_move_changes.present?
     - list.with_item do

--- a/app/components/types_de_champ_editor/champ_component/champ_component.fr.yml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.fr.yml
@@ -13,3 +13,8 @@ fr:
   character_limit:
     unlimited: Pas de limite de caractères
     limit: Limité à %{limit} caractères
+  expression_reguliere:
+    labels:
+      regex: Saisissez votre expression régulière, essayez-la sur https://rubular.com
+      valid_exemple: Exemple valide qui passe l'expression régulière
+      error_message: Message d'erreur à afficher à l'usager en cas de saisie invalide

--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
@@ -46,6 +46,23 @@
               %p
                 %small Nous numérotons automatiquement les titres lorsqu’aucun de vos titres ne commence par un chiffre.
 
+            - if type_de_champ.expression_reguliere?
+              .cell.mt-1
+                = form.label :expression_reguliere, for: dom_id(type_de_champ, :expression_reguliere) do
+                  = t('.expression_reguliere.labels.regex')
+                = form.text_field :expression_reguliere, class: "fr-input small-margin small", id: dom_id(type_de_champ, :expression_reguliere)
+
+              .cell.mt-1
+                = form.label :expression_reguliere_exemple_text, for: dom_id(type_de_champ, :expression_reguliere_exemple_text) do
+                  = t('.expression_reguliere.labels.valid_exemple')
+                = form.text_field :expression_reguliere_exemple_text, class: "fr-input small-margin small", id: dom_id(type_de_champ, :expression_reguliere_exemple_text)
+                - if type_de_champ.invalid_regexp?
+                  %p.fr-message.fr-message--error
+                    = type_de_champ.errors[:expression_reguliere_exemple_text].join(", ")
+              .cell.mt-1
+                = form.label :expression_reguliere_error_message, for: dom_id(type_de_champ, :expression_reguliere_error_message) do
+                  = t('.expression_reguliere.labels.error_message')
+                = form.text_field :expression_reguliere_error_message, class: "fr-input small-margin small", id: dom_id(type_de_champ, :expression_reguliere_error_message)
             - if !type_de_champ.header_section? && !type_de_champ.titre_identite?
               .cell.mt-1
                 = form.label :description, "Description du champ (optionnel)", for: dom_id(type_de_champ, :description)

--- a/app/components/types_de_champ_editor/errors_summary.rb
+++ b/app/components/types_de_champ_editor/errors_summary.rb
@@ -15,6 +15,10 @@ class TypesDeChampEditor::ErrorsSummary < ApplicationComponent
     @revision.errors.include?(:header_section)
   end
 
+  def expression_reguliere_errors?
+    @revision.errors.include?(:expression_reguliere)
+  end
+
   private
 
   def errors_for(key)

--- a/app/components/types_de_champ_editor/errors_summary/errors_summary.fr.yml
+++ b/app/components/types_de_champ_editor/errors_summary/errors_summary.fr.yml
@@ -6,3 +6,7 @@ fr:
   fix_header_section:
     one: 'Le titre de section suivant est invalide, veuillez le corriger :'
     other: 'Les titres de section suivants sont invalides, veuillez les corriger :'
+
+  fix_expressions_regulieres:
+    one: "L'expression régulière suivante est invalide, veuillez la corriger :"
+    other: 'Les expressions régulières suivantes sont invalides, veuillez les corriger :'

--- a/app/components/types_de_champ_editor/errors_summary/errors_summary.html.haml
+++ b/app/components/types_de_champ_editor/errors_summary/errors_summary.html.haml
@@ -9,3 +9,7 @@
         - if header_section_errors?
           %p= t('.fix_header_section', count: errors_for(:header_section).size)
           = error_message_for(:header_section)
+
+        - if expression_reguliere_errors?
+          %p= t('.fix_expressions_regulieres', count: errors_for(:expression_reguliere).size)
+          = error_message_for(:expression_reguliere)

--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -130,6 +130,9 @@ module Administrateurs
         :collapsible_explanation_text,
         :header_section_level,
         :character_limit,
+        :expression_reguliere,
+        :expression_reguliere_exemple_text,
+        :expression_reguliere_error_message,
         editable_options: [
           :cadastres,
           :unesco,

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -540,6 +540,9 @@ module Users
       @dossier.check_mandatory_and_visible_champs.map do |error_on_champ|
         errors.import(error_on_champ)
       end
+      @dossier.check_expressions_regulieres_champs.map do |error_on_champ|
+        errors.import(error_on_champ) if error_on_champ.present?
+      end
       errors
     end
 

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -540,9 +540,6 @@ module Users
       @dossier.check_mandatory_and_visible_champs.map do |error_on_champ|
         errors.import(error_on_champ)
       end
-      @dossier.check_expressions_regulieres_champs.map do |error_on_champ|
-        errors.import(error_on_champ) if error_on_champ.present?
-      end
       errors
     end
 

--- a/app/graphql/api/v2/schema.rb
+++ b/app/graphql/api/v2/schema.rb
@@ -114,7 +114,8 @@ class API::V2::Schema < GraphQL::Schema
     Types::Champs::Descriptor::TextareaChampDescriptorType,
     Types::Champs::Descriptor::TextChampDescriptorType,
     Types::Champs::Descriptor::TitreIdentiteChampDescriptorType,
-    Types::Champs::Descriptor::YesNoChampDescriptorType
+    Types::Champs::Descriptor::YesNoChampDescriptorType,
+    Types::Champs::Descriptor::ExpressionReguliereChampDescriptorType
 
   def self.unauthorized_object(error)
     # Add a top-level error to the response instead of returning nil:

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -2284,6 +2284,34 @@ type ExplicationChampDescriptor implements ChampDescriptor {
   type: TypeDeChamp! @deprecated(reason: "Utilisez le champ `__typename` à la place.")
 }
 
+type ExpressionReguliereChampDescriptor implements ChampDescriptor {
+  """
+  Description des champs d’un bloc répétable.
+  """
+  champDescriptors: [ChampDescriptor!] @deprecated(reason: "Utilisez le champ `RepetitionChampDescriptor.champ_descriptors` à la place.")
+
+  """
+  Description du champ.
+  """
+  description: String
+  id: ID!
+
+  """
+  Libellé du champ.
+  """
+  label: String!
+
+  """
+  Est-ce que le champ est obligatoire ?
+  """
+  required: Boolean!
+
+  """
+  Type de la valeur du champ.
+  """
+  type: TypeDeChamp! @deprecated(reason: "Utilisez le champ `__typename` à la place.")
+}
+
 type File {
   byteSize: Int! @deprecated(reason: "Utilisez le champ `byteSizeBigInt` à la place.")
   byteSizeBigInt: BigInt!
@@ -3944,6 +3972,11 @@ enum TypeDeChamp {
   Explication
   """
   explication
+
+  """
+  Expression régulière
+  """
+  expression_reguliere
 
   """
   Titre de section

--- a/app/graphql/types/champ_descriptor_type.rb
+++ b/app/graphql/types/champ_descriptor_type.rb
@@ -96,6 +96,8 @@ module Types
           Types::Champs::Descriptor::EpciChampDescriptorType
         when TypeDeChamp.type_champs.fetch(:cojo)
           Types::Champs::Descriptor::COJOChampDescriptorType
+        when TypeDeChamp.type_champs.fetch(:expression_reguliere)
+          Types::Champs::Descriptor::ExpressionReguliereChampDescriptorType
         end
       end
     end

--- a/app/graphql/types/champs/descriptor/expression_reguliere_champ_descriptor_type.rb
+++ b/app/graphql/types/champs/descriptor/expression_reguliere_champ_descriptor_type.rb
@@ -1,0 +1,5 @@
+module Types::Champs::Descriptor
+  class ExpressionReguliereChampDescriptorType < Types::BaseObject
+    implements Types::ChampDescriptorType
+  end
+end

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -58,6 +58,9 @@ class Champ < ApplicationRecord
     :character_limit?,
     :character_limit,
     :yes_no?,
+    :expression_reguliere,
+    :expression_reguliere_exemple_text,
+    :expression_reguliere_error_message,
     to: :type_de_champ
 
   delegate :to_typed_id, :to_typed_id_for_query, to: :type_de_champ, prefix: true

--- a/app/models/champs/expression_reguliere_champ.rb
+++ b/app/models/champs/expression_reguliere_champ.rb
@@ -1,0 +1,3 @@
+class Champs::ExpressionReguliereChamp < Champ
+  validates_with ExpressionReguliereValidator, if: -> { validation_context != :brouillon }
+end

--- a/app/models/concerns/dossier_rebase_concern.rb
+++ b/app/models/concerns/dossier_rebase_concern.rb
@@ -32,6 +32,10 @@ module DossierRebaseConcern
     !champs.filter { _1.stable_id == stable_id }.any? { _1.in?(options) }
   end
 
+  def can_rebase_expression_reguliere_change?(stable_id, expression_reguliere)
+    false
+  end
+
   private
 
   def accepted_en_construction_changes?

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -1152,20 +1152,6 @@ class Dossier < ApplicationRecord
       end
   end
 
-  def check_expressions_regulieres_champs
-    champs_public.filter { _1.expression_reguliere && _1.visible? }.map do |champ|
-      if champ.value.present?
-        begin
-          if !champ.value.match(Regexp.new(champ.expression_reguliere, timeout: 5.0))
-            champ.errors.add(:value, :invalid)
-          end
-        rescue Regexp::TimeoutError
-          self.errors.add(:value, I18n.t('errors.messages.evil_regexp'))
-        end
-      end
-    end
-  end
-
   def demander_un_avis!(avis)
     log_dossier_operation(avis.claimant, :demander_un_avis, avis)
   end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -1152,6 +1152,20 @@ class Dossier < ApplicationRecord
       end
   end
 
+  def check_expressions_regulieres_champs
+    champs_public.filter { _1.expression_reguliere && _1.visible? }.map do |champ|
+      if champ.value.present?
+        begin
+          if !champ.value.match(Regexp.new(champ.expression_reguliere, timeout: 5.0))
+            champ.errors.add(:value, :invalid)
+          end
+        rescue Regexp::TimeoutError
+          self.errors.add(:value, I18n.t('errors.messages.evil_regexp'))
+        end
+      end
+    end
+  end
+
   def demander_un_avis!(avis)
     log_dossier_operation(avis.claimant, :demander_un_avis, avis)
   end

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -19,6 +19,7 @@ class ProcedureRevision < ApplicationRecord
 
   validate :conditions_are_valid?
   validate :header_sections_are_valid?
+  validate :expressions_regulieres_are_valid?
 
   delegate :path, to: :procedure, prefix: true
 
@@ -410,6 +411,13 @@ class ProcedureRevision < ApplicationRecord
       .map { errors_for_header_sections_order(_1) }
 
     repetition_tdcs_errors + root_tdcs_errors
+  end
+
+  def expressions_regulieres_are_valid?
+    types_de_champ_public.to_a
+      .flat_map { _1.repetition? ? children_of(_1) : _1 }
+      .filter { _1.expression_reguliere? && _1.invalid_regexp? }
+      .each { |tdc| errors.add(:expression_reguliere, type_de_champ: tdc) }
   end
 
   def errors_for_header_sections_order(tdcs)

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -416,8 +416,11 @@ class ProcedureRevision < ApplicationRecord
   def expressions_regulieres_are_valid?
     types_de_champ_public.to_a
       .flat_map { _1.repetition? ? children_of(_1) : _1 }
-      .filter { _1.expression_reguliere? && _1.invalid_regexp? }
-      .each { |tdc| errors.add(:expression_reguliere, type_de_champ: tdc) }
+      .each do |tdc|
+        if tdc.expression_reguliere? && tdc.invalid_regexp?
+          errors.add(:expression_reguliere, type_de_champ: tdc)
+        end
+      end
   end
 
   def errors_for_header_sections_order(tdcs)

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -376,6 +376,25 @@ class ProcedureRevision < ApplicationRecord
           from_type_de_champ.character_limit,
           to_type_de_champ.character_limit)
       end
+    elsif to_type_de_champ.expression_reguliere?
+      if from_type_de_champ.expression_reguliere != to_type_de_champ.expression_reguliere
+        changes << ProcedureRevisionChange::UpdateChamp.new(from_type_de_champ,
+          :expression_reguliere,
+          from_type_de_champ.expression_reguliere,
+          to_type_de_champ.expression_reguliere)
+      end
+      if from_type_de_champ.expression_reguliere_exemple_text != to_type_de_champ.expression_reguliere_exemple_text
+        changes << ProcedureRevisionChange::UpdateChamp.new(from_type_de_champ,
+          :expression_reguliere_exemple_text,
+          from_type_de_champ.expression_reguliere_exemple_text,
+          to_type_de_champ.expression_reguliere_exemple_text)
+      end
+      if from_type_de_champ.expression_reguliere_error_message != to_type_de_champ.expression_reguliere_error_message
+        changes << ProcedureRevisionChange::UpdateChamp.new(from_type_de_champ,
+          :expression_reguliere_error_message,
+          from_type_de_champ.expression_reguliere_error_message,
+          to_type_de_champ.expression_reguliere_error_message)
+      end
     end
     changes
   end

--- a/app/models/procedure_revision_change.rb
+++ b/app/models/procedure_revision_change.rb
@@ -60,7 +60,6 @@ class ProcedureRevisionChange
 
     def can_rebase?(dossier = nil)
       return true if private?
-
       case attribute
       when :drop_down_options
         (from - to).empty? || dossier&.can_rebase_drop_down_options_change?(stable_id, from - to)
@@ -68,7 +67,7 @@ class ProcedureRevisionChange
         !from && to
       when :mandatory
         (from && !to) || dossier&.can_rebase_mandatory_change?(stable_id)
-      when :type_champ, :condition
+      when :type_champ, :condition, :expression_reguliere
         false
       else
         true

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -3,7 +3,8 @@ class TypeDeChamp < ApplicationRecord
 
   FILE_MAX_SIZE = 200.megabytes
   FEATURE_FLAGS = {
-    cojo: :cojo_type_de_champ
+    cojo: :cojo_type_de_champ,
+    expression_reguliere: :expression_reguliere_type_de_champ
   }
   MINIMUM_TEXTAREA_CHARACTER_LIMIT_LENGTH = 400
 

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -55,7 +55,8 @@ class TypeDeChamp < ApplicationRecord
     dgfip: REFERENTIEL_EXTERNE,
     pole_emploi: REFERENTIEL_EXTERNE,
     mesri: REFERENTIEL_EXTERNE,
-    cojo: REFERENTIEL_EXTERNE
+    cojo: REFERENTIEL_EXTERNE,
+    expression_reguliere: STANDARD
   }
 
   enum type_champs: {
@@ -95,7 +96,8 @@ class TypeDeChamp < ApplicationRecord
     pole_emploi: 'pole_emploi',
     mesri: 'mesri',
     epci: 'epci',
-    cojo: 'cojo'
+    cojo: 'cojo',
+    expression_reguliere: 'expression_reguliere'
   }
 
   ROUTABLE_TYPES = [
@@ -116,6 +118,9 @@ class TypeDeChamp < ApplicationRecord
                  :drop_down_secondary_description,
                  :drop_down_other,
                  :character_limit,
+                 :expression_reguliere,
+                 :expression_reguliere_exemple_text,
+                 :expression_reguliere_error_message,
                  :collapsible_explanation_enabled,
                  :collapsible_explanation_text,
                  :header_section_level
@@ -184,6 +189,7 @@ class TypeDeChamp < ApplicationRecord
 
   before_validation :check_mandatory
   before_validation :normalize_libelle
+
   before_save :remove_piece_justificative_template, if: -> { type_champ_changed? }
   before_validation :remove_drop_down_list, if: -> { type_champ_changed? }
   before_save :remove_block, if: -> { type_champ_changed? }
@@ -414,6 +420,10 @@ class TypeDeChamp < ApplicationRecord
     type_champ == TypeDeChamp.type_champs.fetch(:checkbox)
   end
 
+  def expression_reguliere?
+    type_champ == TypeDeChamp.type_champs.fetch(:expression_reguliere)
+  end
+
   def public?
     !private?
   end
@@ -602,6 +612,24 @@ class TypeDeChamp < ApplicationRecord
 
   def routable?
     type_champ.in?(ROUTABLE_TYPES)
+  end
+
+  def invalid_regexp?
+    return false if expression_reguliere.blank?
+    return false if expression_reguliere_exemple_text.blank?
+    begin
+      if expression_reguliere_exemple_text.match?(Regexp.new(expression_reguliere, timeout: 2.0))
+        return false
+      end
+    rescue Regexp::TimeoutError
+      self.errors.add(:expression_reguliere, I18n.t('errors.messages.evil_regexp'))
+    end
+
+    self.errors.add(:expression_reguliere_exemple_text, I18n.t('errors.messages.mismatch_regexp'))
+    true
+  rescue RegexpError
+    self.errors.add(:expression_reguliere, I18n.t('errors.messages.syntax_error_regexp'))
+    true
   end
 
   private

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -618,15 +618,12 @@ class TypeDeChamp < ApplicationRecord
   def invalid_regexp?
     return false if expression_reguliere.blank?
     return false if expression_reguliere_exemple_text.blank?
-    begin
-      if expression_reguliere_exemple_text.match?(Regexp.new(expression_reguliere, timeout: 2.0))
-        return false
-      end
-    rescue Regexp::TimeoutError
-      self.errors.add(:expression_reguliere, I18n.t('errors.messages.evil_regexp'))
-    end
+    return false if expression_reguliere_exemple_text.match?(Regexp.new(expression_reguliere, timeout: 2.0))
 
     self.errors.add(:expression_reguliere_exemple_text, I18n.t('errors.messages.mismatch_regexp'))
+    true
+  rescue Regexp::TimeoutError
+    self.errors.add(:expression_reguliere, I18n.t('errors.messages.evil_regexp'))
     true
   rescue RegexpError
     self.errors.add(:expression_reguliere, I18n.t('errors.messages.syntax_error_regexp'))

--- a/app/models/types_de_champ/expression_reguliere_type_de_champ.rb
+++ b/app/models/types_de_champ/expression_reguliere_type_de_champ.rb
@@ -1,0 +1,2 @@
+class TypesDeChamp::ExpressionReguliereTypeDeChamp < TypesDeChamp::TypeDeChampBase
+end

--- a/app/validators/expression_reguliere_validator.rb
+++ b/app/validators/expression_reguliere_validator.rb
@@ -1,0 +1,14 @@
+
+class ExpressionReguliereValidator < ActiveModel::Validator
+  def validate(record)
+    if record.value.present?
+      begin
+        if !record.value.match?(Regexp.new(record.expression_reguliere, timeout: 5.0))
+          record.errors.add(:value, I18n.t('errors.messages.invalid_regexp', expression_reguliere_error_message: record.expression_reguliere_error_message))
+        end
+      rescue Regexp::TimeoutError
+        record.errors.add(:expression_reguliere, I18n.t('errors.messages.evil_regexp'))
+      end
+    end
+  end
+end

--- a/app/validators/expression_reguliere_validator.rb
+++ b/app/validators/expression_reguliere_validator.rb
@@ -1,14 +1,11 @@
-
 class ExpressionReguliereValidator < ActiveModel::Validator
   def validate(record)
     if record.value.present?
-      begin
-        if !record.value.match?(Regexp.new(record.expression_reguliere, timeout: 5.0))
-          record.errors.add(:value, I18n.t('errors.messages.invalid_regexp', expression_reguliere_error_message: record.expression_reguliere_error_message))
-        end
-      rescue Regexp::TimeoutError
-        record.errors.add(:expression_reguliere, I18n.t('errors.messages.evil_regexp'))
+      if !record.value.match?(Regexp.new(record.expression_reguliere, timeout: 5.0))
+        record.errors.add(:value, I18n.t('errors.messages.invalid_regexp', expression_reguliere_error_message: record.expression_reguliere_error_message))
       end
     end
+  rescue Regexp::TimeoutError
+    record.errors.add(:expression_reguliere, :evil_regexp)
   end
 end

--- a/app/validators/expression_reguliere_validator.rb
+++ b/app/validators/expression_reguliere_validator.rb
@@ -2,7 +2,7 @@ class ExpressionReguliereValidator < ActiveModel::Validator
   def validate(record)
     if record.value.present?
       if !record.value.match?(Regexp.new(record.expression_reguliere, timeout: 5.0))
-        record.errors.add(:value, I18n.t('errors.messages.invalid_regexp', expression_reguliere_error_message: record.expression_reguliere_error_message))
+        record.errors.add(:value, :invalid_regexp)
       end
     end
   rescue Regexp::TimeoutError

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -687,7 +687,6 @@ en:
       evil_regexp: The regular expression you have entered is potentially dangerous and could lead to performance issues.
       mismatch_regexp: The provided example must match the regular expression
       syntax_error_regexp: The syntax of the regular expression is invalid
-      invalid_regexp: "%{expression_reguliere_error_message}"
       # # procedure_not_draft: "This procedure is not a draft anymore."
       # cadastres_empty:
       #   one: "Aucune parcelle cadastrale sur la zone sélectionnée"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -684,6 +684,10 @@ en:
       procedure_archived:
         with_service_and_phone_email: This procedure has been closed, it is no longer possible to submit a file. For more information, please contact the service %{service_name}, available at %{service_phone_number} or by email %{service_email}
         with_organisation_only: This procedure has been closed, it is no longer possible to submit a file. For more information, please contact the organisation %{organisation_name}
+      evil_regexp: The regular expression you have entered is potentially dangerous and could lead to performance issues.
+      mismatch_regexp: The provided example must match the regular expression
+      syntax_error_regexp: The syntax of the regular expression is invalid
+      invalid_regexp: "%{expression_reguliere_error_message}"
       # # procedure_not_draft: "This procedure is not a draft anymore."
       # cadastres_empty:
       #   one: "Aucune parcelle cadastrale sur la zone sélectionnée"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -689,7 +689,10 @@ fr:
       procedure_archived:
         with_service_and_phone_email: Cette démarche en ligne a été close, il n’est plus possible de déposer de dossier. Pour plus d’informations veuillez contacter le service %{service_name} au %{service_phone_number} ou par email à %{service_email}
         with_organisation_only: Cette démarche en ligne a été close, il n’est plus possible de déposer de dossier. Pour plus d’informations veuillez contacter le service %{organisation_name}
-
+      evil_regexp: L'expression régulière que vous avez entrée est potentiellement dangereuse et pourrait entraîner des problèmes de performance
+      mismatch_regexp: L'exemple doit correspondre à l'expression régulière fournie
+      syntax_error_regexp: La syntaxe de l'expression régulière n'est pas valide
+      invalid_regexp: "%{expression_reguliere_error_message}"
       empty_repetition: '« %{value} » doit comporter au moins un champ répétable'
       empty_drop_down: '« %{value} » doit comporter au moins un choix sélectionnable'
       # procedure_not_draft: "Cette démarche n’est maintenant plus en brouillon."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -692,7 +692,6 @@ fr:
       evil_regexp: L'expression régulière que vous avez entrée est potentiellement dangereuse et pourrait entraîner des problèmes de performance
       mismatch_regexp: L'exemple doit correspondre à l'expression régulière fournie
       syntax_error_regexp: La syntaxe de l'expression régulière n'est pas valide
-      invalid_regexp: "%{expression_reguliere_error_message}"
       empty_repetition: '« %{value} » doit comporter au moins un champ répétable'
       empty_drop_down: '« %{value} » doit comporter au moins un choix sélectionnable'
       # procedure_not_draft: "Cette démarche n’est maintenant plus en brouillon."

--- a/config/locales/models/champs/expression_reguliere_champ/en.yml
+++ b/config/locales/models/champs/expression_reguliere_champ/en.yml
@@ -1,0 +1,8 @@
+en:
+  activerecord:
+    errors:
+      models:
+        champs/expression_reguliere_champ:
+          attributes:
+            value:
+              invalid_regexp: does not match expected format

--- a/config/locales/models/champs/expression_reguliere_champ/fr.yml
+++ b/config/locales/models/champs/expression_reguliere_champ/fr.yml
@@ -1,0 +1,8 @@
+fr:
+  activerecord:
+    errors:
+      models:
+        champs/expression_reguliere_champ:
+          attributes:
+            value:
+              invalid_regexp: ne correspond pas au format attendu

--- a/config/locales/models/type_de_champ/en.yml
+++ b/config/locales/models/type_de_champ/en.yml
@@ -55,6 +55,7 @@ en:
           mesri: "Data from Ministère de l’Enseignement Supérieur, de la Recherche et de l’Innovation"
           epci: "EPCI"
           cojo: "Accreditation Paris 2024"
+          expression_reguliere: 'Regular expression'
     errors:
       type_de_champ:
         attributes:

--- a/config/locales/models/type_de_champ/fr.yml
+++ b/config/locales/models/type_de_champ/fr.yml
@@ -55,6 +55,7 @@ fr:
           mesri: "Données du Ministère de l’Enseignement Supérieur, de la Recherche et de l’Innovation"
           epci: "EPCI"
           cojo: "Accréditation Paris 2024"
+          expression_reguliere: 'Expression régulière'
     errors:
       type_de_champ:
         attributes:

--- a/spec/factories/champ.rb
+++ b/spec/factories/champ.rb
@@ -243,6 +243,10 @@ FactoryBot.define do
       type_de_champ { association :type_de_champ_cojo, procedure: dossier.procedure }
     end
 
+    factory :champ_expression_reguliere, class: 'Champs::ExpressionReguliereChamp' do
+      type_de_champ { association :type_de_champ_expression_reguliere, procedure: dossier.procedure }
+    end
+
     factory :champ_repetition, class: 'Champs::RepetitionChamp' do
       type_de_champ { association :type_de_champ_repetition, procedure: dossier.procedure }
 

--- a/spec/factories/type_de_champ.rb
+++ b/spec/factories/type_de_champ.rb
@@ -99,6 +99,9 @@ FactoryBot.define do
       type_champ { TypeDeChamp.type_champs.fetch(:linked_drop_down_list) }
       drop_down_list_value { "--primary--\nsecondary\n" }
     end
+    factory :type_de_champ_expression_reguliere do
+      type_champ { TypeDeChamp.type_champs.fetch(:expression_reguliere) }
+    end
     factory :type_de_champ_pays do
       type_champ { TypeDeChamp.type_champs.fetch(:pays) }
     end

--- a/spec/lib/tasks/deployment/20220705164551_remove_unused_champs_spec.rb
+++ b/spec/lib/tasks/deployment/20220705164551_remove_unused_champs_spec.rb
@@ -14,9 +14,9 @@ describe '20220705164551_remove_unused_champs' do
 
   describe 'remove_unused_champs' do
     it "with bad champs" do
-      expect(Champ.where(dossier: dossier).count).to eq(41)
+      expect(Champ.where(dossier: dossier).count).to eq(42)
       run_task
-      expect(Champ.where(dossier: dossier).count).to eq(40)
+      expect(Champ.where(dossier: dossier).count).to eq(41)
     end
   end
 end

--- a/spec/models/concern/dossier_rebase_concern_spec.rb
+++ b/spec/models/concern/dossier_rebase_concern_spec.rb
@@ -124,6 +124,21 @@ describe DossierRebaseConcern do
         end
       end
 
+      context 'with type de champ regexp and regexp change' do
+        let(:procedure) { create(:procedure, types_de_champ_public: [{ mandatory: true }, { type: :expression_reguliere }], types_de_champ_private: [{}]) }
+
+        before do
+          procedure.draft_revision.find_and_ensure_exclusive_use(type_de_champ.stable_id).update(expression_reguliere: /\d+/)
+          procedure.publish_revision!
+          dossier.reload
+        end
+
+        it 'should be false' do
+          expect(dossier.pending_changes).not_to be_empty
+          expect(dossier.can_rebase?).to be_falsey
+        end
+      end
+
       context 'with removed type de champ' do
         before do
           procedure.draft_revision.remove_type_de_champ(type_de_champ.stable_id)

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1575,6 +1575,50 @@ describe Dossier, type: :model do
     end
   end
 
+  describe "#check_expressions_regulieres_champs" do
+    include Logic
+
+    let(:procedure) { create(:procedure, types_de_champ_public: types_de_champ) }
+    let(:dossier) { create(:dossier, procedure: procedure) }
+    let(:types_de_champ) { [type_de_champ] }
+    let(:type_de_champ) { { type: :expression_reguliere, expression_reguliere:, expression_reguliere_exemple_text: } }
+    let(:errors) { dossier.check_expressions_regulieres_champs }
+
+    context "with bad example" do
+      let(:expression_reguliere_exemple_text) { "01234567" }
+      let(:expression_reguliere) { "[A-Z]+" }
+
+      before do
+        champ = dossier.champs_public.first
+        champ.value = expression_reguliere_exemple_text
+        champ.save!
+        dossier.reload
+      end
+
+      it 'should have errors' do
+        expect(errors).not_to be_empty
+        expect(errors.first.full_message).to eq("n'est pas valide")
+      end
+    end
+
+    context "with good example" do
+      let(:expression_reguliere_exemple_text) { "AZERTY" }
+      let(:expression_reguliere) { "[A-Z]+" }
+
+      before do
+        champ = dossier.champs_public.first
+        champ.value = expression_reguliere_exemple_text
+        champ.save!
+        dossier.reload
+      end
+
+      it 'should not have errors' do
+        expect(errors).not_to be_empty
+        expect(errors.first).to be_nil
+      end
+    end
+  end
+
   describe 'index_for_section_header' do
     let(:procedure) { create(:procedure, types_de_champ_public: types_de_champ) }
     let(:dossier) { create(:dossier, procedure: procedure) }

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1604,13 +1604,11 @@ describe Dossier, type: :model do
       before do
         champ = dossier.champs_public.first
         champ.value = expression_reguliere_exemple_text
-        champ.save!
-        dossier.reload
+        dossier.save
       end
 
       it 'should not have errors' do
-        expect(errors).not_to be_empty
-        expect(errors.first).to be_nil
+        expect(dossier.errors).to be_empty
       end
     end
   end

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1576,13 +1576,10 @@ describe Dossier, type: :model do
   end
 
   describe "#check_expressions_regulieres_champs" do
-    include Logic
-
     let(:procedure) { create(:procedure, types_de_champ_public: types_de_champ) }
     let(:dossier) { create(:dossier, procedure: procedure) }
     let(:types_de_champ) { [type_de_champ] }
     let(:type_de_champ) { { type: :expression_reguliere, expression_reguliere:, expression_reguliere_exemple_text: } }
-    let(:errors) { dossier.check_expressions_regulieres_champs }
 
     context "with bad example" do
       let(:expression_reguliere_exemple_text) { "01234567" }
@@ -1591,13 +1588,12 @@ describe Dossier, type: :model do
       before do
         champ = dossier.champs_public.first
         champ.value = expression_reguliere_exemple_text
-        champ.save!
-        dossier.reload
+        dossier.save
       end
 
       it 'should have errors' do
-        expect(errors).not_to be_empty
-        expect(errors.first.full_message).to eq("n'est pas valide")
+        expect(dossier.errors).not_to be_empty
+        expect(dossier.errors.full_messages.join(',')).to include("ne correspond pas au format attendu")
       end
     end
 

--- a/spec/models/procedure_revision_spec.rb
+++ b/spec/models/procedure_revision_spec.rb
@@ -908,6 +908,75 @@ describe ProcedureRevision do
     end
   end
 
+  describe "expressions_regulieres_are_valid" do
+    let(:procedure) do
+      create(:procedure).tap do |p|
+        p.draft_revision.add_type_de_champ(type_champ: :expression_reguliere, libelle: 'exemple', expression_reguliere:, expression_reguliere_exemple_text:)
+      end
+    end
+    let(:draft_revision) { procedure.draft_revision }
+
+    subject do
+      draft_revision.save
+      draft_revision.errors
+    end
+
+    context "When no regexp and no example" do
+      let(:expression_reguliere_exemple_text) { nil }
+      let(:expression_reguliere) { nil }
+
+      it { is_expected.to be_empty }
+    end
+
+    context "When expression_reguliere but no example" do
+      let(:expression_reguliere) { "[A-Z]+" }
+      let(:expression_reguliere_exemple_text) { nil }
+
+      it { is_expected.to be_empty }
+    end
+
+    context "When expression_reguliere and bad example" do
+      let(:expression_reguliere_exemple_text) { "01234567" }
+      let(:expression_reguliere) { "[A-Z]+" }
+
+      it { is_expected.not_to be_empty }
+    end
+
+    context "When expression_reguliere and good example" do
+      let(:expression_reguliere_exemple_text) { "A" }
+      let(:expression_reguliere) { "[A-Z]+" }
+      it { is_expected.to be_empty }
+    end
+
+    context "When bad expression_reguliere" do
+      let(:expression_reguliere_exemple_text) { "0123456789" }
+      let(:expression_reguliere) { "(" }
+
+      it { is_expected.not_to be_empty }
+    end
+
+    context "When repetition" do
+      let(:procedure) do
+        create(:procedure,
+               types_de_champ_public: [{ type: :repetition, children: [{ type: :expression_reguliere, expression_reguliere:, expression_reguliere_exemple_text: }] }])
+      end
+
+      context "When bad expression_reguliere" do
+        let(:expression_reguliere_exemple_text) { "0123456789" }
+        let(:expression_reguliere) { "(" }
+
+        it { is_expected.not_to be_empty }
+      end
+
+      context "When expression_reguliere and bad example" do
+        let(:expression_reguliere_exemple_text) { "01234567" }
+        let(:expression_reguliere) { "[A-Z]+" }
+
+        it { is_expected.not_to be_empty }
+      end
+    end
+  end
+
   describe "#dependent_conditions" do
     include Logic
 

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -166,6 +166,31 @@ describe TypeDeChamp do
     end
   end
 
+  describe "validate_regexp" do
+    let(:tdc) { create(:type_de_champ_expression_reguliere, expression_reguliere:, expression_reguliere_exemple_text:) }
+    subject { tdc.invalid_regexp? }
+
+    context "expression_reguliere and bad example" do
+      let(:expression_reguliere_exemple_text) { "01234567" }
+      let(:expression_reguliere) { "[A-Z]+" }
+
+      it "should add error message" do
+        expect(subject).to be_truthy
+        expect(tdc.errors.messages[:expression_reguliere_exemple_text]).to be_present
+      end
+    end
+
+    context "Bad expression_reguliere" do
+      let(:expression_reguliere_exemple_text) { "0123456789" }
+      let(:expression_reguliere) { "(" }
+
+      it "should add error message" do
+        expect(subject).to be_truthy
+        expect(tdc.errors.messages[:expression_reguliere]).to be_present
+      end
+    end
+  end
+
   describe '#drop_down_list_options' do
     let(:value) do
       <<~EOS

--- a/spec/services/procedure_export_service_spec.rb
+++ b/spec/services/procedure_export_service_spec.rb
@@ -89,7 +89,8 @@ describe ProcedureExportService do
           "epci",
           "epci (Code)",
           "epci (Département)",
-          "cojo"
+          "cojo",
+          "expression_reguliere"
         ]
       end
 
@@ -200,7 +201,8 @@ describe ProcedureExportService do
           "epci",
           "epci (Code)",
           "epci (Département)",
-          "cojo"
+          "cojo",
+          "expression_reguliere"
         ]
       end
 
@@ -294,7 +296,8 @@ describe ProcedureExportService do
             "epci",
             "epci (Code)",
             "epci (Département)",
-            "cojo"
+            "cojo",
+            "expression_reguliere"
           ]
         end
 


### PR DESCRIPTION
#9411 

Si le feature flag (`:expression_reguliere_type_de_champ`) est activé, il est possible d'ajouter un champ Expression Regulière : 


<img width="1229" alt="image" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/21340608/c6b3772f-2455-4a02-9cc1-f423abbba68f">


**Coté utilisateur, lorsque le champ ne match pas la regex :** 

<img width="1180" alt="image" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/21340608/679761f7-f4dc-4ec1-a7fd-eaaccaa01d8a">

**Coté utilisateur, lorsque le dossier est soumis mais que le champ est invalide :** 

<img width="1372" alt="image" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/21340608/e3c13ef1-3a59-41a2-809f-736b6ee844ac">


