### PR TITLE
[Fix] ETQ admin, je souhaite associer une démarche existante depuis le bouton "clore" du tableau de bord de la démarche

### DIFF
--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -316,6 +316,7 @@ module Administrateurs
     end
 
     def close
+      @published_procedures = current_administrateur.procedures.publiees.map { |p| ["#{p.libelle} (#{p.id})", p.id] }.to_h
     end
 
     def allow_expert_review

--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -316,7 +316,7 @@ module Administrateurs
     end
 
     def close
-      @published_procedures = current_administrateur.procedures.publiees.map { |p| ["#{p.libelle} (#{p.id})", p.id] }.to_h
+      @published_procedures = current_administrateur.procedures.publiees.to_h { |p| ["#{p.libelle} (#{p.id})", p.id] }
     end
 
     def allow_expert_review

--- a/app/views/administrateurs/procedures/close.html.haml
+++ b/app/views/administrateurs/procedures/close.html.haml
@@ -1,13 +1,22 @@
 = render partial: 'administrateurs/breadcrumbs',
   locals: { steps: [['Démarches', admin_procedures_back_path(@procedure)],
-                    ["#{@procedure.libelle.truncate_words(10)} - archiver"]],
+                    [@procedure.libelle.truncate_words(10), admin_procedure_path(@procedure)],[t('administrateurs.procedures.close.page_title')]],
             metadatas: true }
 
-.container
-  .card
-    %h2.card-title
-      = t('administrateurs.procedures.close.replacement_procedure_title')
-    = form_tag admin_procedure_archive_path(@procedure), method: :put, class: "form" do
-      - options_from_collection_for_select = current_administrateur.procedures.publiees.map { |p| ["#{p.libelle} (#{p.id})", p.id] }.to_h
-      = select_tag :new_procedure, options_for_select(options_from_collection_for_select), include_blank: true
-      = submit_tag  t('administrateurs.procedures.close.actions.close_procedure'), { class: "button primary", id: 'publish', data: { confirm:  "Voulez-vous vraiment clore la démarche ? \nLes dossiers en cours pourront être instruits, mais aucun nouveau dossier ne pourra plus être déposé.", disable_with: "Archivage..."} }
+.fr-container
+  .fr-grid-row
+    .fr-col-12.fr-col-offset-md-2.fr-col-md-8
+      %h1= t('administrateurs.procedures.close.page_title')
+
+      %p= t('administrateurs.procedures.close.replacement_procedure_title')
+
+      = form_tag admin_procedure_archive_path(@procedure), method: :put, class: "form" do
+        - if @published_procedures.present?
+          .fr-select-group
+            = label_tag :new_procedure, class: 'fr-label' do
+              = t('activerecord.attributes.procedure.new_procedure')
+              = t('utils.no_mandatory')
+
+            = select_tag :new_procedure, options_for_select(@published_procedures), include_blank: true, class: 'fr-select'
+
+        = submit_tag  t('administrateurs.procedures.close.actions.close_procedure'), { class: "fr-btn", id: 'publish', data: { confirm:  "Voulez-vous vraiment clore la démarche ? \nLes dossiers en cours pourront être instruits, mais aucun nouveau dossier ne pourra plus être déposé.", disable_with: "Archivage..."} }

--- a/app/views/administrateurs/procedures/close.html.haml
+++ b/app/views/administrateurs/procedures/close.html.haml
@@ -10,7 +10,7 @@
 
       %p= t('administrateurs.procedures.close.replacement_procedure_title')
 
-      = form_tag admin_procedure_archive_path(@procedure), method: :put, class: "form" do
+      = form_tag admin_procedure_archive_path(@procedure), method: :put do
         - if @published_procedures.present?
           .fr-select-group
             = label_tag :new_procedure, class: 'fr-label' do

--- a/app/views/administrateurs/procedures/show.html.haml
+++ b/app/views/administrateurs/procedures/show.html.haml
@@ -24,8 +24,7 @@
         = link_to 'Réactiver', admin_procedure_publication_path(@procedure), class: 'fr-btn fr-btn--primary fr-btn--icon-left fr-icon-success-line', id: 'publish-procedure-link', data: { disable_with: "Publication..." }
 
       - if @procedure.locked? && !@procedure.close?
-        = link_to 'Clore', admin_procedure_archive_path(procedure_id: @procedure.id), method: :put, class: 'fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-archive-line', id: "close-procedure-link", data: { confirm:  "Voulez-vous vraiment clore la démarche ? \nLes dossiers en cours pourront être instruits, mais aucun nouveau dossier ne pourra plus être déposé.", disable_with: "Archivage..."}
-
+        = link_to 'Clore', admin_procedure_close_path(procedure_id: @procedure.id), class: 'fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-archive-line', id: "close-procedure-link"
 
 .fr-container
   = render TypesDeChampEditor::ErrorsSummary.new(revision: @procedure.draft_revision)

--- a/config/locales/models/procedure/en.yml
+++ b/config/locales/models/procedure/en.yml
@@ -22,6 +22,7 @@ en:
         description_pj_placeholder: If you leave this field blank and your form contains attachments, an automatically generated list will be displayed on the home page of your procedure.
         lien_site_web: Where will users find the link to the procedure?
         old_procedure: Replaced procedure number
+        new_procedure: New procedure number
         procedure_path: Procedure link to disseminate to users
         procedure_path_placeholder: procedure-name
         cadre_juridique: Link to the legal text

--- a/config/locales/models/procedure/fr.yml
+++ b/config/locales/models/procedure/fr.yml
@@ -26,6 +26,7 @@ fr:
         description_pj_placeholder: Si vous ne renseignez pas ce champ et que votre formulaire contient des pièces jointes, une liste générée automatiquement s'affichera dans la page d'accueil de votre démarche.
         lien_site_web: Où les usagers trouveront-ils le lien vers la démarche ?
         old_procedure: Numéro de la démarche remplacée
+        new_procedure: Numéro de la nouvelle démarche
         procedure_path: Lien de la démarche à diffuser aux usagers
         procedure_path_placeholder: nom-de-la-demarche
         cadre_juridique: Lien vers le texte

--- a/config/locales/views/administrateurs/procedures/en.yml
+++ b/config/locales/views/administrateurs/procedures/en.yml
@@ -2,6 +2,7 @@ en:
   administrateurs:
     procedures:
       close:
+        page_title: Close the procedure
         replacement_procedure_title: Is this procedure replaced by an existing one? If yes, please indicate the number of the new procedure
         actions:
           close_procedure: Close the procedure

--- a/config/locales/views/administrateurs/procedures/fr.yml
+++ b/config/locales/views/administrateurs/procedures/fr.yml
@@ -2,6 +2,7 @@ fr:
   administrateurs:
     procedures:
       close:
+        page_title: Clore la démarche
         replacement_procedure_title: Cette démarche est-elle remplacée par une existante ? Si oui, veuillez indiquer le n° de la nouvelle démarche
         actions:
           close_procedure: Clore la démarche


### PR DESCRIPTION
closes #9593 

Le bouton du tableau de bord ne clot plus directement la démarche mais redirige vers une page (déjà existante) pour cloturer la démarche et ainsi ajouter un lien vers une démarche existante si besoin.

J'en ai profité pour retirer l'ancien style de card et fixer le breadcrumb.

<img width="1218" alt="Capture d’écran 2023-10-30 à 14 59 58" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/2db462d2-0a32-4fbf-8cf7-b022000effaa">
