### PR TITLE
En tant qu'admin, je peux filtrer les démarches par département

### DIFF
--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -421,6 +421,8 @@ module Administrateurs
         return Procedure.none if service.nil?
       end
 
+      services = Service.where(departement: filter.service_departement) if filter.service_departement.present?
+
       procedures_result = Procedure.select(:id).left_joins(:procedures_zones).distinct.publiees_ou_closes
       procedures_result = procedures_result.where(procedures_zones: { zone_id: filter.zone_ids }) if filter.zone_ids.present?
       procedures_result = procedures_result.where(hidden_at_as_template: nil)
@@ -428,6 +430,7 @@ module Administrateurs
       procedures_result = procedures_result.where("tags @> ARRAY[?]::text[]", filter.tags) if filter.tags.present?
       procedures_result = procedures_result.where('published_at >= ?', filter.from_publication_date) if filter.from_publication_date.present?
       procedures_result = procedures_result.where(service: service) if filter.service_siret.present?
+      procedures_result = procedures_result.where(service: services) if services
       procedures_result = procedures_result.where('unaccent(libelle) ILIKE unaccent(?)', "%#{filter.libelle}%") if filter.libelle.present?
       procedures_sql = procedures_result.to_sql
 

--- a/app/jobs/api_entreprise/service_job.rb
+++ b/app/jobs/api_entreprise/service_job.rb
@@ -10,6 +10,11 @@ class APIEntreprise::ServiceJob < APIEntreprise::Job
     service.etablissement_lat = point&.latitude
     service.etablissement_lng = point&.longitude
 
+    code_insee = service.etablissement_infos['code_insee_localite']
+    if code_insee
+      service.departement = CodeInsee.new(code_insee).to_departement
+    end
+
     service.save!
   end
 end

--- a/app/models/procedures_filter.rb
+++ b/app/models/procedures_filter.rb
@@ -5,7 +5,7 @@ class ProceduresFilter
 
   def initialize(admin, params)
     @admin = admin
-    @params = params.permit(:page, :libelle, :email, :from_publication_date, :service_siret, tags: [], zone_ids: [], statuses: [])
+    @params = params.permit(:page, :libelle, :email, :from_publication_date, :service_siret, :service_departement, tags: [], zone_ids: [], statuses: [])
   end
 
   def admin_zones
@@ -34,6 +34,10 @@ class ProceduresFilter
 
   def service_siret
     params[:service_siret].presence
+  end
+
+  def service_departement
+    params[:service_departement].presence
   end
 
   def from_publication_date

--- a/app/views/administrateurs/procedures/all.html.haml
+++ b/app/views/administrateurs/procedures/all.html.haml
@@ -27,7 +27,7 @@
           = link_to @filter.service_siret, all_admin_procedures_path(@filter.without(:service_siret)), class: 'fr-tag fr-tag--dismiss fr-mb-1w'
       - if @filter.service_departement
         .selected-query.fr-mb-2w
-          = link_to @filter.service_departement, all_admin_procedures_path(@filter.without(:service_departement)), class: 'fr-tag fr-tag--dismiss fr-mb-1w'
+          = link_to "#{@filter.service_departement} – #{APIGeoService.departement_name(@filter.service_departement)}", all_admin_procedures_path(@filter.without(:service_departement)), class: 'fr-tag fr-tag--dismiss fr-mb-1w'
       - if @filter.selected_zones.present?
         .selected-zones.fr-mb-2w
           - @filter.selected_zones.each do |zone|

--- a/app/views/administrateurs/procedures/all.html.haml
+++ b/app/views/administrateurs/procedures/all.html.haml
@@ -25,6 +25,9 @@
       - if @filter.service_siret
         .selected-query.fr-mb-2w
           = link_to @filter.service_siret, all_admin_procedures_path(@filter.without(:service_siret)), class: 'fr-tag fr-tag--dismiss fr-mb-1w'
+      - if @filter.service_departement
+        .selected-query.fr-mb-2w
+          = link_to @filter.service_departement, all_admin_procedures_path(@filter.without(:service_departement)), class: 'fr-tag fr-tag--dismiss fr-mb-1w'
       - if @filter.selected_zones.present?
         .selected-zones.fr-mb-2w
           - @filter.selected_zones.each do |zone|

--- a/app/views/layouts/all.html.haml
+++ b/app/views/layouts/all.html.haml
@@ -51,6 +51,18 @@
                   .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
                     %div
                       = f.text_field :service_siret, placeholder: 'Indiquez le SIRET', class: 'fr-input'
+                %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
+                  .fr-mb-1w
+                    %button{ 'data-action': 'expand#toggle' }
+                      %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
+                      Département
+                  .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
+                    %div
+                      = f.select :service_departement,
+                        APIGeoService.departements.map { ["#{_1[:code]} – #{_1[:name]}", _1[:code]] },
+                        { selected: @filter.service_departement, include_blank: ''},
+                        id: "service_dep_select",
+                        class: 'fr-select'
                 %li.fr-py-2w{ 'data-controller': "expand" }
                   .fr-mb-1w.fr-pl-2w
                     %button{ 'data-action': 'click->expand#toggle' }

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -210,6 +210,19 @@ describe Administrateurs::ProceduresController, type: :controller do
       end
     end
 
+    context 'with service departement' do
+      let(:service) { create(:service, departement: '63') }
+      let(:service2) { create(:service, departement: '75') }
+      let!(:procedure) { create(:procedure, :published, service: service) }
+      let!(:procedure2) { create(:procedure, :published, service: service2) }
+
+      it 'returns procedures with correct departement' do
+        get :all, params: { service_departement: '63' }
+        expect(assigns(:procedures).any? { |p| p.id == procedure.id }).to be_truthy
+        expect(assigns(:procedures).any? { |p| p.id == procedure2.id }).to be_falsey
+      end
+    end
+
     context 'with specific tag' do
       let!(:tags_procedure) { create(:procedure, :published, tags: ['environnement', 'diplomatie']) }
 

--- a/spec/jobs/api_entreprise/service_job_spec.rb
+++ b/spec/jobs/api_entreprise/service_job_spec.rb
@@ -32,7 +32,15 @@ RSpec.describe APIEntreprise::ServiceJob, type: :job do
     expect(infos["adresse"]).to eq(adresse)
     expect(infos["numero_voie"]).to eq("22")
     expect(infos["code_postal"]).to eq("75016")
+    expect(infos["code_insee_localite"]).to eq("75112")
     expect(infos["localite"]).to eq("PARIS 12")
+  end
+
+  it 'updates departement' do
+    subject
+    service.reload
+
+    expect(service.departement).to eq "75"
   end
 
   it "geocode address" do


### PR DESCRIPTION
close #9642

# NE PAS MERGER

Avant de merger cette PR, il faut au préalable que https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/9647 ait été déployée et que la tâche `BackfillDepartementServices` ait été lancée

# Ce que fait cette PR

Cette PR permet de filtrer les démarches à partir du département du service qui opère cette démarche.

![2023-10-27-103912_1245x665_scrot](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/1111966/dd27a2b2-57bd-4485-bc8f-ae6603bb3e71)
 