### PR TITLE
ETQ admin je peux conditionner sur les champs communes, EPCI et région

### DIFF
--- a/app/models/logic/champ_value.rb
+++ b/app/models/logic/champ_value.rb
@@ -6,7 +6,8 @@ class Logic::ChampValue < Logic::Term
     :decimal_number,
     :drop_down_list,
     :multiple_drop_down_list,
-    :departements
+    :departements,
+    :regions
   )
 
   CHAMP_VALUE_TYPE = {
@@ -61,7 +62,7 @@ class Logic::ChampValue < Logic::Term
       CHAMP_VALUE_TYPE.fetch(:boolean)
     when MANAGED_TYPE_DE_CHAMP.fetch(:integer_number), MANAGED_TYPE_DE_CHAMP.fetch(:decimal_number)
       CHAMP_VALUE_TYPE.fetch(:number)
-    when MANAGED_TYPE_DE_CHAMP.fetch(:drop_down_list), MANAGED_TYPE_DE_CHAMP.fetch(:departements)
+    when MANAGED_TYPE_DE_CHAMP.fetch(:drop_down_list),MANAGED_TYPE_DE_CHAMP.fetch(:departements), MANAGED_TYPE_DE_CHAMP.fetch(:regions)
       CHAMP_VALUE_TYPE.fetch(:enum)
     when MANAGED_TYPE_DE_CHAMP.fetch(:multiple_drop_down_list)
       CHAMP_VALUE_TYPE.fetch(:enums)
@@ -95,8 +96,12 @@ class Logic::ChampValue < Logic::Term
 
   def options(type_de_champs)
     tdc = type_de_champ(type_de_champs)
-    if tdc.departement?
+
+    case tdc.type_champ
+    when MANAGED_TYPE_DE_CHAMP.fetch(:departements)
       APIGeoService.departements.map { ["#{_1[:code]} – #{_1[:name]}", _1[:code]] }
+    when MANAGED_TYPE_DE_CHAMP.fetch(:regions)
+      APIGeoService.regions.map { ["#{_1[:code]} – #{_1[:name]}", _1[:code]] }
     else
       opts = tdc.drop_down_list_enabled_non_empty_options.map { |option| [option, option] }
       if tdc.drop_down_other?

--- a/app/models/logic/champ_value.rb
+++ b/app/models/logic/champ_value.rb
@@ -6,6 +6,7 @@ class Logic::ChampValue < Logic::Term
     :decimal_number,
     :drop_down_list,
     :multiple_drop_down_list,
+    :epci,
     :departements,
     :regions
   )
@@ -62,8 +63,11 @@ class Logic::ChampValue < Logic::Term
       CHAMP_VALUE_TYPE.fetch(:boolean)
     when MANAGED_TYPE_DE_CHAMP.fetch(:integer_number), MANAGED_TYPE_DE_CHAMP.fetch(:decimal_number)
       CHAMP_VALUE_TYPE.fetch(:number)
-    when MANAGED_TYPE_DE_CHAMP.fetch(:drop_down_list),MANAGED_TYPE_DE_CHAMP.fetch(:departements), MANAGED_TYPE_DE_CHAMP.fetch(:regions)
-      CHAMP_VALUE_TYPE.fetch(:enum)
+    when MANAGED_TYPE_DE_CHAMP.fetch(:drop_down_list),
+      MANAGED_TYPE_DE_CHAMP.fetch(:departements),
+      MANAGED_TYPE_DE_CHAMP.fetch(:regions),
+      MANAGED_TYPE_DE_CHAMP.fetch(:epci)
+        CHAMP_VALUE_TYPE.fetch(:enum)
     when MANAGED_TYPE_DE_CHAMP.fetch(:multiple_drop_down_list)
       CHAMP_VALUE_TYPE.fetch(:enums)
     else
@@ -98,7 +102,7 @@ class Logic::ChampValue < Logic::Term
     tdc = type_de_champ(type_de_champs)
 
     case tdc.type_champ
-    when MANAGED_TYPE_DE_CHAMP.fetch(:departements)
+    when MANAGED_TYPE_DE_CHAMP.fetch(:departements), MANAGED_TYPE_DE_CHAMP.fetch(:epci)
       APIGeoService.departements.map { ["#{_1[:code]} – #{_1[:name]}", _1[:code]] }
     when MANAGED_TYPE_DE_CHAMP.fetch(:regions)
       APIGeoService.regions.map { ["#{_1[:code]} – #{_1[:name]}", _1[:code]] }

--- a/app/models/logic/champ_value.rb
+++ b/app/models/logic/champ_value.rb
@@ -6,6 +6,7 @@ class Logic::ChampValue < Logic::Term
     :decimal_number,
     :drop_down_list,
     :multiple_drop_down_list,
+    :communes,
     :epci,
     :departements,
     :regions
@@ -64,10 +65,11 @@ class Logic::ChampValue < Logic::Term
     when MANAGED_TYPE_DE_CHAMP.fetch(:integer_number), MANAGED_TYPE_DE_CHAMP.fetch(:decimal_number)
       CHAMP_VALUE_TYPE.fetch(:number)
     when MANAGED_TYPE_DE_CHAMP.fetch(:drop_down_list),
