### PR TITLE
amelioration(dossier.export): ajoute les piece justificative des avis dans les exports

### DIFF
--- a/app/lib/active_storage/downloadable_file.rb
+++ b/app/lib/active_storage/downloadable_file.rb
@@ -9,7 +9,7 @@ class ActiveStorage::DownloadableFile
     include_avis_for_expert: false
   )
     PiecesJustificativesService.generate_dossier_export(dossiers, include_infos_administration:, include_avis_for_expert:) +
-      PiecesJustificativesService.liste_documents(dossiers, with_bills:, with_champs_private:)
+      PiecesJustificativesService.liste_documents(dossiers, with_bills:, with_champs_private:, with_avis_piece_justificative: include_infos_administration)
   end
 
   def self.cleanup_list_from_dossier(files)
@@ -79,6 +79,8 @@ class ActiveStorage::DownloadableFile
       'horodatage/'
     when 'Commentaire'
       'messagerie/'
+    when 'Avis'
+      'avis/'
     else
       'pieces_justificatives/'
     end


### PR DESCRIPTION
voir #9510

* n'ajoute **pas** les pieces justificatives des avis confidentiels pour les exports (donc ETQ expert, j'ai pas les PJs des avis des autres expert dont l'avis est confidentiel)
* ajoute les piece justificatives des avis confidentiel pour les instructeurs