### PR TITLE
Feature ouidou/admin creation delegation gestionnaire page gestionnaire management

### DIFF
--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -9,4 +9,8 @@ class ApplicationComponent < ViewComponent::Base
   def current_administrateur
     controller.current_administrateur
   end
+
+  def current_gestionnaire
+    controller.current_gestionnaire
+  end
 end

--- a/app/components/groupe_gestionnaire/card/gestionnaires_component.rb
+++ b/app/components/groupe_gestionnaire/card/gestionnaires_component.rb
@@ -1,0 +1,5 @@
+class GroupeGestionnaire::Card::GestionnairesComponent < ApplicationComponent
+  def initialize(groupe_gestionnaire:)
+    @groupe_gestionnaire = groupe_gestionnaire
+  end
+end

--- a/app/components/groupe_gestionnaire/card/gestionnaires_component/gestionnaires_component.fr.yml
+++ b/app/components/groupe_gestionnaire/card/gestionnaires_component/gestionnaires_component.fr.yml
@@ -1,0 +1,5 @@
+---
+fr:
+  title:
+    one: Gestionnaire
+    other: Gestionnaires

--- a/app/components/groupe_gestionnaire/card/gestionnaires_component/gestionnaires_component.html.haml
+++ b/app/components/groupe_gestionnaire/card/gestionnaires_component/gestionnaires_component.html.haml
@@ -1,0 +1,13 @@
+.fr-col-6.fr-col-md-4.fr-col-lg-3
+  = link_to gestionnaire_groupe_gestionnaire_gestionnaires_path(@groupe_gestionnaire), id: 'gestionnaires', class: 'fr-tile fr-enlarge-link' do
+    .fr-tile__body.flex.column.align-center.justify-between
+      %div
+        %span.icon.accept
+        %p.fr-tile-status-accept Validé
+      %div
+        .line-count.fr-my-1w
+          %p.fr-tag= @groupe_gestionnaire.gestionnaires.size
+        %h3.fr-h6
+          = t('.title', count: @groupe_gestionnaire.gestionnaires.size)
+        %p.fr-tile-subtitle Gestion de la démarche
+      %p.fr-btn.fr-btn--tertiary= t('views.shared.actions.edit')

--- a/app/components/groupe_gestionnaire/groupe_gestionnaire_gestionnaires/gestionnaire_component.rb
+++ b/app/components/groupe_gestionnaire/groupe_gestionnaire_gestionnaires/gestionnaire_component.rb
@@ -1,0 +1,42 @@
+class GroupeGestionnaire::GroupeGestionnaireGestionnaires::GestionnaireComponent < ApplicationComponent
+  include ApplicationHelper
+
+  def initialize(groupe_gestionnaire:, gestionnaire:)
+    @groupe_gestionnaire = groupe_gestionnaire
+    @gestionnaire = gestionnaire
+  end
+
+  def email
+    if @gestionnaire == current_gestionnaire
+      "#{@gestionnaire.email} (C’est vous !)"
+    else
+      @gestionnaire.email
+    end
+  end
+
+  def created_at
+    try_format_datetime(@gestionnaire.created_at)
+  end
+
+  def registration_state
+    @gestionnaire.registration_state
+  end
+
+  def remove_button
+    if is_there_at_least_another_active_admin?
+      button_to 'Retirer',
+       gestionnaire_groupe_gestionnaire_gestionnaire_path(@groupe_gestionnaire, @gestionnaire),
+       method: :delete,
+       class: 'button',
+       form: { data: { turbo: true, turbo_confirm: "Retirer « #{@gestionnaire.email} » des gestionnaires de « #{@groupe_gestionnaire.name} » ?" } }
+    end
+  end
+
+  def is_there_at_least_another_active_admin?
+    if @gestionnaire.active?
+      @groupe_gestionnaire.gestionnaires.count(&:active?) > 1
+    else
+      @groupe_gestionnaire.gestionnaires.count(&:active?) >= 1
+    end
+  end
+end