+      MANAGED_TYPE_DE_CHAMP.fetch(:communes),
+      MANAGED_TYPE_DE_CHAMP.fetch(:epci),
       MANAGED_TYPE_DE_CHAMP.fetch(:departements),
-      MANAGED_TYPE_DE_CHAMP.fetch(:regions),
-      MANAGED_TYPE_DE_CHAMP.fetch(:epci)
-        CHAMP_VALUE_TYPE.fetch(:enum)
+      MANAGED_TYPE_DE_CHAMP.fetch(:regions)
+      CHAMP_VALUE_TYPE.fetch(:enum)
     when MANAGED_TYPE_DE_CHAMP.fetch(:multiple_drop_down_list)
       CHAMP_VALUE_TYPE.fetch(:enums)
     else
@@ -102,7 +104,7 @@ class Logic::ChampValue < Logic::Term
     tdc = type_de_champ(type_de_champs)
 
     case tdc.type_champ
-    when MANAGED_TYPE_DE_CHAMP.fetch(:departements), MANAGED_TYPE_DE_CHAMP.fetch(:epci)
+    when MANAGED_TYPE_DE_CHAMP.fetch(:communes), MANAGED_TYPE_DE_CHAMP.fetch(:epci), MANAGED_TYPE_DE_CHAMP.fetch(:departements)
       APIGeoService.departements.map { ["#{_1[:code]} – #{_1[:name]}", _1[:code]] }
     when MANAGED_TYPE_DE_CHAMP.fetch(:regions)
       APIGeoService.regions.map { ["#{_1[:code]} – #{_1[:name]}", _1[:code]] }

--- a/spec/components/types_de_champ_editor/conditions_component_spec.rb
+++ b/spec/components/types_de_champ_editor/conditions_component_spec.rb
@@ -81,6 +81,18 @@ describe TypesDeChampEditor::ConditionsComponent, type: :component do
           end
         end
 
+        context 'epcis' do
+          let(:epcis) { create(:type_de_champ_epci) }
+          let(:upper_tdcs) { [epcis] }
+          let(:condition) { empty_operator(champ_value(epcis.stable_id), constant(true)) }
+          let(:departement_options) { APIGeoService.departements.map { "#{_1[:code]} – #{_1[:name]}" } }
+
+          it do
+            expect(page).to have_select('type_de_champ[condition_form][rows][][operator_name]', with_options: ['Est'])
+            expect(page).to have_select('type_de_champ[condition_form][rows][][value]', options: (['Sélectionner'] + departement_options))
+          end
+        end
+
         context 'departements' do
           let(:departements) { create(:type_de_champ_departements) }
           let(:upper_tdcs) { [departements] }

--- a/spec/components/types_de_champ_editor/conditions_component_spec.rb
+++ b/spec/components/types_de_champ_editor/conditions_component_spec.rb
@@ -92,6 +92,18 @@ describe TypesDeChampEditor::ConditionsComponent, type: :component do
             expect(page).to have_select('type_de_champ[condition_form][rows][][value]', options: (['Sélectionner'] + departement_options))
           end
         end
+
+        context 'regions' do
+          let(:regions) { create(:type_de_champ_regions) }
+          let(:upper_tdcs) { [regions] }
+          let(:condition) { empty_operator(champ_value(regions.stable_id), constant(true)) }
+          let(:region_options) { APIGeoService.regions.map { "#{_1[:code]} – #{_1[:name]}" } }
+
+          it do
+            expect(page).to have_select('type_de_champ[condition_form][rows][][operator_name]', with_options: ['Est'])
+            expect(page).to have_select('type_de_champ[condition_form][rows][][value]', options: (['Sélectionner'] + region_options))
+          end
+        end
       end
 
       context 'and 2 conditions' do

--- a/spec/components/types_de_champ_editor/conditions_component_spec.rb
+++ b/spec/components/types_de_champ_editor/conditions_component_spec.rb
@@ -81,6 +81,18 @@ describe TypesDeChampEditor::ConditionsComponent, type: :component do
           end
         end
 
+        context 'communes' do
+          let(:communes) { create(:type_de_champ_communes) }
+          let(:upper_tdcs) { [communes] }
+          let(:condition) { empty_operator(champ_value(communes.stable_id), constant(true)) }
+          let(:departement_options) { APIGeoService.departements.map { "#{_1[:code]} – #{_1[:name]}" } }
+
+          it do
+            expect(page).to have_select('type_de_champ[condition_form][rows][][operator_name]', with_options: ['Est'])
+            expect(page).to have_select('type_de_champ[condition_form][rows][][value]', options: (['Sélectionner'] + departement_options))
+          end
+        end
+
         context 'epcis' do
           let(:epcis) { create(:type_de_champ_epci) }
           let(:upper_tdcs) { [epcis] }


### PR DESCRIPTION
Ces 3 champs sont déjà "routables" mais pas encore "conditionables"côté éditeur des types de champ.
Il faut les rendre conditionables avant de merger la PR sur les règles de routage multi ligne (#9604 ), qui implique d'utilise le `condition_component` pour le routage. 