### PR TITLE
correctif(data): tâche rake recréant les champs manquant à un dossier ayant subi une perte de données

### DIFF
--- a/app/lib/data_fixer/champs_phone_invalid.rb
+++ b/app/lib/data_fixer/champs_phone_invalid.rb
@@ -1,4 +1,4 @@
-class PhoneFixer
+class DataFixer::ChampsPhoneInvalid
   def self.fix(phones_string)
     phone_candidates = phones_string
       .split(/-/)

--- a/app/lib/data_fixer/dossier_champs_missing.rb
+++ b/app/lib/data_fixer/dossier_champs_missing.rb
@@ -20,21 +20,46 @@ class DataFixer::DossierChampsMissing
   end
 
   def apply_fix(dossier)
-    dossier_champs = dossier.champs_public.includes(:type_de_champ)
-    revision_type_de_champ = TypeDeChamp.joins(:revision_type_de_champ).where(revision_type_de_champ: { revision: dossier.revision })
+    added_champs_root = fix_champs_root(dossier)
+    added_champs_in_repetition = fix_champs_in_repetition(dossier)
 
-    dossier_tdc_stable_ids = dossier_champs.map(&:type_de_champ).map(&:stable_id)
-
-    missing_tdcs = revision_type_de_champ.filter { !dossier_tdc_stable_ids.include?(_1.stable_id) }
-    missing_tdcs.map do |missing_champ|
-      dossier.champs_public << missing_champ.build_champ
-    end
-
-    if !missing_tdcs.empty?
+    added_champs = added_champs_root + added_champs_in_repetition
+    if !added_champs.empty?
       dossier.save!
-      missing_tdcs.size
+      added_champs.size
     else
       0
+    end
+  end
+
+  def fix_champs_root(dossier)
+    champs_root, _ = dossier.champs.partition { _1.parent_id.blank? }
+    expected_tdcs = dossier.revision.revision_types_de_champ.filter { _1.parent.blank? }.map(&:type_de_champ)
+
+    expected_tdcs.filter { !champs_root.map(&:stable_id).include?(_1.stable_id) }
+      .map do |missing_tdc|
+                    champ_root_missing = missing_tdc.build_champ
+
+                    dossier.champs_public << champ_root_missing
+                    champ_root_missing
+                  end
+  end
+
+  def fix_champs_in_repetition(dossier)
+    champs_repetition, _ = dossier.champs.partition(&:repetition?)
+
+    champs_repetition.flat_map do |champ_repetition|
+      champ_repetition_missing = champ_repetition.rows.flat_map do |row|
+        row_id = row.first.row_id
+        expected_tdcs = dossier.revision.children_of(champ_repetition.type_de_champ)
+        row_tdcs = row.map(&:type_de_champ)
+
+        (expected_tdcs - row_tdcs).map do |missing_tdc|
+          champ_repetition_missing = missing_tdc.build_champ(row_id: row_id)
+          champ_repetition.champs << champ_repetition_missing
+          champ_repetition_missing
+        end
+      end
     end
   end
 end

--- a/app/lib/data_fixer/dossier_champs_missing.rb
+++ b/app/lib/data_fixer/dossier_champs_missing.rb
@@ -26,6 +26,7 @@ class DataFixer::DossierChampsMissing
     added_champs = added_champs_root + added_champs_in_repetition
     if !added_champs.empty?
       dossier.save!
+      log_champs_added(dossier, added_champs)
       added_champs.size
     else
       0
@@ -61,5 +62,20 @@ class DataFixer::DossierChampsMissing
         end
       end
     end
+  end
+
+  def log_champs_added(dossier, added_champs)
+    app_traces = caller.reject { _1.match?(%r{/ruby/.+/gems/}) }.map { _1.sub(Rails.root.to_s, "") }
+
+    payload = {
+      message: "DataFixer::DossierChampsMissing",
+      dossier_id: dossier.id,
+      champs_ids: added_champs.map(&:id).join(","),
+      caller: app_traces
+    }
+
+    logger = Lograge.logger || Rails.logger
+
+    logger.info payload.to_json
   end
 end