--- a/app/components/groupe_gestionnaire/groupe_gestionnaire_gestionnaires/gestionnaire_component/gestionnaire_component.html.haml
+++ b/app/components/groupe_gestionnaire/groupe_gestionnaire_gestionnaires/gestionnaire_component/gestionnaire_component.html.haml
@@ -1,0 +1,5 @@
+%tr{ id: dom_id(@gestionnaire) }
+  %td= email
+  %td= created_at
+  %td= registration_state
+  %td= remove_button

--- a/app/controllers/gestionnaires/gestionnaire_controller.rb
+++ b/app/controllers/gestionnaires/gestionnaire_controller.rb
@@ -5,5 +5,18 @@ module Gestionnaires
     def nav_bar_profile
       :gestionnaire
     end
+
+    def retrieve_groupe_gestionnaire
+      id = params[:groupe_gestionnaire_id] || params[:id]
+
+      @groupe_gestionnaire = current_gestionnaire.groupe_gestionnaires.find(id)
+
+      Sentry.configure_scope do |scope|
+        scope.set_tags(groupe_gestionnaire: @groupe_gestionnaire.id)
+      end
+    rescue ActiveRecord::RecordNotFound
+      flash.alert = 'Groupe inexistant'
+      redirect_to gestionnaire_groupe_gestionnaires_path, status: 404
+    end
   end
 end

--- a/app/controllers/gestionnaires/groupe_gestionnaire_gestionnaires_controller.rb
+++ b/app/controllers/gestionnaires/groupe_gestionnaire_gestionnaires_controller.rb
@@ -1,0 +1,17 @@
+module Gestionnaires
+  class GroupeGestionnaireGestionnairesController < GestionnaireController
+    before_action :retrieve_groupe_gestionnaire, except: [:new]
+
+    def index
+    end
+
+    def create
+      gestionnaires, flash[:alert], flash[:notice] = @groupe_gestionnaire.add_gestionnaires(emails: [params.require(:gestionnaire)[:email]], current_user: current_gestionnaire)
+      @gestionnaire = gestionnaires[0]
+    end
+
+    def destroy
+      @gestionnaire, flash[:alert], flash[:notice] = @groupe_gestionnaire.remove(params[:id], current_gestionnaire)
+    end
+  end
+end

--- a/app/controllers/gestionnaires/groupe_gestionnaires_controller.rb
+++ b/app/controllers/gestionnaires/groupe_gestionnaires_controller.rb
@@ -1,7 +1,12 @@
 module Gestionnaires
   class GroupeGestionnairesController < GestionnaireController
+    before_action :retrieve_groupe_gestionnaire, only: [:show]
+
     def index
       @groupe_gestionnaires = groupe_gestionnaires
+    end
+
+    def show
     end
 
     private

--- a/app/controllers/manager/groupe_gestionnaires_controller.rb
+++ b/app/controllers/manager/groupe_gestionnaires_controller.rb
@@ -1,42 +1,13 @@
 module Manager
   class GroupeGestionnairesController < Manager::ApplicationController
     def add_gestionnaire
-      emails = (params['emails'].presence || '').split(',').to_json
-      emails = JSON.parse(emails).map { EmailSanitizableConcern::EmailSanitizer.sanitize(_1) }
-
-      gestionnaires, invalid_emails = groupe_gestionnaire.add_gestionnaires(emails:)
-
-      if invalid_emails.present?
-        flash[:alert] = t('.wrong_address',
-          count: invalid_emails.size,
-          emails: invalid_emails)
-      end
-
-      if gestionnaires.present?
-        flash[:notice] = "Les gestionnaires ont bien été affectés au groupe d'administrateurs"
-
-        GroupeGestionnaireMailer
-          .notify_added_gestionnaires(groupe_gestionnaire, gestionnaires, current_super_admin.email)
-          .deliver_later
-      end
+      _gestionnaires, flash[:alert], flash[:notice] = groupe_gestionnaire.add_gestionnaires(emails: (params['emails'].presence || '').split(','), current_user: current_super_admin)
 
       redirect_to manager_groupe_gestionnaire_path(groupe_gestionnaire)
     end
 
     def remove_gestionnaire
