### PR TITLE
ETQ admin je peux conditionner / router à partir d'un champ de type choix multiple avec l'opérateur "Ne contient pas"

### DIFF
--- a/app/components/conditions/conditions_component.rb
+++ b/app/components/conditions/conditions_component.rb
@@ -99,7 +99,8 @@ class Conditions::ConditionsComponent < ApplicationComponent
       ]
     when ChampValue::CHAMP_VALUE_TYPE.fetch(:enums)
       [
-        [t(IncludeOperator.name, scope: 'logic.operators'), IncludeOperator.name]
+        [t(IncludeOperator.name, scope: 'logic.operators'), IncludeOperator.name],
+        [t(ExcludeOperator.name, scope: 'logic.operators'), ExcludeOperator.name]
       ]
     when ChampValue::CHAMP_VALUE_TYPE.fetch(:number)
       [Eq, LessThan, GreaterThan, LessThanEq, GreaterThanEq]

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -92,7 +92,7 @@ class GroupeInstructeur < ApplicationRecord
   end
 
   def valid_rule_line?(rule)
-    ([rule.left, rule, rule.right] in [ChampValue, (LessThan | LessThanEq | Eq | NotEq | GreaterThanEq | GreaterThan | IncludeOperator), Constant]) && routing_rule_matches_tdc?(rule)
+    ([rule.left, rule, rule.right] in [ChampValue, (LessThan | LessThanEq | Eq | NotEq | GreaterThanEq | GreaterThan | IncludeOperator | ExcludeOperator), Constant]) && routing_rule_matches_tdc?(rule)
   end
 
   def non_unique_rule?

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -92,7 +92,7 @@ class GroupeInstructeur < ApplicationRecord
   end
 
   def valid_rule_line?(rule)
-    ([rule.left, rule, rule.right] in [ChampValue, (LessThan | LessThanEq | Eq | NotEq | GreaterThanEq | GreaterThan | IncludeOperator | ExcludeOperator), Constant]) && routing_rule_matches_tdc?(rule)
+    !rule.is_a?(EmptyOperator) && routing_rule_matches_tdc?(rule)
   end
 
   def non_unique_rule?

--- a/app/models/logic.rb
+++ b/app/models/logic.rb
@@ -8,7 +8,7 @@ module Logic
   end
 
   def self.class_from_name(name)
-    [ChampValue, Constant, Empty, LessThan, LessThanEq, Eq, NotEq, GreaterThanEq, GreaterThan, EmptyOperator, IncludeOperator, And, Or]
+    [ChampValue, Constant, Empty, LessThan, LessThanEq, Eq, NotEq, GreaterThanEq, GreaterThan, EmptyOperator, IncludeOperator, ExcludeOperator, And, Or]
       .find { |c| c.name == name }
   end
 
@@ -87,6 +87,8 @@ module Logic
   def less_than_eq(left, right) = Logic::LessThanEq.new(left, right)
 
   def ds_include(left, right) = Logic::IncludeOperator.new(left, right)
+
+  def ds_exclude(left, right) = Logic::ExcludeOperator.new(left, right)
 
   def constant(value) = Logic::Constant.new(value)
 

--- a/app/models/logic/exclude_operator.rb
+++ b/app/models/logic/exclude_operator.rb
@@ -1,0 +1,3 @@
+class Logic::ExcludeOperator < Logic::IncludeOperator
+  def operation = :exclude?
+end

--- a/config/locales/models/logic/fr.yml
+++ b/config/locales/models/logic/fr.yml
@@ -14,3 +14,4 @@ fr:
       'Logic::Or': Ou
       'Logic::NotEq': N’est pas
       'Logic::IncludeOperator': Contient
+      'Logic::ExcludeOperator': Ne contient pas

--- a/spec/models/logic/exclude_operator_spec.rb
+++ b/spec/models/logic/exclude_operator_spec.rb
@@ -1,0 +1,29 @@
+describe Logic::ExcludeOperator do
+  include Logic
+
+  let(:champ) { create(:champ_multiple_drop_down_list, value: '["val1", "val2"]') }
+
+  describe '#compute' do
+    it { expect(ds_exclude(champ_value(champ.stable_id), constant('val1')).compute([champ])).to be(false) }
+    it { expect(ds_exclude(champ_value(champ.stable_id), constant('something else')).compute([champ])).to be(true) }
+  end
+
+  describe '#errors' do
+    it { expect(ds_exclude(champ_value(champ.stable_id), constant('val1')).errors([champ.type_de_champ])).to be_empty }
+    it do
+      expected = {
+        right: constant('something else'),
+        stable_id: champ.stable_id,
+        type: :not_included
+      }
+
+      expect(ds_exclude(champ_value(champ.stable_id), constant('something else')).errors([champ.type_de_champ])).to eq([expected])
+    end
+
+    it { expect(ds_exclude(constant(1), constant('val1')).errors([])).to eq([{ type: :required_list }]) }
+  end
+
+  describe '#==' do
+    it { expect(ds_include(champ_value(champ.stable_id), constant('val1'))).to eq(ds_include(champ_value(champ.stable_id), constant('val1'))) }
+  end
+end

--- a/spec/models/routing_engine_spec.rb
+++ b/spec/models/routing_engine_spec.rb
@@ -28,7 +28,7 @@ describe RoutingEngine, type: :model do
       context 'without any matching rules' do
         before do
           procedure.groupe_instructeurs.each do |gi|
-            gi.update(routing_rule: ds_eq(constant(false), constant(false)))
+            gi.update(routing_rule: ds_eq(constant(false), constant(true)))
           end
         end
 


### PR DESCRIPTION
Ce nouvel opérateur `exclude` ("ne contient pas") va permettre de créer des conditions / règles de routage plus précises à partir d'un type de champ choix multiple. Par exemple : 

![image](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/29131404/0143f1ac-0384-41fc-ade0-20a24600b580)
