### PR TITLE
ETQ Instructeur les urls de mes messages dans la messagerie sont converties en lien

### DIFF
--- a/app/components/dossiers/message_component/message_component.html.haml
+++ b/app/components/dossiers/message_component/message_component.html.haml
@@ -17,7 +17,7 @@
     - elsif commentaire.sent_by_system?
       = sanitize(commentaire.body, scrubber: Sanitizers::MailScrubber.new)
     - else
-      = render SimpleFormatComponent.new(commentaire.body, allow_a: false)
+      = render SimpleFormatComponent.new(commentaire.body, allow_a: false, allow_autolink: commentaire.sent_by_instructeur?)
 
 
   .message-extras.flex.justify-start

--- a/app/components/simple_format_component/simple_format_component.html.haml
+++ b/app/components/simple_format_component/simple_format_component.html.haml
@@ -1,1 +1,1 @@
-= sanitize(@renderer.render(@text), tags:, attributes:)
+= autolink(sanitize(@renderer.render(@text), tags:, attributes:)).html_safe

--- a/spec/components/dossiers/message_component_spec.rb
+++ b/spec/components/dossiers/message_component_spec.rb
@@ -97,6 +97,11 @@ RSpec.describe Dossiers::MessageComponent, type: :component do
         it { is_expected.not_to have_selector("form[action=\"#{form_url}\"]") }
       end
     end
+
+    describe 'autolink simple urls' do
+      let(:commentaire) { create(:commentaire, instructeur: instructeur, body: "rdv sur https://demarches.gouv.fr") }
+      it { is_expected.to have_link("https://demarches.gouv.fr", href: "https://demarches.gouv.fr") }
+    end
   end
 
   describe '#commentaire_from_guest?' do


### PR DESCRIPTION
Closes #9541

![Capture d’écran 2023-11-06 à 19 02 28](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/535a4d07-0fbb-4c4d-8a23-8b313d822710)

Par contre pour limiter les risques de phishing, on n'autorise toujours pas les liens html/markdown.