-      if !groupe_gestionnaire.root_groupe_gestionnaire? || groupe_gestionnaire.gestionnaires.one?
-        flash[:alert] = "Suppression impossible : il doit y avoir au moins un gestionnaire dans le groupe racine"
-      else
-        gestionnaire = Gestionnaire.find(gestionnaire_id)
-        if groupe_gestionnaire.remove(gestionnaire)
-          flash[:notice] = "Le gestionnaire « #{gestionnaire.email} » a été retiré du groupe."
-          GroupeGestionnaireMailer
-            .notify_removed_gestionnaire(groupe_gestionnaire, gestionnaire, current_super_admin.email)
-            .deliver_later
-        else
-          flash[:alert] = "Le gestionnaire « #{gestionnaire.email} » n’est pas dans le groupe."
-        end
-      end
+      _gestionnaire, flash[:alert], flash[:notice] = groupe_gestionnaire.remove(gestionnaire_id, current_super_admin)
 
       redirect_to manager_groupe_gestionnaire_path(groupe_gestionnaire)
     end

--- a/app/models/gestionnaire.rb
+++ b/app/models/gestionnaire.rb
@@ -11,6 +11,14 @@ class Gestionnaire < ApplicationRecord
     find_by(users: { email: email })
   end
 
+  def email
+    user&.email
+  end
+
+  def active?
+    user&.active?
+  end
+
   def self.find_all_by_identifier(ids: [], emails: [])
     find_all_by_identifier_with_emails(ids:, emails:).first
   end

--- a/app/models/groupe_gestionnaire.rb
+++ b/app/models/groupe_gestionnaire.rb
@@ -15,14 +15,28 @@ class GroupeGestionnaire < ApplicationRecord
     gestionnaires << gestionnaire
   end
 
-  def remove(gestionnaire)
-    return if gestionnaire.nil?
-    return if !in?(gestionnaire.groupe_gestionnaires)
+  def remove(gestionnaire_id, current_user)
+    if !self.root_groupe_gestionnaire? || self.gestionnaires.one?
+      alert = "Suppression impossible : il doit y avoir au moins un gestionnaire dans le groupe racine"
+    else
+      gestionnaire = Gestionnaire.find(gestionnaire_id)
 
-    gestionnaire.groupe_gestionnaires.destroy(self)
+      if gestionnaire.nil? || !in?(gestionnaire.groupe_gestionnaires) || !gestionnaire.groupe_gestionnaires.destroy(self)
+        alert = "Le gestionnaire « #{gestionnaire.email} » n’est pas dans le groupe."
+      else
+        notice = "Le gestionnaire « #{gestionnaire.email} » a été retiré du groupe."
+        GroupeGestionnaireMailer
+          .notify_removed_gestionnaire(self, gestionnaire, current_user.email)
+          .deliver_later
+      end
+    end
+    [gestionnaire, alert, notice]
   end
 
-  def add_gestionnaires(ids: [], emails: [])
+  def add_gestionnaires(ids: [], emails: [], current_user: nil)
+    emails = emails.to_json
+    emails = JSON.parse(emails).map { EmailSanitizableConcern::EmailSanitizer.sanitize(_1) }
+
     gestionnaires_to_add, valid_emails, invalid_emails = Gestionnaire.find_all_by_identifier_with_emails(ids:, emails:)
     not_found_emails = valid_emails - gestionnaires_to_add.map(&:email)
 
@@ -36,9 +50,29 @@ class GroupeGestionnaire < ApplicationRecord
     end
 
     # We dont't want to assign a user to an groupe_gestionnaire if they are already assigned to it
+    gestionnaires_duplicate = gestionnaires_to_add & gestionnaires
     gestionnaires_to_add -= gestionnaires
     gestionnaires_to_add.each { add(_1) }
 
