### PR TITLE
ETQ usager aère le form quand on clic sur une ancre d'un champ en erreur

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,7 +239,7 @@ GEM
     excon (0.102.0)
     factory_bot (6.1.0)
       activesupport (>= 5.0.0)
-    ffi (1.15.5)
+    ffi (1.16.2)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
@@ -658,7 +658,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scss_lint (0.59.0)
+    scss_lint (0.60.0)
       sass (~> 3.5, >= 3.5.5)
     selectize-rails (0.12.6)
     selenium-devtools (0.114.0)

--- a/app/assets/stylesheets/flex.scss
+++ b/app/assets/stylesheets/flex.scss
@@ -61,7 +61,7 @@
 }
 
 .flex-gap-2 {
-  gap: 2 * $default-spacer; // scss-lint:disable PropertySpelling
+  gap: 2 * $default-spacer;
 }
 
 .flex-1 {

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -138,6 +138,10 @@
         margin-bottom: $default-fields-spacer;
       }
     }
+
+    .fr-label {
+      scroll-margin: $default-spacer * 2;
+    }
   }
 
   .radios {


### PR DESCRIPTION
Quand on clic sur l'ancre d'un champ en erreur : 

## AVANT
Le doc se positionne au ras de la fenêtre
![Capture d’écran 2023-09-29 à 15 22 06](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/d03ba351-1f50-4868-b86c-ed295fa9f8de)

## APRES
On respire
![Capture d’écran 2023-09-29 à 15 21 47](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/9c5be8dd-3c1d-4873-a397-1e70c2064c0f)



Update aussi `scss-lint` qui supporte (entre autres) les propriétés `scroll-margin` et `gap`