### PR TITLE
ETQ admin le bouton de publication des modifications passe à gauche

### DIFF
--- a/app/views/administrateurs/procedures/show.html.haml
+++ b/app/views/administrateurs/procedures/show.html.haml
@@ -38,8 +38,8 @@
 
       - c.bottom do
         %ul.fr-mt-2w.fr-btns-group.fr-btns-group--inline
-          %li= button_to "Réinitialiser les modifications", admin_procedure_reset_draft_path(@procedure), class: 'fr-btn fr-btn--secondary fr-mr-2w', data: { confirm: 'Êtes-vous sûr de vouloir réinitialiser les modifications ?' }, method: :put
           %li= button_to 'Publier les modifications', admin_procedure_publication_path(@procedure), class: 'fr-btn', id: 'publish-procedure-link', data: { disable_with: "Publication..." }, disabled: !@procedure.draft_revision.valid?, method: :get
+          %li= button_to "Réinitialiser les modifications", admin_procedure_reset_draft_path(@procedure), class: 'fr-btn fr-btn--secondary fr-mr-2w', data: { confirm: 'Êtes-vous sûr de vouloir réinitialiser les modifications ?' }, method: :put
 
 - if !@procedure.procedure_expires_when_termine_enabled?
   = render partial: 'administrateurs/procedures/suggest_expires_when_termine', locals: { procedure: @procedure }


### PR DESCRIPTION
C'est plus naturel d'avoir de mettre le bouton principal du côté de l'alignement des boutons (à gauche pour des boutons alignés à gauche etc…). On met donc **Publier** à gauche de **Réinitialiser**.
![Capture d’écran 2023-09-28 à 18 34 47](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/bd6b5666-92ba-4313-99a0-8bc59f935b27)


Tant que j'y suis : actuellement ce bouton redirige vers une autre page qui dit la même chose : 
![Capture d’écran 2023-09-28 à 18 39 53](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/e47b15a4-8d8e-4c67-9d38-580cdbf891a3)

Ça me paraît pertinent pour une nouvelle démarche avec d'autres trucs à gérer, mais pour une démarche déjà publiée, on pourrait s'en passer et publier dès la première étape non ? ping @lisa-durand 

