### PR TITLE
Tech: synchronize schema.rb

### DIFF
--- a/.github/workflows/rails_schema_check.yml
+++ b/.github/workflows/rails_schema_check.yml
@@ -1,0 +1,42 @@
+name: Rails Schema Check
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'db/migrate/**'
+      - 'db/schema.rb'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'db/migrate/**'
+      - 'db/schema.rb'
+
+jobs:
+  check-migration-and-schema:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 2  # Fetch the last 2 commits to be able to compare with the base branch
+
+    - name: Check for migration and schema.rb changes
+      run: |
+        #!/bin/bash
+        set -e
+
+        latest_migration_file=$(ls -v db/migrate/*.rb | tail -n 1)
+        latest_migration_version=$(basename $latest_migration_file | grep -oE '^[0-9]+')
+
+        # Get the schema version, without underscores
+        schema_version=$(grep -oE 'define.version: [0-9_]+' db/schema.rb | cut -d ' ' -f 2 | tr -d _)
+
+        if [ "$latest_migration_version" != "$schema_version" ]; then
+          echo "schema.rb version does not match the latest migration version. Have you forgotten to update the schema.rb?"
+          echo "            SCHEMA VERSION = $schema_version (config/schema.rb)"
+          echo "  LATEST MIGRATION VERSION = $latest_migration_version ($latest_migration_file)"
+          exit 1
+        fi
+

--- a/db/migrate/20230929091948_add_ancestry_to_groupe_gestionnaires.rb
+++ b/db/migrate/20230929091948_add_ancestry_to_groupe_gestionnaires.rb
@@ -1,4 +1,4 @@
-class AddAncestryToGroupeGestionnaires < ActiveRecord::Migration[6.1]
+class AddAncestryToGroupeGestionnaires < ActiveRecord::Migration[7.0]
   disable_ddl_transaction!
 
   def change

--- a/db/migrate/20231010083144_add_instructeur_foreign_key_to_exports.rb
+++ b/db/migrate/20231010083144_add_instructeur_foreign_key_to_exports.rb
@@ -1,11 +1,17 @@
 class AddInstructeurForeignKeyToExports < ActiveRecord::Migration[7.0]
   disable_ddl_transaction!
 
-  def change
+  def up
     # Foreign keys were already added on developer machines, but timeouted in production.
     if !foreign_key_exists?(:exports, :instructeurs)
       add_foreign_key :exports, :instructeurs, validate: false
       validate_foreign_key :exports, :instructeurs
+    end
+  end
+
+  def down
+    if foreign_key_exists?(:exports, :instructeurs)
+      remove_foreign_key :exports, :instructeurs
     end
   end
 end

--- a/db/migrate/20231108120254_add_missing_exports_instructeur_index.rb
+++ b/db/migrate/20231108120254_add_missing_exports_instructeur_index.rb
@@ -1,0 +1,15 @@
+class AddMissingExportsInstructeurIndex < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    if !index_exists?(:exports, :instructeur_id) # index may have already been added on other environments by a previous migration
+      add_index :exports, :instructeur_id, algorithm: :concurrently
+    end
+  end
+
+  def down
+    if index_exists?(:exports, :instructeur_id)
+      remove_index :exports, :instructeur_id
+    end
+  end
+end

--- a/db/migrate/20231108120731_add_missing_administrateurs_groupe_gestionnaire_index.rb
+++ b/db/migrate/20231108120731_add_missing_administrateurs_groupe_gestionnaire_index.rb
@@ -1,0 +1,15 @@
+class AddMissingAdministrateursGroupeGestionnaireIndex < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    if !index_exists?(:administrateurs, :groupe_gestionnaire_id) # index may have already been added on other environments by a previous migration
+      add_index :administrateurs, :groupe_gestionnaire_id, algorithm: :concurrently
+    end
+  end
+
+  def down
+    if index_exists?(:administrateurs, :groupe_gestionnaire_id)
+      remove_index :administrateurs, :groupe_gestionnaire_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,17 +19,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
 
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", precision: nil, null: false
     t.string "name", null: false
     t.bigint "record_id", null: false
     t.string "record_type", null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
   end
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", precision: nil, null: false
     t.string "name", null: false
     t.bigint "record_id", null: false
     t.string "record_type", null: false
@@ -41,15 +41,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
     t.bigint "byte_size", null: false
     t.string "checksum"
     t.string "content_type"
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", precision: nil, null: false
     t.string "filename", null: false
     t.string "key", null: false
     t.integer "lock_version"
     t.text "metadata"
     t.string "service_name", null: false
     t.string "virus_scan_result"
-    t.datetime "virus_scanned_at", precision: 6
-    t.datetime "watermarked_at", precision: 6
+    t.datetime "virus_scanned_at", precision: nil
+    t.datetime "watermarked_at", precision: nil
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
     t.index ["virus_scan_result"], name: "index_active_storage_blobs_on_virus_scan_result"
   end
@@ -61,9 +61,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
   end
 
   create_table "administrateurs", id: :serial, force: :cascade do |t|
-    t.datetime "created_at", precision: 6
+    t.datetime "created_at", precision: nil
     t.bigint "groupe_gestionnaire_id"
-    t.datetime "updated_at", precision: 6
+    t.datetime "updated_at", precision: nil
     t.bigint "user_id", null: false
     t.index ["groupe_gestionnaire_id"], name: "index_administrateurs_on_groupe_gestionnaire_id"
     t.index ["user_id"], name: "index_administrateurs_on_user_id"
@@ -71,9 +71,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
 
   create_table "administrateurs_instructeurs", id: false, force: :cascade do |t|
     t.integer "administrateur_id", null: false
-    t.datetime "created_at", precision: 6
+    t.datetime "created_at", precision: nil
     t.integer "instructeur_id", null: false
-    t.datetime "updated_at", precision: 6
+    t.datetime "updated_at", precision: nil
     t.index ["administrateur_id"], name: "index_administrateurs_instructeurs_on_administrateur_id"
     t.index ["instructeur_id", "administrateur_id"], name: "unique_couple_administrateur_instructeur", unique: true
     t.index ["instructeur_id"], name: "index_administrateurs_instructeurs_on_instructeur_id"
@@ -81,10 +81,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
 
   create_table "administrateurs_procedures", id: false, force: :cascade do |t|
     t.bigint "administrateur_id", null: false
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", precision: nil, null: false
     t.boolean "manager"
     t.bigint "procedure_id", null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["administrateur_id", "procedure_id"], name: "index_unique_admin_proc_couple", unique: true
     t.index ["administrateur_id"], name: "index_administrateurs_procedures_on_administrateur_id"
     t.index ["procedure_id"], name: "index_administrateurs_procedures_on_procedure_id"
@@ -93,38 +93,38 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
   create_table "api_tokens", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.bigint "administrateur_id", null: false
     t.bigint "allowed_procedure_ids", array: true
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", null: false
     t.string "encrypted_token", null: false
     t.datetime "last_v1_authenticated_at"
     t.datetime "last_v2_authenticated_at"
     t.string "name", null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", null: false
     t.integer "version", default: 3, null: false
     t.boolean "write_access", default: true, null: false
     t.index ["administrateur_id"], name: "index_api_tokens_on_administrateur_id"
   end
 
   create_table "archives", force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", null: false
     t.string "job_status", null: false
     t.text "key", null: false
     t.date "month"
     t.string "time_span_type", null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", null: false
     t.index ["key", "time_span_type", "month"], name: "index_archives_on_key_and_time_span_type_and_month", unique: true
   end
 
   create_table "archives_groupe_instructeurs", force: :cascade do |t|
     t.bigint "archive_id", null: false
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", null: false
     t.bigint "groupe_instructeur_id", null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", null: false
     t.index ["archive_id"], name: "index_archives_groupe_instructeurs_on_archive_id"
     t.index ["groupe_instructeur_id"], name: "index_archives_groupe_instructeurs_on_groupe_instructeur_id"
   end
 
   create_table "assign_tos", id: :serial, force: :cascade do |t|
-    t.datetime "created_at", precision: 6
+    t.datetime "created_at", precision: nil
     t.boolean "daily_email_notifications_enabled", default: false, null: false
     t.bigint "groupe_instructeur_id"
     t.boolean "instant_email_dossier_notifications_enabled", default: false, null: false
@@ -132,7 +132,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
     t.boolean "instant_expert_avis_email_notifications_enabled", default: false
     t.integer "instructeur_id"
     t.boolean "manager", default: false
-    t.datetime "updated_at", precision: 6
+    t.datetime "updated_at", precision: nil
     t.boolean "weekly_email_notifications_enabled", default: true, null: false
     t.index ["groupe_instructeur_id", "instructeur_id"], name: "unique_couple_groupe_instructeur_instructeur", unique: true
     t.index ["groupe_instructeur_id"], name: "index_assign_tos_on_groupe_instructeur_id"
@@ -143,20 +143,20 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
   create_table "attestation_templates", id: :serial, force: :cascade do |t|
     t.boolean "activated"
     t.text "body"
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", precision: nil, null: false
     t.text "footer"
     t.jsonb "json_body"
     t.integer "procedure_id"
     t.text "title"
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["procedure_id"], name: "index_attestation_templates_on_procedure_id", unique: true
   end
 
   create_table "attestations", id: :serial, force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", precision: nil, null: false
     t.integer "dossier_id", null: false
     t.string "title"
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["dossier_id"], name: "index_attestations_on_dossier_id", unique: true
   end
 
@@ -165,55 +165,55 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
     t.integer "claimant_id", null: false
     t.string "claimant_type"
     t.boolean "confidentiel", default: false, null: false
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", precision: nil, null: false
     t.integer "dossier_id"
     t.string "email"
     t.bigint "experts_procedure_id"
     t.text "introduction"
     t.boolean "question_answer"
     t.string "question_label"
-    t.datetime "reminded_at", precision: 6
-    t.datetime "revoked_at", precision: 6
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "reminded_at", precision: nil
+    t.datetime "revoked_at", precision: nil
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["claimant_id"], name: "index_avis_on_claimant_id"
     t.index ["dossier_id"], name: "index_avis_on_dossier_id"
     t.index ["experts_procedure_id"], name: "index_avis_on_experts_procedure_id"
   end
 
   create_table "batch_operations", force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", null: false
     t.bigint "failed_dossier_ids", default: [], null: false, array: true
-    t.datetime "finished_at", precision: 6
+    t.datetime "finished_at", precision: nil
     t.bigint "instructeur_id", null: false
     t.string "operation", null: false
     t.jsonb "payload", default: {}, null: false
-    t.datetime "run_at", precision: 6
-    t.datetime "seen_at", precision: 6
+    t.datetime "run_at", precision: nil
+    t.datetime "seen_at", precision: nil
     t.bigint "success_dossier_ids", default: [], null: false, array: true
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "batch_operations_groupe_instructeurs", force: :cascade do |t|
     t.bigint "batch_operation_id", null: false
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", null: false
     t.bigint "groupe_instructeur_id", null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "bill_signatures", force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", precision: nil, null: false
     t.string "digest"
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", precision: nil, null: false
   end
 
   create_table "bulk_messages", force: :cascade do |t|
     t.text "body", null: false
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", null: false
     t.integer "dossier_count"
     t.string "dossier_state"
     t.bigint "instructeur_id", null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "sent_at", precision: 6, null: false
+    t.datetime "sent_at", precision: nil, null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "bulk_messages_groupe_instructeurs", id: false, force: :cascade do |t|
@@ -225,7 +225,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
   end
 
   create_table "champs", id: :serial, force: :cascade do |t|
-    t.datetime "created_at", precision: 6
+    t.datetime "created_at", precision: nil
     t.jsonb "data"
     t.integer "dossier_id"
     t.integer "etablissement_id"
@@ -234,11 +234,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
     t.bigint "parent_id"
     t.boolean "prefilled"
     t.boolean "private", default: false, null: false
-    t.datetime "rebased_at", precision: 6
+    t.datetime "rebased_at", precision: nil
     t.string "row_id"
     t.string "type"
     t.integer "type_de_champ_id"
-    t.datetime "updated_at", precision: 6
+    t.datetime "updated_at", precision: nil
     t.string "value"
     t.jsonb "value_json"
     t.index ["dossier_id"], name: "index_champs_on_dossier_id"
@@ -253,25 +253,38 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
 
   create_table "closed_mails", id: :serial, force: :cascade do |t|
     t.text "body"
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", precision: nil, null: false
     t.integer "procedure_id"
     t.string "subject"
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["procedure_id"], name: "index_closed_mails_on_procedure_id"
   end
 
   create_table "commentaires", id: :serial, force: :cascade do |t|
     t.string "body"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "discarded_at", precision: 6
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "discarded_at", precision: nil
     t.integer "dossier_id"
     t.string "email"
     t.bigint "expert_id"
     t.bigint "instructeur_id"
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["dossier_id"], name: "index_commentaires_on_dossier_id"
     t.index ["expert_id"], name: "index_commentaires_on_expert_id"
     t.index ["instructeur_id"], name: "index_commentaires_on_instructeur_id"
+  end
+
+  create_table "contact_informations", force: :cascade do |t|
+    t.text "adresse", null: false
+    t.datetime "created_at", null: false
+    t.string "email", null: false
+    t.bigint "groupe_instructeur_id", null: false
+    t.text "horaires", null: false
+    t.string "nom", null: false
+    t.string "telephone", null: false
+    t.datetime "updated_at", null: false
+    t.index ["groupe_instructeur_id", "nom"], name: "index_contact_informations_on_gi_and_nom", unique: true
+    t.index ["groupe_instructeur_id"], name: "index_contact_informations_on_groupe_instructeur_id"
   end
 
   create_table "default_zones_administrateurs", id: false, force: :cascade do |t|
@@ -283,30 +296,30 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
 
   create_table "delayed_jobs", id: :serial, force: :cascade do |t|
     t.integer "attempts", default: 0, null: false
-    t.datetime "created_at", precision: 6
+    t.datetime "created_at", precision: nil
     t.string "cron"
-    t.datetime "failed_at", precision: 6
+    t.datetime "failed_at", precision: nil
     t.text "handler", null: false
     t.text "last_error"
-    t.datetime "locked_at", precision: 6
+    t.datetime "locked_at", precision: nil
     t.string "locked_by"
     t.integer "priority", default: 0, null: false
     t.string "queue"
-    t.datetime "run_at", precision: 6
-    t.datetime "updated_at", precision: 6
+    t.datetime "run_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
   create_table "deleted_dossiers", force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "deleted_at", precision: nil
     t.bigint "dossier_id"
     t.bigint "groupe_instructeur_id"
     t.bigint "procedure_id"
     t.string "reason"
     t.bigint "revision_id"
     t.string "state"
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.bigint "user_id"
     t.index ["deleted_at"], name: "index_deleted_dossiers_on_deleted_at"
     t.index ["dossier_id"], name: "index_deleted_dossiers_on_dossier_id", unique: true
@@ -327,21 +340,21 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
 
   create_table "dossier_batch_operations", force: :cascade do |t|
     t.bigint "batch_operation_id", null: false
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", null: false
     t.bigint "dossier_id", null: false
     t.string "state", default: "pending", null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", null: false
     t.index ["batch_operation_id"], name: "index_dossier_batch_operations_on_batch_operation_id"
     t.index ["dossier_id"], name: "index_dossier_batch_operations_on_dossier_id"
   end
 
   create_table "dossier_corrections", force: :cascade do |t|
     t.bigint "commentaire_id"
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", null: false
     t.bigint "dossier_id", null: false
-    t.datetime "resolved_at", precision: 6
-    t.datetime "updated_at", precision: 6, null: false
     t.string "reason", default: "incorrect", null: false
+    t.datetime "resolved_at"
+    t.datetime "updated_at", null: false
     t.index ["commentaire_id"], name: "index_dossier_corrections_on_commentaire_id"
     t.index ["dossier_id"], name: "index_dossier_corrections_on_dossier_id"
     t.index ["resolved_at"], name: "index_dossier_corrections_on_resolved_at", where: "((resolved_at IS NULL) OR (resolved_at IS NOT NULL))"
@@ -350,87 +363,86 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
   create_table "dossier_operation_logs", force: :cascade do |t|
     t.boolean "automatic_operation", default: false, null: false
     t.bigint "bill_signature_id"
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", precision: nil, null: false
     t.jsonb "data"
     t.text "digest"
     t.bigint "dossier_id"
-    t.datetime "executed_at", precision: 6
-    t.datetime "keep_until", precision: 6
+    t.datetime "executed_at", precision: nil
+    t.datetime "keep_until", precision: nil
     t.string "operation", null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["bill_signature_id"], name: "index_dossier_operation_logs_on_bill_signature_id"
     t.index ["dossier_id"], name: "index_dossier_operation_logs_on_dossier_id"
     t.index ["keep_until"], name: "index_dossier_operation_logs_on_keep_until"
   end
 
   create_table "dossier_submitted_messages", force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", null: false
     t.string "message_on_submit_by_usager"
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "dossier_transfer_logs", force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", null: false
     t.bigint "dossier_id", null: false
     t.string "from", null: false
     t.string "to", null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", null: false
     t.index ["dossier_id"], name: "index_dossier_transfer_logs_on_dossier_id"
   end
 
   create_table "dossier_transfers", force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", null: false
     t.string "email", null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", null: false
     t.index ["email"], name: "index_dossier_transfers_on_email"
   end
 
   create_table "dossiers", id: :serial, force: :cascade do |t|
     t.string "api_entreprise_job_exceptions", array: true
     t.boolean "archived", default: false
-    t.datetime "archived_at", precision: 6
+    t.datetime "archived_at", precision: nil
     t.string "archived_by"
     t.boolean "autorisation_donnees"
     t.bigint "batch_operation_id"
-    t.datetime "brouillon_close_to_expiration_notice_sent_at", precision: 6
+    t.datetime "brouillon_close_to_expiration_notice_sent_at", precision: nil
     t.interval "conservation_extension", default: "PT0S"
-    t.datetime "created_at", precision: 6
-    t.datetime "declarative_triggered_at", precision: 6
+    t.datetime "created_at", precision: nil
+    t.datetime "declarative_triggered_at", precision: nil
     t.string "deleted_user_email_never_send"
-    t.datetime "depose_at", precision: 6
+    t.datetime "depose_at", precision: nil
     t.bigint "dossier_transfer_id"
     t.bigint "editing_fork_origin_id"
-    t.datetime "en_construction_at", precision: 6
-    t.datetime "en_construction_close_to_expiration_notice_sent_at", precision: 6
-    t.datetime "en_instruction_at", precision: 6
+    t.datetime "en_construction_at", precision: nil
+    t.datetime "en_construction_close_to_expiration_notice_sent_at", precision: nil
+    t.datetime "en_instruction_at", precision: nil
     t.boolean "for_procedure_preview", default: false, null: false
     t.boolean "forced_groupe_instructeur", default: false, null: false
     t.bigint "groupe_instructeur_id"
-    t.datetime "groupe_instructeur_updated_at", precision: 6
-    t.datetime "hidden_at", precision: 6
-    t.datetime "hidden_by_administration_at", precision: 6
+    t.datetime "groupe_instructeur_updated_at", precision: nil
+    t.datetime "hidden_at", precision: nil
+    t.datetime "hidden_by_administration_at", precision: nil
     t.string "hidden_by_reason"
-    t.datetime "hidden_by_user_at", precision: 6
-    t.datetime "identity_updated_at", precision: 6
-    t.datetime "last_avis_updated_at", precision: 6
-    t.datetime "last_champ_private_updated_at", precision: 6
-    t.datetime "last_champ_updated_at", precision: 6
-    t.datetime "last_commentaire_updated_at", precision: 6
-    t.boolean "migrated_champ_routage"
+    t.datetime "hidden_by_user_at", precision: nil
+    t.datetime "identity_updated_at", precision: nil
+    t.datetime "last_avis_updated_at", precision: nil
+    t.datetime "last_champ_private_updated_at", precision: nil
+    t.datetime "last_champ_updated_at", precision: nil
+    t.datetime "last_commentaire_updated_at", precision: nil
     t.text "motivation"
     t.bigint "parent_dossier_id"
     t.string "prefill_token"
     t.boolean "prefilled"
     t.string "private_search_terms"
-    t.datetime "processed_at", precision: 6
+    t.datetime "processed_at", precision: nil
     t.datetime "re_instructed_at"
     t.bigint "revision_id"
     t.string "search_terms"
     t.string "state"
-    t.datetime "termine_close_to_expiration_notice_sent_at", precision: 6
-    t.datetime "updated_at", precision: 6
     t.date "sva_svr_decision_on"
-    t.datetime "sva_svr_decision_triggered_at", precision: 6
+    t.datetime "sva_svr_decision_triggered_at"
+    t.datetime "termine_close_to_expiration_notice_sent_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.integer "user_id"
     t.index ["archived"], name: "index_dossiers_on_archived"
     t.index ["batch_operation_id"], name: "index_dossiers_on_batch_operation_id"
@@ -446,14 +458,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
   end
 
   create_table "email_events", force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", null: false
     t.string "message_id"
     t.string "method", null: false
-    t.datetime "processed_at", precision: 6
+    t.datetime "processed_at", precision: nil
     t.string "status", null: false
     t.string "subject", null: false
     t.string "to", null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "etablissements", id: :serial, force: :cascade do |t|
@@ -467,7 +479,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
     t.string "code_insee_localite"
     t.string "code_postal"
     t.string "complement_adresse"
-    t.datetime "created_at", precision: 6
+    t.datetime "created_at", precision: nil
     t.boolean "diffusable_commercialement"
     t.integer "dossier_id"
     t.string "enseigne"
@@ -499,42 +511,42 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
     t.boolean "siege_social"
     t.string "siret"
     t.string "type_voie"
-    t.datetime "updated_at", precision: 6
+    t.datetime "updated_at", precision: nil
     t.index ["dossier_id"], name: "index_etablissements_on_dossier_id", unique: true
   end
 
   create_table "exercices", id: :serial, force: :cascade do |t|
     t.string "ca"
-    t.datetime "created_at", precision: 6
-    t.datetime "dateFinExercice", precision: 6
-    t.datetime "date_fin_exercice", precision: 6
+    t.datetime "created_at", precision: nil
+    t.datetime "dateFinExercice", precision: nil
+    t.datetime "date_fin_exercice", precision: nil
     t.integer "date_fin_exercice_timestamp"
     t.integer "etablissement_id"
-    t.datetime "updated_at", precision: 6
+    t.datetime "updated_at", precision: nil
     t.index ["etablissement_id"], name: "index_exercices_on_etablissement_id"
   end
 
   create_table "experts", force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_experts_on_user_id"
   end
 
   create_table "experts_procedures", force: :cascade do |t|
     t.boolean "allow_decision_access", default: false, null: false
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", null: false
     t.bigint "expert_id", null: false
     t.bigint "procedure_id", null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "revoked_at", precision: 6
+    t.datetime "revoked_at", precision: nil
+    t.datetime "updated_at", null: false
     t.index ["expert_id", "procedure_id"], name: "index_experts_procedures_on_expert_id_and_procedure_id", unique: true
     t.index ["expert_id"], name: "index_experts_procedures_on_expert_id"
     t.index ["procedure_id"], name: "index_experts_procedures_on_procedure_id"
   end
 
   create_table "exports", force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", precision: nil, null: false
     t.integer "dossiers_count"
     t.string "format", null: false
     t.bigint "instructeur_id"
@@ -544,45 +556,45 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
     t.jsonb "procedure_presentation_snapshot"
     t.string "statut", default: "tous"
     t.string "time_span_type", default: "everything", null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["instructeur_id"], name: "index_exports_on_instructeur_id"
     t.index ["key"], name: "index_exports_on_key"
     t.index ["procedure_presentation_id"], name: "index_exports_on_procedure_presentation_id"
   end
 
   create_table "exports_groupe_instructeurs", force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", precision: nil, null: false
     t.bigint "export_id", null: false
     t.bigint "groupe_instructeur_id", null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "flipper_features", id: false, force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
-    t.bigserial "id", null: false
+  create_table "flipper_features", force: :cascade do |t|
+    t.datetime "created_at", precision: nil, null: false
     t.string "key", null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.index ["key"], name: "index_flipper_features_on_key", unique: true
   end
 
   create_table "flipper_gates", force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", precision: nil, null: false
     t.string "feature_key", null: false
     t.string "key", null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "value"
     t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
   create_table "follows", id: :serial, force: :cascade do |t|
-    t.datetime "annotations_privees_seen_at", precision: 6, null: false
-    t.datetime "avis_seen_at", precision: 6, null: false
-    t.datetime "created_at", precision: 6
-    t.datetime "demande_seen_at", precision: 6, null: false
+    t.datetime "annotations_privees_seen_at", precision: nil, null: false
+    t.datetime "avis_seen_at", precision: nil, null: false
+    t.datetime "created_at", precision: nil
+    t.datetime "demande_seen_at", precision: nil, null: false
     t.integer "dossier_id", null: false
     t.integer "instructeur_id", null: false
-    t.datetime "messagerie_seen_at", precision: 6, null: false
-    t.datetime "unfollowed_at", precision: 6
-    t.datetime "updated_at", precision: 6
+    t.datetime "messagerie_seen_at", precision: nil, null: false
+    t.datetime "unfollowed_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.index ["dossier_id"], name: "index_follows_on_dossier_id"
     t.index ["instructeur_id", "dossier_id", "unfollowed_at"], name: "uniqueness_index", unique: true
     t.index ["instructeur_id"], name: "index_follows_on_instructeur_id"
@@ -592,7 +604,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
   create_table "france_connect_informations", id: :serial, force: :cascade do |t|
     t.date "birthdate"
     t.string "birthplace"
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", precision: nil, null: false
     t.jsonb "data"
     t.string "email_france_connect"
     t.string "family_name"
@@ -600,8 +612,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
     t.string "gender"
     t.string "given_name"
     t.string "merge_token"
-    t.datetime "merge_token_created_at", precision: 6
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "merge_token_created_at", precision: nil
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "user_id"
     t.index ["merge_token"], name: "index_france_connect_informations_on_merge_token"
     t.index ["user_id"], name: "index_france_connect_informations_on_user_id"
@@ -609,27 +621,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
 
   create_table "geo_areas", force: :cascade do |t|
     t.bigint "champ_id"
-    t.datetime "created_at", precision: 6
+    t.datetime "created_at", precision: nil
     t.string "geo_reference_id"
     t.jsonb "geometry"
     t.jsonb "properties"
     t.string "source"
-    t.datetime "updated_at", precision: 6
+    t.datetime "updated_at", precision: nil
     t.index ["champ_id"], name: "index_geo_areas_on_champ_id"
     t.index ["source"], name: "index_geo_areas_on_source"
-  end
-
-  create_table "contact_informations", force: :cascade do |t|
-    t.text "adresse", null: false
-    t.datetime "created_at", null: false
-    t.string "email", null: false
-    t.bigint "groupe_instructeur_id", null: false
-    t.text "horaires", null: false
-    t.string "nom", null: false
-    t.string "telephone", null: false
-    t.datetime "updated_at", null: false
-    t.index ["groupe_instructeur_id", "nom"], name: "index_contact_informations_on_gi_and_nom", unique: true
-    t.index ["groupe_instructeur_id"], name: "index_contact_informations_on_groupe_instructeur_id"
   end
 
   create_table "gestionnaires", force: :cascade do |t|
@@ -659,11 +658,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
 
   create_table "groupe_instructeurs", force: :cascade do |t|
     t.boolean "closed", default: false
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", precision: nil, null: false
     t.text "label", null: false
     t.bigint "procedure_id", null: false
     t.jsonb "routing_rule"
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["closed", "procedure_id"], name: "index_groupe_instructeurs_on_closed_and_procedure_id"
     t.index ["procedure_id", "label"], name: "index_groupe_instructeurs_on_procedure_id_and_label", unique: true
     t.index ["procedure_id"], name: "index_groupe_instructeurs_on_procedure_id"
@@ -671,43 +670,43 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
 
   create_table "individuals", id: :serial, force: :cascade do |t|
     t.date "birthdate"
-    t.datetime "created_at", precision: 6
+    t.datetime "created_at", precision: nil
     t.integer "dossier_id"
     t.string "gender"
     t.string "nom"
     t.string "prenom"
-    t.datetime "updated_at", precision: 6
+    t.datetime "updated_at", precision: nil
     t.index ["dossier_id"], name: "index_individuals_on_dossier_id", unique: true
   end
 
   create_table "initiated_mails", id: :serial, force: :cascade do |t|
     t.text "body"
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", precision: nil, null: false
     t.integer "procedure_id"
     t.string "subject"
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["procedure_id"], name: "index_initiated_mails_on_procedure_id"
   end
 
   create_table "instructeurs", id: :serial, force: :cascade do |t|
     t.string "agent_connect_id"
     t.boolean "bypass_email_login_token", default: false, null: false
-    t.datetime "created_at", precision: 6
+    t.datetime "created_at", precision: nil
     t.text "encrypted_login_token"
-    t.datetime "login_token_created_at", precision: 6
-    t.datetime "updated_at", precision: 6
+    t.datetime "login_token_created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.bigint "user_id", null: false
     t.index ["agent_connect_id"], name: "index_instructeurs_on_agent_connect_id", unique: true
     t.index ["user_id"], name: "index_instructeurs_on_user_id"
   end
 
   create_table "invites", id: :serial, force: :cascade do |t|
-    t.datetime "created_at", precision: 6
+    t.datetime "created_at", precision: nil
     t.integer "dossier_id"
     t.string "email"
     t.string "email_sender"
     t.text "message"
-    t.datetime "updated_at", precision: 6
+    t.datetime "updated_at", precision: nil
     t.integer "user_id"
     t.index ["dossier_id"], name: "index_invites_on_dossier_id"
     t.index ["email", "dossier_id"], name: "index_invites_on_email_and_dossier_id", unique: true
@@ -735,42 +734,42 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
   end
 
   create_table "merge_logs", force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", null: false
     t.string "from_user_email", null: false
     t.bigint "from_user_id", null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_merge_logs_on_user_id"
   end
 
   create_table "module_api_cartos", id: :serial, force: :cascade do |t|
     t.boolean "cadastre", default: false
-    t.datetime "created_at", precision: 6
+    t.datetime "created_at", precision: nil
     t.boolean "migrated"
     t.integer "procedure_id"
     t.boolean "quartiers_prioritaires", default: false
-    t.datetime "updated_at", precision: 6
+    t.datetime "updated_at", precision: nil
     t.boolean "use_api_carto", default: false
     t.index ["procedure_id"], name: "index_module_api_cartos_on_procedure_id", unique: true
   end
 
   create_table "procedure_presentations", id: :serial, force: :cascade do |t|
     t.integer "assign_to_id"
-    t.datetime "created_at", precision: 6
-    t.jsonb "displayed_fields", default: [{ "label" => "Demandeur", "table" => "user", "column" => "email" }], null: false
-    t.jsonb "filters", default: { "tous" => [], "suivis" => [], "traites" => [], "a-suivre" => [], "archives" => [], "expirant" => [], "supprimes_recemment" => [] }, null: false
-    t.jsonb "sort", default: { "order" => "desc", "table" => "notifications", "column" => "notifications" }, null: false
-    t.datetime "updated_at", precision: 6
+    t.datetime "created_at", precision: nil
+    t.jsonb "displayed_fields", default: [{"label"=>"Demandeur", "table"=>"user", "column"=>"email"}], null: false
+    t.jsonb "filters", default: {"tous"=>[], "suivis"=>[], "traites"=>[], "a-suivre"=>[], "archives"=>[], "expirant"=>[], "supprimes_recemment"=>[]}, null: false
+    t.jsonb "sort", default: {"order"=>"desc", "table"=>"notifications", "column"=>"notifications"}, null: false
+    t.datetime "updated_at", precision: nil
     t.index ["assign_to_id"], name: "index_procedure_presentations_on_assign_to_id", unique: true
   end
 
   create_table "procedure_revision_types_de_champ", force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", precision: nil, null: false
     t.bigint "parent_id"
     t.integer "position", null: false
     t.bigint "revision_id", null: false
     t.bigint "type_de_champ_id", null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["parent_id"], name: "index_procedure_revision_types_de_champ_on_parent_id"
     t.index ["revision_id"], name: "index_procedure_revision_types_de_champ_on_revision_id"
     t.index ["type_de_champ_id"], name: "index_procedure_revision_types_de_champ_on_type_de_champ_id"
@@ -778,12 +777,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
 
   create_table "procedure_revisions", force: :cascade do |t|
     t.bigint "attestation_template_id"
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", precision: nil, null: false
     t.bigint "dossier_submitted_message_id"
-    t.boolean "migrated_champ_routage"
     t.bigint "procedure_id", null: false
-    t.datetime "published_at", precision: 6
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "published_at", precision: nil
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["attestation_template_id"], name: "index_procedure_revisions_on_attestation_template_id"
     t.index ["dossier_submitted_message_id"], name: "index_procedure_revisions_on_dossier_submitted_message_id"
     t.index ["procedure_id"], name: "index_procedure_revisions_on_procedure_id"
@@ -803,15 +801,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
     t.boolean "cerfa_flag", default: false
     t.jsonb "chorus", default: {}, null: false
     t.boolean "cloned_from_library", default: false
-    t.datetime "closed_at", precision: 6
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "closed_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
     t.string "declarative_with_state"
     t.bigint "defaut_groupe_instructeur_id"
     t.string "description"
     t.string "description_pj"
     t.string "description_target_audience"
     t.string "direction"
-    t.datetime "dossiers_count_computed_at", precision: 6
+    t.datetime "dossiers_count_computed_at", precision: nil
     t.bigint "draft_revision_id"
     t.integer "duree_conservation_dossiers_dans_ds"
     t.boolean "duree_conservation_etendue_par_ds", default: false, null: false
@@ -822,8 +820,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
     t.boolean "euro_flag", default: false
     t.boolean "experts_require_administrateur_invitation", default: false
     t.boolean "for_individual", default: false
-    t.datetime "hidden_at", precision: 6
-    t.datetime "hidden_at_as_template", precision: 6
+    t.datetime "hidden_at", precision: nil
+    t.datetime "hidden_at_as_template", precision: nil
     t.boolean "instructeurs_self_management_enabled"
     t.boolean "juridique_required", default: true
     t.string "libelle"
@@ -834,7 +832,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
     t.text "lien_notice_error"
     t.string "lien_site_web"
     t.integer "max_duree_conservation_dossiers_dans_ds", default: 12, null: false
-    t.boolean "migrated_champ_routage"
     t.text "monavis_embed"
     t.boolean "opendata", default: true
     t.string "organisation"
@@ -842,18 +839,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
     t.string "path", null: false
     t.boolean "piece_justificative_multiple", default: true, null: false
     t.boolean "procedure_expires_when_termine_enabled", default: true
-    t.datetime "published_at", precision: 6
+    t.datetime "published_at", precision: nil
     t.bigint "published_revision_id"
     t.bigint "replaced_by_procedure_id"
     t.boolean "routing_enabled"
     t.bigint "service_id"
     t.jsonb "sva_svr", default: {}, null: false
     t.text "tags", default: [], array: true
-    t.datetime "test_started_at", precision: 6
-    t.datetime "unpublished_at", precision: 6
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "test_started_at", precision: nil
+    t.datetime "unpublished_at", precision: nil
+    t.datetime "updated_at", precision: nil, null: false
     t.string "web_hook_url"
-    t.datetime "whitelisted_at", precision: 6
+    t.datetime "whitelisted_at", precision: nil
     t.bigint "zone_id"
     t.index ["api_particulier_sources"], name: "index_procedures_on_api_particulier_sources", using: :gin
     t.index ["declarative_with_state"], name: "index_procedures_on_declarative_with_state"
@@ -872,9 +869,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
   end
 
   create_table "procedures_zones", id: false, force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", null: false
     t.bigint "procedure_id"
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", null: false
     t.bigint "zone_id"
     t.index ["procedure_id"], name: "index_procedures_zones_on_procedure_id"
     t.index ["zone_id"], name: "index_procedures_zones_on_zone_id"
@@ -900,10 +897,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
 
   create_table "refused_mails", id: :serial, force: :cascade do |t|
     t.text "body"
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", precision: nil, null: false
     t.integer "procedure_id"
     t.string "subject"
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["procedure_id"], name: "index_refused_mails_on_procedure_id"
   end
 
@@ -919,15 +916,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
   end
 
   create_table "safe_mailers", force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", null: false
     t.string "forced_delivery_method"
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "services", force: :cascade do |t|
     t.bigint "administrateur_id"
     t.text "adresse"
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", precision: nil, null: false
     t.string "departement"
     t.string "email"
     t.jsonb "etablissement_infos", default: {}
@@ -939,7 +936,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
     t.string "siret"
     t.string "telephone"
     t.string "type_organisme", null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["administrateur_id", "nom"], name: "index_services_on_administrateur_id_and_nom", unique: true
     t.index ["administrateur_id"], name: "index_services_on_administrateur_id"
     t.index ["departement"], name: "index_services_on_departement"
@@ -947,7 +944,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
 
   create_table "stats", force: :cascade do |t|
     t.bigint "administrations_partenaires", default: 0
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", null: false
     t.bigint "dossiers_brouillon", default: 0
     t.jsonb "dossiers_cumulative", default: "{}", null: false
     t.bigint "dossiers_depose_avant_30_jours", default: 0
@@ -957,13 +954,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
     t.jsonb "dossiers_in_the_last_4_months", default: "{}", null: false
     t.bigint "dossiers_not_brouillon", default: 0
     t.bigint "dossiers_termines", default: 0
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "super_admins", id: :serial, force: :cascade do |t|
     t.integer "consumed_timestep"
-    t.datetime "created_at", precision: 6
-    t.datetime "current_sign_in_at", precision: 6
+    t.datetime "created_at", precision: nil
+    t.datetime "current_sign_in_at", precision: nil
     t.string "current_sign_in_ip"
     t.string "email", default: "", null: false
     t.string "encrypted_otp_secret"
@@ -971,28 +968,28 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
     t.string "encrypted_otp_secret_salt"
     t.string "encrypted_password", default: "", null: false
     t.integer "failed_attempts", default: 0, null: false
-    t.datetime "last_sign_in_at", precision: 6
+    t.datetime "last_sign_in_at", precision: nil
     t.string "last_sign_in_ip"
-    t.datetime "locked_at", precision: 6
+    t.datetime "locked_at", precision: nil
     t.boolean "otp_required_for_login"
-    t.datetime "remember_created_at", precision: 6
-    t.datetime "reset_password_sent_at", precision: 6
     t.string "otp_secret"
+    t.datetime "remember_created_at", precision: nil
+    t.datetime "reset_password_sent_at", precision: nil
     t.string "reset_password_token"
     t.integer "sign_in_count", default: 0, null: false
     t.string "unlock_token"
-    t.datetime "updated_at", precision: 6
+    t.datetime "updated_at", precision: nil
     t.index ["email"], name: "index_super_admins_on_email", unique: true
     t.index ["reset_password_token"], name: "index_super_admins_on_reset_password_token", unique: true
     t.index ["unlock_token"], name: "index_super_admins_on_unlock_token", unique: true
   end
 
   create_table "targeted_user_links", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", null: false
     t.string "target_context", null: false
     t.bigint "target_model_id", null: false
     t.string "target_model_type", null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.index ["target_model_id"], name: "index_targeted_user_links_on_target_model_id"
     t.index ["user_id"], name: "index_targeted_user_links_on_user_id"
@@ -1011,23 +1008,24 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
     t.string "motivation"
     t.boolean "process_expired"
     t.boolean "process_expired_migrated", default: false
-    t.datetime "processed_at", precision: 6
+    t.datetime "processed_at", precision: nil
     t.string "state"
     t.index ["dossier_id"], name: "index_traitements_on_dossier_id"
     t.index ["process_expired"], name: "index_traitements_on_process_expired"
   end
 
   create_table "trusted_device_tokens", force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", precision: nil, null: false
     t.bigint "instructeur_id"
-    t.string "token"
-    t.datetime "updated_at", precision: 6, null: false
+    t.string "token", null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["instructeur_id"], name: "index_trusted_device_tokens_on_instructeur_id"
+    t.index ["token"], name: "index_trusted_device_tokens_on_token", unique: true
   end
 
   create_table "types_de_champ", id: :serial, force: :cascade do |t|
     t.jsonb "condition"
-    t.datetime "created_at", precision: 6
+    t.datetime "created_at", precision: nil
     t.text "description"
     t.string "libelle"
     t.boolean "mandatory", default: false
@@ -1035,41 +1033,40 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
     t.boolean "private", default: false, null: false
     t.bigint "stable_id"
     t.string "type_champ"
-    t.datetime "updated_at", precision: 6
+    t.datetime "updated_at", precision: nil
     t.index ["private"], name: "index_types_de_champ_on_private"
     t.index ["stable_id"], name: "index_types_de_champ_on_stable_id"
   end
 
   create_table "users", id: :serial, force: :cascade do |t|
-    t.datetime "confirmation_sent_at", precision: 6
-    t.datetime "blocked_at", precision: 6
-    t.datetime "announces_seen_at", precision: 6
+    t.datetime "announces_seen_at"
+    t.datetime "blocked_at"
     t.text "blocked_reason"
+    t.datetime "confirmation_sent_at", precision: nil
     t.string "confirmation_token"
-    t.datetime "confirmed_at", precision: 6
-    t.datetime "created_at", precision: 6
-    t.datetime "current_sign_in_at", precision: 6
+    t.datetime "confirmed_at", precision: nil
+    t.datetime "created_at", precision: nil
+    t.datetime "current_sign_in_at", precision: nil
     t.string "current_sign_in_ip"
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.integer "failed_attempts", default: 0, null: false
     t.datetime "inactive_close_to_expiration_notice_sent_at"
-    t.datetime "last_sign_in_at", precision: 6
+    t.datetime "last_sign_in_at", precision: nil
     t.string "last_sign_in_ip"
-
     t.string "locale"
-    t.datetime "locked_at", precision: 6
+    t.datetime "locked_at", precision: nil
     t.string "loged_in_with_france_connect", default: "false"
-    t.datetime "remember_created_at", precision: 6
+    t.datetime "remember_created_at", precision: nil
     t.bigint "requested_merge_into_id"
-    t.datetime "reset_password_sent_at", precision: 6
+    t.datetime "reset_password_sent_at", precision: nil
     t.string "reset_password_token"
     t.integer "sign_in_count", default: 0, null: false
     t.string "siret"
     t.boolean "team_account", default: false
     t.text "unconfirmed_email"
     t.string "unlock_token"
-    t.datetime "updated_at", precision: 6
+    t.datetime "updated_at", precision: nil
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["last_sign_in_at"], name: "index_users_on_last_sign_in_at"
@@ -1081,37 +1078,37 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
   create_table "virus_scans", force: :cascade do |t|
     t.string "blob_key"
     t.bigint "champ_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "scanned_at", precision: 6
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "scanned_at", precision: nil
     t.string "status"
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["champ_id"], name: "index_virus_scans_on_champ_id"
   end
 
   create_table "without_continuation_mails", id: :serial, force: :cascade do |t|
     t.text "body"
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", precision: nil, null: false
     t.integer "procedure_id"
     t.string "subject"
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["procedure_id"], name: "index_without_continuation_mails_on_procedure_id"
   end
 
   create_table "zone_labels", force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", null: false
     t.date "designated_on", null: false
     t.string "name", null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", null: false
     t.bigint "zone_id", null: false
     t.index ["zone_id"], name: "index_zone_labels_on_zone_id"
   end
 
   create_table "zones", force: :cascade do |t|
     t.string "acronym", null: false
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", null: false
     t.string "label"
     t.string "tchap_hs", default: [], array: true
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", null: false
     t.index ["acronym"], name: "index_zones_on_acronym", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -65,7 +65,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
     t.bigint "groupe_gestionnaire_id"
     t.datetime "updated_at", precision: nil
     t.bigint "user_id", null: false
-    t.index ["groupe_gestionnaire_id"], name: "index_administrateurs_on_groupe_gestionnaire_id"
     t.index ["user_id"], name: "index_administrateurs_on_user_id"
   end
 
@@ -557,7 +556,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
     t.string "statut", default: "tous"
     t.string "time_span_type", default: "everything", null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.index ["instructeur_id"], name: "index_exports_on_instructeur_id"
     t.index ["key"], name: "index_exports_on_key"
     t.index ["procedure_presentation_id"], name: "index_exports_on_procedure_presentation_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -556,6 +556,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
     t.string "statut", default: "tous"
     t.string "time_span_type", default: "everything", null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.index ["instructeur_id"], name: "index_exports_on_instructeur_id"
     t.index ["key"], name: "index_exports_on_key"
     t.index ["procedure_presentation_id"], name: "index_exports_on_procedure_presentation_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -65,6 +65,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
     t.bigint "groupe_gestionnaire_id"
     t.datetime "updated_at", precision: nil
     t.bigint "user_id", null: false
+    t.index ["groupe_gestionnaire_id"], name: "index_administrateurs_on_groupe_gestionnaire_id"
     t.index ["user_id"], name: "index_administrateurs_on_user_id"
   end
 

--- a/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
@@ -160,7 +160,7 @@ describe API::V2::GraphqlController do
 
       context 'include Dossiers' do
         def cursor_for(item, column)
-          cursor = [item.read_attribute(column).utc.strftime("%Y-%m-%dT%H:%M:%S.%NZ"), item.id].join(';')
+          cursor = [item.reload.read_attribute(column).utc.strftime("%Y-%m-%dT%H:%M:%S.%NZ"), item.id].join(';')
           API::V2::Schema.cursor_encoder.encode(cursor, nonce: true)
         end
 
@@ -456,7 +456,7 @@ describe API::V2::GraphqlController do
 
       context 'include deleted Dossiers' do
         def cursor_for(item)
-          cursor = [item.deleted_at.utc.strftime("%Y-%m-%dT%H:%M:%S.%NZ"), item.id].join(';')
+          cursor = [item.reload.deleted_at.utc.strftime("%Y-%m-%dT%H:%M:%S.%NZ"), item.id].join(';')
           API::V2::Schema.cursor_encoder.encode(cursor, nonce: true)
         end
 
@@ -575,7 +575,7 @@ describe API::V2::GraphqlController do
 
       context 'include pending deleted Dossiers' do
         def cursor_for(item)
-          cursor = [(item.en_construction? ? item.hidden_by_user_at : item.hidden_by_administration_at).utc.strftime("%Y-%m-%dT%H:%M:%S.%NZ"), item.id].join(';')
+          cursor = [(item.reload.en_construction? ? item.hidden_by_user_at : item.hidden_by_administration_at).utc.strftime("%Y-%m-%dT%H:%M:%S.%NZ"), item.id].join(';')
           API::V2::Schema.cursor_encoder.encode(cursor, nonce: true)
         end
 

--- a/spec/models/concern/dossier_clone_concern_spec.rb
+++ b/spec/models/concern/dossier_clone_concern_spec.rb
@@ -173,6 +173,7 @@ RSpec.describe DossierCloneConcern do
 
     context "as a fork" do
       let(:new_dossier) { dossier.clone(fork: true) }
+      before { dossier.champs_public.reload } # we compare timestamps so we have to get the precision limit from the db }
 
       it { expect(new_dossier.editing_fork_origin).to eq(dossier) }
       it { expect(new_dossier.champs_public[0].id).not_to eq(dossier.champs_public[0].id) }
@@ -181,7 +182,7 @@ RSpec.describe DossierCloneConcern do
 
       context "piece justificative champ" do
         let(:champ_pj) { create(:champ_piece_justificative, dossier_id: dossier.id) }
-        before { dossier.champs_public << champ_pj }
+        before { dossier.champs_public << champ_pj.reload }
 
         it {
           champ_pj_fork = Champs::PieceJustificativeChamp.where(dossier: new_dossier).first


### PR DESCRIPTION
## TL;DR
- `schema.rb` devrait maintenant refléter le vrai schema qu'on a en base et rester (presque) toujours à jour après chaque migration.
- une github action s'assure qu'on a bien commité le schema après une migration (on l'a plusieurs fois manqué cette année)
- **faire attention à ne pas commiter accidentellement des retraits ou ajouts d'index** car une machine de dev issu d'un dump ne les a pas forcément tous (ou en contraire en a qui n'étaient pas passées en prod, même si on devrait pouvoir régler ce cas là)
- pour être sûr d'être raccord, soit récupérer un dump récent (sachant que les gros index pourraient ne pas être recréés), soit réinitialiser une base vierge avec `rails db:drop db:setup`

---

## timestamp precision
- les colonnes crées depuis rails 7 ne doivent pas avoir de `precision` , car elles utilisent la nouvelle valeur par défaut (6), (qui est aussi la valeur habituelle d'une base pg)
- les colonnes crées avant rails 7 ont une `precision: nil` car cette précision dépend de la config système & pg (du point de vue rails, elle est indéfinie). 
- notre migration rails 7 a par erreur commité des `precision: 6` au lieu de `precision: nil`. (99% des changements de cette PR concernent ce pb)
- rappel: ce fichier n'a aucun impact sur la prod : il ne sert que quand on fait un `schema:load`, soit pour reconstituer la structure d'une base de dev, mais surtout pour la base de tests à chaque fois sur le CI
- quelques tests de cette année qui dépendent des timestamps ne passaient plus: sur ces "vieilles" colonnes, rails/factory_bot créé des instances avec une précision plus élevée (issue du système) que celle de pg qui va l'arrondir à 6. Si le test compare des timestamps, il y avait une différence tant qu'on ne relit (reload) pas la valeur qui a été limitée par pg. Une alternative aurait été de créer une migration pour forcer la précision à 6 pour toutes ces colonnes, mais c'est plus lourd, et de toute façon le cas réel qu'on veut tester est que la valeur à considérer vient de la base, pas du Time.now d'un objet fraichement créé par factory bot)

## index & fk
- des migrations ont déclaré des index & fk mais qui ne sont pas passés en prod
- -> les dumps qu'on récupère ne les contiennent pas, ainsi quand rails dump le schema après une migration, il les retire du schema
- j'ai supprimé les FK du schema, il faudra les recréer plus tard avec une migration si on les veut vraiment (mais pour le moment la prod vit sans)
- j'ai créé des migrations conditionnelles pour rajouter proprement les 2 index manquants en prod (mais qu'on a déjà sur nos machines, ou qui sont passées sur d'autres instances)
- **pour toutes ces raisons, un dump du schema après une migration pourrait à tort ajouter ou retirer des index ou fk du schema:** 
    - une machine qui a un vieux dump et a joué les migrations de création d'index, ré-ajoutera ces index au schema   
    - une machine qui ne contient pas certains index (typiquement lors de l'import de la base, la création des plus gros peuvent échouer par manque d'espace disque), alors un dump les retirera
 
(J'ai tenté une github action simple pour avoir un warning et si on retire des index, sans succès)

Sources: 
https://github.com/rails/rails/issues/44571#issuecomment-1054758649
https://github.com/rails/rails/pull/44358
