### PR TITLE
Schema: fixup failed migrations, ensure exports->instructeurs FK exists

### DIFF
--- a/db/migrate/20230813091946_add_groupe_gestionnaire_to_administrateurs.rb
+++ b/db/migrate/20230813091946_add_groupe_gestionnaire_to_administrateurs.rb
@@ -2,6 +2,7 @@ class AddGroupeGestionnaireToAdministrateurs < ActiveRecord::Migration[7.0]
   disable_ddl_transaction!
 
   def change
-    add_reference :administrateurs, :groupe_gestionnaire, index: { algorithm: :concurrently }, null: true
+    # Foreign key is added in a later migration
+    add_reference :administrateurs, :groupe_gestionnaire, index: { algorithm: :concurrently }, null: true, foreign_key: false
   end
 end

--- a/db/migrate/20231009070354_add_dossiers_count_to_exports.rb
+++ b/db/migrate/20231009070354_add_dossiers_count_to_exports.rb
@@ -1,6 +1,4 @@
-class AddContextToExports < ActiveRecord::Migration[7.0]
-  disable_ddl_transaction!
-
+class AddDossiersCountToExports < ActiveRecord::Migration[7.0]
   def change
     add_column :exports, :dossiers_count, :integer, null: true, default: nil
   end

--- a/db/migrate/20231009143331_add_reference_to_exports_instructeur.rb
+++ b/db/migrate/20231009143331_add_reference_to_exports_instructeur.rb
@@ -1,8 +1,8 @@
 class AddReferenceToExportsInstructeur < ActiveRecord::Migration[7.0]
   disable_ddl_transaction!
+
   def change
-    safety_assured do
-      add_reference :exports, :instructeur, foreign_key: true, null: true, default: nil, index: { algorithm: :concurrently }
-    end
+    # Foreign key is added in a later migration
+    add_reference :exports, :instructeur, null: true, default: nil, index: { algorithm: :concurrently }, foreign_key: false
   end
 end

--- a/db/migrate/20231010083144_add_instructeur_foreign_key_to_exports.rb
+++ b/db/migrate/20231010083144_add_instructeur_foreign_key_to_exports.rb
@@ -1,0 +1,11 @@
+class AddInstructeurForeignKeyToExports < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    # Foreign keys were already added on developer machines, but timeouted in production.
+    if !foreign_key_exists?(:exports, :instructeurs)
+      add_foreign_key :exports, :instructeurs, validate: false
+      validate_foreign_key :exports, :instructeurs
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_09_143331) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_10_083144) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"


### PR DESCRIPTION
Suite des échecs de FK en prod hier, on corrige (et renomme) les migrations problématiques, et on s'assure que la FK manquante existe