### PR TITLE
[admin] Ajout d'une page de confirmation après la publication d'une procédure - mise en avant de l'URL à partager

### DIFF
--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -305,12 +305,10 @@ module Administrateurs
     end
 
     def publish_revision
-      if @procedure.draft_changed?
-        @procedure.publish_revision!
-        flash.notice = "Nouvelle version de la démarche publiée"
+      @procedure.publish_revision!
+      flash.notice = "Nouvelle version de la démarche publiée"
 
-        redirect_to admin_procedure_path(@procedure)
-      end
+      redirect_to admin_procedure_path(@procedure)
     end
 
     def transfert

--- a/app/views/administrateurs/procedures/confirmation.html.haml
+++ b/app/views/administrateurs/procedures/confirmation.html.haml
@@ -1,0 +1,23 @@
+= render partial: 'administrateurs/breadcrumbs',
+  locals: { steps: [['Démarches', admin_procedures_back_path(@procedure)],
+                    [@procedure.libelle.truncate_words(10), admin_procedure_path(@procedure)],
+                    ['Confirmation']] }
+
+.fr-container
+  .fr-grid-row
+    .fr-col-12.fr-col-offset-md-2.fr-col-md-8
+      %h1= t('administrateurs.procedures.publication.confirmation')
+
+      = render Dsfr::CalloutComponent.new(title: nil) do |c|
+        - c.with_body do
+          %p= t('administrateurs.procedures.publication.share_link')
+          %p
+            %strong= commencer_url(@procedure.path)
+            = render Dsfr::CopyButtonComponent.new(text: commencer_url(@procedure.path), title: t("administrateurs.procedures.publication.copy_url"))
+
+      %ul.fr-mt-2w.fr-btns-group.fr-btns-group--inline
+        %li= link_to t('administrateurs.procedures.publication.back_to_procedure'), admin_procedure_path(id: @procedure), class: 'fr-btn'
+        %li= link_to t('administrateurs.procedures.publication.new_procedure'), new_from_existing_admin_procedures_path, class: 'fr-btn fr-btn--secondary'
+
+      .text-center
+        = image_tag('landing/hero/dematerialiser.svg', "aria-hidden": true)

--- a/app/views/administrateurs/procedures/show.html.haml
+++ b/app/views/administrateurs/procedures/show.html.haml
@@ -38,7 +38,10 @@
 
       - c.bottom do
         %ul.fr-mt-2w.fr-btns-group.fr-btns-group--inline
-          %li= button_to 'Publier les modifications', admin_procedure_publication_path(@procedure), class: 'fr-btn', id: 'publish-procedure-link', data: { disable_with: "Publication..." }, disabled: !@procedure.draft_revision.valid?, method: :get
+          - if @procedure.publiee?
+            %li= button_to 'Publier les modifications', admin_procedure_publish_revision_path(@procedure), class: 'fr-btn', id: 'publish-procedure-link', data: { disable_with: "Publication...", confirm: 'Êtes-vous sûr de vouloir publier les modifications ?' }, disabled: !@procedure.draft_revision.valid?, method: :put
+          - else
+            %li= button_to 'Publier les modifications', admin_procedure_publication_path(@procedure), class: 'fr-btn', id: 'publish-procedure-link', data: { disable_with: "Publication..." }, disabled: !@procedure.draft_revision.valid?, method: :get
           %li= button_to "Réinitialiser les modifications", admin_procedure_reset_draft_path(@procedure), class: 'fr-btn fr-btn--secondary fr-mr-2w', data: { confirm: 'Êtes-vous sûr de vouloir réinitialiser les modifications ?' }, method: :put
 
 - if !@procedure.procedure_expires_when_termine_enabled?

--- a/config/locales/views/administrateurs/procedures/en.yml
+++ b/config/locales/views/administrateurs/procedures/en.yml
@@ -22,6 +22,9 @@ en:
           other: "%{count} files « instructing » on this procedure version."
       publication:
         publish_title: Publish your procedure
