### PR TITLE
Usager: légères harmonisations visuelles de la combobox

### DIFF
--- a/app/assets/stylesheets/dsfr.scss
+++ b/app/assets/stylesheets/dsfr.scss
@@ -29,6 +29,10 @@ trix-editor.fr-input {
   max-height: none;
 }
 
+.fr-label + .fr-ds-combobox { // same as .fr-label + .fr-input
+  margin-top: 0.5rem;
+}
+
 // Fix firefox < 80, Safari < 15.4, Chrome < 83 not supporting "appearance: auto" on inputs
 // This rule was set by DSFR for DSFR design, but broke our legacy forms.
 // scss-lint:disable DuplicateProperty

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -252,7 +252,7 @@
     }
   }
 
-  input[type=text]:not([data-address='true']) {
+  input[type=text]:not(.fr-input):not(.fr-select) {
     border: solid 1px $border-grey;
     padding: $default-padding;
 


### PR DESCRIPTION
Pour l'instant, juste le style apparent. Pour le menu on attendra la version de novembre du dsfr qui devrait apporter ce qu'il faut.


## APRES
![Capture d’écran 2023-10-30 à 15 07 58](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/79df0b71-8dc6-432d-92d4-a118c6d3d558)


## AVANT
![Capture d’écran 2023-10-30 à 15 08 22](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/95e2d106-9e5a-449a-8dc6-fd776b0688cc)
