### PR TITLE
ETQ usager, lorsque j'ai déjà des dossiers sur une procédure, la page de garde me donne de meilleurs liens

### DIFF
--- a/app/controllers/users/commencer_controller.rb
+++ b/app/controllers/users/commencer_controller.rb
@@ -20,10 +20,9 @@ module Users
         check_prefilled_dossier_ownership if @prefilled_dossier
 
         revision = @revision.draft? ? @revision : @procedure.revisions.where.not(id: @procedure.draft_revision_id)
-        @dossiers = current_user.dossiers.visible_by_user.where(revision:)
-        @drafts = @dossiers.brouillon
-        @not_drafts = @dossiers.state_not_brouillon
-        @preview_dossiers = @dossiers.order(created_at: :desc).limit(3)
+        @dossiers = current_user.dossiers.select(:id, :created_at, :depose_at, :state).visible_by_user.where(revision:).order(created_at: :desc).to_a
+        @drafts, @not_drafts = @dossiers.partition(&:brouillon?)
+        @preview_dossiers = @dossiers.take(3)
       end
 
       @usual_traitement_time = @procedure.stats_usual_traitement_time

--- a/app/controllers/users/commencer_controller.rb
+++ b/app/controllers/users/commencer_controller.rb
@@ -18,6 +18,12 @@ module Users
       if user_signed_in?
         set_prefilled_dossier_ownership if @prefilled_dossier&.orphan?
         check_prefilled_dossier_ownership if @prefilled_dossier
+
+        revision = @revision.draft? ? @revision : @procedure.revisions.where.not(id: @procedure.draft_revision_id)
+        @dossiers = current_user.dossiers.visible_by_user.where(revision:)
+        @drafts = @dossiers.brouillon
+        @not_drafts = @dossiers.state_not_brouillon
+        @preview_dossiers = @dossiers.order(created_at: :desc).limit(3)
       end
 
       @usual_traitement_time = @procedure.stats_usual_traitement_time

--- a/app/views/commencer/show.html.haml
+++ b/app/views/commencer/show.html.haml
@@ -2,7 +2,7 @@
 
 .commencer.form
   - if !user_signed_in?
-    = render Dsfr::CalloutComponent.new(title: t("views.commencer.show.start_procedure"), heading_level: 'h2') do |c|
+    = render Dsfr::CalloutComponent.new(title: t(".start_procedure"), heading_level: 'h2') do |c|
       - c.body do
         = render partial: 'shared/france_connect_login', locals: { url: commencer_france_connect_path(path: @procedure.path, prefill_token: @prefilled_dossier&.prefill_token) }
         %ul.fr-btns-group.fr-btns-group--inline
@@ -20,45 +20,45 @@
     - not_drafts = dossiers.merge(Dossier.state_not_brouillon)
 
     - if @prefilled_dossier
-      = render Dsfr::CalloutComponent.new(title: t("views.commencer.show.prefilled_draft"), heading_level: 'h2') do |c|
+      = render Dsfr::CalloutComponent.new(title: t(".prefilled_draft"), heading_level: 'h2') do |c|
         - c.body do
-          %p= t('views.commencer.show.prefilled_draft_detail_html', time_ago: time_ago_in_words(@prefilled_dossier.created_at), procedure: @procedure.libelle)
-          = link_to t('views.commencer.show.go_to_prefilled_file'), url_for_dossier(@prefilled_dossier), class: 'fr-btn fr-mb-2w'
+          %p= t('.prefilled_draft_detail_html', time_ago: time_ago_in_words(@prefilled_dossier.created_at), procedure: @procedure.libelle)
+          = link_to t('.go_to_prefilled_file'), url_for_dossier(@prefilled_dossier), class: 'fr-btn fr-mb-2w'
 
     - elsif dossiers.empty?
-      = link_to t('views.commencer.show.start_procedure'), url_for_new_dossier(@revision), class: 'fr-btn fr-mb-2w'
+      = link_to t('.start_procedure'), url_for_new_dossier(@revision), class: 'fr-btn fr-mb-2w'
 
     - elsif drafts.size == 1 && not_drafts.empty?
       - dossier = drafts.first
