### PR TITLE
Fix type de champ expression_reguliere

### DIFF
--- a/app/models/concerns/dossier_rebase_concern.rb
+++ b/app/models/concerns/dossier_rebase_concern.rb
@@ -32,10 +32,6 @@ module DossierRebaseConcern
     !champs.filter { _1.stable_id == stable_id }.any? { _1.in?(options) }
   end
 
-  def can_rebase_expression_reguliere_change?(stable_id, expression_reguliere)
-    false
-  end
-
   private
 
   def accepted_en_construction_changes?

--- a/app/validators/expression_reguliere_validator.rb
+++ b/app/validators/expression_reguliere_validator.rb
@@ -2,7 +2,7 @@ class ExpressionReguliereValidator < ActiveModel::Validator
   def validate(record)
     if record.value.present?
       if !record.value.match?(Regexp.new(record.expression_reguliere, timeout: 5.0))
-        record.errors.add(:value, :invalid_regexp)
+        record.errors.add(:value, :invalid_regexp, expression_reguliere_error_message: record.expression_reguliere_error_message)
       end
     end
   rescue Regexp::TimeoutError

--- a/config/locales/models/champs/expression_reguliere_champ/en.yml
+++ b/config/locales/models/champs/expression_reguliere_champ/en.yml
@@ -5,4 +5,4 @@ en:
         champs/expression_reguliere_champ:
           attributes:
             value:
-              invalid_regexp: does not match expected format
+              invalid_regexp: '%{expression_reguliere_error_message}'

--- a/config/locales/models/champs/expression_reguliere_champ/fr.yml
+++ b/config/locales/models/champs/expression_reguliere_champ/fr.yml
@@ -5,4 +5,4 @@ fr:
         champs/expression_reguliere_champ:
           attributes:
             value:
-              invalid_regexp: ne correspond pas au format attendu
+              invalid_regexp: '%{expression_reguliere_error_message}'

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1579,11 +1579,12 @@ describe Dossier, type: :model do
     let(:procedure) { create(:procedure, types_de_champ_public: types_de_champ) }
     let(:dossier) { create(:dossier, procedure: procedure) }
     let(:types_de_champ) { [type_de_champ] }
-    let(:type_de_champ) { { type: :expression_reguliere, expression_reguliere:, expression_reguliere_exemple_text: } }
+    let(:type_de_champ) { { type: :expression_reguliere, expression_reguliere:, expression_reguliere_exemple_text:, expression_reguliere_error_message: } }
 
     context "with bad example" do
       let(:expression_reguliere_exemple_text) { "01234567" }
       let(:expression_reguliere) { "[A-Z]+" }
+      let(:expression_reguliere_error_message) { "Le champ doit être composé de lettres majuscules" }
 
       before do
         champ = dossier.champs_public.first
@@ -1593,13 +1594,14 @@ describe Dossier, type: :model do
 
       it 'should have errors' do
         expect(dossier.errors).not_to be_empty
-        expect(dossier.errors.full_messages.join(',')).to include("ne correspond pas au format attendu")
+        expect(dossier.errors.full_messages.join(',')).to include(dossier.champs_public.first.expression_reguliere_error_message)
       end
     end
 
     context "with good example" do
       let(:expression_reguliere_exemple_text) { "AZERTY" }
       let(:expression_reguliere) { "[A-Z]+" }
+      let(:expression_reguliere_error_message) { "Le champ doit être composé de lettres majuscules" }
 
       before do
         champ = dossier.champs_public.first


### PR DESCRIPTION
1. Supprime une méthode morte
2. Affiche le message d'erreur rentré par l'admin dans l'interface usager