-    [gestionnaires_to_add, invalid_emails]
+    if invalid_emails.present?
+      alert = I18n.t('activerecord.wrong_address',
+        count: invalid_emails.size,
+        emails: invalid_emails)
+    end
+    if gestionnaires_duplicate.present?
+      alert = I18n.t('activerecord.errors.duplicate_email',
+        count: invalid_emails.size,
+        emails: gestionnaires_duplicate.map{ |gestionnaire| gestionnaire.email })
+    end
+
+    if gestionnaires_to_add.present?
+      notice = "Les gestionnaires ont bien été affectés au groupe d'administrateurs"
+
+      GroupeGestionnaireMailer
+        .notify_added_gestionnaires(self, gestionnaires_to_add, current_user.email)
+        .deliver_later
+    end
+
+    [gestionnaires_to_add, alert, notice]
   end
 end

--- a/app/models/groupe_gestionnaire.rb
+++ b/app/models/groupe_gestionnaire.rb
@@ -62,7 +62,7 @@ class GroupeGestionnaire < ApplicationRecord
     if gestionnaires_duplicate.present?
       alert = I18n.t('activerecord.errors.duplicate_email',
         count: invalid_emails.size,
-        emails: gestionnaires_duplicate.map{ |gestionnaire| gestionnaire.email })
+        emails: gestionnaires_duplicate.map(&:email))
     end
 
     if gestionnaires_to_add.present?

--- a/app/views/gestionnaires/_breadcrumbs.html.haml
+++ b/app/views/gestionnaires/_breadcrumbs.html.haml
@@ -3,14 +3,16 @@
     %nav.fr-breadcrumb.mt-0{ role: "navigation", aria: { label: t('you_are_here', scope: [:layouts, :breadcrumb]) } }
       %button.fr-breadcrumb__button{ aria: { expanded: "false", controls: "breadcrumb-1" } }
         = t('show', scope: [:layouts, :breadcrumb])
-
       .fr-collapse#breadcrumb-1
         %ol.fr-breadcrumb__list
           %li= link_to t('root', scope: [:layouts, :breadcrumb]), root_path, class: 'fr-breadcrumb__link'
-
           - steps.each.with_index do |step, i|
             - if i == steps.size - 1
               %li{ aria: { current: "page" } }
                 %span.fr-breadcrumb__link= step[0]
             - else
               %li= link_to step[0], step[1], class: 'fr-breadcrumb__link'
+    - if defined?(metadatas)
+      .metadatas.pb-3
+        %h1.fr-h6.fr-mb-1w
+          = @groupe_gestionnaire.name

--- a/app/views/gestionnaires/groupe_gestionnaire_gestionnaires/_add_admin_form.html.haml
+++ b/app/views/gestionnaires/groupe_gestionnaire_gestionnaires/_add_admin_form.html.haml
@@ -1,0 +1,13 @@
+= form_for groupe_gestionnaire.gestionnaires.new(user: User.new),
+  url: { controller: 'groupe_gestionnaire_gestionnaires' },
+  html: { id: "new_gestionnaire" },
+  data: { turbo: true, turbo_force: :server } do |f|
+  .fr-input-group
+    = f.label :email, class: "fr-label" do
+      Ajouter un gestionnaire
+      %span.fr-hint-text
+        = "Renseignez l’email d’un gestionnaire pour lui permettre de gérer le groupe « #{groupe_gestionnaire.name} ». Exemple : marie.dupont@exemple.fr"
+
+    = f.email_field :email, required: true, class: "fr-input", autofocus: true
+
+  = f.submit 'Ajouter comme gestionnaire', class: 'fr-btn'

--- a/app/views/gestionnaires/groupe_gestionnaire_gestionnaires/create.turbo_stream.haml
+++ b/app/views/gestionnaires/groupe_gestionnaire_gestionnaires/create.turbo_stream.haml
@@ -1,0 +1,5 @@
+- if @gestionnaire.present?
+  = turbo_stream.update 'gestionnaires' do
+    = render GroupeGestionnaire::GroupeGestionnaireGestionnaires::GestionnaireComponent.with_collection(@groupe_gestionnaire.gestionnaires.order('users.email'), groupe_gestionnaire: @groupe_gestionnaire)
+  = turbo_stream.replace "new_gestionnaire", partial: 'add_admin_form', locals: { groupe_gestionnaire: @groupe_gestionnaire }
+  = turbo_stream.focus 'gestionnaire_email'

