### PR TITLE
Tech: retry system tests JS seulement sur CI pour avoir les erreurs rapidement en local

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,6 +69,14 @@ RSpec.configure do |config|
   # show exception that triggers a retry if verbose_retry is set to true
   config.display_try_failure_messages = true
 
+  config.retry_count_condition = proc do |ex|
+    if ENV["CI"] == "true" && ex.metadata[:js]
+      3
+    else # in dev we want to have real error fast
+      1
+    end
+  end
+
   # callback to be run between retries
   config.retry_callback = proc do |ex|
     # run some additional clean up task - can be filtered by example metadata

--- a/spec/system/accessibilite/wcag_usager_spec.rb
+++ b/spec/system/accessibilite/wcag_usager_spec.rb
@@ -1,4 +1,4 @@
-describe 'wcag rules for usager', js: true, retry: 3 do
+describe 'wcag rules for usager', js: true do
   let(:procedure) { create(:procedure, :published, :with_all_champs, :with_service, :for_individual) }
   let(:password) { 'a very complicated password' }
   let(:litteraire_user) { create(:user, password: password) }

--- a/spec/system/administrateurs/admin_creation_spec.rb
+++ b/spec/system/administrateurs/admin_creation_spec.rb
@@ -1,4 +1,4 @@
-describe 'As an administrateur', js: true, retry: 3 do
+describe 'As an administrateur', js: true do
   let(:super_admin) { create(:super_admin) }
   let(:admin_email) { 'new_admin@gouv.fr' }
   let(:new_admin) { Administrateur.by_email(admin_email) }
@@ -15,7 +15,7 @@ describe 'As an administrateur', js: true, retry: 3 do
     end
   end
 
-  scenario 'I can register', js: true, retry: 3 do
+  scenario 'I can register', js: true do
     expect(new_admin.reload.user.active?).to be(false)
 
     confirmation_email = open_email(admin_email)

--- a/spec/system/administrateurs/annotations_spec.rb
+++ b/spec/system/administrateurs/annotations_spec.rb
@@ -1,4 +1,4 @@
-describe 'As an administrateur I can edit annotation', js: true, retry: 3 do
+describe 'As an administrateur I can edit annotation', js: true do
   let(:administrateur) { procedure.administrateurs.first }
   let(:procedure) { create(:procedure) }
 

--- a/spec/system/administrateurs/condition_spec.rb
+++ b/spec/system/administrateurs/condition_spec.rb
@@ -1,4 +1,4 @@
-describe 'As an administrateur I can edit types de champ condition', js: true, retry: 3 do
+describe 'As an administrateur I can edit types de champ condition', js: true do
   include Logic
 
   let(:administrateur) { procedure.administrateurs.first }

--- a/spec/system/administrateurs/procedure_administrateurs_spec.rb
+++ b/spec/system/administrateurs/procedure_administrateurs_spec.rb
@@ -1,6 +1,6 @@
 require 'system/administrateurs/procedure_spec_helper'
 
-describe 'Administrateurs can manage administrateurs', js: true, retry: 3 do
+describe 'Administrateurs can manage administrateurs', js: true do
   include ProcedureSpecHelper
 
   let(:administrateur) { create(:administrateur) }

--- a/spec/system/administrateurs/procedure_archive_and_export_spec.rb
+++ b/spec/system/administrateurs/procedure_archive_and_export_spec.rb
@@ -1,6 +1,6 @@
 require 'system/administrateurs/procedure_spec_helper'
 
-describe 'Creating a new procedure', js: true, retry: 3 do
+describe 'Creating a new procedure', js: true do
   include ProcedureSpecHelper
 
   let(:administrateur) { create(:administrateur) }

--- a/spec/system/administrateurs/procedure_attestation_template_spec.rb
+++ b/spec/system/administrateurs/procedure_attestation_template_spec.rb
@@ -1,6 +1,6 @@
 require 'system/administrateurs/procedure_spec_helper'
 
-describe 'As an administrateur, I want to manage the procedure’s attestation', js: true, retry: 3 do
+describe 'As an administrateur, I want to manage the procedure’s attestation', js: true do
   include ProcedureSpecHelper
 
   let(:administrateur) { create(:administrateur) }

