### PR TITLE
correctif(pjs.upload.multiple): ETQ usager, lorsqu'une demarche n'a pas activé les PJ multiples, je ne dois pas pouvoir uploader plus d'une pj

### DIFF
--- a/app/components/attachment/multiple_component/multiple_component.html.haml
+++ b/app/components/attachment/multiple_component/multiple_component.html.haml
@@ -7,7 +7,7 @@
         %li{ id: dom_id(attachment) }
           = render Attachment::EditComponent.new(champ:, attached_file:, attachment:, index:, as_multiple: true, view_as:, user_can_destroy:, user_can_replace:, form_object_name:)
 
-  %div{ id: empty_component_id, class: class_names("hidden": !can_attach_next?) }
+  %div{ id: empty_component_id, class: class_names("hidden": !can_attach_next?), data: { turbo_force: :server } }
     = render Attachment::EditComponent.new(champ:, attached_file:, attachment: nil, index: attachments_count, user_can_destroy:, user_can_replace:, form_object_name:)
 
   // single poll and refresh message for all attachments


### PR DESCRIPTION
hs: https://secure.helpscout.net/conversation/2385797066/2042677?folderId=5935139

C'etait un problème de coldwire (il virait la classe hidden :/)