### PR TITLE
Perf: accélération du chargement des dossiers visibles

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -223,7 +223,7 @@ class Dossier < ApplicationRecord
   scope :prefilled,                 -> { where(prefilled: true) }
   scope :hidden_by_user,            -> { where.not(hidden_by_user_at: nil) }
   scope :hidden_by_administration,  -> { where.not(hidden_by_administration_at: nil) }
-  scope :visible_by_user,           -> { where(for_procedure_preview: false).or(where(for_procedure_preview: nil)).where(hidden_by_user_at: nil, editing_fork_origin_id: nil) }
+  scope :visible_by_user,           -> { where(for_procedure_preview: false).where(hidden_by_user_at: nil, editing_fork_origin_id: nil) }
   scope :visible_by_administration, -> {
     state_not_brouillon
       .where(hidden_by_administration_at: nil)

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -709,7 +709,7 @@ class Procedure < ApplicationRecord
       close!
     end
 
-    dossiers.visible_by_administration.each do |dossier|
+    dossiers.visible_by_administration.find_each do |dossier|
       dossier.hide_and_keep_track!(author, :procedure_removed)
     end
 

--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -32,7 +32,7 @@ class Stat < ApplicationRecord
           COUNT(*) FILTER ( WHERE state != 'brouillon' ) AS "not_brouillon",
           COUNT(*) FILTER ( WHERE state != 'brouillon' and depose_at BETWEEN :one_month_ago AND :now ) AS "dossiers_depose_avant_30_jours",
           COUNT(*) FILTER ( WHERE state != 'brouillon' and depose_at BETWEEN :two_months_ago AND :one_month_ago ) AS "dossiers_deposes_entre_60_et_30_jours",
-          COUNT(*) FILTER ( WHERE state = 'brouillon' AND editing_fork_origin_id IS NULL AND (for_procedure_preview IS NULL OR for_procedure_preview = false)) AS "brouillon",
+          COUNT(*) FILTER ( WHERE state = 'brouillon' AND editing_fork_origin_id IS NULL AND for_procedure_preview = false) AS "brouillon",
           COUNT(*) FILTER ( WHERE state = 'en_construction' ) AS "en_construction",
           COUNT(*) FILTER ( WHERE state = 'en_instruction' ) AS "en_instruction",
           COUNT(*) FILTER ( WHERE state in ('accepte', 'refuse', 'sans_suite') ) AS "termines"

--- a/db/migrate/20231110135532_alter_dossiers_for_procedure_preview_not_nullable.rb
+++ b/db/migrate/20231110135532_alter_dossiers_for_procedure_preview_not_nullable.rb
@@ -1,0 +1,5 @@
+class AlterDossiersForProcedurePreviewNotNullable < ActiveRecord::Migration[7.0]
+  def change
+    add_check_constraint :dossiers, "for_procedure_preview IS NOT NULL", name: "dossiers_for_procedure_preview_null", validate: false
+  end
+end

--- a/db/migrate/20231110135533_validate_alter_dossiers_for_procedure_preview_not_nullable.rb
+++ b/db/migrate/20231110135533_validate_alter_dossiers_for_procedure_preview_not_nullable.rb
@@ -1,0 +1,7 @@
+class ValidateAlterDossiersForProcedurePreviewNotNullable < ActiveRecord::Migration[7.0]
+  def change
+    validate_check_constraint :dossiers, name: "dossiers_for_procedure_preview_null"
+    change_column_null :dossiers, :for_procedure_preview, false, false
+    remove_check_constraint :dossiers, name: "dossiers_for_procedure_preview_null"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_07_150217) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_10_135533) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -402,7 +402,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_07_150217) do
     t.datetime "en_construction_at", precision: 6
     t.datetime "en_construction_close_to_expiration_notice_sent_at", precision: 6
     t.datetime "en_instruction_at", precision: 6
-    t.boolean "for_procedure_preview", default: false
+    t.boolean "for_procedure_preview", default: false, null: false
     t.boolean "forced_groupe_instructeur", default: false, null: false
     t.bigint "groupe_instructeur_id"
     t.datetime "groupe_instructeur_updated_at", precision: 6

--- a/spec/models/stat_spec.rb
+++ b/spec/models/stat_spec.rb
@@ -27,7 +27,6 @@ describe Stat, type: :model do
       create_list(:dossier, 2, :en_construction, depose_at: 10.days.ago, procedure:)
       create_list(:dossier, 3, :en_construction, depose_at: 40.days.ago, procedure:)
 
-      create_list(:dossier, 3, :brouillon, procedure:, for_procedure_preview: nil)
       create_list(:dossier, 1, :brouillon, procedure:, for_procedure_preview: false)
 
       create_list(:dossier, 6, :en_instruction, procedure:)
@@ -48,7 +47,7 @@ describe Stat, type: :model do
       expect(stats["not_brouillon"]).to eq(18)
       expect(stats["dossiers_depose_avant_30_jours"]).to eq(2)
       expect(stats["dossiers_deposes_entre_60_et_30_jours"]).to eq(3)
-      expect(stats["brouillon"]).to eq(4)
+      expect(stats["brouillon"]).to eq(1)
       expect(stats["en_construction"]).to eq(5)
       expect(stats["en_instruction"]).to eq(6)
       expect(stats["termines"]).to eq(7)


### PR DESCRIPTION
Les `OR` dans les requêtes PG sont généralement une source de ralentissement car elles freinent certaines optimisations.

En supprimant `OR for_procedure_preview IS NULL` du scope `Dossiers.visible_by_user` on améliore le scope jusqu'à ~30% pour récupérer des dossiers (c'est à peu près ISO pour un count). Sur certaines démarches ça prend plusieurs centaines de ms

La colonne n'était pas non nullable pour les besoins de la création mais ça avait été rattrapé ici ,et d'ailleurs on a aucun dossier avec une valeur NULL.
[`lib/tasks/deployment/20220427195148_set_default_for_procedure_preview_on_dossiers.rake`](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/commit/27f9a820cc59652c5f9095b8e2affdcf33f05ded#diff-7202c64222deec0c5957bb82c4e6d655be822b5f2db661eeb1cfd09402812a6c)

Cette PR enforce donc la contrainte non nullable, et optimise le scope.


```ruby
  task dossiers_visible_by_user: :environment do
    require 'benchmark/ips'
    procedure = Procedure.find(62746)

    Benchmark.ips do |x|
      x.report("fast") { procedure.dossiers.visible_by_user.all }
      x.report("slow") { procedure.dossiers.visible_by_user_slow.all }
      x.compare!
    end
  end


Warming up --------------------------------------
                fast     1.738k i/100ms
                slow     1.341k i/100ms
Calculating -------------------------------------
                fast     17.214k (± 3.0%) i/s -     86.900k in   5.052921s
                slow     12.926k (± 3.6%) i/s -     65.709k in   5.090313s

Comparison:
                fast:    17213.9 i/s
                slow:    12926.1 i/s - 1.33x  slower
```