### PR TITLE
[Fix] Retirer le soulignement du dernier item du fil d'ariane

### DIFF
--- a/app/views/administrateurs/_breadcrumbs.html.haml
+++ b/app/views/administrateurs/_breadcrumbs.html.haml
@@ -10,8 +10,7 @@
 
           - steps.each.with_index do |step, i|
             - if i == steps.size - 1
-              %li{ aria: { current: "page" } }
-                %span.fr-breadcrumb__link= step[0]
+              %li= link_to step[0], '', { aria: { current: "page" } , class: 'fr-breadcrumb__link' }
             - else
               %li= link_to step[0], step[1], class: 'fr-breadcrumb__link'
 


### PR DESCRIPTION
Utiliser le bon markup pour être cohérent avec le DSFR

**APRES**
<img width="602" alt="Capture d’écran 2023-10-10 à 15 57 34" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/5559be4c-b046-45fd-863a-7ea880d7aea1">

**AVANT**
<img width="485" alt="Capture d’écran 2023-10-10 à 15 57 48" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/f8ba28a1-488a-41bc-8bc1-0405e70a1ad4">