--- a/spec/system/administrateurs/procedure_cloning_spec.rb
+++ b/spec/system/administrateurs/procedure_cloning_spec.rb
@@ -1,6 +1,6 @@
 require 'system/administrateurs/procedure_spec_helper'
 
-describe 'As an administrateur I wanna clone a procedure', js: true, retry: 3 do
+describe 'As an administrateur I wanna clone a procedure', js: true do
   include ProcedureSpecHelper
 
   let(:administrateur) { create(:administrateur) }

--- a/spec/system/administrateurs/procedure_creation_spec.rb
+++ b/spec/system/administrateurs/procedure_creation_spec.rb
@@ -1,6 +1,6 @@
 require 'system/administrateurs/procedure_spec_helper'
 
-describe 'Creating a new procedure', js: true, retry: 3 do
+describe 'Creating a new procedure', js: true do
   include ProcedureSpecHelper
 
   let(:administrateur) { create(:administrateur) }

--- a/spec/system/administrateurs/procedure_groupe_instructeur_spec.rb
+++ b/spec/system/administrateurs/procedure_groupe_instructeur_spec.rb
@@ -1,6 +1,6 @@
 require 'system/administrateurs/procedure_spec_helper'
 
-describe 'Manage procedure instructeurs', js: true, retry: 3 do
+describe 'Manage procedure instructeurs', js: true do
   include ProcedureSpecHelper
 
   let(:administrateur) { create(:administrateur) }

--- a/spec/system/administrateurs/procedure_publish_spec.rb
+++ b/spec/system/administrateurs/procedure_publish_spec.rb
@@ -1,6 +1,6 @@
 require 'system/administrateurs/procedure_spec_helper'
 
-describe 'Publishing a procedure', js: true, retry: 3 do
+describe 'Publishing a procedure', js: true do
   include ProcedureSpecHelper
 
   let(:administrateur) { create(:administrateur) }

--- a/spec/system/administrateurs/procedure_update_spec.rb
+++ b/spec/system/administrateurs/procedure_update_spec.rb
@@ -1,6 +1,6 @@
 require 'system/administrateurs/procedure_spec_helper'
 
-describe 'Administrateurs can edit procedures', js: true, retry: 3 do
+describe 'Administrateurs can edit procedures', js: true do
   include ProcedureSpecHelper
 
   let(:administrateur) { create(:administrateur) }

--- a/spec/system/administrateurs/types_de_champ_spec.rb
+++ b/spec/system/administrateurs/types_de_champ_spec.rb
@@ -1,4 +1,4 @@
-describe 'As an administrateur I can edit types de champ', js: true, retry: 3 do
+describe 'As an administrateur I can edit types de champ', js: true do
   include ActionView::RecordIdentifier
 
   let(:administrateur) { procedure.administrateurs.first }

--- a/spec/system/api_particulier/api_particulier_spec.rb
+++ b/spec/system/api_particulier/api_particulier_spec.rb
@@ -1,4 +1,4 @@
-describe 'fetch API Particulier Data', js: true, retry: 3 do
+describe 'fetch API Particulier Data', js: true do
   let(:administrateur) { create(:administrateur) }
 
   let(:expected_token) { 'd7e9c9f4c3ca00caadde31f50fd4521a' }

--- a/spec/system/experts/expert_spec.rb
+++ b/spec/system/experts/expert_spec.rb
@@ -130,7 +130,7 @@ describe 'Inviting an expert:' do
     # scenario 'I can invite other experts' do
     # end
 
-    context 'with dossiers having attached files', js: true, retry: 3 do
+    context 'with dossiers having attached files', js: true do
       let(:path) { 'spec/fixtures/files/piece_justificative_0.pdf' }
       let(:commentaire) { create(:commentaire, instructeur: instructeur, dossier: dossier) }
 

--- a/spec/system/france_connect/france_connect_particulier_spec.rb
+++ b/spec/system/france_connect/france_connect_particulier_spec.rb
@@ -73,7 +73,7 @@ describe 'France Connect Particulier Connexion' do
               expect(page).to have_content('Dossiers')
             end
 
