### PR TITLE
Sécurité (champ regex): timeout plus agressif à 1 seconde

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -538,6 +538,17 @@
   }
 }
 
+.type-de-champ-expression-reguliere {
+  display: flex;
+  align-items: center;
+
+  &:before,
+  &:after {
+    font-weight: bold;
+    content: "/";
+  }
+}
+
 [data-react-component-value^="ComboMultiple"] {
   margin-bottom: $default-fields-spacer;
 

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -293,7 +293,7 @@
   input[type=number],
   input[type=datetime-local],
   textarea,
-  input[type=tel], {
+  input[type=tel] {
     @media (max-width: $two-columns-breakpoint) {
       width: 100%;
     }

--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
@@ -50,7 +50,8 @@
               .cell.mt-1
                 = form.label :expression_reguliere, for: dom_id(type_de_champ, :expression_reguliere) do
                   = t('.expression_reguliere.labels.regex')
-                = form.text_field :expression_reguliere, class: "fr-input small-margin small", id: dom_id(type_de_champ, :expression_reguliere)
+                .type-de-champ-expression-reguliere
+                  = form.text_field :expression_reguliere, class: "fr-input small-margin small", id: dom_id(type_de_champ, :expression_reguliere)
 
               .cell.mt-1
                 = form.label :expression_reguliere_exemple_text, for: dom_id(type_de_champ, :expression_reguliere_exemple_text) do

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -618,7 +618,7 @@ class TypeDeChamp < ApplicationRecord
   def invalid_regexp?
     return false if expression_reguliere.blank?
     return false if expression_reguliere_exemple_text.blank?
-    return false if expression_reguliere_exemple_text.match?(Regexp.new(expression_reguliere, timeout: 2.0))
+    return false if expression_reguliere_exemple_text.match?(Regexp.new(expression_reguliere, timeout: ExpressionReguliereValidator::TIMEOUT))
 
     self.errors.add(:expression_reguliere_exemple_text, I18n.t('errors.messages.mismatch_regexp'))
     true

--- a/app/validators/expression_reguliere_validator.rb
+++ b/app/validators/expression_reguliere_validator.rb
@@ -1,7 +1,9 @@
 class ExpressionReguliereValidator < ActiveModel::Validator
+  TIMEOUT = 1.second.freeze
+
   def validate(record)
     if record.value.present?
-      if !record.value.match?(Regexp.new(record.expression_reguliere, timeout: 5.0))
+      if !record.value.match?(Regexp.new(record.expression_reguliere, timeout: TIMEOUT))
         record.errors.add(:value, :invalid_regexp, expression_reguliere_error_message: record.expression_reguliere_error_message)
       end
     end


### PR DESCRIPTION
A priori pour le moment l'objectif n'est pas de chercher à valider de très longues chaines complexes, et on ne veut pas autoriser plus d'1s de temps CPU par requête (ce qui est déjà beaucoup)

J'ai rajouté un hint visuel comme quoi il ne faut pas saisir de délimiters
![Capture d’écran 2023-10-24 à 12 54 04](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/137e0f0a-97af-4c60-a3a4-2d9c8dc58877)

