### PR TITLE
Feature ouidou/admin creation delegation gestionnaire page group gestionnaire management

### DIFF
--- a/app/controllers/gestionnaires/groupe_gestionnaires_controller.rb
+++ b/app/controllers/gestionnaires/groupe_gestionnaires_controller.rb
@@ -1,6 +1,6 @@
 module Gestionnaires
   class GroupeGestionnairesController < GestionnaireController
-    before_action :retrieve_groupe_gestionnaire, only: [:show]
+    before_action :retrieve_groupe_gestionnaire, only: [:show, :edit, :update, :destroy]
 
     def index
       @groupe_gestionnaires = groupe_gestionnaires
@@ -9,11 +9,41 @@ module Gestionnaires
     def show
     end
 
+    def edit
+    end
+
+    def update
+      if @groupe_gestionnaire.update(groupe_gestionnaire_params)
+        flash.notice = "Le groupe a bien été modifié"
+
+        redirect_to gestionnaire_groupe_gestionnaire_path(@groupe_gestionnaire)
+      else
+        flash.now.alert = "Le groupe contient des erreurs et n'a pas pu être enregistré. Veuiller les corriger"
+
+        render :edit
+      end
+    end
+
+    def destroy
+      if !@groupe_gestionnaire.can_be_deleted?(current_gestionnaire)
+        fail "Impossible de supprimer ce groupe.."
+      end
+      @groupe_gestionnaire.destroy
+
+      flash[:notice] = "Le groupe #{@groupe_gestionnaire.id} est supprimé"
+
+      redirect_to gestionnaire_groupe_gestionnaires_path
+    end
+
     private
 
     def groupe_gestionnaires
       groupe_gestionnaire_ids = current_gestionnaire.groupe_gestionnaire_ids
       GroupeGestionnaire.where(id: groupe_gestionnaire_ids.compact.uniq)
+    end
+
+    def groupe_gestionnaire_params
+      params.require(:groupe_gestionnaire).permit(:name)
     end
   end
 end

--- a/app/models/groupe_gestionnaire.rb
+++ b/app/models/groupe_gestionnaire.rb
@@ -24,6 +24,9 @@ class GroupeGestionnaire < ApplicationRecord
       if gestionnaire.nil? || !in?(gestionnaire.groupe_gestionnaires) || !gestionnaire.groupe_gestionnaires.destroy(self)
         alert = "Le gestionnaire « #{gestionnaire.email} » n’est pas dans le groupe."
       else
+        if gestionnaire.groupe_gestionnaires.empty?
+          gestionnaire.destroy
+        end
         notice = "Le gestionnaire « #{gestionnaire.email} » a été retiré du groupe."
         GroupeGestionnaireMailer
           .notify_removed_gestionnaire(self, gestionnaire, current_user.email)
@@ -74,5 +77,9 @@ class GroupeGestionnaire < ApplicationRecord
     end
 
     [gestionnaires_to_add, alert, notice]
+  end
+
+  def can_be_deleted?(current_user)
+    (gestionnaires.empty? || (gestionnaires == [current_user])) && administrateurs.empty? && children.empty?
   end
 end

--- a/app/views/gestionnaires/groupe_gestionnaire_gestionnaires/index.html.haml
+++ b/app/views/gestionnaires/groupe_gestionnaire_gestionnaires/index.html.haml
@@ -1,6 +1,6 @@
 = render partial: 'gestionnaires/breadcrumbs',
   locals: { steps: [['Groupes gestionnaire', gestionnaire_groupe_gestionnaires_path],
-                    ["#{@groupe_gestionnaire.name.truncate_words(10)}"],
+                    ["#{@groupe_gestionnaire.name.truncate_words(10)}", gestionnaire_groupe_gestionnaire_path(@groupe_gestionnaire)],
                     ['Gestionnaires']], preview: false }
 
 .container

