### PR TITLE
[amélioration] Affichage de plus d'info RNA coté usager + amélioration affichage coté instructeur/usager

### DIFF
--- a/app/views/shared/champs/rna/_show.html.haml
+++ b/app/views/shared/champs/rna/_show.html.haml
@@ -4,12 +4,12 @@
   - if champ.data.blank?
     %p= t('.not_found', rna: champ.value)
   - else
-    %div.fr-background-alt--grey.fr-p-3v
+    .fr-background-alt--grey.fr-p-3v
       = render Dossiers::RowShowComponent.new(label: t("activemodel.attributes.rna_champ.value")) do |c|
         - c.with_value do
           %p
             = champ.value
-            =render Dsfr::CopyButtonComponent.new(text: champ.value, title: t("activemodel.attributes.rna_champ.paste"), success: t("activemodel.attributes.rna_champ.paste_success"))
+            = render Dsfr::CopyButtonComponent.new(text: champ.value, title: t("activemodel.attributes.rna_champ.paste"), success: t("activemodel.attributes.rna_champ.paste_success"))
 
       - ['association_titre', 'association_objet', ].each do |scope|
         - if champ.data[scope].present?

--- a/app/views/shared/champs/rna/_show.html.haml
+++ b/app/views/shared/champs/rna/_show.html.haml
@@ -1,16 +1,23 @@
 - if champ.value.blank?
   %p= t('.not_filled')
-- elsif profile == 'instructeur'
+- else
   - if champ.data.blank?
     %p= t('.not_found', rna: champ.value)
   - else
-    %p= t('.data_fetched_title', rna: champ.value)
-    %ul
+    %div.fr-background-alt--grey.fr-p-3v
+      = render Dossiers::RowShowComponent.new(label: t("activemodel.attributes.rna_champ.value")) do |c|
+        - c.with_value do
+          %p
+            = champ.value
+            =render Dsfr::CopyButtonComponent.new(text: champ.value, title: t("activemodel.attributes.rna_champ.paste"), success: t("activemodel.attributes.rna_champ.paste_success"))
+
       - ['association_titre', 'association_objet', ].each do |scope|
         - if champ.data[scope].present?
-          %li #{t("activemodel.attributes.rna_champ.data.#{scope}")} : #{champ.data[scope].capitalize}
+          = render Dossiers::RowShowComponent.new(label: t("activemodel.attributes.rna_champ.data.#{scope}")) do |c|
+            - c.with_value do
+              %p= champ.data[scope]
       - ['association_date_creation', 'association_date_declaration', 'association_date_publication'].each do |scope|
         - if champ.data[scope].present?
-          %li #{t("activemodel.attributes.rna_champ.data.#{scope}")} : #{l(champ.data[scope].to_date)}
-- else
-  %p= champ.identifier
+          = render Dossiers::RowShowComponent.new(label: t("activemodel.attributes.rna_champ.data.#{scope}")) do |c|
+            - c.with_value do
+              %p= l(champ.data[scope].to_date)

--- a/config/locales/models/champs/rna_champ/en.yml
+++ b/config/locales/models/champs/rna_champ/en.yml
@@ -2,12 +2,15 @@ en:
   activemodel:
     attributes:
       rna_champ:
+        value: N° RNA
         data:
           association_titre: Association name
           association_objet: Association purpose
           association_date_creation: Creation date
           association_date_declaration: Declaration date
           association_date_publication: Publication date
+        paste: Copy the RNA to the clipboard
+        paste_success: The RNA has been copied to the clipboard
   activerecord:
     attributes:
       champs/rna_champ:

--- a/config/locales/models/champs/rna_champ/fr.yml
+++ b/config/locales/models/champs/rna_champ/fr.yml
@@ -9,6 +9,8 @@ fr:
           association_date_creation: Date de création
           association_date_declaration: Date de déclaration
           association_date_publication: Date de publication
+        paste: Copier le RNA dans le presse-papier
+        paste_success: Le RNA a été copié dans le presse-papier
   activerecord:
     attributes:
       champs/rna_champ:

--- a/config/locales/shared.en.yml
+++ b/config/locales/shared.en.yml
@@ -26,7 +26,6 @@ en:
         show:
           not_filled: not filled
           not_found: "RNA number %{rna} (no association found)"
-          data_fetched_title: Data received from RNA number "%{rna}"
         association:
           data_fetched: "This RNA number is linked to %{title}"
           not_found: "No association found"

--- a/config/locales/shared.fr.yml
+++ b/config/locales/shared.fr.yml
@@ -28,7 +28,6 @@ fr:
         show:
           not_filled: non renseigné
           not_found: "RNA %{rna} (aucun établissement trouvé)"
-          data_fetched_title: Données obtenues grâce au RNA "%{rna}"
         association:
           data_fetched: "Ce RNA correspond à %{title}"
           not_found: "Aucun établissement trouvé"


### PR DESCRIPTION
closes #9503 

Dans le contexte du formulaire, on affiche déjà le nom de l'association lorsqu'on remplit le champ. Ça ne me semblait pas pertinent de rajouter plus d'informations à ce moment là - pour ne pas couper le flow de l'usager.

**CONTEXTE FORMULAIRE** trouvé / pas trouvé
<img width="393" alt="Capture d’écran 2023-10-11 à 11 45 57" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/592167af-1b23-4b8e-a548-268948eb52c6">

<img width="412" alt="Capture d’écran 2023-10-11 à 11 46 07" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/7f9c5bee-515a-42a7-95f0-96777e2ff3e4">

**CONTEXTE DOSSIER** trouvé / pas trouvé
<img width="793" alt="Capture d’écran 2023-10-11 à 11 45 41" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/21a6c638-476b-43d4-b3d0-8e3751421215">
----
<img width="812" alt="Capture d’écran 2023-10-11 à 11 46 24" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/8aff5f9a-24d4-4384-aa13-b2f46a4c61f9">
