### PR TITLE
chore(browser): show browser outdated message to more (very) old browsers

### DIFF
--- a/app/services/browser_support.rb
+++ b/app/services/browser_support.rb
@@ -1,12 +1,12 @@
 class BrowserSupport
   def self.supported?(browser)
     [
-      browser.chrome? && browser.version.to_i >= 50 && !browser.platform.ios?,
-      browser.edge? && browser.version.to_i >= 14 && !browser.compatibility_view?,
-      browser.firefox? && browser.version.to_i >= 50 && !browser.platform.ios?,
-      browser.opera? && browser.version.to_i >= 40,
-      browser.safari? && browser.version.to_i >= 8,
-      browser.platform.ios? && browser.platform.version.to_i >= 8
+      browser.chrome? && browser.version.to_i >= 79 && !browser.platform.ios?,
+      browser.edge? && browser.version.to_i >= 79 && !browser.compatibility_view?,
+      browser.firefox? && browser.version.to_i >= 67 && !browser.platform.ios?,
+      browser.opera? && browser.version.to_i >= 50,
+      browser.safari? && browser.version.to_i >= 12,
+      browser.platform.ios? && browser.platform.version.to_i >= 12
     ].any?
   end
 end


### PR DESCRIPTION
J'ai pris comme point de référence les imports dynamiques :
https://caniuse.com/es6-module-dynamic-import

En dehors d'IE 11 [ 11, "3118 (0.05%)" ], les seuls navigateurs qui nous posent problème sont Firefox [ 52, "3730 (0.07%)" ] et [ 60, "5070 (0.09%)" ]