--- a/app/views/gestionnaires/groupe_gestionnaires/edit.html.haml
+++ b/app/views/gestionnaires/groupe_gestionnaires/edit.html.haml
@@ -1,0 +1,24 @@
+- content_for(:root_class, 'scroll-margins-for-sticky-footer')
+
+= render partial: 'gestionnaires/breadcrumbs',
+  locals: { steps: [['Groupes gestionnaire', gestionnaire_groupe_gestionnaires_path],
+                    ["#{@groupe_gestionnaire.name.truncate_words(10)}", gestionnaire_groupe_gestionnaire_path(@groupe_gestionnaire)],
+                    ['Edit']] }
+
+= render  NestedForms::FormOwnerComponent.new
+= form_for @groupe_gestionnaire,
+  url: url_for({ controller: 'gestionnaires/groupe_gestionnaires', action: :update, id: @groupe_gestionnaire.id }),
+  html: { class: 'form', multipart: true } do |f|
+  .fr-container
+    .fr-grid-row
+      .fr-col-12.fr-col-offset-md-2.fr-col-md-8
+        %h1.fr-h2 Description
+
+        = render Dsfr::InputComponent.new(form: f, attribute: :name, input_type: :text_field, opts: {})
+
+  .sticky-action-footer
+    .fr-container
+      .fr-grid-row
+        .fr-col-12.fr-col-offset-md-2.fr-col-md-8
+          = f.button 'Enregistrer', class: 'fr-btn fr-mr-2w'
+          = link_to 'Annuler', gestionnaire_groupe_gestionnaire_path(id: @groupe_gestionnaire), class: 'fr-btn fr-btn--secondary', data: { confirm: 'Êtes-vous sûr de vouloir annuler les modifications effectuées ?'}

--- a/app/views/gestionnaires/groupe_gestionnaires/show.html.haml
+++ b/app/views/gestionnaires/groupe_gestionnaires/show.html.haml
@@ -6,8 +6,15 @@
 .fr-container.procedure-admin-container
   %ul.fr-btns-group.fr-btns-group--inline-sm.fr-btns-group--icon-left
     = link_to 'Modifier', edit_gestionnaire_groupe_gestionnaire_path(@groupe_gestionnaire), class: 'fr-btn fr-btn--primary fr-btn--icon-left fr-icon-success-line'
+    - if @groupe_gestionnaire.can_be_deleted?(current_gestionnaire)
+      = link_to gestionnaire_groupe_gestionnaire_path(@groupe_gestionnaire), class: "fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-delete-line", method: :delete, data: { confirm: "Voulez-vous vraiment supprimer ce groupe !" } do
+        = t('views.gestionnaires.groupe_gestionnaires.delete')
 
 .fr-container
   %h2= "Gestion du groupe gestionnaire № #{@groupe_gestionnaire.id}"
+  - if @groupe_gestionnaire.groupe_gestionnaire_id.present?
+    %p
+      groupe parent :
+      %a{ href: gestionnaire_groupe_gestionnaire_path(@groupe_gestionnaire.groupe_gestionnaire) }= @groupe_gestionnaire.groupe_gestionnaire.name
   .fr-grid-row.fr-grid-row--gutters.fr-mb-5w
     = render GroupeGestionnaire::Card::GestionnairesComponent.new(groupe_gestionnaire: @groupe_gestionnaire)

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -349,6 +349,9 @@ fr:
           form: "Sections du formulaire"
           edit_siret: "Modifier le SIRET"
           edit_identity: "Modifier l’identité"
+    gestionnaires:
+      groupe_gestionnaires:
+        delete: Supprimer
     instructeurs:
       dossiers:
         tab_steps:

--- a/config/locales/models/groupe_gestionnaire/fr.yml
+++ b/config/locales/models/groupe_gestionnaire/fr.yml
@@ -5,8 +5,8 @@ fr:
         gestionnaires: Gestionnaires
     models:
       groupe_gestionnaire:
-        one: Groupe d'administrateurs
-        other: Groupes d'administrateurs
+        one: Groupe Gestionnaire
+        other: Groupes Gestionnaire
     errors:
       duplicate_email: 
         one: "%{emails} est déjà gestionnaire de ce groupe"

--- a/spec/controllers/gestionnaires/groupe_gestionnaires_controller_spec.rb
+++ b/spec/controllers/gestionnaires/groupe_gestionnaires_controller_spec.rb
@@ -24,4 +24,88 @@ describe Gestionnaires::GroupeGestionnairesController, type: :controller do
       it { expect(assigns(:groupe_gestionnaires)).not_to include(not_my_groupe_gestionnaire) }
     end
   end