--- a/app/views/gestionnaires/groupe_gestionnaire_gestionnaires/destroy.turbo_stream.haml
+++ b/app/views/gestionnaires/groupe_gestionnaire_gestionnaires/destroy.turbo_stream.haml
@@ -1,0 +1,6 @@
+= turbo_stream.update 'gestionnaires' do
+  = render GroupeGestionnaire::GroupeGestionnaireGestionnaires::GestionnaireComponent.with_collection(@groupe_gestionnaire.gestionnaires.order('users.email'), groupe_gestionnaire: @groupe_gestionnaire)
+- if @groupe_gestionnaire.gestionnaires.one?
+  = turbo_stream.focus 'gestionnaire_email'
+- else
+  = turbo_stream.focus_all '#gestionnaires tr:first-child input[type="submit"]'

--- a/app/views/gestionnaires/groupe_gestionnaire_gestionnaires/index.html.haml
+++ b/app/views/gestionnaires/groupe_gestionnaire_gestionnaires/index.html.haml
@@ -1,0 +1,18 @@
+= render partial: 'gestionnaires/breadcrumbs',
+  locals: { steps: [['Groupes gestionnaire', gestionnaire_groupe_gestionnaires_path],
+                    ["#{@groupe_gestionnaire.name.truncate_words(10)}"],
+                    ['Gestionnaires']], preview: false }
+
+.container
+  %h1 Gérer les gestionnaires de « #{@groupe_gestionnaire.name} »
+
+  %table.table
+    %thead
+      %th= 'Adresse email'
+      %th= 'Enregistré le'
+      %th= 'État'
+    %tbody#gestionnaires
+      = render(GroupeGestionnaire::GroupeGestionnaireGestionnaires::GestionnaireComponent.with_collection(@groupe_gestionnaire.gestionnaires.order('users.email'), groupe_gestionnaire: @groupe_gestionnaire))
+
+  .fr-mt-4w
+    = render 'add_admin_form', groupe_gestionnaire: @groupe_gestionnaire

--- a/app/views/gestionnaires/groupe_gestionnaires/_main_menu.html.haml
+++ b/app/views/gestionnaires/groupe_gestionnaires/_main_menu.html.haml
@@ -1,0 +1,4 @@
+.fr-container
+  %nav#header-navigation.fr-nav{ role: 'navigation', 'aria-label': 'Menu principal gestionnaire' }
+    %ul.fr-nav__list
+      %li.fr-nav__item= link_to 'Mes groupes gestionnaire', gestionnaire_groupe_gestionnaires_path, class:'fr-nav__link', 'aria-current': current_page?(controller: 'groupe_gestionnaires', action: :index) ? 'true' : nil

--- a/app/views/gestionnaires/groupe_gestionnaires/index.html.haml
+++ b/app/views/gestionnaires/groupe_gestionnaires/index.html.haml
@@ -1,9 +1,8 @@
-= render partial: 'gestionnaires/breadcrumbs',
-  locals: { steps: [['Groupes d\'administrateurs', gestionnaire_groupe_gestionnaires_path]] }
+= render 'main_menu'
 
-#groupe_gestionnaires-index.container
-  %h1.fr-h1 Liste des groupes d'administrateurs
+.sub-header
 
+.fr-container#groupe_gestionnaire
   %table.fr-table.width-100.mt-3
     %thead
       %tr
@@ -14,4 +13,4 @@
       - @groupe_gestionnaires.each do |groupe_gestionnaire|
         %tr
           %td
-            = groupe_gestionnaire.name
+            = link_to groupe_gestionnaire.name, gestionnaire_groupe_gestionnaire_path(groupe_gestionnaire)

