### PR TITLE
ETQ instructeur, la page de mes démarches est un peu plus rapide

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -116,6 +116,7 @@ group :test do
 end
 
 group :development do
+  gem 'benchmark-ips', require: false
   gem 'brakeman', require: false
   gem 'haml-lint'
   gem 'letter_opener_web'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,7 @@ GEM
       activesupport (>= 3.1)
       caxlsx (>= 2.0.2)
     bcrypt (3.1.18)
+    benchmark-ips (2.12.0)
     better_html (1.0.16)
       actionview (>= 4.0)
       activesupport (>= 4.0)
@@ -813,6 +814,7 @@ DEPENDENCIES
   anchored
   axe-core-rspec
   bcrypt
+  benchmark-ips
   bootsnap (>= 1.4.4)
   brakeman
   browser

--- a/lib/tasks/benchmarks.rake
+++ b/lib/tasks/benchmarks.rake
@@ -38,4 +38,85 @@ namespace :benchmarks do
       x.report("Démarche 68139") { TagsSubstitutionConcern::TagsParser.parse(procedure.attestation_template.body) }
     end
   end
+
+  # Benchmark une action Rails spécifique, y compris le temps de génération des views.
+  # Optionnellement, compare avec une autre implémentation de l'action
+  # sur la même branche ou sur deux branches git.
+  #
+  # Le benchmark se fait en deux temps (2 processes ruby séparés à lancer l'un après l'autre)
+  # en stockant les résultats intermédiaires dans un fichier.
+  #
+  # === Prérequis ===
+  #
+  # 1. On fake l'authentification. Commenter le `before_action :authenticate_*` concerné
+  #
+  # 2. Override dans le controller le(s) `current_*` concernés
+  #
+  #    Par exemple :
+  #
+  #    def current_instructeur
+  #      @current_instructeur ||= Instructeur.find(12_345)
+  #    end
+  #
+  # 3. Pour se rapprocher un peu plus de l'environnement de prod, activer le cache:
+  #    `rails dev:cache` puis redémarrer le serveur (à refaire à la fin pour l'enlever)
+  #
+  # 4a. Pour comparer l'implémentation de deux actions sur la même branche (par ex `index` et `index_main`):
+  #    la seconde implémentation doit :
+  #    - avoir une route définie (ie. `get :index_main`)
+  #    - adapter les `before_action`
+  #    - la conclure par `render :index` si la vue est identique, ou adapter les vues.
+  #
+  #    Exécuter 2 foix:
+  #
+  #    rake benchmarks:action[Instructeurs::ProceduresController,index,index_main]
+  #
+  # 4b. Pour comparer l'implémentation d'une même action sur 2 branches,
+  #     exécuter sur chacune d'entre elle :
+  #
+  #     rake benchmarks:action[Instructeurs::ProceduresController,index,index]
+  #
+  #     Attention : penser à refaire les étapes 1 et 2 sur la seconde branche !
+  #
+  desc "Benchmark a Rails action"
+  task :action, [:controller, :action1, :action2] => :environment do |_, args|
+    require 'benchmark/ips'
+
+    controller_class = args[:controller].constantize
+    action1_name = args[:action1]
+    action2_name = args[:action2]
+
+    warden_mock = Struct.new(:user) do
+      def authenticate(*_args); end
+    end
+
+    warden = warden_mock.new(nil)
+
+    setup_controller_instance = Proc.new do |controller_class, warden|
+      controller = controller_class.new
+      controller.request = ActionDispatch::TestRequest.create
+      controller.response = ActionDispatch::TestResponse.new
+      controller.request.env['warden'] = warden
+      controller
+    end
+
+    Benchmark.ips do |x|
+      x.config(time: 30, warmup: 10)
+      x.hold! 'tmp/benchmarks_action_hold' # run in different processes so we can switch branches
+
+      x.report("#{controller_class}##{action1_name}1") do
+        controller = setup_controller_instance.call(controller_class, warden)
+        controller.process(action1_name)
+      end
+
+      if action2_name
+        x.report("#{controller_class}##{action2_name}2") do
+          controller = setup_controller_instance.call(controller_class, warden)
+          controller.process(action2_name)
+        end
+      end
+
+      x.compare!
+    end
+  end
 end


### PR DESCRIPTION
Suite de #9517 qui chargeait la home en 20-30s

- limite les jointures sur `dossiers`, tout en ne récupérant que l'info qui nous intéresse (la `procedure_id` via la révision)
- ne préload pas du contenu inutile , en particulier tous les dossiers de chaque procédure


J'en ai profité pour créér une tache rake qui permet de benchmarker des actions :


```
Instructeurs::ProceduresController#index
                          9.725  (±10.3%) i/s -     48.000  in   5.061325s
Instructeurs::ProceduresController#index_slow
                          0.459  (± 0.0%) i/s -      3.000  in   6.622812s

Comparison:
Instructeurs::ProceduresController#index:              9.7 i/s
Instructeurs::ProceduresController#index_slow:         0.5 i/s - 21.19x  slower
```


On reste à peu près iso par rapport à la prod actuelle (tag@2023-09-27-01) :
```
Instructeurs::ProceduresController#index
                          9.841  (±20.3%) i/s -    284.000  in  30.012959s
Instructeurs::ProceduresController#index_prod
                         11.065  (± 9.0%) i/s -    329.000  in  30.022673s

Comparison:
Instructeurs::ProceduresController#index_prod:       11.1 i/s
Instructeurs::ProceduresController#index:            9.8 i/s - same-ish: difference falls within error
```