-      = render Dsfr::CalloutComponent.new(title: t("views.commencer.show.already_draft"), heading_level: 'h2') do |c|
+      = render Dsfr::CalloutComponent.new(title: t(".already_draft"), heading_level: 'h2') do |c|
         - c.body do
           %p
-            = t('views.commencer.show.already_draft_detail_html', time_ago: time_ago_in_words(dossier.created_at), procedure: dossier.procedure.libelle)
+            = t('.already_draft_detail_html', time_ago: time_ago_in_words(dossier.created_at), procedure: dossier.procedure.libelle)
           %ul.fr-btns-group.fr-btns-group--inline
-            %li= link_to t('views.commencer.show.continue_file'), url_for_dossier(dossier), class: 'fr-btn'
-            %li= link_to t('views.commencer.show.start_new_file'), url_for_new_dossier(@revision), class: 'fr-btn fr-btn--secondary'
+            %li= link_to t('.continue_file'), url_for_dossier(dossier), class: 'fr-btn'
+            %li= link_to t('.start_new_file'), url_for_new_dossier(@revision), class: 'fr-btn fr-btn--secondary'
 
     - elsif not_drafts.size == 1
       - dossier = not_drafts.first
-      = render Dsfr::CalloutComponent.new(title: t("views.commencer.show.already_not_draft"), heading_level: 'h2') do |c|
+      = render Dsfr::CalloutComponent.new(title: t(".already_not_draft"), heading_level: 'h2') do |c|
         - c.body do
           %p
-            = t('views.commencer.show.already_not_draft_detail_html', time_ago: time_ago_in_words(dossier.depose_at), procedure: dossier.procedure.libelle)
+            = t('.already_not_draft_detail_html', time_ago: time_ago_in_words(dossier.depose_at), procedure: dossier.procedure.libelle)
           %ul.fr-btns-group.fr-btns-group--inline
-            %li= link_to t('views.commencer.show.show_my_submitted_file'), url_for_dossier(dossier), class: 'fr-btn'
-            %li= link_to t('views.commencer.show.start_new_file'), url_for_new_dossier(@revision), class: 'fr-btn fr-btn--secondary'
+            %li= link_to t('.show_my_submitted_file'), url_for_dossier(dossier), class: 'fr-btn'
+            %li= link_to t('.start_new_file'), url_for_new_dossier(@revision), class: 'fr-btn fr-btn--secondary'
 
     - else
-      = render Dsfr::CalloutComponent.new(title: t("views.commencer.show.existing_dossiers"), heading_level: 'h2') do |c|
+      = render Dsfr::CalloutComponent.new(title: t(".existing_dossiers"), heading_level: 'h2') do |c|
         - c.body do
           %ul.fr-btns-group.fr-btns-group--inline
-            %li= link_to t('views.commencer.show.show_dossiers'), dossiers_path(procedure_id: @procedure.id), class: "fr-btn"
-            %li= link_to t('views.commencer.show.start_new_file'), url_for_new_dossier(@revision), class: "fr-btn fr-btn--secondary"
+            %li= link_to t('.show_dossiers'), dossiers_path(procedure_id: @procedure.id), class: "fr-btn"
+            %li= link_to t('.start_new_file'), url_for_new_dossier(@revision), class: "fr-btn fr-btn--secondary"
           - preview_dossiers = dossiers.order(created_at: :desc).limit(3)
-          %p= t('views.commencer.show.already_created', count: preview_dossiers.size)
+          %p= t('.already_created', count: preview_dossiers.size)
           %ul
             - preview_dossiers.each do |dossier|