+        confirmation: Your procedure is now published !
+        copy_url: Copy procedure URL
+        share_link: "To share your procedure, always use the full link below:"
         closed_procedure_html: "This procedure is <strong>closed</strong> and is therefore no longer accessible to the public. You can publish it back"
         draft_changed_procedure_html: "This procedure is already <strong>published</strong>. It has been <strong>edited</strong> since publication. You can publish the changes made in a new version."
         published_procedure_html: "This procedure is <strong>published</strong>, some elements can no longer be modified. To access it you can use the link:"
@@ -34,6 +37,7 @@ en:
         dubious_fields: "Please note that some fields cannot be requested by the administration. Here are the fields that look suspicious to us:"
         click_here: Click here
         back_to_procedure: Return to the procedure page
+        new_procedure: Create a new procedure
       publication_form:
         faq_test_alert: Have you thought about testing your procedure before publishing it? To help you in this test phase, you can
         faq_test_alert_link: consult our best practices guide.

--- a/config/locales/views/administrateurs/procedures/fr.yml
+++ b/config/locales/views/administrateurs/procedures/fr.yml
@@ -22,6 +22,9 @@ fr:
           other: Il y a %{count} dossiers « en instruction » sur cette version de la démarche.
       publication:
         publish_title: Publier votre démarche
+        confirmation: Votre démarche est désormais publiée !
+        copy_url: Copiez le lien de la procédure
+        share_link: "Pour partager votre démarche, utilisez toujours le lien complet ci-dessous :"
         closed_procedure_html: "Cette démarche est <strong>close</strong> et n’est donc plus accessible par le public. Vous pouvez la réactiver :"
         draft_changed_procedure_html: "Cette démarche est déjà <strong>publiée</strong>. Elle a été <strong>modifiée</strong> depuis sa publication. Vous pouvez publier les changements effectués dans une nouvelle version de cette démarche :"
         published_procedure_html: "Cette démarche est <strong>publiée</strong>, certains éléments ne peuvent plus être modifiés. Pour y accéder vous pouvez utiliser le lien :"
@@ -34,6 +37,7 @@ fr:
         dubious_fields: "Attention, certains champs ne peuvent être demandés par l’administration. Voici les champs qui nous semblent suspects :"
         click_here: Cliquez ici.
         back_to_procedure: Revenir à la page de la démarche
+        new_procedure: Créer une nouvelle démarche
       publication_form:
         faq_test_alert: Avez-vous bien pensé à tester votre démarche avant de la publier ? Pour vous aider dans cette phase de test, vous pouvez
         faq_test_alert_link: consulter notre guide de bonnes pratiques.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -554,8 +554,10 @@ Rails.application.routes.draw do
       get 'publication' => 'procedures#publication', as: :publication
       put 'publish' => 'procedures#publish', as: :publish
       put 'reset_draft' => 'procedures#reset_draft', as: :reset_draft
+      put 'publish_revision' => 'procedures#publish_revision', as: :publish_revision
       get 'transfert' => 'procedures#transfert', as: :transfert
       get 'close' => 'procedures#close', as: :close
+      get 'confirmation' => 'procedures#confirmation', as: :confirmation
       post 'transfer' => 'procedures#transfer', as: :transfer
       resources :mail_templates, only: [:edit, :update, :show]
 

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -965,10 +965,9 @@ describe Administrateurs::ProceduresController, type: :controller do
           expect(procedure.lien_site_web).to eq(lien_site_web)
         end
 
-        it 'redirects to the procedure page' do
+        it 'redirects to the confirmation page' do
           expect(response.status).to eq 302
-          expect(response.body).to include(admin_procedure_path(procedure.id))
-          expect(flash[:notice]).to have_content 'Démarche publiée'
+          expect(response.body).to include(admin_procedure_confirmation_path(procedure.id))
         end
       end
 
@@ -992,10 +991,9 @@ describe Administrateurs::ProceduresController, type: :controller do
           expect(procedure2.depubliee?).to be_truthy
         end
 
