### PR TITLE
ETQ admin, les procédures clonées conservent les features flags

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -539,6 +539,12 @@ class Procedure < ApplicationRecord
       .find_by(label: defaut_groupe_instructeur.label) || procedure.groupe_instructeurs.first
     procedure.update!(defaut_groupe_instructeur: new_defaut_groupe)
 
+    Flipper.features.each do |feature|
+      if feature_enabled?(feature.key)
+        Flipper.enable(feature.key, procedure)
+      end
+    end
+
     procedure
   end
 

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -847,6 +847,28 @@ describe Procedure do
         expect(subject.canonical_procedure).to be_nil
       end
     end
+
+    describe 'feature flag' do
+      context 'with a feature flag enabled' do
+        before do
+          Flipper.enable(:procedure_routage_api, procedure)
+        end
+
+        it 'should enable feature' do
+          expect(subject.feature_enabled?(:procedure_routage_api)).to be true
+        end
+      end
+
+      context 'with a feature flag disabled' do
+        before do
+          Flipper.disable(:procedure_routage_api, procedure)
+        end
+
+        it 'should not enable feature' do
+          expect(subject.feature_enabled?(:procedure_routage_api)).to be false
+        end
+      end
+    end
   end
 
   describe '#publish!' do


### PR DESCRIPTION
ETQ admin, lorsqu'une démarche est clonée, les feature flags associé aux champs devraient être copiés

ceci est une demande pour le DS de la polynesie (mes-demarches) 


--------------------
> `trackingGovPFContrib`  `trackingIdtPFContrib `