### PR TITLE
Administrateurs/Instructeurs/Experts : lien vers la page des nouveautés et refactorise les barres de navigation principale

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ gem 'rails', '~> 7.0.5' # allows update to security fixes at any time
 
 gem 'aasm'
 gem 'acsv'
-gem 'active_link_to' # Automatically set a class on active links
 gem 'active_model_serializers'
 gem 'activestorage-openstack'
 gem 'active_storage_validations'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,9 +49,6 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    active_link_to (1.0.5)
-      actionpack
-      addressable
     active_model_serializers (0.10.13)
       actionpack (>= 4.1, < 7.1)
       activemodel (>= 4.1, < 7.1)
@@ -814,7 +811,6 @@ PLATFORMS
 DEPENDENCIES
   aasm
   acsv
-  active_link_to
   active_model_serializers
   active_storage_validations
   activestorage-openstack

--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -13,3 +13,14 @@ span.notifications {
   top: 5px;
   right: 8px;
 }
+
+.fr-nav {
+  &__notifiable {
+    position: relative;
+  }
+
+  .notifications {
+    top: 1rem;
+    right: 0.25rem;
+  }
+}

--- a/app/components/main_navigation/announces_link_component.rb
+++ b/app/components/main_navigation/announces_link_component.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class MainNavigation::AnnouncesLinkComponent < ApplicationComponent
+  def render?
+    # also see app/controllers/release_notes_controller.rb#ensure_access_allowed!
+    return false if !helpers.instructeur_signed_in? && !helpers.administrateur_signed_in? && !helpers.expert_signed_in?
+
+    @most_recent_released_on = load_most_recent_released_on
+
+    @most_recent_released_on.present?
+  end
+
+  def something_new?
+    return true if current_user.announces_seen_at.nil?
+
+    @most_recent_released_on.after? current_user.announces_seen_at
+  end
+
+  def load_most_recent_released_on
+    categories = helpers.infer_default_announce_categories
+
+    ReleaseNote.most_recent_announce_date_for_categories(categories)
+  end
+end

--- a/app/components/main_navigation/announces_link_component/announces_link_component.en.yml
+++ b/app/components/main_navigation/announces_link_component/announces_link_component.en.yml
@@ -1,0 +1,4 @@
+---
+en:
+  news: News
+  something_new: New informations about the website may be of interest to you.

--- a/app/components/main_navigation/announces_link_component/announces_link_component.fr.yml
+++ b/app/components/main_navigation/announces_link_component/announces_link_component.fr.yml
@@ -1,0 +1,4 @@
+---
+fr:
+  news: Nouveautés
+  something_new: De nouvelles informations à propos du site pourraient vous intéresser.

--- a/app/components/main_navigation/announces_link_component/announces_link_component.html.haml
+++ b/app/components/main_navigation/announces_link_component/announces_link_component.html.haml
@@ -1,0 +1,4 @@
+%li.fr-nav__item.fr-nav__notifiable
+  = link_to t('.news'), release_notes_path, class: "fr-nav__link",'aria-current': current_page?(release_notes_path) ? 'page' : nil
+  - if something_new?
+    %span.notifications{ 'aria-label': t('.something_new') }

--- a/app/components/main_navigation/instructeur_expert_navigation_component.rb
+++ b/app/components/main_navigation/instructeur_expert_navigation_component.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class MainNavigation::InstructeurExpertNavigationComponent < ApplicationComponent
+  def instructeur?
+    helpers.instructeur_signed_in?
+  end
+
+  def expert?
+    helpers.expert_signed_in?
+  end
+
+  def aria_current_for(page)
+    { current: page == current_page ? :page : nil }
+  end
+
+  private
+
+  def current_page
+    case controller_name
+    when 'avis'
+      :avis
+    when 'procedures', 'dossiers'
+      :procedure
+    end
+  end
+end

--- a/app/components/main_navigation/instructeur_expert_navigation_component/instructeur_expert_navigation_component.html.haml
+++ b/app/components/main_navigation/instructeur_expert_navigation_component/instructeur_expert_navigation_component.html.haml
@@ -10,3 +10,5 @@
           = Avis.model_name.human(count: 10)
           - if helpers.current_expert.avis_summary[:unanswered] > 0
             %span.badge.warning= helpers.current_expert.avis_summary[:unanswered]
+
+    = render MainNavigation::AnnouncesLinkComponent.new

