### PR TITLE
En tant qu'instructeur, je peux exporter les données RNF des dossiers

### DIFF
--- a/app/models/champs/rnf_champ.rb
+++ b/app/models/champs/rnf_champ.rb
@@ -20,4 +20,12 @@ class Champs::RNFChamp < Champ
   def blank?
     rnf_id.blank?
   end
+
+  def for_export
+    if data
+      [rnf_id, data['title'], data.dig('address', 'label'), data.dig('address', 'cityCode'), "#{data['department']} - #{APIGeoService.departement_name(data['department'])}"]
+    else
+      [rnf_id, nil, nil, nil, nil]
+    end
+  end
 end

--- a/app/models/types_de_champ/rnf_type_de_champ.rb
+++ b/app/models/types_de_champ/rnf_type_de_champ.rb
@@ -1,2 +1,5 @@
 class TypesDeChamp::RNFTypeDeChamp < TypesDeChamp::TextTypeDeChamp
+  def libelle_for_export(index)
+    [libelle, "#{libelle} (Nom)", "#{libelle} (Adresse)", "#{libelle} (Code insee Ville)", "#{libelle} (Département)"][index]
+  end
 end

--- a/spec/models/champs/rnf_champ_spec.rb
+++ b/spec/models/champs/rnf_champ_spec.rb
@@ -73,4 +73,11 @@ describe Champs::RNFChamp, type: :model do
       }
     end
   end
+
+  describe 'for_export' do
+    let(:champ) { build(:champ_rnf, external_id:, data: JSON.parse(body)) }
+    it do
+      expect(champ.for_export).to eq(['075-FDD-00003-01', 'Fondation SFR', '16 Rue du Général de Boissieu 75015 Paris', '75115', '75 - Paris'])
+    end
+  end
 end

--- a/spec/services/procedure_export_service_spec.rb
+++ b/spec/services/procedure_export_service_spec.rb
@@ -92,6 +92,10 @@ describe ProcedureExportService do
           "cojo",
           "expression_reguliere",
           "rnf",
+          "rnf (Nom)",
+          "rnf (Adresse)",
+          "rnf (Code insee Ville)",
+          "rnf (Département)",
           "engagement_juridique"
         ]
       end
@@ -221,6 +225,10 @@ describe ProcedureExportService do
           "cojo",
           "expression_reguliere",
           "rnf",
+          "rnf (Nom)",
+          "rnf (Adresse)",
+          "rnf (Code insee Ville)",
+          "rnf (Département)",
           "engagement_juridique"
         ]
       end
@@ -318,6 +326,10 @@ describe ProcedureExportService do
             "cojo",
             "expression_reguliere",
             "rnf",
+            "rnf (Nom)",
+            "rnf (Adresse)",
+            "rnf (Code insee Ville)",
+            "rnf (Département)",
             "engagement_juridique"
           ]
         end


### PR DESCRIPTION
En tant qu'instructeur, quand j'exporte les dossiers d'une démarche qui contient un champ RNF, dans le fichier tableur, sont exportées : 
- l'id RNF
- le nom de la fondation
- l'adresse
- le code insee
- le département