### PR TITLE
Correction : tâche Rake pour corriger les numéros de téléphone invalides

### DIFF
--- a/app/lib/phone_fixer.rb
+++ b/app/lib/phone_fixer.rb
@@ -1,0 +1,13 @@
+class PhoneFixer
+  def self.fix(phones_string)
+    phone_candidates = phones_string
+      .split(/-/)
+      .map { |phone_with_space| phone_with_space.gsub(/\s/, '') }
+
+    phone_candidates.find { |phone| phone.start_with?(/0(6|7)/) } || phone_candidates.first
+  end
+
+  def self.fixable?(phones_string)
+    /-/.match?(phones_string)
+  end
+end

--- a/lib/tasks/phone_fixer.rake
+++ b/lib/tasks/phone_fixer.rake
@@ -1,0 +1,29 @@
+require Rails.root.join("lib", "tasks", "task_helper")
+
+namespace :phone_fixer do
+  desc <<~EOD
+    Given a procedure_id in argument, run the PhoneFixer.
+    ex: rails phone_fixer:run\[1\]
+  EOD
+  task :run, [:procedure_id] => :environment do |_t, args|
+    procedure = Procedure.find(args[:procedure_id])
+
+    phone_champs = Champ
+      .where(dossier_id: procedure.dossiers.pluck(:id))
+      .where(type: "Champs::PhoneChamp")
+
+    invalid_phone_champs = phone_champs.reject(&:valid?)
+
+    fixable_phone_champs = invalid_phone_champs.filter { |phone| PhoneFixer.fixable?(phone.value) }
+
+    fixable_phone_champs.each do |phone|
+      fixable_phone_value = phone.value
+      fixed_phone_value = PhoneFixer.fix(fixable_phone_value)
+      if phone.update(value: fixed_phone_value)
+        rake_puts "Invalid phone #{fixable_phone_value} is fixed as #{fixed_phone_value}"
+      else
+        rake_puts "Failed to fix #{fixable_phone_value}"
+      end
+    end
+  end
+end

--- a/spec/lib/phone_fixer_spec.rb
+++ b/spec/lib/phone_fixer_spec.rb
@@ -1,6 +1,5 @@
 describe PhoneFixer do
   describe '#fix' do
-
     subject { described_class.fix(phone_str) }
 
     context 'when separated evenly with space between and after dash' do
@@ -22,7 +21,6 @@ describe PhoneFixer do
   end
 
   describe '#fixable' do
-
     subject { described_class.fixable?(phone_str) }
 
     context 'when separated evenly with space between and after dash' do

--- a/spec/lib/phone_fixer_spec.rb
+++ b/spec/lib/phone_fixer_spec.rb
@@ -1,0 +1,49 @@
+describe PhoneFixer do
+  describe '#fix' do
+
+    subject { described_class.fix(phone_str) }
+
+    context 'when separated evenly with space between and after dash' do
+      let(:phone_str) { "0203040506 - 0607080900" }
+      it { is_expected.to eq('0607080900') }
+    end
+    context 'when separated oddly without space after dash' do
+      let(:phone_str) { "0203040506 -0607080900" }
+      it { is_expected.to eq('0607080900') }
+    end
+    context 'when separated oddly without space after dash' do
+      let(:phone_str) { "0203040506- 0607080900" }
+      it { is_expected.to eq('0607080900') }
+    end
+    context 'when having space inside number' do
+      let(:phone_str) { "020 3040 506 - 06070  8 09 00 " }
+      it { is_expected.to eq('0607080900') }
+    end
+  end
+
+  describe '#fixable' do
+
+    subject { described_class.fixable?(phone_str) }
+
+    context 'when separated evenly with space between and after dash' do
+      let(:phone_str) { "0203040506 - 0607080900" }
+      it { is_expected.to be_truthy }
+    end
+    context 'when separated oddly without space after dash' do
+      let(:phone_str) { "0203040506 -0607080900" }
+      it { is_expected.to be_truthy }
+    end
+    context 'when separated oddly without space after dash' do
+      let(:phone_str) { "0203040506- 0607080900" }
+      it { is_expected.to be_truthy }
+    end
+    context 'when having space inside number' do
+      let(:phone_str) { "020 3040 506 - 06070  8 09 00 " }
+      it { is_expected.to be_truthy }
+    end
+    context 'when separated by space' do
+      let(:phone_str) { "0203040506 0607080900" }
+      it { is_expected.to be_falsey }
+    end
+  end
+end


### PR DESCRIPTION
En coproduction avec @mfo cette PR ajoute une tâche Rake pour corriger des numéros de téléphone invalides de type "01XXXXXXXX - 06XXXXXXXX"
Le ticket HS à l'origine : https://secure.helpscout.net/conversation/2300310912/2035165