### PR TITLE
tech: ajoute le departement aux services

### DIFF
--- a/app/lib/code_insee.rb
+++ b/app/lib/code_insee.rb
@@ -1,0 +1,14 @@
+class CodeInsee
+  def initialize(code_insee)
+    @code_insee = code_insee
+  end
+
+  def to_departement
+    dept = @code_insee.strip.first(2)
+    if dept < "97"
+      dept
+    else
+      @code_insee.strip.first(3)
+    end
+  end
+end

--- a/app/tasks/maintenance/backfill_departement_services_task.rb
+++ b/app/tasks/maintenance/backfill_departement_services_task.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class BackfillDepartementServicesTask < MaintenanceTasks::Task
+    def collection
+      Service.where.not(etablissement_infos: nil)
+    end
+
+    def process(service)
+      code_insee_localite = service.etablissement_infos['code_insee_localite']
+      if code_insee_localite.present?
+        departement = CodeInsee.new(code_insee_localite).to_departement
+        service.update!(departement: departement)
+      end
+    end
+
+    def count
+      collection.count
+    end
+  end
+end

--- a/db/migrate/20231025161609_add_departement_to_services.rb
+++ b/db/migrate/20231025161609_add_departement_to_services.rb
@@ -1,0 +1,8 @@
+class AddDepartementToServices < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_column :services, :departement, :string
+    add_index :services, :departement, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_10_103144) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_25_161609) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -904,6 +904,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_10_103144) do
     t.bigint "administrateur_id"
     t.text "adresse"
     t.datetime "created_at", precision: 6, null: false
+    t.string "departement"
     t.string "email"
     t.jsonb "etablissement_infos", default: {}
     t.decimal "etablissement_lat", precision: 10, scale: 6
@@ -917,6 +918,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_10_103144) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["administrateur_id", "nom"], name: "index_services_on_administrateur_id_and_nom", unique: true
     t.index ["administrateur_id"], name: "index_services_on_administrateur_id"
+    t.index ["departement"], name: "index_services_on_departement"
   end
 
   create_table "stats", force: :cascade do |t|

--- a/spec/lib/code_insee_spec.rb
+++ b/spec/lib/code_insee_spec.rb
@@ -1,0 +1,9 @@
+describe CodeInsee do
+  it 'converts to departement' do
+    expect(CodeInsee.new('75002').to_departement).to eq('75')
+    expect(CodeInsee.new('2B033').to_departement).to eq('2B')
+    expect(CodeInsee.new('01345').to_departement).to eq('01')
+    expect(CodeInsee.new('97100').to_departement).to eq('971')
+    expect(CodeInsee.new('98735').to_departement).to eq('987')
+  end
+end

--- a/spec/tasks/maintenance/backfill_departement_services_task_spec.rb
+++ b/spec/tasks/maintenance/backfill_departement_services_task_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  describe BackfillDepartementServicesTask do
+    describe "#process" do
+      subject(:process) { described_class.process(service) }
+      context 'with service with code_insee_localite' do
+        let(:service) {
+          create(:service,
+                 etablissement_infos: {
+                   adresse: "70 rue du Louvre\n75002\nPARIS\nFRANCE",
+                   code_insee_localite: "75002"
+                 })
+        }
+
+        it "updates departement" do
+          subject
+          expect(service.reload.departement).to eq "75"
+        end
+      end
+
+      context 'with service with code_insee_localite' do
+        let(:service) {
+          create(:service,
+                 etablissement_infos: {
+                   adresse: "70 rue du Louvre\n75002\nPARIS\nFRANCE"
+                 })
+        }
+        it 'does nothing if no code_insee_localite' do
+          subject
+          expect(service.reload.departement).to eq nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
En vue de filtrer les demarchces par département, cette PR  
- ajoute la colonne departement aux services (il représente le code du département)
- backfill le departement des services