-            context 'and the user wants an email that belongs to another account', js: true, retry: 3 do
+            context 'and the user wants an email that belongs to another account', js: true do
               let!(:another_user) { create(:user, email: 'an_existing_email@a.com', password: SECURE_PASSWORD) }
 
               scenario 'it uses another email that belongs to another account' do

--- a/spec/system/instructeurs/batch_operation_spec.rb
+++ b/spec/system/instructeurs/batch_operation_spec.rb
@@ -1,4 +1,4 @@
-describe 'BatchOperation a dossier:', js: true, retry: 3 do
+describe 'BatchOperation a dossier:', js: true do
   include ActionView::RecordIdentifier
   include ActiveJob::TestHelper
 

--- a/spec/system/instructeurs/expert_spec.rb
+++ b/spec/system/instructeurs/expert_spec.rb
@@ -1,4 +1,4 @@
-describe 'Inviting an expert:', js: true, retry: 3 do
+describe 'Inviting an expert:', js: true do
   include ActiveJob::TestHelper
   include ActionView::Helpers
 

--- a/spec/system/instructeurs/instructeur_creation_spec.rb
+++ b/spec/system/instructeurs/instructeur_creation_spec.rb
@@ -1,4 +1,4 @@
-describe 'As an instructeur', js: true, retry: 3 do
+describe 'As an instructeur', js: true do
   let(:administrateur) { create(:administrateur, :with_procedure) }
   let(:procedure) { administrateur.procedures.first }
   let(:instructeur_email) { 'new_instructeur@gouv.fr' }

--- a/spec/system/instructeurs/instruction_spec.rb
+++ b/spec/system/instructeurs/instruction_spec.rb
@@ -1,4 +1,4 @@
-describe 'Instructing a dossier:', js: true, retry: 3 do
+describe 'Instructing a dossier:', js: true do
   include ActiveJob::TestHelper
   include Logic
 
@@ -211,7 +211,7 @@ describe 'Instructing a dossier:', js: true, retry: 3 do
       expect(Archive.first.month).not_to be_nil
     end
   end
-  context 'with dossiers having attached files', js: true, retry: 3 do
+  context 'with dossiers having attached files', js: true do
     let(:procedure) { create(:procedure, :published, :with_piece_justificative, instructeurs: [instructeur]) }
     let(:dossier) { create(:dossier, :en_construction, procedure: procedure) }
     let(:champ) { dossier.champs_public.first }

--- a/spec/system/instructeurs/procedure_filters_spec.rb
+++ b/spec/system/instructeurs/procedure_filters_spec.rb
@@ -40,7 +40,7 @@ describe "procedure filters" do
     end
   end
 
-  scenario "should add be able to add created_at column", js: true, retry: 3 do
+  scenario "should add be able to add created_at column", js: true do
     add_column("Créé le")
     within ".dossiers-table" do
       expect(page).to have_link("Créé le")
@@ -48,7 +48,7 @@ describe "procedure filters" do
     end
   end
 
-  scenario "should add be able to add and remove custom type_de_champ column", js: true, retry: 3 do
+  scenario "should add be able to add and remove custom type_de_champ column", js: true do
     add_column(type_de_champ.libelle)
     within ".dossiers-table" do
       expect(page).to have_link(type_de_champ.libelle)
@@ -62,7 +62,7 @@ describe "procedure filters" do
     end
   end
 
-  scenario "should be able to add and remove filter", js: true, retry: 3 do
+  scenario "should be able to add and remove filter", js: true do
     add_filter(type_de_champ.libelle, champ.value)
 
     expect(page).to have_content("#{type_de_champ.libelle} : #{champ.value}")
@@ -86,7 +86,7 @@ describe "procedure filters" do
     end
   end
 
-  scenario "should be able to user custom fiters", js: true, retry: 3 do
+  scenario "should be able to user custom fiters", js: true do
     # use date filter
     click_on 'Sélectionner un filtre'
     select "En construction le", from: "Colonne"
@@ -112,7 +112,7 @@ describe "procedure filters" do
   end
 
   describe 'with a vcr cached cassette' do