--- a/app/components/main_navigation/instructeur_expert_navigation_component/instructeur_expert_navigation_component.html.haml
+++ b/app/components/main_navigation/instructeur_expert_navigation_component/instructeur_expert_navigation_component.html.haml
@@ -1,0 +1,12 @@
+%nav#header-navigation.fr-nav{ role: :navigation, "aria-label" => t('main_menu', scope: [:layouts, :header]) }
+  %ul.fr-nav__list
+    - if instructeur?
+      %li.fr-nav__item
+        = link_to Procedure.model_name.human(count: 10), instructeur_procedures_path, class: 'fr-nav__link', aria: aria_current_for(:procedure)
+
+    - if expert?
+      %li.fr-nav__item
+        = link_to expert_all_avis_path, class: 'fr-nav__link', aria: aria_current_for(:avis) do
+          = Avis.model_name.human(count: 10)
+          - if helpers.current_expert.avis_summary[:unanswered] > 0
+            %span.badge.warning= helpers.current_expert.avis_summary[:unanswered]

--- a/app/controllers/users/commencer_controller.rb
+++ b/app/controllers/users/commencer_controller.rb
@@ -76,6 +76,10 @@ module Users
       retrieve_procedure
     end
 
+    def nav_bar_profile
+      current_user ? :user : :guest
+    end
+
     private
 
     def extra_query_params

--- a/app/helpers/release_notes_helper.rb
+++ b/app/helpers/release_notes_helper.rb
@@ -27,4 +27,18 @@ module ReleaseNotesHelper
       ReleaseNote.default_categories_for_role(:usager)
     end
   end
+
+  def render_release_note_content(content)
+    allowed_attributes.merge ["rel", "target"] # title already allowed
+
+    content.body.fragment.source.css("a[href]").each do |link|
+      uri = URI.parse(link['href'])
+
+      link.set_attribute('rel', 'noreferrer noopener')
+      link.set_attribute('target', '_blank')
+      link.set_attribute('title', new_tab_suffix(uri.host))
+    end
+
+    content
+  end
 end

--- a/app/helpers/release_notes_helper.rb
+++ b/app/helpers/release_notes_helper.rb
@@ -15,4 +15,16 @@ module ReleaseNotesHelper
 
     content_tag(:span, ReleaseNote.human_attribute_name("categories.#{category}"), class: "fr-badge #{color_class}")
   end
+
+  def infer_default_announce_categories
+    if administrateur_signed_in?
+      ReleaseNote.default_categories_for_role(:administrateur, current_administrateur)
+    elsif instructeur_signed_in?
+      ReleaseNote.default_categories_for_role(:instructeur, current_instructeur)
+    elsif expert_signed_in?
+      ReleaseNote.default_categories_for_role(:expert, current_expert)
+    else
+      ReleaseNote.default_categories_for_role(:usager)
+    end
+  end
 end

--- a/app/models/release_note.rb
+++ b/app/models/release_note.rb
@@ -14,4 +14,21 @@ class ReleaseNote < ApplicationRecord
 
   scope :published, -> { where(published: true, released_on: ..Date.current) }
   scope :for_categories, -> (categories) { where("categories && ARRAY[?]::varchar[]", categories) }
+
+  def self.default_categories_for_role(role, instance = nil)
+    case role
+    when :administrateur
+      ['administrateur', 'usager', instance.api_tokens.exists? ? 'api' : nil]
+    when :instructeur
+      ['instructeur', instance.user.expert? ? 'expert' : nil]
+    when :expert
+      ['expert', instance.user.instructeur? ? 'instructeur' : nil]
+    else
+      ['usager']
+    end
+  end
+
+  def self.most_recent_announce_date_for_categories(categories)
+    published.for_categories(categories).maximum(:released_on)
+  end
 end

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -1,6 +1,6 @@
 <figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
   <% if blob.representable? %>
