### PR TITLE
correctif(combobox): ETQ usager, les combobox sur mobile n'etaient pas utilisable

### DIFF
--- a/app/assets/stylesheets/dsfr.scss
+++ b/app/assets/stylesheets/dsfr.scss
@@ -33,6 +33,22 @@ trix-editor.fr-input {
   margin-top: 0.5rem;
 }
 
+@media (max-width: 62em) {
+  .fr-ds-combobox {
+    .fr-menu {
+      .fr-menu__list {
+        z-index: calc(var(--ground) + 1000);
+        width: 100%;
+        background-color: var(--background-default-grey);
+        --idle: transparent;
+        --hover: var(--background-overlap-grey-hover);
+        --active: var(--background-overlap-grey-active);
+        filter: drop-shadow(var(--overlap-shadow));
+        box-shadow: inset 0 1px 0 0 var(--border-open-blue-france);
+      }
+    }
+  }
+}
 // Fix firefox < 80, Safari < 15.4, Chrome < 83 not supporting "appearance: auto" on inputs
 // This rule was set by DSFR for DSFR design, but broke our legacy forms.
 // scss-lint:disable DuplicateProperty


### PR DESCRIPTION
problème de z-index et de fond sur combobox 

**avant**
<img width="443" alt="Screenshot 2023-11-13 at 10 02 53 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/5fe7387f-f53c-4ca0-858b-d6d94a57b340">

**apres**
<img width="469" alt="Screenshot 2023-11-13 at 10 02 04 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/d8fa3557-51cc-43a5-9915-ff59e4ccbc1b">