--- a/app/views/gestionnaires/groupe_gestionnaires/show.html.haml
+++ b/app/views/gestionnaires/groupe_gestionnaires/show.html.haml
@@ -1,0 +1,13 @@
+= render partial: 'gestionnaires/breadcrumbs',
+    locals: { steps: [['Groupes gestionnaire', gestionnaire_groupe_gestionnaires_path],
+                      ["#{@groupe_gestionnaire.name.truncate_words(10)}"]],
+              metadatas: true }
+
+.fr-container.procedure-admin-container
+  %ul.fr-btns-group.fr-btns-group--inline-sm.fr-btns-group--icon-left
+    = link_to 'Modifier', edit_gestionnaire_groupe_gestionnaire_path(@groupe_gestionnaire), class: 'fr-btn fr-btn--primary fr-btn--icon-left fr-icon-success-line'
+
+.fr-container
+  %h2= "Gestion du groupe gestionnaire № #{@groupe_gestionnaire.id}"
+  .fr-grid-row.fr-grid-row--gutters.fr-mb-5w
+    = render GroupeGestionnaire::Card::GestionnairesComponent.new(groupe_gestionnaire: @groupe_gestionnaire)

--- a/app/views/layouts/_flash_messages.html.haml
+++ b/app/views/layouts/_flash_messages.html.haml
@@ -9,6 +9,6 @@
             - value.each do |message|
               = sanitize_with_link(message)
               %br
-        - else
+        - elsif value.present?
           .alert{ class: flash_class(key, sticky: sticky, fixed: fixed), role: flash_role(key) }
             = sanitize_with_link(value)

--- a/config/locales/models/groupe_gestionnaire/fr.yml
+++ b/config/locales/models/groupe_gestionnaire/fr.yml
@@ -7,3 +7,10 @@ fr:
       groupe_gestionnaire:
         one: Groupe d'administrateurs
         other: Groupes d'administrateurs
+    errors:
+      duplicate_email: 
+        one: "%{emails} est déjà gestionnaire de ce groupe"
+        other: "%{emails} sont déjà gestionnaires de ce groupe"
+    wrong_address:
+      one: "%{emails} n’est pas une adresse email valide"
+      other: "%{emails} ne sont pas des adresses emails valides"

--- a/config/locales/views/manager/en.yml
+++ b/config/locales/views/manager/en.yml
@@ -1,9 +1,4 @@
 en:
   manager:
-    groupe_gestionnaires:
-      add_gestionnaire:
-        wrong_address:
-          one: "%{emails} is not a valid email address"
-          other: "%{emails} are not valid email addresses"
     gestionnaires:
       manage_root_groupe_gestionnaire: Root group management

--- a/config/locales/views/manager/fr.yml
+++ b/config/locales/views/manager/fr.yml
@@ -1,9 +1,4 @@
 fr:
   manager:
-    groupe_gestionnaires:
-      add_gestionnaire:
-        wrong_address:
-          one: "%{emails} n’est pas une adresse email valide"
-          other: "%{emails} ne sont pas des adresses emails valides"
     gestionnaires:
       manage_root_groupe_gestionnaire: Gestion du groupe racine

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -481,7 +481,9 @@ Rails.application.routes.draw do
     #
 
     scope module: 'gestionnaires', as: 'gestionnaire' do
-      resources :groupe_gestionnaires, path: 'groupe_administrateurs', only: [:index, :create]
+      resources :groupe_gestionnaires, path: 'groupes', only: [:index, :show, :create, :edit, :update, :destroy] do
+        resources :gestionnaires, controller: 'groupe_gestionnaire_gestionnaires', only: [:index, :create, :destroy]
+      end
     end
   end
 