-    <%= image_tag blob.representation(resize_to_fit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
+    <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
   <% end %>
 
   <figcaption class="attachment__caption">

--- a/app/views/administrateurs/_main_navigation.html.haml
+++ b/app/views/administrateurs/_main_navigation.html.haml
@@ -1,0 +1,5 @@
+%nav#header-navigation.fr-nav{ role: 'navigation', 'aria-label': 'Menu principal administrateur' }
+  %ul.fr-nav__list
+    %li.fr-nav__item= link_to 'Mes démarches', admin_procedures_path, class:'fr-nav__link', 'aria-current': current_page?(controller: 'administrateurs/procedures', action: :index) ? 'true' : nil
+    - if Rails.application.config.ds_zonage_enabled
+      %li.fr-nav__item= link_to 'Toutes les démarches', all_admin_procedures_path(zone_ids: current_administrateur.zones), class:'fr-nav__link', 'aria-current': current_page?(all_admin_procedures_path) ? 'page' : nil

--- a/app/views/administrateurs/_main_navigation.html.haml
+++ b/app/views/administrateurs/_main_navigation.html.haml
@@ -3,3 +3,5 @@
     %li.fr-nav__item= link_to 'Mes démarches', admin_procedures_path, class:'fr-nav__link', 'aria-current': current_page?(controller: 'administrateurs/procedures', action: :index) ? 'true' : nil
     - if Rails.application.config.ds_zonage_enabled
       %li.fr-nav__item= link_to 'Toutes les démarches', all_admin_procedures_path(zone_ids: current_administrateur.zones), class:'fr-nav__link', 'aria-current': current_page?(all_admin_procedures_path) ? 'page' : nil
+
+    = render MainNavigation::AnnouncesLinkComponent.new

--- a/app/views/administrateurs/_main_navigation.html.haml
+++ b/app/views/administrateurs/_main_navigation.html.haml
@@ -1,6 +1,6 @@
 %nav#header-navigation.fr-nav{ role: 'navigation', 'aria-label': 'Menu principal administrateur' }
   %ul.fr-nav__list
-    %li.fr-nav__item= link_to 'Mes démarches', admin_procedures_path, class:'fr-nav__link', 'aria-current': current_page?(controller: 'administrateurs/procedures', action: :index) ? 'true' : nil
+    %li.fr-nav__item= link_to 'Mes démarches', admin_procedures_path, class:'fr-nav__link', 'aria-current': current_page?(controller: 'administrateurs/procedures', action: :index) ? 'page' : nil
     - if Rails.application.config.ds_zonage_enabled
       %li.fr-nav__item= link_to 'Toutes les démarches', all_admin_procedures_path(zone_ids: current_administrateur.zones), class:'fr-nav__link', 'aria-current': current_page?(all_admin_procedures_path) ? 'page' : nil
 

--- a/app/views/administrateurs/procedures/_main_menu.html.haml
+++ b/app/views/administrateurs/procedures/_main_menu.html.haml
@@ -1,6 +1,0 @@
-.fr-container
-  %nav#header-navigation.fr-nav{ role: 'navigation', 'aria-label': 'Menu principal administrateur' }
-    %ul.fr-nav__list
-      %li.fr-nav__item= link_to 'Mes démarches', admin_procedures_path, class:'fr-nav__link', 'aria-current': current_page?(controller: 'procedures', action: :index) ? 'true' : nil
-      - if Rails.application.config.ds_zonage_enabled
-        %li.fr-nav__item= link_to 'Toutes les démarches', all_admin_procedures_path(zone_ids: current_administrateur.zones), class:'fr-nav__link', 'aria-current': current_page?(all_admin_procedures_path) ? 'page' : nil

--- a/app/views/administrateurs/procedures/index.html.haml
+++ b/app/views/administrateurs/procedures/index.html.haml
@@ -1,5 +1,3 @@
-= render 'main_menu'
-
 .sub-header
   .procedure-admin-listing-container
     = link_to "Nouvelle Démarche", new_from_existing_admin_procedures_path, id: 'new-procedure', class: 'fr-btn'

--- a/app/views/gestionnaires/groupe_gestionnaires/_main_menu.html.haml
+++ b/app/views/gestionnaires/groupe_gestionnaires/_main_menu.html.haml
@@ -1,4 +1,0 @@
-.fr-container
-  %nav#header-navigation.fr-nav{ role: 'navigation', 'aria-label': 'Menu principal gestionnaire' }
-    %ul.fr-nav__list
-      %li.fr-nav__item= link_to 'Mes groupes gestionnaire', gestionnaire_groupe_gestionnaires_path, class:'fr-nav__link', 'aria-current': current_page?(controller: 'groupe_gestionnaires', action: :index) ? 'true' : nil

--- a/app/views/gestionnaires/groupe_gestionnaires/_main_navigation.html.haml
+++ b/app/views/gestionnaires/groupe_gestionnaires/_main_navigation.html.haml
@@ -1,0 +1,4 @@
+- content_for(:main_navigation) do
+  %nav#header-navigation.fr-nav{ role: 'navigation', 'aria-label': 'Menu principal gestionnaire' }
+    %ul.fr-nav__list
+      %li.fr-nav__item= link_to 'Mes groupes gestionnaire', gestionnaire_groupe_gestionnaires_path, class:'fr-nav__link', 'aria-current': current_page?(controller: 'groupe_gestionnaires', action: :index) ? 'page' : nil

--- a/app/views/gestionnaires/groupe_gestionnaires/index.html.haml
+++ b/app/views/gestionnaires/groupe_gestionnaires/index.html.haml
@@ -1,4 +1,4 @@
-= render 'main_menu'
+= render 'main_navigation'
 
 .sub-header
 

--- a/app/views/layouts/_header.haml
+++ b/app/views/layouts/_header.haml
@@ -3,6 +3,7 @@
 - dossier = controller.try(:dossier_for_help)
 - procedure = controller.try(:procedure_for_help)
 - is_instructeur_context = nav_bar_profile == :instructeur && instructeur_signed_in?
+- is_administrateur_context = nav_bar_profile == :administrateur && administrateur_signed_in?
 - is_expert_context = nav_bar_profile == :expert && expert_signed_in?
 - is_user_context = nav_bar_profile == :user
 - is_search_enabled = [params[:controller] == 'recherche', is_instructeur_context, is_expert_context, is_user_context && current_user.dossiers.count].any?
@@ -20,7 +21,7 @@
             .fr-header__navbar
               - if is_search_enabled
                 %button.fr-btn--search.fr-btn{ "aria-controls" => "search-modal", "data-fr-opened" => "false", :title => t('views.users.dossiers.search.search_file') }= t('views.users.dossiers.search.search_file')
-              %button.fr-btn--menu.fr-btn{ "aria-controls" => "burger-menu", "aria-haspopup" => "menu", "data-fr-opened" => "false", :title => "Menu" } Menu
+              %button#navbar-burger-button.fr-btn--menu.fr-btn{ "aria-controls" => "modal-header__menu", "aria-haspopup" => "menu", "data-fr-opened" => "false", title: "Menu" } Menu
           .fr-header__service
             - root_profile_link, root_profile_libelle = root_path_info_for_profile(nav_bar_profile)
 
@@ -68,39 +69,20 @@
           - if is_expert_context
             = render partial: 'layouts/search_dossiers_form'
 
-  - has_header = [is_instructeur_context, is_expert_context, is_user_context]
-  #burger-menu.fr-header__menu.fr-modal
+  #modal-header__menu.fr-header__menu.fr-modal{ "aria-labelledby": "navbar-burger-button" }
     .fr-container
-      %button#burger_button.fr-btn--close.fr-btn{ "aria-controls" => "burger-menu", :title => t('close_modal', scope: [:layouts, :header]) }= t('close_modal', scope: [:layouts, :header])
+      %button.fr-btn--close.fr-btn{ "aria-controls" => "modal-header__menu", title: t('close_modal', scope: [:layouts, :header]) }= t('close_modal', scope: [:layouts, :header])
       .fr-header__menu-links
-      %nav#navigation-478.fr-nav{ "aria-label" => t('main_menu', scope: [:layouts, :header]) , :role => "navigation" }
-        %ul.fr-nav__list
-          -# Questionner UX pour un back JS
-          - if params[:controller] == 'users/commencer'
-            %li.fr-nav__item
-              = link_to t('back', scope: [:layouts, :header]), url_for(:back), title: t('back_title', scope: [:layouts, :header]), class: 'fr-nav__link'
+        -# populated by dsfr js
 
-          - if is_instructeur_context
-            - if current_instructeur.procedures.any?
-              - current_url = request.path_info
-              %li.fr-nav__item
-                = active_link_to t('utils.procedure'), instructeur_procedures_path, active: ['dossiers','procedures'].include?(controller_name), class: 'fr-nav__link', aria: { current: current_url == instructeur_procedures_path ? 'page' : true }
-            - if current_instructeur.user.expert && current_expert.avis_summary[:total] > 0
-              = render partial: 'layouts/header/avis_tab', locals: { current_expert: current_expert }
+      - if content_for?(:main_navigation)
+        = yield(:main_navigation)
+      - elsif is_administrateur_context
+        = render 'administrateurs/main_navigation'
+      - elsif is_instructeur_context || is_expert_context
+        = render MainNavigation::InstructeurExpertNavigationComponent.new
+      - elsif is_user_context
+        = render 'users/main_navigation'
 
-          - if is_expert_context
-            - if current_expert.user.instructeur && current_instructeur.procedures.any?
-              %li.fr-nav__item= active_link_to t('utils.procedure'), instructeur_procedures_path, active: ['dossiers','procedures'].include?(controller_name), class: 'fr-nav__link', aria: { current: true }
-            - if current_expert.avis_summary[:total] > 0
-              = render partial: 'layouts/header/avis_tab', locals: { current_expert: current_expert }
-
-          - if is_user_context
-            %li.fr-nav__item= active_link_to t('.files'), dossiers_path, active: :inclusive, class: 'fr-nav__link', aria: { current: true }
-            - if current_user.expert && current_expert.avis_summary[:total] > 0
-              = render partial: 'layouts/header/avis_tab', locals: { current_expert: current_expert }
-
-  - if content_for?(:navigation_principale)
-    .fr-container
-      = yield(:navigation_principale)
 
   = yield(:notice_info)

--- a/app/views/layouts/all.html.haml
+++ b/app/views/layouts/all.html.haml
@@ -1,5 +1,7 @@
+- content_for(:main_navigation) do
+  = render 'administrateurs/main_navigation'
+
 - content_for :content do
-  = render 'main_menu'
   .fr-container
     %h1.fr-my-4w Toutes les démarches
 

--- a/app/views/layouts/header/_avis_tab.html.haml
+++ b/app/views/layouts/header/_avis_tab.html.haml
@@ -1,5 +1,0 @@
-%li.fr-nav__item
-  = active_link_to expert_all_avis_path, active: controller_name == 'avis', class: 'fr-nav__link' do
-    Avis
-    - if current_expert.avis_summary[:unanswered] > 0
-      %span.badge.warning= current_expert.avis_summary[:unanswered]

--- a/app/views/release_notes/_announce.html.haml
+++ b/app/views/release_notes/_announce.html.haml
@@ -2,9 +2,9 @@
   %h3= l(notes[0].released_on, format: :long)
 
   - notes.each do |note|
-    .fr-mb-4w.fr-px-2w.fr-py-2w.fr-background-alt--grey
+    .fr-mb-4w.fr-px-2w.fr-py-2w.fr-background-alt--grey{ data: { turbo: "false" } }
       %p
         - note.categories.each do |category|
           = announce_category_badge(category)
 
-      = note.body
+      = render_release_note_content(note.body)

--- a/app/views/super_admins/release_notes/_main_navigation.html.haml
+++ b/app/views/super_admins/release_notes/_main_navigation.html.haml
@@ -1,17 +1,16 @@
-- content_for(:navigation_principale) do
-  .fr-container
-    %nav.fr-nav#header-navigation{ role: "navigation", aria: { label: 'Menu principal annonces' } }
-      %ul.fr-nav__list
-        %li.fr-nav__item
-          = link_to "Toutes les annonces", super_admins_release_notes_path, class: "fr-nav__link", target: "_self", aria: { current: action == :index ? "page" : nil }
+- content_for(:main_navigation) do
+  %nav.fr-nav#header-navigation{ role: "navigation", aria: { label: 'Menu principal annonces' } }
+    %ul.fr-nav__list
+      %li.fr-nav__item
+        = link_to "Toutes les annonces", super_admins_release_notes_path, class: "fr-nav__link", target: "_self", aria: { current: action == :index ? "page" : nil }
 
-        %li.fr-nav__item
-          = link_to("Nouvelle annonce", new_super_admins_release_note_path(date: @release_note&.released_on), class: "fr-nav__link", target: "_self", aria: { current: action == :new ? "page" : nil })
+      %li.fr-nav__item
+        = link_to("Nouvelle annonce", new_super_admins_release_note_path(date: @release_note&.released_on), class: "fr-nav__link", target: "_self", aria: { current: action == :new ? "page" : nil })
 
-        - if action == :edit
-          %li.fr-nav__item
-            = link_to "Annonce", '', class: "fr-nav__link", target: "_self", aria: { current: "page" }
-
+      - if action == :edit
         %li.fr-nav__item
-          = link_to "Annonces publiées", release_notes_path, class: "fr-nav__link", target: "_self"
+          = link_to "Annonce", '', class: "fr-nav__link", target: "_self", aria: { current: "page" }
+
+      %li.fr-nav__item
+        = link_to "Annonces publiées", release_notes_path, class: "fr-nav__link", target: "_self"
 

--- a/app/views/users/_main_navigation.html.haml
+++ b/app/views/users/_main_navigation.html.haml
@@ -1,0 +1,8 @@
+%nav#header-navigation.fr-nav{ role: :navigation, "aria-label" => t('main_menu', scope: [:layouts, :header]) }
+  %ul.fr-nav__list
+    - if params[:controller] == 'users/commencer'
+      %li.fr-nav__item
+        = link_to t('back', scope: [:layouts, :header]), url_for(:back), title: t('back_title', scope: [:layouts, :header]), class: 'fr-nav__link', "aria-controls" => "modal-header__menu"
+
+    %li.fr-nav__item
+      = link_to t('files', scope: [:layouts, :header]), dossiers_path, class: 'fr-nav__link', aria: { current: current_page?(dossiers_path) ? 'page' : nil, controls: "modal-header__menu" }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,7 +56,6 @@ en:
     subject: Subject
     message: Message
     send_mail: Send message
-    procedure: Procedures
     new_tab: New tab
   helpers:
     procedure:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -47,7 +47,6 @@ fr:
     subject: Sujet
     message: Message
     send_mail: Envoyer le message
-    procedure: Démarches
     new_tab: "Nouvel onglet"
   helpers:
     procedure:

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@vitejs/plugin-legacy": "^4.0.3",
     "@vitejs/plugin-react": "^4.0.0",
     "autoprefixer": "^10.4.15",
-    "axe-core": "^4.7.2",
+    "axe-core": "^4.8.2",
     "del-cli": "^5.1.0",
     "eslint": "^8.48.0",
     "eslint-config-prettier": "^9.0.0",

--- a/spec/components/main_navigation/announces_link_component_spec.rb
+++ b/spec/components/main_navigation/announces_link_component_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe MainNavigation::AnnouncesLinkComponent, type: :component do
+  let(:user) { build(:user) }
+  let!(:admin_release_note) { create(:release_note, released_on: Date.yesterday, categories: ["administrateur"]) }
+  let!(:instructeur_release_note) { create(:release_note, released_on: Date.yesterday, categories: ["instructeur"]) }
+  let(:not_published_release_note) { create(:release_note, published: false, released_on: Date.tomorrow) }
+
+  let(:as_administrateur) { false }
+  let(:as_instructeur) { false }
+
+  before do
+    if as_administrateur
+      user.build_administrateur
+    end
+
+    if as_instructeur
+      user.build_instructeur
+    end
+
+    allow(controller).to receive(:current_user).and_return(user)
+  end
+
+  subject { render_inline(described_class.new) }
+
+  context 'when signed as simple user' do
+    it 'does not render the announcements link if not signed in' do
+      expect(subject.to_html).to be_empty
+    end
+  end
+
+  context 'when no signed in' do
+    let(:current_user) { nil }
+
+    it 'does not render the announcements link if not signed in' do
+      expect(subject.to_html).to be_empty
+    end
+  end
+
+  context 'when instructeur signed in' do
+    let(:as_instructeur) { true }
+
+    it 'renders the announcements link' do
+      expect(subject).to have_link("Nouveautés")
+    end
+
+    context 'when there are new announcements' do
+      before do
+        user.announces_seen_at = 5.days.ago
+      end
+
+      it 'does not render the notification badge' do
+        expect(subject).to have_link("Nouveautés")
+        expect(subject).to have_css(".notifications")
+      end
+    end
+
+    context 'when there are no new announcements' do
+      before do
+        user.announces_seen_at = 1.minute.ago
+      end
+
+      it 'does not render the notification badge' do
+        expect(subject).to have_link("Nouveautés")
+        expect(subject).not_to have_css(".notifications")
+      end
+    end
+
+    context 'when there are no announcement at all' do
+      let(:instructeur_release_note) { nil }
+
+      it 'does not render anything' do
+        expect(subject.to_html).to be_empty
+      end
+    end
+  end
+
+  context 'when administrateur signed in' do
+    let(:as_administrateur) { true }
+
+    it 'renders the announcements link' do
+      expect(subject).to have_link("Nouveautés")
+    end
+  end
+end

--- a/spec/components/main_navigation/instructeur_expert_navigation_component_spec.rb
+++ b/spec/components/main_navigation/instructeur_expert_navigation_component_spec.rb
@@ -1,0 +1,85 @@
+describe MainNavigation::InstructeurExpertNavigationComponent, type: :component do
+  let(:component) { described_class.new }
+  let(:as_instructeur) { true }
+  let(:as_expert) { false }
+  let(:controller_name) { 'dossiers' }
+  let(:user) { build(:user) }
+
+  subject { render_inline(component) }
+
+  before do
+    if as_instructeur
+      user.build_instructeur
+    end
+
+    if as_expert
+      user.build_expert
+    end
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    allow_any_instance_of(ApplicationController).to receive(:administrateur_signed_in?).and_return(false)
+    allow_any_instance_of(ApplicationController).to receive(:controller_name).and_return(controller_name)
+  end
+
+  describe 'when instructor is signed in' do
+    it 'renders a link to instructeur procedures with current page class' do
+      expect(subject).to have_link('Démarches', href: component.helpers.instructeur_procedures_path)
+      expect(subject).to have_selector('a[aria-current="page"]', text: 'Démarches')
+    end
+
+    it 'does not have Avis' do
+      expect(subject).not_to have_link('Avis')
+    end
+
+    context 'when instructor is also an expert' do
+      let(:as_expert) { true }
+      before do
+        allow(user.expert).to receive(:avis_summary).and_return({ unanswered: 0 })
+      end
+
+      it 'render have Avis link' do
+        expect(subject).to have_link('Avis', href: component.helpers.expert_all_avis_path)
+        expect(subject).not_to have_selector('a[aria-current="page"]', text: 'Avis')
+      end
+    end
+  end
+
+  describe 'when expert is signed in' do
+    let(:as_instructeur) { false }
+    let(:as_expert) { true }
+
+    let(:unanswered) { 0 }
+    let(:controller_name) { 'avis' }
+
+    before do
+      allow(user.expert).to receive(:avis_summary).and_return({ unanswered: })
+    end
+
+    it 'renders a link to expert all avis with current page class' do
+      expect(subject).to have_link('Avis', href: component.helpers.expert_all_avis_path)
+      expect(subject).to have_selector('a[aria-current="page"]', text: 'Avis')
+      expect(subject).not_to have_selector('span.badge')
+    end
+
+    it 'does not have Démarches link' do
+      expect(subject).not_to have_link('Démarches')
+    end
+
+    context 'when there are unanswered avis' do
+      let(:unanswered) { 2 }
+
+      it 'renders an unanswered avis badge for the expert' do
+        expect(subject).to have_selector('span.badge.warning', text: '2')
+      end
+    end
+
+    context 'when expert is also instructor' do
+      let(:as_instructeur) { true }
+
+      it 'render have Démarches link' do
+        expect(subject).to have_link('Démarches', href: component.helpers.instructeur_procedures_path)
+        expect(subject).not_to have_selector('a[aria-current="page"]', text: 'Démarches')
+      end
+    end
+  end
+end

--- a/spec/components/main_navigation/instructeur_expert_navigation_component_spec.rb
+++ b/spec/components/main_navigation/instructeur_expert_navigation_component_spec.rb
@@ -42,6 +42,14 @@ describe MainNavigation::InstructeurExpertNavigationComponent, type: :component 
         expect(subject).not_to have_selector('a[aria-current="page"]', text: 'Avis')
       end
     end
+
+    context 'when there are release notes' do
+      let!(:release_note) { create(:release_note, categories: ['instructeur']) }
+
+      it 'renders a link to Announces page' do
+        expect(subject).to have_link('Nouveautés')
+      end
+    end
   end
 
   describe 'when expert is signed in' do

--- a/spec/controllers/release_notes_controller_spec.rb
+++ b/spec/controllers/release_notes_controller_spec.rb
@@ -47,5 +47,31 @@ RSpec.describe ReleaseNotesController, type: :controller do
         it { is_expected.to be_redirection }
       end
     end
+
+    describe 'touch user announces_seen_at' do
+      let(:user) { create(:user, administrateur: build(:administrateur)) }
+
+      context 'when default categories' do
+        it 'touch announces_seen_at' do
+          expect { subject }.to change { user.reload.announces_seen_at }
+        end
+
+        context 'when current announces_seen_at is more recent than last announce' do
+          before { user.update(announces_seen_at: 1.second.ago) }
+
+          it 'does not touch announces_seen_at' do
+            expect { subject }.not_to change { user.reload.announces_seen_at }
+          end
+        end
+      end
+
+      context 'when specific categories' do
+        subject { get :index, params: { categories: ['administrateur', 'instructeur'] } }
+
+        it 'does not touch announces_seen_at' do
+          expect { subject }.not_to change { user.reload.announces_seen_at }
+        end
+      end
+    end
   end
 end

--- a/spec/helpers/release_notes_helper_spec.rb
+++ b/spec/helpers/release_notes_helper_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe ReleaseNotesHelper, type: :helper do
+  describe "#render_release_note_content" do
+    let(:release_note) { build(:release_note) }
+
+    it "adds noreferrer, noopener, and target to absolute links" do
+      release_note.body = "Go to <a href='http://example.com'>Example</a>"
+      processed_content = helper.render_release_note_content(release_note.body)
+
+      expect(processed_content.body.to_s).to include('Go to <a href="http://example.com" rel="noreferrer noopener" target="_blank" title="example.com — Nouvel onglet">Example</a>')
+    end
+
+    it "handles content without links" do
+      release_note.body = "No links here"
+      processed_content = helper.render_release_note_content(release_note.body)
+
+      expect(processed_content.body.to_s).to include("No links here")
+    end
+  end
+end

--- a/spec/system/accessibilite/wcag_usager_spec.rb
+++ b/spec/system/accessibilite/wcag_usager_spec.rb
@@ -27,6 +27,18 @@ describe 'wcag rules for usager', js: true do
     end
   end
 
+  def expect_axe_clean_without_main_navigation
+    # On page without main navigation content (like anonymous home page),
+    # there are either a bug in axe, either dsfr markup is not conform to wcag2a.
+    # There is no issue on pages having a child navigation.
+    expect(page).to be_axe_clean.excluding("#modal-header__menu")
+    expect(page).to be_axe_clean.within("#modal-header__menu").skipping("aria-prohibited-attr")
+  end
+
+  shared_examples "axe clean without main navigation" do
+    it { expect_axe_clean_without_main_navigation }
+  end
+
   context 'pages without the need to be logged in' do
     before do
       visit path
@@ -34,14 +46,14 @@ describe 'wcag rules for usager', js: true do
 
     context 'homepage' do
       let(:path) { root_path }
-      it { expect(page).to be_axe_clean }
+      it_behaves_like "axe clean without main navigation"
       it_behaves_like "external links have title says it opens in a new tab"
       it_behaves_like "aria-label do not mix with title attribute"
     end
 
     context 'sign_up page' do
       let(:path) { new_user_registration_path }
-      it { expect(page).to be_axe_clean }
+      it_behaves_like "axe clean without main navigation"
       it_behaves_like "external links have title says it opens in a new tab"
       it_behaves_like "aria-label do not mix with title attribute"
     end
@@ -54,11 +66,11 @@ describe 'wcag rules for usager', js: true do
 
       perform_enqueued_jobs do
         click_button 'Créer un compte'
-        expect(page).to be_axe_clean
+        expect_axe_clean_without_main_navigation
       end
     end
 
-    context 'sign_upc confirmation' do
+    context 'sign_up confirmation' do
       let(:path) { user_confirmation_path("user[email]" => "some@email.com") }
 
       it_behaves_like "external links have title says it opens in a new tab"
@@ -67,21 +79,21 @@ describe 'wcag rules for usager', js: true do
 
     context 'sign_in page' do
       let(:path) { new_user_session_path }
-      it { expect(page).to be_axe_clean.excluding '#user_email' }
+      it_behaves_like "axe clean without main navigation"
       it_behaves_like "external links have title says it opens in a new tab"
       it_behaves_like "aria-label do not mix with title attribute"
     end
 
     context 'contact page' do
       let(:path) { contact_path }
-      it { expect(page).to be_axe_clean }
+      it_behaves_like "axe clean without main navigation"
       it_behaves_like "external links have title says it opens in a new tab"
       it_behaves_like "aria-label do not mix with title attribute"
     end
 
     context 'commencer page' do
       let(:path) { commencer_path(path: procedure.path) }
-      it { expect(page).to be_axe_clean }
+      it_behaves_like "axe clean without main navigation"
       it_behaves_like "external links have title says it opens in a new tab"
       it_behaves_like "aria-label do not mix with title attribute"
     end
@@ -90,7 +102,7 @@ describe 'wcag rules for usager', js: true do
       visit commencer_path(path: procedure.reload.path)
 
       page.find("#help-menu_button").click
-      expect(page).to be_axe_clean
+      expect_axe_clean_without_main_navigation
     end
   end
 

--- a/spec/views/layouts/_header_spec.rb
+++ b/spec/views/layouts/_header_spec.rb
@@ -5,6 +5,8 @@ describe 'layouts/_header', type: :view do
     allow(view).to receive(:multiple_devise_profile_connect?).and_return(false)
     allow(view).to receive(:instructeur_signed_in?).and_return((profile == :instructeur))
     allow(view).to receive(:current_instructeur).and_return(current_instructeur)
+    allow(view).to receive(:administrateur_signed_in?).and_return(false)
+    allow(view).to receive(:expert_signed_in?).and_return(false)
     allow(view).to receive(:localization_enabled?).and_return(false)
 
     if user
@@ -57,6 +59,7 @@ describe 'layouts/_header', type: :view do
     let(:user) { instructeur.user }
     let(:profile) { :instructeur }
     let(:current_instructeur) { instructeur }
+    let!(:release_note) { create(:release_note, categories: ['instructeur']) }
 
     it { is_expected.to have_css(".fr-header__logo") }
     it { is_expected.to have_selector(:button, user.email, class: "account-btn") }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2987,10 +2987,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axe-core@^4.7.2:
-  version "4.7.2"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.7.2.tgz#040a7342b20765cb18bb50b628394c21bccc17a0"
-  integrity sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==
+axe-core@^4.8.2:
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.8.2.tgz#2f6f3cde40935825cf4465e3c1c9e77b240ff6ae"
+  integrity sha512-/dlp0fxyM3R8YW7MFzaHWXrf4zzbr0vaYb23VBFCl83R7nWNPg/yaQw2Dc8jzCMmDVLhSdzH8MjrsuIUuvX+6g==
 
 babel-plugin-polyfill-corejs2@^0.3.3:
   version "0.3.3"


### PR DESCRIPTION
2è partie de la PR des annonces #9638 qui : 

- intègre le lien vers la nouvelle page depuis la barre de navigation principale contextuelles par profile (sauf usager). Les catégories visibles par défaut correspondent à celles concernées profil 
- réorganise toute la logique de génération de la navigation principale dans le header et le markup est maintenant conforme au dsfr (sauf erreur)
- fix un bug d'affichage des images intégrées
- fix un bug des liens intégrés aux annonces 

## Exemples
![Capture d’écran 2023-11-02 à 10 50 10](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/d3d67b8e-b588-4265-bc4e-25cbabf41eb0)
![Capture d’écran 2023-11-02 à 10 49 51](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/165b9ed5-6c4c-4737-8643-bb693673abba)


![Capture d’écran 2023-10-31 à 17 49 58](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/20da8bb2-2de0-49f6-8911-d9d9cbc56c63)

