### PR TITLE
Administrateur : correction de l'affichage du bouton "logique conditionnelle" dans l'éditeur de champ

### DIFF
--- a/app/controllers/administrateurs/conditions_controller.rb
+++ b/app/controllers/administrateurs/conditions_controller.rb
@@ -56,13 +56,7 @@ module Administrateurs
     def retrieve_coordinate_and_uppers
       @tdc = draft_revision.find_and_ensure_exclusive_use(params[:stable_id])
       @coordinate = draft_revision.coordinate_for(@tdc)
-
-      upper_coordinates = @coordinate.upper_siblings
-      if @coordinate.child?
-        upper_coordinates += @coordinate.parent.upper_siblings
-      end
-
-      @upper_tdcs = upper_coordinates.map(&:type_de_champ)
+      @upper_tdcs = @coordinate.upper_coordinates.map(&:type_de_champ)
     end
 
     def draft_revision

--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -105,7 +105,7 @@ module Administrateurs
     def champ_component_from(coordinate, focused: false, errors: '')
       TypesDeChampEditor::ChampComponent.new(
         coordinate:,
-        upper_coordinates: coordinate.upper_siblings,
+        upper_coordinates: coordinate.upper_coordinates,
         focused: focused,
         errors:
       )

--- a/app/models/procedure_revision_type_de_champ.rb
+++ b/app/models/procedure_revision_type_de_champ.rb
@@ -39,8 +39,14 @@ class ProcedureRevisionTypeDeChamp < ApplicationRecord
     end
   end
 
-  def upper_siblings
-    siblings.filter { |s| s.position < position }
+  def upper_coordinates
+    upper = siblings.filter { |s| s.position < position }
+
+    if child?
+      upper += parent.upper_coordinates
+    end
+
+    upper
   end
 
   def siblings_starting_at(offset)

--- a/spec/models/procedure_revision_type_de_champ_spec.rb
+++ b/spec/models/procedure_revision_type_de_champ_spec.rb
@@ -1,0 +1,27 @@
+describe ProcedureRevisionTypeDeChamp do
+  describe '#upper_coordinates' do
+    context 'when the coordinate is in a bloc bellow another coordinate' do
+      let(:procedure) do
+        create(:procedure,
+               types_de_champ_public: [
+                 { libelle: 'l1' },
+                 {
+                   type: :repetition, children: [
+                     { libelle: 'l2.1' },
+                     { libelle: 'l2.2' }
+                   ]
+                 }
+               ])
+      end
+
+      let(:l2_2) do
+        procedure
+          .draft_revision
+          .revision_types_de_champ.joins(:type_de_champ)
+          .find_by(type_de_champ: { libelle: 'l2.2' })
+      end
+
+      it { expect(l2_2.upper_coordinates.map(&:libelle)).to match_array(["l1", "l2.1"]) }
+    end
+  end
+end


### PR DESCRIPTION
Le bouton logique conditionnelle ne s'affichait pas toujours dans l'éditeur de champs pour les types de champs compris dans un bloc répétable.

Cela était du à un mauvais calcul des champs supérieurs.

Avant :
![avant](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/907405/25662087-ed98-4b73-89b0-4b4b7bd24441)

Après :
![apres](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/907405/f85d5bab-8590-4e40-b716-275b6ef5b526)