--- a/spec/controllers/gestionnaires/groupe_gestionnaire_gestionnaires_controller_spec.rb
+++ b/spec/controllers/gestionnaires/groupe_gestionnaire_gestionnaires_controller_spec.rb
@@ -1,0 +1,61 @@
+describe Gestionnaires::GroupeGestionnaireGestionnairesController, type: :controller do
+  let(:gestionnaire) { create(:gestionnaire).tap { _1.user.update(last_sign_in_at: Time.zone.now) } }
+  let(:groupe_gestionnaire) { create(:groupe_gestionnaire, gestionnaires: [gestionnaire]) }
+
+  before { sign_in gestionnaire.user }
+
+  describe '#create' do
+    before do
+      post :create,
+        params: {
+          groupe_gestionnaire_id: groupe_gestionnaire.id,
+          gestionnaire: { email: new_gestionnaire_email }
+        },
+        format: :turbo_stream
+    end
+
+    context 'of a new gestionnaire' do
+      let(:new_gestionnaire_email) { 'new_gestionnaire@mail.com' }
+
+      it { expect(groupe_gestionnaire.reload.gestionnaires.map(&:email)).to include(new_gestionnaire_email) }
+      it { expect(flash.notice).to eq("Les gestionnaires ont bien été affectés au groupe d'administrateurs") }
+    end
+  end
+
+  describe '#destroy' do
+    let(:gestionnaire) { create(:gestionnaire) }
+    let(:new_gestionnaire) { create(:gestionnaire) }
+
+    before do
+      groupe_gestionnaire.gestionnaires << gestionnaire << new_gestionnaire
+    end
+
+    def remove_gestionnaire(gestionnaire)
+      delete :destroy,
+        params: {
+          groupe_gestionnaire_id: groupe_gestionnaire.id,
+          id: gestionnaire.id
+        },
+        format: :turbo_stream
+    end
+
+    context 'when there are many gestionnaires' do
+      before { remove_gestionnaire(new_gestionnaire) }
+
+      it { expect(groupe_gestionnaire.gestionnaires).to include(gestionnaire) }
+      it { expect(groupe_gestionnaire.reload.gestionnaires.count).to eq(1) }
+      it { expect(flash.notice).to eq("Le gestionnaire « #{new_gestionnaire.email} » a été retiré du groupe.") }
+    end
+
+    context 'when there is only one gestionnaire' do
+      before do
+        remove_gestionnaire(new_gestionnaire)
+        remove_gestionnaire(gestionnaire)
+      end
+
+      it { expect(groupe_gestionnaire.gestionnaires).to include(gestionnaire) }
+      it { expect(groupe_gestionnaire.gestionnaires.count).to eq(1) }
+      it { expect(flash.alert).to eq('Suppression impossible : il doit y avoir au moins un gestionnaire dans le groupe racine') }
+    end
+  end
+end

--- a/spec/controllers/gestionnaires/groupe_gestionnaires_controller_spec.rb
+++ b/spec/controllers/gestionnaires/groupe_gestionnaires_controller_spec.rb
@@ -11,6 +11,8 @@ describe Gestionnaires::GroupeGestionnairesController, type: :controller do
 
     context "when logged in" do
       let!(:groupe_gestionnaire) { create(:groupe_gestionnaire, gestionnaires: [gestionnaire]) }
+      let!(:other_groupe_gestionnaire) { create(:groupe_gestionnaire, gestionnaires: [gestionnaire]) }
+      let!(:not_my_groupe_gestionnaire) { create(:groupe_gestionnaire) }
       before do
         sign_in(gestionnaire.user)
         subject
@@ -18,6 +20,8 @@ describe Gestionnaires::GroupeGestionnairesController, type: :controller do
 
       it { expect(response).to have_http_status(:ok) }
       it { expect(assigns(:groupe_gestionnaires)).to include(groupe_gestionnaire) }
+      it { expect(assigns(:groupe_gestionnaires)).to include(other_groupe_gestionnaire) }
+      it { expect(assigns(:groupe_gestionnaires)).not_to include(not_my_groupe_gestionnaire) }
     end
   end
 end

--- a/spec/models/groupe_gestionnaire_spec.rb
+++ b/spec/models/groupe_gestionnaire_spec.rb
@@ -21,20 +21,43 @@ describe GroupeGestionnaire, type: :model do
   describe "#add_gestionnaires" do
     let(:groupe_gestionnaire) { create(:groupe_gestionnaire) }
     let(:gestionnaire) { create(:gestionnaire) }
+    let(:gestionnaire_to_add) { create(:gestionnaire) }
 
     it 'adds the gestionnaire by id' do
-      groupe_gestionnaire.add_gestionnaires(ids: [gestionnaire.id])
-      expect(groupe_gestionnaire.reload.gestionnaires).to include(gestionnaire)
+      groupe_gestionnaire.add_gestionnaires(ids: [gestionnaire_to_add.id], current_user: gestionnaire)
+      expect(groupe_gestionnaire.reload.gestionnaires).to include(gestionnaire_to_add)
     end
 
     it 'adds the existing gestionnaire by email' do