+
+  describe "#show" do
+    subject { get :show, params: { id: child_groupe_gestionnaire.id } }
+    let!(:groupe_gestionnaire_root) { create(:groupe_gestionnaire, gestionnaires: [gestionnaire]) }
+    let!(:child_groupe_gestionnaire) { create(:groupe_gestionnaire, groupe_gestionnaire: groupe_gestionnaire_root, gestionnaires: [gestionnaire]) }
+
+    context "when not logged" do
+      before { subject }
+      it { expect(response).to redirect_to(new_user_session_path) }
+    end
+
+    context "when logged in" do
+      before do
+        sign_in(gestionnaire.user)
+        subject
+      end
+
+      it { expect(response).to have_http_status(:ok) }
+      it { expect(assigns(:groupe_gestionnaire)).to eq(child_groupe_gestionnaire) }
+    end
+  end
+
+  describe "#edit" do
+    subject { get :edit, params: { id: child_groupe_gestionnaire.id } }
+    let!(:groupe_gestionnaire_root) { create(:groupe_gestionnaire, gestionnaires: [gestionnaire]) }
+    let!(:child_groupe_gestionnaire) { create(:groupe_gestionnaire, groupe_gestionnaire: groupe_gestionnaire_root, gestionnaires: [gestionnaire]) }
+
+    context "when not logged" do
+      before { subject }
+      it { expect(response).to redirect_to(new_user_session_path) }
+    end
+
+    context "when logged in" do
+      before do
+        sign_in(gestionnaire.user)
+        subject
+      end
+
+      it { expect(response).to have_http_status(:ok) }
+      it { expect(assigns(:groupe_gestionnaire)).to eq(child_groupe_gestionnaire) }
+    end
+  end
+
+  describe "#update" do
+    subject { post :update, params: { id: child_groupe_gestionnaire.id, groupe_gestionnaire: { name: 'new child name' } } }
+    let!(:groupe_gestionnaire_root) { create(:groupe_gestionnaire, gestionnaires: [gestionnaire]) }
+    let!(:child_groupe_gestionnaire) { create(:groupe_gestionnaire, groupe_gestionnaire: groupe_gestionnaire_root, gestionnaires: [gestionnaire]) }
+
+    context "when not logged" do
+      before { subject }
+      it { expect(response).to redirect_to(new_user_session_path) }
+    end
+
+    context "when logged in" do
+      before do
+        sign_in(gestionnaire.user)
+        subject
+      end
+
+      it { expect(child_groupe_gestionnaire.reload.name).to eq('new child name') }
+      it { expect(response).to redirect_to(gestionnaire_groupe_gestionnaire_path(child_groupe_gestionnaire)) }
+    end
+  end
+
+  describe "#destroy" do
+    subject { post :destroy, params: { id: child_groupe_gestionnaire.id } }
+    let!(:groupe_gestionnaire_root) { create(:groupe_gestionnaire, gestionnaires: [gestionnaire]) }
+    let!(:child_groupe_gestionnaire) { create(:groupe_gestionnaire, groupe_gestionnaire: groupe_gestionnaire_root, gestionnaires: [gestionnaire]) }
+
+    context "when not logged" do
+      before { subject }
+      it { expect(response).to redirect_to(new_user_session_path) }
+    end
+
+    context "when logged in" do
+      before do
+        sign_in(gestionnaire.user)
+        subject
+      end
+
+      it { expect(GroupeGestionnaire.all.count).to eq(1) }
+      it { expect(response).to redirect_to(gestionnaire_groupe_gestionnaires_path) }
+    end
+  end
 end


### PR DESCRIPTION
[#9111](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/9111)
[ETQ super-admin, déléguer la création des comptes administrateurs à des "gestionnaires de groupe - USER STORIES](https://gitlab.adullact.net/demarches-simplifiees/evolution-du-logiciel-demarches-simplifiees/-/issues/54)

[ETQ super-admin, déléguer la création des comptes administrateurs à des "gestionnaires de groupe - LOT 2 de DEV](https://gitlab.adullact.net/demarches-simplifiees/evolution-du-logiciel-demarches-simplifiees/-/issues/56)

modifier le nom du groupe
![Screenshot 2023-10-05 at 11-20-37 demarches-simplifiees syn](https://github.com/adullact/demarches-simplifiees.fr/assets/137039013/72b95ac6-67dc-4e3c-a9cd-220f260d552d)

confirmation
![Screenshot from 2023-10-05 11-21-29](https://github.com/adullact/demarches-simplifiees.fr/assets/137039013/f074a93d-698f-4a4e-986d-56d8552baa9a)
 modification et demande confirmation suppresion

confirmation suppresion
![Screenshot 2023-10-05 at 11-21-38 demarches-simplifiees syn](https://github.com/adullact/demarches-simplifiees.fr/assets/137039013/72e25480-3e99-462c-95c1-1dc1a41c6cb6)

      
US 4.3.7.1 bouton ajouter un gestionnaire
US 4.3.7.2 bouton supprimer un gestionnaire (pour ce groupe uniquement. si il est gestionnaire d'un seul groupe on lui supprimer son rôle de gestionnaire)

--------------------
> `trackingAdullactContrib`  `trackingAdullactARNiaContrib `