-    scenario "should be able to find by departements with custom enum lookup", js: true, retry: 3 do
+    scenario "should be able to find by departements with custom enum lookup", js: true do
       departement_champ = new_unfollow_dossier.champs.find(&:departement?)
       departement_champ.update!(value: 'Oise', external_id: '60')
       departement_champ.reload
@@ -127,7 +127,7 @@ describe "procedure filters" do
       expect(page).to have_link(new_unfollow_dossier.id.to_s)
     end
 
-    scenario "should be able to find by region with custom enum lookup", js: true, retry: 3 do
+    scenario "should be able to find by region with custom enum lookup", js: true do
       region_champ = new_unfollow_dossier.champs.find(&:region?)
       region_champ.update!(value: 'Bretagne', external_id: '53')
       region_champ.reload
@@ -142,7 +142,7 @@ describe "procedure filters" do
     end
   end
 
-  scenario "should be able to add and remove two filters for the same field", js: true, retry: 3 do
+  scenario "should be able to add and remove two filters for the same field", js: true do
     add_filter(type_de_champ.libelle, champ.value)
     add_filter(type_de_champ.libelle, champ_2.value)
     add_enum_filter('Groupe instructeur', procedure.groupe_instructeurs.first.label)

--- a/spec/system/instructeurs/procedure_sort_spec.rb
+++ b/spec/system/instructeurs/procedure_sort_spec.rb
@@ -1,4 +1,4 @@
-describe "procedure sort", js: true, retry: 3 do
+describe "procedure sort", js: true do
   let(:instructeur) { create(:instructeur) }
   let(:procedure) { create(:procedure, :published, :with_type_de_champ, instructeurs: [instructeur]) }
   let!(:new_unfollow_dossier) { create(:dossier, procedure: procedure, state: Dossier.states.fetch(:en_instruction)) }

--- a/spec/system/integrateurs/procedure_prefilling_spec.rb
+++ b/spec/system/integrateurs/procedure_prefilling_spec.rb
@@ -1,4 +1,4 @@
-describe 'As an integrator:', js: true, retry: 3 do
+describe 'As an integrator:', js: true do
   let(:procedure) { create(:procedure, :for_individual, :published, opendata: true) }
   let!(:type_de_champ) { create(:type_de_champ_text, procedure: procedure) }
 

--- a/spec/system/routing/rules_full_scenario_spec.rb
+++ b/spec/system/routing/rules_full_scenario_spec.rb
@@ -1,4 +1,4 @@
-describe 'The routing with rules', js: true, retry: 3 do
+describe 'The routing with rules', js: true do
   let(:password) { 'a very complicated password' }
 
   let(:procedure) do

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -6,7 +6,7 @@ describe 'The user' do
   let(:user_dossier) { user.dossiers.first }
   let!(:dossier_to_link) { create(:dossier) }
 
-  scenario 'fill a dossier', js: true, retry: 3 do
+  scenario 'fill a dossier', js: true do
     log_in(user, procedure)
 
     fill_individual
@@ -104,7 +104,7 @@ describe 'The user' do
     expect(page).to have_text('Analyse antivirus en cours')
   end
 
-  scenario 'fill nothing and every error anchor links points to an existing element', js: true, retry: 3 do
+  scenario 'fill nothing and every error anchor links points to an existing element', js: true do
     log_in(user, procedure)
     fill_individual
     click_on 'Déposer le dossier'
@@ -120,7 +120,7 @@ describe 'The user' do
     create(:procedure, :published, :for_individual, types_de_champ_public: [{ type: :repetition, mandatory: true, children: [{ libelle: 'sub type de champ' }] }])
   end
 
-  scenario 'fill a dossier with repetition', js: true, retry: 3 do
+  scenario 'fill a dossier with repetition', js: true do
     log_in(user, procedure_with_repetition)
 
     fill_individual
@@ -154,7 +154,7 @@ describe 'The user' do
     ])
   }
 
-  scenario 'save an incomplete dossier as draft but cannot not submit it', js: true, retry: 3 do
+  scenario 'save an incomplete dossier as draft but cannot not submit it', js: true do
     log_in(user, simple_procedure)
     fill_individual
 
@@ -189,7 +189,7 @@ describe 'The user' do
     expect(page).to have_current_path(merci_dossier_path(user_dossier))
   end
 