-      groupe_gestionnaire.add_gestionnaires(emails: [gestionnaire.email])
-      expect(groupe_gestionnaire.reload.gestionnaires).to include(gestionnaire)
+      groupe_gestionnaire.add_gestionnaires(emails: [gestionnaire_to_add.email], current_user: gestionnaire)
+      expect(groupe_gestionnaire.reload.gestionnaires).to include(gestionnaire_to_add)
     end
 
     it 'adds the new gestionnaire by email' do
-      groupe_gestionnaire.add_gestionnaires(emails: ['new_gestionnaire@ds.fr'])
+      groupe_gestionnaire.add_gestionnaires(emails: ['new_gestionnaire@ds.fr'], current_user: gestionnaire)
       expect(groupe_gestionnaire.reload.gestionnaires.last.email).to eq('new_gestionnaire@ds.fr')
+    end
+  end
+
+  describe "#remove" do
+    let(:gestionnaire) { create(:gestionnaire) }
+    let(:gestionnaire_to_remove) { create(:gestionnaire) }
+    let(:groupe_gestionnaire) { create(:groupe_gestionnaire, gestionnaires: [gestionnaire, gestionnaire_to_remove]) }
+
+    it 'removes the gestionnaire by id' do
+      expect(groupe_gestionnaire.reload.gestionnaires.size).to eq(2)
+      groupe_gestionnaire.remove(gestionnaire_to_remove.id, gestionnaire)
+      expect(groupe_gestionnaire.reload.gestionnaires).not_to include(gestionnaire_to_remove)
+      expect(groupe_gestionnaire.reload.gestionnaires.size).to eq(1)
+    end
+
+    it 'does not remove the gestionnaire if last' do
+      expect(groupe_gestionnaire.reload.gestionnaires.size).to eq(2)
+      groupe_gestionnaire.remove(gestionnaire.id, gestionnaire)
+      expect(groupe_gestionnaire.reload.gestionnaires.size).to eq(1)
+      groupe_gestionnaire.remove(gestionnaire_to_remove.id, gestionnaire)
+      expect(groupe_gestionnaire.reload.gestionnaires).to include(gestionnaire_to_remove)
+      expect(groupe_gestionnaire.reload.gestionnaires.size).to eq(1)
     end
   end
 end


### PR DESCRIPTION
[#9111](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/9111)
[ETQ super-admin, déléguer la création des comptes administrateurs à des "gestionnaires de groupe - USER STORIES](https://gitlab.adullact.net/demarches-simplifiees/evolution-du-logiciel-demarches-simplifiees/-/issues/54)

[ETQ super-admin, déléguer la création des comptes administrateurs à des "gestionnaires de groupe - LOT 2 de DEV](https://gitlab.adullact.net/demarches-simplifiees/evolution-du-logiciel-demarches-simplifiees/-/issues/56)

liste des groupes gestionnaire
![Screenshot 2023-10-04 at 19-35-08 demarches-simplifiees syn](https://github.com/adullact/demarches-simplifiees.fr/assets/137039013/66736b96-3986-43d4-bfe1-100ed44e4e96)

show groupe gestionnaire
![Screenshot 2023-10-04 at 19-35-45 demarches-simplifiees syn](https://github.com/adullact/demarches-simplifiees.fr/assets/137039013/87d906c2-97dc-4f75-92b8-2448b84a0d84)

manage gestionnaires of groupes gestionnaire
![Screenshot 2023-10-04 at 19-37-08 demarches-simplifiees syn](https://github.com/adullact/demarches-simplifiees.fr/assets/137039013/b2d5c7c7-311d-4572-b4bc-89aaae8431a2)

      
US 4.3.7.1 bouton ajouter un gestionnaire
US 4.3.7.2 bouton supprimer un gestionnaire (pour ce groupe uniquement. si il est gestionnaire d'un seul groupe on lui supprimer son rôle de gestionnaire)

--------------------
> `trackingAdullactContrib`  `trackingAdullactARNiaContrib `