### PR TITLE
correctif(tech.export): il arrive que des exports soient mal identifié (le content-type), ce qui par la suite renvoie des exports vide (0kb)

### DIFF
--- a/app/services/archive_uploader.rb
+++ b/app/services/archive_uploader.rb
@@ -38,8 +38,7 @@ class ArchiveUploader
   end
 
   def upload_with_active_storage
-    params = blob_default_params(filepath).merge(io: File.open(filepath),
-                                                 identify: false)
+    params = blob_default_params(filepath).merge(io: File.open(filepath))
     blob = ActiveStorage::Blob.create_and_upload!(**params)
     return blob
   end
@@ -64,7 +63,7 @@ class ArchiveUploader
       key: namespaced_object_key,
       filename: filename,
       content_type: 'application/zip',
-      metadata: { analyzed: true, virus_scan_result: ActiveStorage::VirusScanner::SAFE }
+      metadata: { analyzed: true, identified: true, virus_scan_result: ActiveStorage::VirusScanner::SAFE }
     }
   end
 

--- a/app/services/procedure_export_service.rb
+++ b/app/services/procedure_export_service.rb
@@ -56,7 +56,7 @@ class ProcedureExportService
       content_type: content_type(format),
       identify: false,
       # We generate the exports ourselves, so they are safe
-      metadata: { virus_scan_result: ActiveStorage::VirusScanner::SAFE }
+      metadata: { virus_scan_result: ActiveStorage::VirusScanner::SAFE, identified: true }
     )
   end
 

--- a/spec/jobs/export_job_spec.rb
+++ b/spec/jobs/export_job_spec.rb
@@ -1,0 +1,29 @@
+describe ExportJob do
+  let(:procedure) { create(:procedure, instructeurs: [instructeur]) }
+  let(:instructeur) { create(:instructeur) }
+  let(:time_span_type) { :everything }
+  let(:status) { :tous }
+  let(:key) { '123' }
+  let(:export) do
+    create(:export, format:,
+                    time_span_type:,
+                    key:,
+                    instructeur:,
+                    groupe_instructeurs: procedure.groupe_instructeurs)
+  end
+
+  subject do
+    ExportJob.perform_now(export)
+  end
+  before do
+    allow_any_instance_of(ArchiveUploader).to receive(:syscall_to_custom_uploader).and_return(true)
+  end
+
+  context 'zip' do
+    let(:format) { :zip }
+
+    it 'does not try to identify file' do
+      expect { subject }.not_to raise_error(ActiveStorage::FileNotFoundError)
+    end
+  end
+end


### PR DESCRIPTION
c'est un peu le bazard ces api active storage. apres avoir creusé la codebase de rails, l'impression que : 
* dans certains cas il faut passer `identify: false` (ex: https://api.rubyonrails.org/classes/ActiveStorage/Blob.html#method-c-create_and_upload-21) 
* et d'autres `metadata[:identified]=true` (ex: https://api.rubyonrails.org/classes/ActiveStorage/Blob.html#method-c-create_before_direct_upload-21)

aussi, l'attribute pour verifier si il faut inferer le content_type (donc via le identifiable) est stocké sur le metadata nommé `identified` : https://github.com/rails/rails/blob/main/activestorage/app/models/active_storage/blob.rb#L29

mon impression est que la difference entre 
* create_and_upload utilisant `identify`, c'est un paramêtre "transiant" qui vient a etre repliqué sur le metadata en fin de cycle.
* create_before_direct_upload utilise le `metadata[:identified]` car le cycle de vie de l'upload est different