### PR TITLE
tech(maintenance): ajoute `maintenance_task` une  pour ajouter des champs manquant a un dossier

### DIFF
--- a/app/tasks/maintenance/add_dossiers_missing_champs_task.rb
+++ b/app/tasks/maintenance/add_dossiers_missing_champs_task.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class AddDossiersMissingChampsTask < MaintenanceTasks::Task
+    csv_collection
+
+    def process(row)
+      DataFixer::DossierChampsMissing(dossier: row["dossier_id"]).fix
+    end
+  end
+end


### PR DESCRIPTION
hs : https://secure.helpscout.net/conversation/2354110452/2039513

le problème est revenu suite a notre perte de donnée de mai 2023. Nous avions un dossier tjr en vracs (vu ac colin)