### PR TITLE
Geocoder: ensure to use exact rails redis cache configuration

### DIFF
--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,7 +1,7 @@
-cache_configuration = if ENV['REDIS_CACHE_URL'].present?
-  { cache: Redis.new(url: ENV['REDIS_CACHE_URL']), cache_options: { prefix: "geocoder:", expiration: 6.hours } }
+cache_configuration = if Rails.cache.respond_to?(:redis)
+  { cache: Rails.cache.redis, cache_options: { prefix: "geocoder:", expiration: 6.hours } }
 else
-  { cache: Geocoder::CacheStore::Generic.new(Rails.cache, { prefix: "geocoder:" }) } # generic has no specific expiration support as of geocoder 1.8
+  { cache: Geocoder::CacheStore::Generic.new(Rails.cache, { prefix: "geocoder:" }) } # generic uses default Rails.cache expiration as of geocoder 1.8
 end
 
 Geocoder.configure(lookup: :ban_data_gouv_fr, use_https: true, **cache_configuration)


### PR DESCRIPTION
Suite de https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/9687

La config redis peut avoir d'autres options que l'url (ssl, etc…), donc on fait en sorte de récupérer exactement la même config que `Rails.cache` quand il est configuré sur du redis.

Sinon ça fallback sur un cache générique, qui est NOOP quand pas configuré (null cache).