-  scenario 'fill address not in BAN', js: true, retry: 3 do
+  scenario 'fill address not in BAN', js: true do
     log_in(user, simple_procedure)
     fill_individual
 
@@ -200,7 +200,7 @@ describe 'The user' do
     expect(champ_for('address').full_address?).to be_falsey
   end
 
-  scenario 'numbers champs formatting', js: true, retry: 3 do
+  scenario 'numbers champs formatting', js: true do
     log_in(user, simple_procedure)
     fill_individual
 
@@ -257,7 +257,7 @@ describe 'The user' do
     }
   end
 
-  scenario 'extends dossier experation date more than one time, ', js: true, retry: 3 do
+  scenario 'extends dossier experation date more than one time, ', js: true do
     simple_procedure.update(procedure_expires_when_termine_enabled: true)
     user_old_dossier = create(:dossier,
                               procedure: simple_procedure,
@@ -282,7 +282,7 @@ describe 'The user' do
   let(:procedure_with_pjs) { create(:procedure, :published, :for_individual, types_de_champ_public: [{ type: :piece_justificative, mandatory: true, libelle: 'Pièce justificative 1' }, { type: :piece_justificative, mandatory: true, libelle: 'Pièce justificative 2' }]) }
   let(:old_procedure_with_disabled_pj_validation) { create(:procedure, :published, :for_individual, types_de_champ_public: [{ type: :piece_justificative, mandatory: true, libelle: 'Pièce justificative 1', skip_pj_validation: true }]) }
 
-  scenario 'add an attachment', js: true, retry: 3 do
+  scenario 'add an attachment', js: true do
     log_in(user, procedure_with_pjs)
     fill_individual
 
@@ -306,7 +306,7 @@ describe 'The user' do
     expect(page).to have_text('RIB.pdf')
   end
 
-  scenario 'add an invalid attachment on an old procedure where pj validation is disabled', js: true, retry: 3 do
+  scenario 'add an invalid attachment on an old procedure where pj validation is disabled', js: true do
     log_in(user, old_procedure_with_disabled_pj_validation)
     fill_individual
 
@@ -316,7 +316,7 @@ describe 'The user' do
     expect(page).to have_text('Analyse antivirus en cours', count: 1, wait: 5)
   end
 
-  scenario 'retry on transcient upload error', js: true, retry: 3 do
+  scenario 'retry on transcient upload error', js: true do
     log_in(user, procedure_with_pjs)
     fill_individual
 
@@ -345,7 +345,7 @@ describe 'The user' do
     expect(page).to have_text('file.pdf')
   end
 
-  scenario "upload multiple pieces justificatives on same champ", js: true, retry: 3 do
+  scenario "upload multiple pieces justificatives on same champ", js: true do
     log_in(user, procedure_with_pjs)
     fill_individual
 
@@ -410,7 +410,7 @@ describe 'The user' do
           ])
       end
 
-      scenario 'submit a dossier with an hidden mandatory champ within a repetition', js: true, retry: 3 do
+      scenario 'submit a dossier with an hidden mandatory champ within a repetition', js: true do
         log_in(user, procedure)
 
         fill_individual
@@ -440,7 +440,7 @@ describe 'The user' do
           ])
       end
 
-      scenario 'fill a dossier', js: true, retry: 3 do
+      scenario 'fill a dossier', js: true do
         log_in(user, procedure)
 
         fill_individual
@@ -472,7 +472,7 @@ describe 'The user' do
           ])
       end
 
-      scenario 'submit a dossier with an hidden mandatory champ ', js: true, retry: 3 do
+      scenario 'submit a dossier with an hidden mandatory champ ', js: true do
         log_in(user, procedure)
 
         fill_individual
@@ -481,7 +481,7 @@ describe 'The user' do
         expect(page).to have_current_path(merci_dossier_path(user_dossier))
       end
 
-      scenario 'cannot submit a reveal dossier with a revealed mandatory champ ', js: true, retry: 3 do
+      scenario 'cannot submit a reveal dossier with a revealed mandatory champ ', js: true do
         log_in(user, procedure)
 
         fill_individual
