### PR TITLE
Fix thème sombre: ne clignote pas avec le thème clair au moment du render

### DIFF
--- a/app/views/layouts/_setup_theme.html.haml
+++ b/app/views/layouts/_setup_theme.html.haml
@@ -1,0 +1,9 @@
+:javascript
+  function setDarkBeforeRender() {
+    const localScheme = localStorage.getItem('scheme')
+    if (localScheme == 'dark' || (localScheme == 'system' && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+      document.documentElement.setAttribute('data-fr-theme', 'dark');
+    }
+  }
+  setDarkBeforeRender();
+

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -35,6 +35,7 @@
     = stylesheet_link_tag 'application', media: 'all'
 
     = yield(:invisible_captcha_styles)
+    = render partial: 'layouts/setup_theme'
 
   %body{ { id: content_for(:page_id), class: browser.platform.ios? ? 'ios' : nil, data: { controller: 'turbo number-input' } }.compact }
     = render partial: 'layouts/skiplinks'

--- a/app/views/layouts/component_preview.html.haml
+++ b/app/views/layouts/component_preview.html.haml
@@ -1,5 +1,5 @@
 !!! 5
-%html{ lang: html_lang, class: yield(:root_class) }
+%html{ lang: html_lang, data: { fr_scheme: 'system' }, class: yield(:root_class) }
   %head
     %meta{ "http-equiv": "Content-Type", content: "text/html; charset=UTF-8" }
     %meta{ "http-equiv": "X-UA-Compatible", content: "IE=edge" }
@@ -22,6 +22,8 @@
 
     = vite_stylesheet_tag 'main', media: 'all'
     = stylesheet_link_tag 'application', media: 'all'
+
+    = render partial: 'layouts/setup_theme'
 
   %body{ class: browser.platform.ios? ? 'ios' : nil, data: { controller: 'turbo' } }
     .page-wrapper


### PR DESCRIPTION
On ne veut pas attendre la fin du render pour que le JS du DSFR set le theme à partir du scheme, autrement on voit le thème clair pendant le render.


NB: je sais pas s'il ya  un risque à utiliser `const` inline pour les vieux navigateur, (qui n'aurait de toute façon probablement pas de mode sombre 