### PR TITLE
amelioration(export): suggère l'usage de 7zip et de renommer l'archive pour un nommage plus court sur la page des exports afin d'eviter les problèmes au support

### DIFF
--- a/app/views/instructeurs/procedures/exports.html.haml
+++ b/app/views/instructeurs/procedures/exports.html.haml
@@ -15,5 +15,10 @@
     %div{ data: @exports.any?(&:pending?) ? { controller: "turbo-poll", turbo_poll_url_value: "", turbo_poll_interval_value: 10_000, turbo_poll_max_checks_value: 6 } : {} }
       = render Dossiers::ExportLinkComponent.new(procedure: @procedure, exports: @exports, statut: @statut, count: @dossiers_count, class_btn: 'fr-btn--tertiary', export_url: method(:download_export_instructeur_procedure_path))
 
+    - if @exports.any?{_1.format == Export.formats.fetch(:zip)}
+      = render Dsfr::AlertComponent.new(title: t('.title_zip'), state: :info, extra_class_names: 'fr-mb-3w') do |c|
+        - c.body do
+          %p= t('.export_description_zip_html')
+
   - else
     = t('.no_export_html', expiration_time: Export::MAX_DUREE_CONSERVATION_EXPORT.in_hours.to_i )

--- a/config/locales/views/instructeurs/procedures/exports/en.yml
+++ b/config/locales/views/instructeurs/procedures/exports/en.yml
@@ -8,4 +8,10 @@ en:
         export_description: |
           This list of exports contains the last exports you requested as well as those requested by instructors belonging to the same group.
           They are available for %{expiration_time} hours after generation.
+        title_zip: A problem with the zip format ?
+        export_description_zip_html: |
+          Are you facing an issue when you try to extract the export.zip ? Try it with <a href="https://www.7-zip.org/" target="_blank" rel="noopener noreferrer">7zip</a>.<br />
+          Are you facing an issue when you try to extract the export.zip on your company network ? Try to rename it with a shorter name first, then extract it.
+
+
         no_export_html: You have no export at the moment. <br> Can't find an export? It may have expired, exports are deleted after %{expiration_time} hours.

--- a/config/locales/views/instructeurs/procedures/exports/fr.yml
+++ b/config/locales/views/instructeurs/procedures/exports/fr.yml
@@ -8,4 +8,9 @@ fr:
         export_description: |
           Cette liste d'exports contient les derniers exports que vous avez demandés ainsi que ceux demandés par les instructeurs appartenant au même groupe.
           Ils sont disponibles pendant %{expiration_time} heures après leur génération.
+        title_zip: Un problème avec le format zip ?
+        export_description_zip_html: |
+          Vous n'arrivez pas à extraire un export au format .zip et un message d'erreur s'affiche comme quoi il est corrompu ? Essayez avec <a href="https://www.7-zip.org/" target="_blank" rel="noopener noreferrer">7zip</a>.<br />
+          Vous n'arrivez pas à extraire un export au format .zip sur un réseau d'entreprise ? Essayer de renommer l'archive avec un nom plus court et ré-essayer de l'extraire.
+
         no_export_html: Vous n'avez pas d'export pour le moment. <br> Vous ne trouvez pas un export ? Il a peut-être expiré, les exports sont supprimés au bout de %{expiration_time} heures.


### PR DESCRIPTION
hs: https://secure.helpscout.net/conversation/2251377548/2030270 (et d'autres)
parcequ'on passe du tmps au support a recommander ça aux instructeurs. Se sera mieux pr tous le monde

**Apres (uniquement quand il y a des zip ds les exports)**
> <img width="1225" alt="Screenshot 2023-11-02 at 9 08 11 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/c3468204-6f35-436a-94b7-4ee5ef6be9f7">



**Avant**
> <img width="1225" alt="Screenshot 2023-10-31 at 5 29 10 PM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/5b81036b-e07b-4689-a0ae-9f20e0099ae6">