--- a/app/lib/data_fixer/dossier_champs_missing.rb
+++ b/app/lib/data_fixer/dossier_champs_missing.rb
@@ -1,0 +1,40 @@
+# some race condition (regarding double submit of dossier.passer_en_construction!) might remove champs
+#   until now we haven't decided to push a stronger fix than an UI change
+#   so we might have to recreate some deleted champs and notify administration
+class DataFixer::DossierChampsMissing
+  def fix
+    fixed_on_origin = apply_fix(@original_dossier)
+
+    fixed_on_other = Dossier.where(editing_fork_origin_id: @original_dossier.id)
+      .map(&method(:apply_fix))
+
+    [fixed_on_origin, fixed_on_other.sum].sum
+  end
+
+  private
+
+  attr_reader :original_dossier
+
+  def initialize(dossier:)
+    @original_dossier = dossier
+  end
+
+  def apply_fix(dossier)
+    dossier_champs = dossier.champs_public.includes(:type_de_champ)
+    revision_type_de_champ = TypeDeChamp.joins(:revision_type_de_champ).where(revision_type_de_champ: { revision: dossier.revision })
+
+    dossier_tdc_stable_ids = dossier_champs.map(&:type_de_champ).map(&:stable_id)
+
+    missing_tdcs = revision_type_de_champ.filter { !dossier_tdc_stable_ids.include?(_1.stable_id) }
+    missing_tdcs.map do |missing_champ|
+      dossier.champs_public << missing_champ.build_champ
+    end
+
+    if !missing_tdcs.empty?
+      dossier.save!
+      missing_tdcs.size
+    else
+      0
+    end
+  end
+end

--- a/lib/tasks/data_fixer.rake
+++ b/lib/tasks/data_fixer.rake
@@ -2,7 +2,7 @@ require Rails.root.join("lib", "tasks", "task_helper")
 
 namespace :data_fixer do
   desc <<~EOD
-    Given a procedure_id in argument, run the PhoneFixer.
+    Given a procedure_id in argument, run the DataFixer::ChampsPhoneInvalid.
     ex: rails data_fixer:fix_phones\[1\]
   EOD
   task :fix_phones, [:procedure_id] => :environment do |_t, args|
@@ -14,11 +14,11 @@ namespace :data_fixer do
 
     invalid_phone_champs = phone_champs.reject(&:valid?)
 
-    fixable_phone_champs = invalid_phone_champs.filter { |phone| PhoneFixer.fixable?(phone.value) }
+    fixable_phone_champs = invalid_phone_champs.filter { |phone| DataFixer::ChampsPhoneInvalid.fixable?(phone.value) }
 
     fixable_phone_champs.each do |phone|
       fixable_phone_value = phone.value
-      fixed_phone_value = PhoneFixer.fix(fixable_phone_value)
+      fixed_phone_value = DataFixer::ChampsPhoneInvalid.fix(fixable_phone_value)
       if phone.update(value: fixed_phone_value)
         rake_puts "Invalid phone #{fixable_phone_value} is fixed as #{fixed_phone_value}"
       else

--- a/lib/tasks/data_fixer.rake
+++ b/lib/tasks/data_fixer.rake
@@ -26,4 +26,19 @@ namespace :data_fixer do
       end
     end
   end
+
+  desc <<~EOD
+    Given a dossier_id in argument, run the DossierChampsMissing.
+    ex: rails data_fixer:dossier_missing_champ\[1\]
+  EOD
+  task :dossier_missing_champ, [:dossier_id] => :environment do |_t, args|
+    dossier = Dossier.find(args[:dossier_id])
+    result = DataFixer::DossierChampsMissing.new(dossier:).fix
+
+    if result > 0
+      rake_puts "Dossier#[#{args[:dossier_id]}] fixed"
+    else
+      rake_puts "Dossier#[#{args[:dossier_id]}] not fixed"
+    end
+  end
 end

--- a/lib/tasks/data_fixer.rake
+++ b/lib/tasks/data_fixer.rake
@@ -1,11 +1,11 @@
 require Rails.root.join("lib", "tasks", "task_helper")
 
-namespace :phone_fixer do
+namespace :data_fixer do
   desc <<~EOD
     Given a procedure_id in argument, run the PhoneFixer.