@@ -513,7 +513,7 @@ describe 'The user' do
           ])
       end
 
-      scenario 'fill a dossier', js: true, retry: 3 do
+      scenario 'fill a dossier', js: true do
         log_in(user, procedure)
 
         fill_individual
@@ -562,7 +562,7 @@ describe 'The user' do
   end
 
   context 'draft autosave' do
-    scenario 'autosave a draft', js: true, retry: 3 do
+    scenario 'autosave a draft', js: true do
       log_in(user, simple_procedure)
       fill_individual
 
@@ -577,7 +577,7 @@ describe 'The user' do
       expect(page).to have_field('texte obligatoire', with: 'a valid user input')
     end
 
-    scenario 'retry on autosave error', :capybara_ignore_server_errors, js: true, retry: 3 do
+    scenario 'retry on autosave error', :capybara_ignore_server_errors, js: true do
       log_in(user, simple_procedure)
       fill_individual
 
@@ -597,7 +597,7 @@ describe 'The user' do
       expect(page).to have_field('texte obligatoire', with: 'a valid user input')
     end
 
-    scenario 'autosave redirects to sign-in after being disconnected', js: true, retry: 3 do
+    scenario 'autosave redirects to sign-in after being disconnected', js: true do
       log_in(user, simple_procedure)
       fill_individual
 

--- a/spec/system/users/dossier_details_spec.rb
+++ b/spec/system/users/dossier_details_spec.rb
@@ -48,7 +48,7 @@ describe 'Dossier details:' do
     expect(page).to have_current_path(dossier_path(dossier))
   end
 
-  context 'with js', js: true, retry: 3 do
+  context 'with js', js: true do
     it_behaves_like 'the user can edit the submitted demande'
     it_behaves_like 'the user can send messages to the instructeur'
   end

--- a/spec/system/users/dossier_prefill_get_spec.rb
+++ b/spec/system/users/dossier_prefill_get_spec.rb
@@ -1,4 +1,4 @@
-describe 'Prefilling a dossier (with a GET request):', js: true, retry: 3 do
+describe 'Prefilling a dossier (with a GET request):', js: true do
   let(:password) { SECURE_PASSWORD }
 
   let(:procedure) { create(:procedure, :for_individual, :published, opendata: true) }

--- a/spec/system/users/dossier_prefill_post_spec.rb
+++ b/spec/system/users/dossier_prefill_post_spec.rb
@@ -1,4 +1,4 @@
-describe 'Prefilling a dossier (with a POST request):', js: true, retry: 3 do
+describe 'Prefilling a dossier (with a POST request):', js: true do
   let(:password) { SECURE_PASSWORD }
 
   let(:procedure) { create(:procedure, :for_individual, :published) }

--- a/spec/system/users/dossier_shared_examples.rb
+++ b/spec/system/users/dossier_shared_examples.rb
@@ -1,5 +1,5 @@
 RSpec.shared_examples 'the user can edit the submitted demande' do
-  scenario js: true, retry: 3 do
+  scenario js: true do
     visit dossier_path(dossier)
 
     expect(page).to have_current_path(dossier_path(dossier))

--- a/spec/system/users/dropdown_spec.rb
+++ b/spec/system/users/dropdown_spec.rb
@@ -1,4 +1,4 @@
-describe 'dropdown list with other option activated', js: true, retry: 3 do
+describe 'dropdown list with other option activated', js: true do
   let(:password) { SECURE_PASSWORD }
   let!(:user) { create(:user, password: password) }
 
@@ -20,14 +20,14 @@ describe 'dropdown list with other option activated', js: true, retry: 3 do
       ]
     end
 
-    scenario 'Select other option and the other input hidden must appear', js: true, retry: 3 do
+    scenario 'Select other option and the other input hidden must appear', js: true do
       fill_individual
 
       find('.fr-fieldset__content .fr-radio-group:last-of-type input').select_option
       expect(page).to have_selector('.drop_down_other', visible: true)
     end
 
-    scenario "Getting back from other save the new option", js: true, retry: 3 do
+    scenario "Getting back from other save the new option", js: true do
       fill_individual
 
       choose "Autre"

