### PR TITLE
Correction : ETQ usager je peux saisir des nombres négatifs

### DIFF
--- a/app/components/editable_champ/integer_number_component/integer_number_component.html.haml
+++ b/app/components/editable_champ/integer_number_component/integer_number_component.html.haml
@@ -1,1 +1,1 @@
-= @form.text_field(:value, input_opts(id: @champ.input_id, aria: { describedby: @champ.describedby_id }, pattern: "[0-9]*", inputmode: :numeric, required: @champ.required?, data: { controller: 'format', format: :integer }))
+= @form.text_field(:value, input_opts(id: @champ.input_id, aria: { describedby: @champ.describedby_id }, pattern: "-?[0-9]*", inputmode: :numeric, required: @champ.required?, data: { controller: 'format', format: :integer }))

--- a/app/components/editable_champ/number_component/number_component.html.haml
+++ b/app/components/editable_champ/number_component/number_component.html.haml
@@ -1,1 +1,1 @@
-= @form.text_field(:value, input_opts(id: @champ.input_id, aria: { describedby: @champ.describedby_id }, placeholder: @champ.libelle, required: @champ.required?, pattern: "[0-9]*", inputmode: :decimal))
+= @form.text_field(:value, input_opts(id: @champ.input_id, aria: { describedby: @champ.describedby_id }, placeholder: @champ.libelle, required: @champ.required?, pattern: "-?[0-9]*", inputmode: :decimal))

--- a/app/javascript/controllers/format_controller.ts
+++ b/app/javascript/controllers/format_controller.ts
@@ -44,7 +44,7 @@ export class FormatController extends ApplicationController {
   }
 
   private formatInteger(value: string) {
-    return value.replace(/[^\d]/g, '');
+    return value.replace(/[^-?\d]/g, '');
   }
 
   private formatDecimal(value: string) {

--- a/app/javascript/controllers/format_controller.ts
+++ b/app/javascript/controllers/format_controller.ts
@@ -54,6 +54,6 @@ export class FormatController extends ApplicationController {
     const decimalSeparator =
       value.lastIndexOf(',') > value.lastIndexOf('.') ? ',' : '.';
 
-    return value.replace(new RegExp(`[^\\d${decimalSeparator}]`, 'g'), '');
+    return value.replace(new RegExp(`[^-?\\d${decimalSeparator}]`, 'g'), '');
   }
 }

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -185,6 +185,11 @@ describe 'The user' do
       champ_value_for('nombre entier') == '300'
     }
 
+    fill_in('nombre entier', with: '-256')
+    wait_until {
+      champ_value_for('nombre entier') == '-256'
+    }
+
     fill_in('nombre décimal', with: '123 456,78')
     wait_until {
       champ_value_for('nombre décimal') == '123456.78'

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -199,6 +199,11 @@ describe 'The user' do
     wait_until {
       champ_value_for('nombre décimal') == '1234.56'
     }
+
+    fill_in('nombre décimal', with: '-1,234.56')
+    wait_until {
+      champ_value_for('nombre décimal') == '-1234.56'
+    }
   end
 
   scenario 'extends dossier experation date more than one time, ', js: true, retry: 3 do


### PR DESCRIPTION
Suite à https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/9516, un usager ne pouvait plus saisir de nombres négatifs.
La PR corrige ce bug pour les champs de type nombre entier et nombre décimal.
J'ai corrigé aussi un composant de type nombre (`number_component`), mais peut-être que ce composant n'est plus utilisé et devrait être enlevé du code. Je le laisse dans le doute pour l'instant