### PR TITLE
Test: fix flaky brouillon on repetition

### DIFF
--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -81,7 +81,11 @@ module SystemHelpers
   end
 
   def blur
-    page.find('body').click
+    if page.has_css?('body', wait: 0)
+      page.find('body').click
+    else # page after/inside a `within` block does not match body
+      page.first('div').click
+    end
   end
 
   def pause

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -128,12 +128,12 @@ describe 'The user' do
     expect(page).to have_field('sub type de champ', with: 'super texte')
 
     click_on 'Ajouter un élément pour'
+    expect(page).to have_content('Supprimer', count: 2)
 
     within '.repetition .row:first-child' do
       fill_in('sub type de champ', with: 'un autre texte')
+      blur
     end
-
-    expect(page).to have_content('Supprimer', count: 2)
 
     expect do
       within '.repetition .row:first-child' do


### PR DESCRIPTION
depuis le refacto de l'autosave, celui-ci popait presque tout le temps car l'autosave se déclenchait *après* la suppression de la répétition, ce qui provoquait une erreur.