### PR TITLE
Suppression de l'adresse email de contact dans la page 500

### DIFF
--- a/public/500.html
+++ b/public/500.html
@@ -45,7 +45,7 @@
     <div class='container'>
       <h1 class='new-h1'>Une erreur est survenue</h1>
       <div class='description'>
-        Nos équipes ont été averties. Si le problème persiste ou si vous voulez nous donner des détails concernant l'erreur qui vient de se produire, vous pouvez nous contacter à l'adresse <a href="mailto:contact@demarches-simplifiees.fr" target="_blank" rel="noopener">contact@demarches-simplifiees.fr</a>.
+        Nos équipes ont été averties. Nous mettons tout en oeuvre pour résoudre ce problème dans les meilleurs délais.
       </div>
     </div>
   </div>


### PR DESCRIPTION
Pour alléger le support, l'adresse email n'est plus indiquée dans la page 500. 
Ces emails alourdissent le support, et n'ont pas lieu d'être vu que l'équipe de developpement est déjà avertie via l'outil de tracking d'error.