-              %li= link_to t('views.commencer.show.already_created_details_html',
+              %li= link_to t('.already_created_details_html',
                 id: number_with_html_delimiter(dossier.id),
                 created_at: time_ago_in_words(dossier.created_at),
                 state: dossier_display_state(dossier.state, lower: true)),
@@ -67,7 +67,7 @@
 
   - if @procedure.feature_enabled?(:dossier_pdf_vide)
     %hr
-    %p= t('views.commencer.show.want_empty_pdf', service: @procedure&.service&.nom, adresse: @procedure&.service&.adresse)
+    %p= t('.want_empty_pdf', service: @procedure&.service&.nom, adresse: @procedure&.service&.adresse)
 
     %br
-    = link_to t('views.commencer.show.download_empty_pdf'), commencer_dossier_vide_for_revision_path(@revision), class: "fr-btn fr-btn--secondary fr-mb-2w"
+    = link_to t('.download_empty_pdf'), commencer_dossier_vide_for_revision_path(@revision), class: "fr-btn fr-btn--secondary fr-mb-2w"

--- a/app/views/commencer/show.html.haml
+++ b/app/views/commencer/show.html.haml
@@ -52,7 +52,7 @@
       = render Dsfr::CalloutComponent.new(title: t("views.commencer.show.existing_dossiers"), heading_level: 'h2') do |c|
         - c.body do
           %ul.fr-btns-group.fr-btns-group--inline
-            %li= link_to t('views.commencer.show.show_dossiers'), dossiers_path, class: "fr-btn"
+            %li= link_to t('views.commencer.show.show_dossiers'), dossiers_path(procedure_id: @procedure.id), class: "fr-btn"
             %li= link_to t('views.commencer.show.start_new_file'), url_for_new_dossier(@revision), class: "fr-btn fr-btn--secondary"
 
 

--- a/app/views/commencer/show.html.haml
+++ b/app/views/commencer/show.html.haml
@@ -28,7 +28,7 @@
       = render Dsfr::CalloutComponent.new(title: t(".already_draft"), heading_level: 'h2') do |c|
         - c.body do
           %p
-            = t('.already_draft_detail_html', time_ago: time_ago_in_words(dossier.created_at), procedure: dossier.procedure.libelle)
+            = t('.already_draft_detail_html', time_ago: time_ago_in_words(dossier.created_at), procedure: @procedure.libelle)
           %ul.fr-btns-group.fr-btns-group--inline
             %li= link_to t('.continue_file'), url_for_dossier(dossier), class: 'fr-btn'
             %li= link_to t('.start_new_file'), url_for_new_dossier(@revision), class: 'fr-btn fr-btn--secondary'
@@ -38,7 +38,7 @@
       = render Dsfr::CalloutComponent.new(title: t(".already_not_draft"), heading_level: 'h2') do |c|
         - c.body do
           %p
-            = t('.already_not_draft_detail_html', time_ago: time_ago_in_words(dossier.depose_at), procedure: dossier.procedure.libelle)
+            = t('.already_not_draft_detail_html', time_ago: time_ago_in_words(dossier.depose_at), procedure: @procedure.libelle)
           %ul.fr-btns-group.fr-btns-group--inline
             %li= link_to t('.show_my_submitted_file'), url_for_dossier(dossier), class: 'fr-btn'
             %li= link_to t('.start_new_file'), url_for_new_dossier(@revision), class: 'fr-btn fr-btn--secondary'

--- a/app/views/commencer/show.html.haml
+++ b/app/views/commencer/show.html.haml
@@ -14,22 +14,17 @@
           %li= link_to t('views.shared.account.already_user'), commencer_sign_in_path(path: @procedure.path, prefill_token: @prefilled_dossier&.prefill_token), class: 'fr-btn fr-btn--secondary'
 
   - else
-    - revision = @revision.draft? ? @revision : @procedure.revisions.where.not(id: @procedure.draft_revision_id)
-    - dossiers = current_user.dossiers.visible_by_user.where(revision:)
-    - drafts = dossiers.brouillon
-    - not_drafts = dossiers.state_not_brouillon
-
     - if @prefilled_dossier
       = render Dsfr::CalloutComponent.new(title: t(".prefilled_draft"), heading_level: 'h2') do |c|
         - c.body do
           %p= t('.prefilled_draft_detail_html', time_ago: time_ago_in_words(@prefilled_dossier.created_at), procedure: @procedure.libelle)
           = link_to t('.go_to_prefilled_file'), url_for_dossier(@prefilled_dossier), class: 'fr-btn fr-mb-2w'
 
-    - elsif dossiers.empty?
+    - elsif @dossiers.empty?
       = link_to t('.start_procedure'), url_for_new_dossier(@revision), class: 'fr-btn fr-mb-2w'
 
-    - elsif drafts.size == 1 && not_drafts.empty?
-      - dossier = drafts.first
+    - elsif @drafts.size == 1 && @not_drafts.empty?
+      - dossier = @drafts.first
       = render Dsfr::CalloutComponent.new(title: t(".already_draft"), heading_level: 'h2') do |c|
         - c.body do
           %p
@@ -38,8 +33,8 @@
             %li= link_to t('.continue_file'), url_for_dossier(dossier), class: 'fr-btn'
             %li= link_to t('.start_new_file'), url_for_new_dossier(@revision), class: 'fr-btn fr-btn--secondary'
 
-    - elsif not_drafts.size == 1
-      - dossier = not_drafts.first
+    - elsif @not_drafts.size == 1
+      - dossier = @not_drafts.first
       = render Dsfr::CalloutComponent.new(title: t(".already_not_draft"), heading_level: 'h2') do |c|
         - c.body do
           %p
@@ -54,10 +49,9 @@
           %ul.fr-btns-group.fr-btns-group--inline
             %li= link_to t('.show_dossiers'), dossiers_path(procedure_id: @procedure.id), class: "fr-btn"
             %li= link_to t('.start_new_file'), url_for_new_dossier(@revision), class: "fr-btn fr-btn--secondary"
-          - preview_dossiers = dossiers.order(created_at: :desc).limit(3)
-          %p= t('.already_created', count: preview_dossiers.size)
+          %p= t('.already_created', count: @preview_dossiers.size)
           %ul
-            - preview_dossiers.each do |dossier|
+            - @preview_dossiers.each do |dossier|
               %li= link_to t('.already_created_details_html',
                 id: number_with_html_delimiter(dossier.id),
                 created_at: time_ago_in_words(dossier.created_at),

--- a/app/views/commencer/show.html.haml
+++ b/app/views/commencer/show.html.haml
@@ -15,9 +15,9 @@
 
   - else
     - revision = @revision.draft? ? @revision : @procedure.revisions.where.not(id: @procedure.draft_revision_id)
-    - dossiers = current_user.dossiers.visible_by_user.where(revision: revision)
-    - drafts = dossiers.merge(Dossier.state_brouillon)
-    - not_drafts = dossiers.merge(Dossier.state_not_brouillon)
+    - dossiers = current_user.dossiers.visible_by_user.where(revision:)
+    - drafts = dossiers.brouillon
+    - not_drafts = dossiers.state_not_brouillon
 
     - if @prefilled_dossier
       = render Dsfr::CalloutComponent.new(title: t(".prefilled_draft"), heading_level: 'h2') do |c|

--- a/app/views/commencer/show.html.haml
+++ b/app/views/commencer/show.html.haml
@@ -54,6 +54,15 @@
           %ul.fr-btns-group.fr-btns-group--inline
             %li= link_to t('views.commencer.show.show_dossiers'), dossiers_path(procedure_id: @procedure.id), class: "fr-btn"
             %li= link_to t('views.commencer.show.start_new_file'), url_for_new_dossier(@revision), class: "fr-btn fr-btn--secondary"
+          - preview_dossiers = dossiers.order(created_at: :desc).limit(3)
+          %p= t('views.commencer.show.already_created', count: preview_dossiers.size)
+          %ul
+            - preview_dossiers.each do |dossier|
+              %li= link_to t('views.commencer.show.already_created_details_html',
+                id: number_with_html_delimiter(dossier.id),
+                created_at: time_ago_in_words(dossier.created_at),
+                state: dossier_display_state(dossier.state, lower: true)),
+                dossier_path(dossier)
 
 
   - if @procedure.feature_enabled?(:dossier_pdf_vide)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -208,28 +208,6 @@ en:
           url: "https://www.defenseurdesdroits.fr/fr/saisir/delegues"
           title: "Contact the delegate of the Human Rights Defender in your region - new tab"
         remedies_three: "Send a letter by post (free of charge, do not put a stamp) Défenseur des droits Libre réponse 71120 75342 Paris CEDEX 07"
-    commencer:
-      show:
-        start_procedure: Start the procedure
-        existing_dossiers: You already have files for this procedure
-        show_dossiers: View my current files
-        prefilled_draft: "You have a prefilled file"
-        prefilled_draft_detail_html: "You are ready to continue a prefilled file for the \"%{procedure}\" procedure, started <strong>%{time_ago} ago</strong>."
-        already_draft: "You already started to fill a file"
-        already_draft_detail_html: "You started to fill a file for the \"%{procedure}\" procedure <strong>%{time_ago} ago</strong>"
-        already_not_draft: "You already submitted a file"
-        already_not_draft_detail_html: "You submitted a file for the \"%{procedure}\" procedure <strong>%{time_ago} ago</strong>."
-        go_to_prefilled_file: 'Continue to fill my prefilled file'
-        continue_file: "Continue to fill my file"
-        start_new_file: "Start a new file"
-        show_my_submitted_file: 'Show my submitted file'
-        want_empty_pdf: "You prefer to submit a paper form? You can download an empty PDF file, and send it to the right administration : %{service} - %{adresse}"
-        download_empty_pdf: 'Download an empty PDF file'
-        already_created:
-          one: "Your previous file :"
-          other: "Your last %{count} created files :" 
-        already_created_details_html:
-          "N° %{id}, created %{created_at} ago and %{state}"
     prefill_descriptions:
       edit:
         intro_html: "You'd like to allow your users to <strong>create a prefilled file</strong>, with data you already have, for the procedure « %{libelle} »."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -225,6 +225,11 @@ en:
         show_my_submitted_file: 'Show my submitted file'
         want_empty_pdf: "You prefer to submit a paper form? You can download an empty PDF file, and send it to the right administration : %{service} - %{adresse}"
         download_empty_pdf: 'Download an empty PDF file'
+        already_created:
+          one: "Your previous file :"
+          other: "Your last %{count} created files :" 
+        already_created_details_html:
+          "N° %{id}, created %{created_at} ago and %{state}"
     prefill_descriptions:
       edit:
         intro_html: "You'd like to allow your users to <strong>create a prefilled file</strong>, with data you already have, for the procedure « %{libelle} »."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -221,6 +221,11 @@ fr:
         show_my_submitted_file: 'Voir mon dossier déposé'
         want_empty_pdf: "Vous souhaitez effectuer une demande par papier ? Vous pouvez télécharger un dossier vide au format PDF, et l’envoyer à l’administration concernée : %{service} - %{adresse}"
         download_empty_pdf: 'Télécharger un dossier vide au format PDF'
+        already_created:
+          one: "Votre dernier dossier :"
+          other: "Vos %{count} derniers dossiers créés :" 
+        already_created_details_html:
+          "N° %{id}, créé il y a %{created_at} et %{state}"
     prefill_descriptions:
       edit:
         intro_html: "Vous souhaitez permettre à vos usager·ères la <strong>création d'un dossier prérempli</strong>, à partir de données dont vous disposez déjà, pour la démarche « %{libelle} »."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -204,28 +204,6 @@ fr:
           url: "https://www.defenseurdesdroits.fr/fr/saisir/delegues"
           title: "Contacter le délégué du Défenseur des droits dans votre région - nouvel onglet"
         remedies_three: "Envoyer un courrier par la poste (gratuit, ne pas mettre de timbre) Défenseur des droits Libre réponse 71120 75342 Paris CEDEX 07"
-    commencer:
-      show:
-        start_procedure: Commencer la démarche
-        existing_dossiers: Vous avez déjà des dossiers pour cette démarche
-        show_dossiers: Voir mes dossiers en cours
-        prefilled_draft: "Vous avez un dossier prérempli"
-        prefilled_draft_detail_html: "Vous êtes prêt·e à poursuivre un dossier prérempli sur la démarche « %{procedure} », commencé il y a <strong>%{time_ago}</strong>."
-        already_draft: "Vous avez déjà commencé à remplir un dossier"
-        already_draft_detail_html: "Il y a <strong>%{time_ago}</strong>, vous avez commencé à remplir un dossier sur la démarche « %{procedure} »."
-        already_not_draft: "Vous avez déjà déposé un dossier"
-        already_not_draft_detail_html: "Il y a <strong>%{time_ago}</strong>, vous avez déposé un dossier sur la démarche « %{procedure} »."
-        go_to_prefilled_file: 'Poursuivre mon dossier prérempli'
-        continue_file: 'Continuer à remplir mon dossier'
-        start_new_file: 'Commencer un nouveau dossier'
-        show_my_submitted_file: 'Voir mon dossier déposé'
-        want_empty_pdf: "Vous souhaitez effectuer une demande par papier ? Vous pouvez télécharger un dossier vide au format PDF, et l’envoyer à l’administration concernée : %{service} - %{adresse}"
-        download_empty_pdf: 'Télécharger un dossier vide au format PDF'
-        already_created:
-          one: "Votre dernier dossier :"
-          other: "Vos %{count} derniers dossiers créés :" 
-        already_created_details_html:
-          "N° %{id}, créé il y a %{created_at} et %{state}"
     prefill_descriptions:
       edit:
         intro_html: "Vous souhaitez permettre à vos usager·ères la <strong>création d'un dossier prérempli</strong>, à partir de données dont vous disposez déjà, pour la démarche « %{libelle} »."

--- a/config/locales/views/users/commencer/en.yml
+++ b/config/locales/views/users/commencer/en.yml
@@ -1,0 +1,23 @@
+en:
+  commencer:
+    show:
+      start_procedure: Start the procedure
+      existing_dossiers: You already have files for this procedure
+      show_dossiers: View my current files
+      prefilled_draft: "You have a prefilled file"
+      prefilled_draft_detail_html: "You are ready to continue a prefilled file for the \"%{procedure}\" procedure, started <strong>%{time_ago} ago</strong>."
+      already_draft: "You already started to fill a file"
+      already_draft_detail_html: "You started to fill a file for the \"%{procedure}\" procedure <strong>%{time_ago} ago</strong>"
+      already_not_draft: "You already submitted a file"
+      already_not_draft_detail_html: "You submitted a file for the \"%{procedure}\" procedure <strong>%{time_ago} ago</strong>."
+      go_to_prefilled_file: 'Continue to fill my prefilled file'
+      continue_file: "Continue to fill my file"
+      start_new_file: "Start a new file"
+      show_my_submitted_file: 'Show my submitted file'
+      want_empty_pdf: "You prefer to submit a paper form? You can download an empty PDF file, and send it to the right administration : %{service} - %{adresse}"
+      download_empty_pdf: 'Download an empty PDF file'
+      already_created:
+        one: "Your previous file :"
+        other: "Your last %{count} created files :" 
+      already_created_details_html:
+        "N° %{id}, created %{created_at} ago and %{state}"

--- a/config/locales/views/users/commencer/fr.yml
+++ b/config/locales/views/users/commencer/fr.yml
@@ -1,0 +1,23 @@
+fr:
+  commencer:
+    show:
+      start_procedure: Commencer la démarche
+      existing_dossiers: Vous avez déjà des dossiers pour cette démarche
+      show_dossiers: Voir mes dossiers en cours
+      prefilled_draft: "Vous avez un dossier prérempli"
+      prefilled_draft_detail_html: "Vous êtes prêt·e à poursuivre un dossier prérempli sur la démarche « %{procedure} », commencé il y a <strong>%{time_ago}</strong>."
+      already_draft: "Vous avez déjà commencé à remplir un dossier"
+      already_draft_detail_html: "Il y a <strong>%{time_ago}</strong>, vous avez commencé à remplir un dossier sur la démarche « %{procedure} »."
+      already_not_draft: "Vous avez déjà déposé un dossier"
+      already_not_draft_detail_html: "Il y a <strong>%{time_ago}</strong>, vous avez déposé un dossier sur la démarche « %{procedure} »."
+      go_to_prefilled_file: 'Poursuivre mon dossier prérempli'
+      continue_file: 'Continuer à remplir mon dossier'
+      start_new_file: 'Commencer un nouveau dossier'
+      show_my_submitted_file: 'Voir mon dossier déposé'
+      want_empty_pdf: "Vous souhaitez effectuer une demande par papier ? Vous pouvez télécharger un dossier vide au format PDF, et l’envoyer à l’administration concernée : %{service} - %{adresse}"
+      download_empty_pdf: 'Télécharger un dossier vide au format PDF'
+      already_created:
+        one: "Votre dernier dossier :"
+        other: "Vos %{count} derniers dossiers créés :" 
+      already_created_details_html:
+        "N° %{id}, créé il y a %{created_at} et %{state}"

--- a/spec/views/commencer/show.html.haml_spec.rb
+++ b/spec/views/commencer/show.html.haml_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'commencer/show', type: :view do
 
       it 'renders a link to the dossiers list' do
         subject
-        expect(rendered).to have_link('Voir mes dossiers en cours', href: dossiers_path)
+        expect(rendered).to have_link('Voir mes dossiers en cours', href: dossiers_path(procedure_id: procedure.id))
       end
     end
 

--- a/spec/views/commencer/show.html.haml_spec.rb
+++ b/spec/views/commencer/show.html.haml_spec.rb
@@ -3,10 +3,18 @@ RSpec.describe 'commencer/show', type: :view do
 
   let(:stored_query_params) { false }
   let(:procedure) { create(:procedure, :published, :for_individual, :with_service) }
+  let(:dossiers) { drafts + not_drafts }
+  let(:drafts) { [] }
+  let(:not_drafts) { [] }
+  let(:preview_dossiers) { dossiers.take(3) }
 
   before do
     assign(:procedure, procedure)
     assign(:revision, procedure.published_revision)
+    assign(:dossiers, dossiers)
+    assign(:drafts, drafts)
+    assign(:not_drafts, not_drafts)
+    assign(:preview_dossiers, preview_dossiers)
     if user
       sign_in user
     end
@@ -42,33 +50,33 @@ RSpec.describe 'commencer/show', type: :view do
     end
 
     context 'and they have a pending draft' do
-      let!(:brouillon) { create(:dossier, user: user, procedure: procedure) }
+      let!(:drafts) { [create(:dossier, user: user, procedure: procedure)] }
 
       it_behaves_like 'it renders a link to create a new dossier', 'Commencer un nouveau dossier'
 
       it 'renders a link to resume the pending draft' do
         subject
-        expect(rendered).to have_text(time_ago_in_words(brouillon.created_at))
-        expect(rendered).to have_link('Continuer à remplir mon dossier', href: brouillon_dossier_path(brouillon))
+        expect(rendered).to have_text(time_ago_in_words(drafts.first.created_at))
+        expect(rendered).to have_link('Continuer à remplir mon dossier', href: brouillon_dossier_path(drafts.first))
       end
     end
 
     context 'and they have a submitted dossier' do
-      let!(:brouillon) { create(:dossier, user: user, procedure: procedure) }
-      let!(:dossier) { create(:dossier, :en_construction, :with_individual, user: user, procedure: procedure) }
+      let!(:drafts) { [create(:dossier, user: user, procedure: procedure)] }
+      let!(:not_drafts) { [create(:dossier, :en_construction, :with_individual, user: user, procedure: procedure)] }
 
       it_behaves_like 'it renders a link to create a new dossier', 'Commencer un nouveau dossier'
 
       it 'renders a link to the submitted dossier' do
         subject
-        expect(rendered).to have_text(time_ago_in_words(dossier.depose_at))
-        expect(rendered).to have_link('Voir mon dossier', href: dossier_path(dossier))
+        expect(rendered).to have_text(time_ago_in_words(not_drafts.first.depose_at))
+        expect(rendered).to have_link('Voir mon dossier', href: dossier_path(not_drafts.first))
       end
     end
 
     context 'and they have several submitted dossiers' do
-      let!(:brouillon) { create(:dossier, user: user, procedure: procedure) }
-      let!(:dossiers) { create_list(:dossier, 2, :en_construction, :with_individual, user: user, procedure: procedure) }
+      let!(:drafts) { [create(:dossier, user: user, procedure: procedure)] }
+      let!(:not_drafts) { create_list(:dossier, 2, :en_construction, :with_individual, user: user, procedure: procedure) }
 
       it_behaves_like 'it renders a link to create a new dossier', 'Commencer un nouveau dossier'
 


### PR DESCRIPTION
- le lien "voir mes dossiers" renvoie sur la liste des dossiers filtrées pour la bonne procédure
- on affiche un raccourcis vers les 3 derniers dossiers créés de la procédure

en bonus :
- on déplace les trads dans le fichier correspondant à la view
- on ne fait plus de query db dans la view et on en réduit le nombre

Avant:
![Screenshot 2023-10-09 at 17-03-20 old and new pjs · demarches-simplifiees fr](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/907405/f70efbab-42c4-49ad-b62b-30b13b7898f6)

Après:
![Screenshot 2023-10-09 at 21-56-32 old and new pjs · demarches-simplifiees fr](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/907405/aee5a22a-c4cb-4c01-add9-a535864f020c)
