### PR TITLE
correctif(Champs::CommuneChamp): il restait des champs commune a normaliser

### DIFF
--- a/app/jobs/migrations/normalize_communes_job.rb
+++ b/app/jobs/migrations/normalize_communes_job.rb
@@ -1,27 +1,31 @@
 class Migrations::NormalizeCommunesJob < ApplicationJob
   def perform(ids)
     Champs::CommuneChamp.where(id: ids).find_each do |champ|
-      next if champ.external_id.blank?
+      if champ.external_id.blank?
+        champ.value = nil
+        champ.value_json = {}
+        champ.save!
+      else
+        value_json = champ.value_json || {}
 
-      value_json = champ.value_json || {}
+        if !champ.departement? || champ.code_departement == 'undefined' || champ.code_departement == '99'
+          metro_code = champ.external_id[0..1]
+          drom_com_code = champ.external_id[0..2]
 
-      if !champ.departement? || champ.code_departement == 'undefined' || champ.code_departement == '99'
-        metro_code = champ.external_id[0..1]
-        drom_com_code = champ.external_id[0..2]
-
-        if metro_code == '97' || metro_code == '98'
-          value_json[:code_departement] = drom_com_code
-        else
-          value_json[:code_departement] = metro_code
+          if metro_code == '97' || metro_code == '98'
+            value_json[:code_departement] = drom_com_code
+          else
+            value_json[:code_departement] = metro_code
+          end
         end
-      end
 
-      if !champ.code_postal? && code_postal_with_fallback(champ).present?
-        value_json[:code_postal] = code_postal_with_fallback(champ)
-      end
+        if !champ.code_postal? && code_postal_with_fallback(champ).present?
+          value_json[:code_postal] = code_postal_with_fallback(champ)
+        end
 
-      if value_json.present?
-        champ.update_column(:value_json, value_json)
+        if value_json.present?
+          champ.update_column(:value_json, value_json)
+        end
       end
     end
   end

--- a/lib/tasks/deployment/20231110092044_fix_not_normalized_champs_commune.rake
+++ b/lib/tasks/deployment/20231110092044_fix_not_normalized_champs_commune.rake
@@ -1,0 +1,22 @@
+namespace :after_party do
+  desc 'Deployment task: fix_not_normalized_champs_commune'
+  task fix_not_normalized_champs_commune: :environment do
+    puts "Running deploy task 'fix_not_normalized_champs_commune'"
+
+    champs = Champs::CommuneChamp.where(external_id: "")
+      .where("value_json->>'code_departement' = ?", 'undefined')
+    progress = ProgressReport.new(champs.count)
+
+    champs.pluck(:id).in_groups_of(10_000, false) do |champ_ids|
+      Migrations::NormalizeCommunesJob.perform_later(champ_ids)
+      progress.inc(champ_ids.count)
+    end
+
+    progress.finish
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/jobs/migrations/normalize_communes_job_spec.rb
+++ b/spec/jobs/migrations/normalize_communes_job_spec.rb
@@ -1,0 +1,13 @@
+describe Migrations::NormalizeCommunesJob, type: :job do
+  context 'when value is "", external_id is "", and code_departement is "undefined"' do
+    let(:champ) { create(:champ_communes) }
+    before { champ.update_columns(external_id: "", value: "", value_json: { code_departement: 'undefined', departement: 'undefined' }) }
+    subject { described_class.perform_now([champ.id]) }
+    it 'empty the champs' do
+      subject
+      champ.reload
+      expect(champ.code_postal).to be_nil
+      expect(champ.code_departement).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
sentry: https://demarches-simplifiees.sentry.io/issues/4568715676/?project=1429550&query=&referrer=issue-stream&statsPeriod=14d&stream_index=0
hs: https://secure.helpscout.net/conversation/2415492521/2045378?folderId=1653799

Il restait des champs commune avec external_id: "", value_json->>'code_departement' = undefined. Resultat on arrive pas a serialiser le dossier [prob graphql]. ce qui empeche le passage a un des états terminé

En prod
```ruby
ids=[]
Champs::CommuneChamp.where(external_id: "").where("value_json->>'code_departement' = ?", "undefined").pluck(:id).in_groups_of(10_000, false) do |champ_ids|
  puts champ_ids
  ids = ids.concat(champ_ids)
end
ids.size
=> 1410
```