--- a/spec/system/users/en_construction_spec.rb
+++ b/spec/system/users/en_construction_spec.rb
@@ -11,7 +11,7 @@ describe "Dossier en_construction" do
     dossier.find_editing_fork(dossier.user).champs_public.find { _1.type_de_champ_id == tdc.id }
   }
 
-  scenario 'delete a non mandatory piece justificative', js: true, retry: 3 do
+  scenario 'delete a non mandatory piece justificative', js: true do
     visit_dossier(dossier)
 
     expect(page).not_to have_button("Remplacer")
@@ -26,7 +26,7 @@ describe "Dossier en_construction" do
       tdc.update_attribute(:mandatory, true)
     end
 
-    scenario 'remplace a mandatory piece justificative', js: true, retry: 3 do
+    scenario 'remplace a mandatory piece justificative', js: true do
       visit_dossier(dossier)
 
       click_on "Supprimer le fichier toto.txt"
@@ -50,7 +50,7 @@ describe "Dossier en_construction" do
       tdc.update_attribute(:mandatory, true)
     end
 
-    scenario 'remplace a mandatory titre identite', js: true, retry: 3 do
+    scenario 'remplace a mandatory titre identite', js: true do
       visit_dossier(dossier)
 
       click_on "Supprimer le fichier toto.png"

--- a/spec/system/users/invite_spec.rb
+++ b/spec/system/users/invite_spec.rb
@@ -9,7 +9,7 @@ describe 'Invitations' do
   context 'when the dossier is a brouillon' do
     let!(:dossier) { create(:dossier, :with_individual, state: Dossier.states.fetch(:brouillon), user: owner, procedure: procedure) }
 
-    scenario 'on the form, the owner of a dossier can invite another user to collaborate on the dossier', js: true, retry: 3 do
+    scenario 'on the form, the owner of a dossier can invite another user to collaborate on the dossier', js: true do
       log_in(owner)
       navigate_to_brouillon(dossier)
       fill_in 'Texte obligatoire', with: 'Some edited value'
@@ -94,7 +94,7 @@ describe 'Invitations' do
       end
     end
 
-    scenario 'an invited user can see and edit the draft', js: true, retry: 3 do
+    scenario 'an invited user can see and edit the draft', js: true do
       navigate_to_invited_dossier(invite)
       expect(page).to have_current_path(brouillon_dossier_path(dossier))
 
@@ -117,7 +117,7 @@ describe 'Invitations' do
   context 'when the dossier is en_construction' do
     let!(:dossier) { create(:dossier, :with_individual, :en_construction, user: owner, procedure: procedure) }
 
-    scenario 'on dossier details, the owner of a dossier can invite another user to collaborate on the dossier', js: true, retry: 3 do
+    scenario 'on dossier details, the owner of a dossier can invite another user to collaborate on the dossier', js: true do
       log_in(owner)
       navigate_to_dossier(dossier)
 
@@ -128,7 +128,7 @@ describe 'Invitations' do
       expect(page).to have_text("user_invite@exemple.fr")
     end
 
-    context 'as an invited user', js: true, retry: 3 do
+    context 'as an invited user', js: true do
       before do
         navigate_to_invited_dossier(invite)
         expect(page).to have_current_path(dossier_path(invite.dossier))

--- a/spec/system/users/linked_dropdown_spec.rb
+++ b/spec/system/users/linked_dropdown_spec.rb
@@ -19,7 +19,7 @@ describe 'linked dropdown lists' do
   let(:user_dossier) { user.dossiers.first }
   context 'not mandatory' do
     let(:mandatory) { false }
-    scenario 'change primary value, secondary options are updated', js: true, retry: 3 do
+    scenario 'change primary value, secondary options are updated', js: true do
       log_in(user.email, password, procedure)
 
       fill_individual
@@ -42,7 +42,7 @@ describe 'linked dropdown lists' do
   context 'mandatory' do
     let(:mandatory) { true }
 
-    scenario 'change primary value, secondary options are updated', js: true, retry: 3 do
+    scenario 'change primary value, secondary options are updated', js: true do
       log_in(user.email, password, procedure)
 
       fill_individual

