### PR TITLE
correctif(tags): ETQ admin, je peux utiliser un tag referençant un type de champ dont le libellé contient deux espaces consécutif

### DIFF
--- a/app/views/administrateurs/mail_templates/_form.html.haml
+++ b/app/views/administrateurs/mail_templates/_form.html.haml
@@ -20,7 +20,7 @@
   .items
     - tags.each do |tag|
       .item
-        %code.tag
+        %code.tag{ style: "white-space: pre-wrap;" }
           = "--#{tag[:libelle]}--"
         .description
           = tag[:description]


### PR DESCRIPTION
hs: https://secure.helpscout.net/conversation/2413455170/2045226/