-    ex: rails phone_fixer:run\[1\]
+    ex: rails data_fixer:fix_phones\[1\]
   EOD
-  task :run, [:procedure_id] => :environment do |_t, args|
+  task :fix_phones, [:procedure_id] => :environment do |_t, args|
     procedure = Procedure.find(args[:procedure_id])
 
     phone_champs = Champ

--- a/spec/lib/data_fixer/champs_phone_invalid_spec.rb
+++ b/spec/lib/data_fixer/champs_phone_invalid_spec.rb
@@ -1,4 +1,4 @@
-describe PhoneFixer do
+describe DataFixer::ChampsPhoneInvalid do
   describe '#fix' do
     subject { described_class.fix(phone_str) }
 

--- a/spec/lib/data_fixer/dossier_champs_missing_spec.rb
+++ b/spec/lib/data_fixer/dossier_champs_missing_spec.rb
@@ -1,0 +1,36 @@
+describe DataFixer::DossierChampsMissing do
+  describe '#fix' do
+    let(:procedure) { create(:procedure, :with_datetime, :with_dossier_link) }
+    let(:dossier) { create(:dossier, procedure:) }
+
+    context 'when dossier does not have a fork' do
+      before { dossier.champs_public.first.destroy }
+      subject { described_class.new(dossier:).fix }
+
+      it 'add missing champs to the dossier' do
+        expect { subject }.to change { dossier.champs_public.count }.from(1).to(2)
+      end
+
+      it 'returns number of added champs' do
+        expect(subject).to eq(1)
+      end
+    end
+
+    context 'when dossier have a fork' do
+      before { dossier.champs_public.first.destroy }
+      let(:create_fork) { dossier.find_or_create_editing_fork(dossier.user) }
+      subject do
+        create_fork
+        described_class.new(dossier:).fix
+      end
+
+      it 'add missing champs to the fork too' do
+        expect { subject }.to change { create_fork.champs_public.count }.from(1).to(2)
+      end
+
+      it 'sums number of added champs for dossier and editing_fork_origin_id' do
+        expect(subject).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/lib/data_fixer/dossier_champs_missing_spec.rb
+++ b/spec/lib/data_fixer/dossier_champs_missing_spec.rb
@@ -32,5 +32,25 @@ describe DataFixer::DossierChampsMissing do
         expect(subject).to eq(2)
       end
     end
+
+    context 'when dossier have missing champ on repetition' do
+      let(:procedure) { create(:procedure, :with_repetition) }
+      let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
+      let(:champ_repetition) { dossier.champs_public.first }
+      let(:initial_champ_count) { dossier.champs.count }
+      before do
+        initial_champ_count
+        champ_repetition.champs.first.destroy
+      end
+      subject { described_class.new(dossier:).fix }
+
+      it 'add missing champs to repetition' do
+        expect { subject }.to change { dossier.champs.count }.from(initial_champ_count - 1).to(initial_champ_count)
+      end
+
+      it 'counts number of added champs for dossier.repetitions' do
+        expect(subject).to eq(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
# contexte
un instructeur / admin sur DS nous a remonté qu'un champ c'était fait la mal sur un dossier.
après investigation, les pointeurs laissent à croire que le problème viendrait d'un probleme de "race condition" arrivant par un double submit lorsqu'un usager depose son dossier. Donc ça se passerait autour de `Users::DossiersController#submit_en_construction`, plus précisement `editing_fork_origin = @dossier.editing_fork_origin && editing_fork_origin.merge_fork(@dossier)` qui peuvent enclancher de grosses transaction SQL. 

# solution 
pour le moment on essaie d'eviter le double submit par l'UI (le plus simple).  
puis on va remettre les champs manquant en prod et s'outiller ainsi.  

todo : 

- [x] coder le fixer
- [ ] deployer le fixer
- [ ] faire tourner le fixer en prod sur les dossiers impactées cf: https://mattermost.incubateur.net/betagouv/pl/6ep6nun45j8sibfzuz1cg37rpr
- [ ] notifier les admins des dossiers impacté
- [ ] répondre au crisp en ayant mis en lumière le problème : https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_d2ae1b2f-962b-4069-a8dd-3f55cda6eee8/
