### PR TITLE
Tech: active le cache pour le geocoder pour contourner le rate limiting dans certains contextes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,7 +272,7 @@ GEM
       et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.4)
     geo_coord (0.2.0)
-    geocoder (1.6.5)
+    geocoder (1.8.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
     gon (6.4.0)

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,1 +1,7 @@
-Geocoder.configure(lookup: :ban_data_gouv_fr, use_https: true)
+cache_configuration = if ENV['REDIS_CACHE_URL'].present?
+  { cache: Redis.new(url: ENV['REDIS_CACHE_URL']), cache_options: { prefix: "geocoder:", expiration: 6.hours } }
+else
+  { cache: Geocoder::CacheStore::Generic.new(Rails.cache, { prefix: "geocoder:" }) } # generic has no specific expiration support as of geocoder 1.8
+end
+
+Geocoder.configure(lookup: :ban_data_gouv_fr, use_https: true, **cache_configuration)


### PR DESCRIPTION
## contexte 
Démarche pour une personne morale qui a plusieurs cartes dans la démarche

Pour générer l'affichage de chaque carte du formulaire, on la centre sur l'adresse du SIRET du dossier, ce qui provoque X  requêtes identiques de géocodage, déclenchant rate limiting et des timeouts d'affichage.
