### PR TITLE
amelioration(combobox): ETQ usager, les combobox de DS se comportent comme un `<select>`

### DIFF
--- a/app/assets/stylesheets/dsfr.scss
+++ b/app/assets/stylesheets/dsfr.scss
@@ -33,22 +33,29 @@ trix-editor.fr-input {
   margin-top: 0.5rem;
 }
 
-@media (max-width: 62em) {
-  .fr-ds-combobox {
-    .fr-menu {
-      .fr-menu__list {
-        z-index: calc(var(--ground) + 1000);
-        width: 100%;
-        background-color: var(--background-default-grey);
-        --idle: transparent;
-        --hover: var(--background-overlap-grey-hover);
-        --active: var(--background-overlap-grey-active);
-        filter: drop-shadow(var(--overlap-shadow));
-        box-shadow: inset 0 1px 0 0 var(--border-open-blue-france);
-      }
+
+.fr-ds-combobox {
+  .fr-menu {
+    width: 100%;
+
+    .fr-menu__list {
+      width: 100%;
     }
   }
 }
+
+@media (max-width: 62em) {
+  .fr-ds-combobox  .fr-menu .fr-menu__list {
+    z-index: calc(var(--ground) + 1000);
+    background-color: var(--background-default-grey);
+    --idle: transparent;
+    --hover: var(--background-overlap-grey-hover);
+    --active: var(--background-overlap-grey-active);
+    filter: drop-shadow(var(--overlap-shadow));
+    box-shadow: inset 0 1px 0 0 var(--border-open-blue-france);
+  }
+}
+
 // Fix firefox < 80, Safari < 15.4, Chrome < 83 not supporting "appearance: auto" on inputs
 // This rule was set by DSFR for DSFR design, but broke our legacy forms.
 // scss-lint:disable DuplicateProperty


### PR DESCRIPTION
P-e un faux problème, mais ca me fait bizarre ces comboxbox qui ne sont pas en full screen. Au moins la on a un comportement coherent quelque soit le device

**avant**
<img width="1090" alt="Screenshot 2023-11-13 at 10 02 26 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/c42a2537-b196-48a6-aaf1-bbcc2425d422">

**apres**
<img width="1081" alt="Screenshot 2023-11-13 at 10 13 14 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/b9bed342-b107-4fea-b6eb-60ce08c71166">