--- a/spec/system/users/list_dossiers_spec.rb
+++ b/spec/system/users/list_dossiers_spec.rb
@@ -1,4 +1,4 @@
-describe 'user access to the list of their dossiers', js: true, retry: 3 do
+describe 'user access to the list of their dossiers', js: true do
   let(:user) { create(:user) }
   let!(:dossier_brouillon)          { create(:dossier, user: user) }
   let!(:dossier_en_construction)    { create(:dossier, :with_populated_champs, :en_construction, user: user) }
@@ -155,7 +155,7 @@ describe 'user access to the list of their dossiers', js: true, retry: 3 do
       expect(page).not_to have_link('Supprimer le dossier', href: dossier_path(dossier_en_instruction))
     end
 
-    context 'when user clicks on delete button', js: true, retry: 3 do
+    context 'when user clicks on delete button', js: true do
       scenario 'the dossier is deleted' do
         expect(page).to have_content(dossier_en_construction.procedure.libelle)
         within(:css, ".card", match: :first) do
@@ -177,7 +177,7 @@ describe 'user access to the list of their dossiers', js: true, retry: 3 do
         expect(page).to have_link(nil, href: clone_dossier_path(dossier_en_instruction))
       end
 
-      context 'when user clicks on clone button', js: true, retry: 3 do
+      context 'when user clicks on clone button', js: true do
         scenario 'the dossier is cloned' do
           within(:css, ".card", match: :first) do
             click_on 'Autres actions'

--- a/spec/system/users/managing_password_spec.rb
+++ b/spec/system/users/managing_password_spec.rb
@@ -1,4 +1,4 @@
-describe 'Managing password:', js: true, retry: 3 do
+describe 'Managing password:', js: true do
   context 'for simple users' do
     let(:user) { create(:user) }
     let(:new_password) { 'a simple password' }
@@ -34,7 +34,7 @@ describe 'Managing password:', js: true, retry: 3 do
     let(:weak_password) { '12345678' }
     let(:strong_password) { 'a new, long, and complicated password!' }
 
-    scenario 'an admin can reset their password', js: true, retry: 3 do
+    scenario 'an admin can reset their password', js: true do
       visit root_path
       within('.fr-header .fr-container .fr-header__tools .fr-btns-group') do
         click_on 'Se connecter'
@@ -73,7 +73,7 @@ describe 'Managing password:', js: true, retry: 3 do
     let(:weak_password) { '12345678' }
     let(:strong_password) { 'a new, long, and complicated password!' }
 
-    scenario 'a super-admin can reset their password', js: true, retry: 3 do
+    scenario 'a super-admin can reset their password', js: true do
       visit manager_root_path
       click_on 'Mot de passe oublié'
       expect(page).to have_current_path(new_super_admin_password_path)

--- a/spec/system/users/sign_up_spec.rb
+++ b/spec/system/users/sign_up_spec.rb
@@ -25,21 +25,21 @@ describe 'Signing up:' do
       fill_in 'Mot de passe', with: '12345'
     end
 
-    scenario 'they can accept the suggestion', js: true, retry: 3 do
+    scenario 'they can accept the suggestion', js: true do
       expect(page).to have_selector('.suspect-email', visible: true)
       click_on 'Oui'
       expect(page).to have_field("Adresse électronique", :with => 'bidou@yahoo.fr')
       expect(page).to have_selector('.suspect-email', visible: false)
     end
 
-    scenario 'they can discard the suggestion', js: true, retry: 3 do
+    scenario 'they can discard the suggestion', js: true do
       expect(page).to have_selector('.suspect-email', visible: true)
       click_on 'Non'
       expect(page).to have_field("Adresse électronique", :with => 'bidou@yahoo.rf')
       expect(page).to have_selector('.suspect-email', visible: false)
     end
 
-    scenario 'they can fix the typo themselves', js: true, retry: 3 do
+    scenario 'they can fix the typo themselves', js: true do
       expect(page).to have_selector('.suspect-email', visible: true)
       fill_in 'Adresse électronique', with: 'bidou@yahoo.fr'
       blur


### PR DESCRIPTION
J'ai refacto avec le proc `retry_count_condition` car le `retry:`  était parfois oublié sur des specs récentes