-        it 'redirects to the procedures page' do
+        it 'redirects to the confirmation page' do
           expect(response.status).to eq 302
-          expect(response.body).to include(admin_procedure_path(procedure.id))
-          expect(flash[:notice]).to have_content 'Démarche publiée'
+          expect(response.body).to include(admin_procedure_confirmation_path(procedure.id))
         end
       end
 

--- a/spec/system/administrateurs/procedure_attestation_template_spec.rb
+++ b/spec/system/administrateurs/procedure_attestation_template_spec.rb
@@ -45,6 +45,7 @@ describe 'As an administrateur, I want to manage the procedure’s attestation',
       click_on("Publier")
       # validate publication
       within('form') { click_on 'Publier' }
+      click_on("Revenir à la page de la démarche")
 
       # now process to disable attestation
       find_attestation_card.click

--- a/spec/system/administrateurs/procedure_publish_spec.rb
+++ b/spec/system/administrateurs/procedure_publish_spec.rb
@@ -43,7 +43,8 @@ describe 'Publishing a procedure', js: true, retry: 3 do
       fill_in 'lien_site_web', with: 'http://some.website'
       within('form') { click_on 'Publier' }
 
-      expect(page).to have_text('Démarche publiée')
+      expect(page).to have_text('Votre démarche est désormais publiée !')
+      expect(page).to have_button(title: 'Copiez le lien de la procédure')
     end
 
     context 'when the procedure has invalid champs' do
@@ -91,7 +92,7 @@ describe 'Publishing a procedure', js: true, retry: 3 do
       fill_in 'lien_site_web', with: 'http://some.website'
       click_on 'publish'
 
-      expect(page).to have_text('Démarche publiée')
+      expect(page).to have_text('Votre démarche est désormais publiée !')
     end
   end
 
@@ -122,7 +123,7 @@ describe 'Publishing a procedure', js: true, retry: 3 do
       fill_in 'lien_site_web', with: 'http://some.website'
       find('#publish').click
 
-      expect(page).to have_text('Démarche publiée')
+      expect(page).to have_text('Votre démarche est désormais publiée !')
     end
   end
 

--- a/spec/system/api_particulier/api_particulier_spec.rb
+++ b/spec/system/api_particulier/api_particulier_spec.rb
@@ -230,7 +230,7 @@ describe 'fetch API Particulier Data', js: true, retry: 3 do
       fill_in 'lien_site_web', with: 'http://some.website'
       within('form') { click_on 'Publier' }
 
-      expect(page).to have_text('Démarche publiée')
+      expect(page).to have_text('Votre démarche est désormais publiée !')
     end
   end
 

--- a/spec/system/routing/rules_full_scenario_spec.rb
+++ b/spec/system/routing/rules_full_scenario_spec.rb
@@ -254,7 +254,7 @@ describe 'The routing with rules', js: true, retry: 3 do
     fill_in 'lien_site_web', with: 'http://some.website'
     within('form') { click_on 'Publier' }
 
-    expect(page).to have_text('Démarche publiée')
+    expect(page).to have_text('Votre démarche est désormais publiée !')
   end
 
   def user_send_dossier(user, groupe)


### PR DESCRIPTION
closes #9498 
<img width="1228" alt="Capture d’écran 2023-11-06 à 17 43 59" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/69322f09-8a65-4766-8b95-6c9b9d372385">

Lorsqu'une demarche est publiée et qu'on apporte des modifications on ne passe plus par la page de "publication" (la démarche est déja publiée), il y a par contre un message de confirmation pour plus de sécurité.
(Si on apporte des modifications à une procedure close - on continue de passer par la page de publication)


<img width="1401" alt="Capture d’écran 2023-11-08 à 10 43 39" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/96b4c6bd-64a6-4bda-8d6d-2aa979517078">
<img width="1360" alt="Capture d’écran 2023-11-08 à 10 43 46" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/2463fdef-46e7-44b8-8afd-b79e34f9ca9b">
 un 

