### PR TITLE
ETQ usager modifiant un dossier en construction je n'ai plus besoin de cocher la case de correction effectuée

### DIFF
--- a/app/components/dossiers/pending_correction_checkbox_component.rb
+++ b/app/components/dossiers/pending_correction_checkbox_component.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class Dossiers::PendingCorrectionCheckboxComponent < ApplicationComponent
+  attr_reader :dossier
+
+  # Pass the editing fork origin, ie. dossier en construction holding the correction
+  def initialize(dossier:)
+    @dossier = dossier
+  end
+
+  def render?
+    return false unless dossier.procedure.sva_svr_enabled?
+
+    dossier.pending_correction?
+  end
+
+  def error? = dossier.errors.include?(:pending_correction)
+
+  def error_message
+    dossier.errors.generate_message(:pending_correction, :blank)
+  end
+
+  def check_box_aria_attributes
+    return unless error?
+
+    { describedby: :dossier_pending_correction_error_messages }
+  end
+end

--- a/app/components/dossiers/pending_correction_checkbox_component/pending_correction_checkbox_component.en.yml
+++ b/app/components/dossiers/pending_correction_checkbox_component/pending_correction_checkbox_component.en.yml
@@ -1,0 +1,3 @@
+---
+en:
+  confirm_label: I certify that I have made all corrections requested by the administration.

--- a/app/components/dossiers/pending_correction_checkbox_component/pending_correction_checkbox_component.fr.yml
+++ b/app/components/dossiers/pending_correction_checkbox_component/pending_correction_checkbox_component.fr.yml
@@ -1,0 +1,3 @@
+---
+fr:
+  confirm_label: Je certifie avoir effectué toutes les corrections demandées par l’administration.

--- a/app/components/dossiers/pending_correction_checkbox_component/pending_correction_checkbox_component.html.haml
+++ b/app/components/dossiers/pending_correction_checkbox_component/pending_correction_checkbox_component.html.haml
@@ -1,0 +1,10 @@
+.fr-checkbox-group.fr-my-3w{ class: class_names("fr-checkbox-group--error" => error?) }
+  = check_box_tag field_name(:dossier, :pending_correction), "1", false, form: "form-submit-en-construction", required: true, aria: check_box_aria_attributes
+  %label.fr-label{ for: :dossier_pending_correction }
+    = t('.confirm_label')
+    = render EditableChamp::AsteriskMandatoryComponent.new
+
+  - if error?
+    #dossier_pending_correction_error_messages.fr-messages-group{ aria: { live: "assertlive" } }
+      %p.fr-message.fr-message--error= error_message
+

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -250,19 +250,23 @@ module Users
 
     def submit_en_construction
       @dossier = dossier_with_champs(pj_template: false)
+      editing_fork_origin = @dossier.editing_fork_origin
+
+      if cast_bool(params.dig(:dossier, :pending_correction))
+        editing_fork_origin.resolve_pending_correction
+      end
+
       @errors = submit_dossier_and_compute_errors
 
       if @errors.blank?
-        pending_correction_confirm = cast_bool(params.dig(:dossier, :pending_correction_confirm))
-        editing_fork_origin = @dossier.editing_fork_origin
         editing_fork_origin.merge_fork(@dossier)
-        editing_fork_origin.submit_en_construction!(pending_correction_confirm:)
+        editing_fork_origin.submit_en_construction!
 
         redirect_to dossier_path(editing_fork_origin)
       else
         respond_to do |format|
           format.html do
-            @dossier = @dossier.editing_fork_origin
+            @dossier = editing_fork_origin
             render :modifier
           end
 
@@ -537,8 +541,16 @@ module Users
       @dossier.validate(:champs_public_value)
 
       errors = @dossier.errors
-      @dossier.check_mandatory_and_visible_champs.map do |error_on_champ|
+      @dossier.check_mandatory_and_visible_champs.each do |error_on_champ|
         errors.import(error_on_champ)
+      end
+
+      if @dossier.editing_fork_origin&.pending_correction?
+        @dossier.editing_fork_origin.validate(:champs_public_value)
+        @dossier.editing_fork_origin.errors.where(:pending_correction).each do |error|
+          errors.import(error)
+        end
+
       end
 
       errors

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -888,16 +888,14 @@ class Dossier < ApplicationRecord
     RoutingEngine.compute(self)
   end
 
-  def submit_en_construction!(pending_correction_confirm: false)
+  def submit_en_construction!
     self.traitements.submit_en_construction
     save!
 
     RoutingEngine.compute(self)
 
-    if pending_correction_confirm
-      resolve_pending_correction!
-      process_sva_svr!
-    end
+    resolve_pending_correction!
+    process_sva_svr!
   end
 
   def after_passer_en_instruction(h)

--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -24,10 +24,6 @@
 
     = render EditableChamp::SectionComponent.new(champs: dossier_for_editing.champs_public)
 
-    - if dossier.pending_correction?
-      .fr-checkbox-group.fr-my-3w
-        = check_box_tag field_name(:dossier, :pending_correction_confirm), "1", false, form: "form-submit-en-construction"
-        %label.fr-label{ for: :dossier_pending_correction_confirm }= t('views.shared.dossiers.edit.pending_correction.confirm_label')
-
+    = render Dossiers::PendingCorrectionCheckboxComponent.new(dossier: dossier)
 
   = render Dossiers::EditFooterComponent.new(dossier: dossier_for_editing, annotation: false)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -333,8 +333,6 @@ en:
           updated_at: "Updated on %{datetime}"
         edit:
           autosave: Your file is automatically saved after each modification. You can close the window at any time and pick up where you left off later.
-          pending_correction:
-            confirm_label: I certify that I have made all corrections requested by the administration.
         messages:
           form:
             send_message: "Send message"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -333,8 +333,6 @@ fr:
           updated_at: "Modifié le %{datetime}"
         edit:
           autosave: Votre dossier est enregistré automatiquement après chaque modification. Vous pouvez à tout moment fermer la fenêtre et reprendre plus tard là où vous en étiez.
-          pending_correction:
-            confirm_label: Je certifie avoir effectué toutes les corrections demandées par l’administration.
         messages:
           form:
             send_message: "Envoyer le message"

--- a/config/locales/models/dossier/en.yml
+++ b/config/locales/models/dossier/en.yml
@@ -8,6 +8,7 @@ en:
       dossier:
         id: "File number"
         state: "State"
+        pending_correction: Requested correction
       dossier/state: &state
         brouillon: "Draft"
         en_construction: "In progress"
@@ -24,3 +25,9 @@ en:
         state: "State"
       traitement/state:
         <<: *state
+    errors:
+      models:
+        dossier:
+          attributes:
+            pending_correction:
+              blank: Check to confirm that you have made the requested corrections.

--- a/config/locales/models/dossier/fr.yml
+++ b/config/locales/models/dossier/fr.yml
@@ -12,6 +12,7 @@ fr:
         date_previsionnelle: "La date de début prévisionnelle"
         state: "État"
         autorisation_donnees: Acceptation des CGU
+        pending_correction: Demande de correction
       dossier/state: &state
         brouillon: "Brouillon"
         en_construction: "En construction"
@@ -28,3 +29,9 @@ fr:
         state: "État"
       traitement/state:
         <<: *state
+    errors:
+      models:
+        dossier:
+          attributes:
+            pending_correction:
+              blank: "Cochez la case indiquant avoir effectué les corrections demandées."

--- a/spec/components/dossiers/pending_correction_checkbox_component_spec.rb
+++ b/spec/components/dossiers/pending_correction_checkbox_component_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.describe Dossiers::PendingCorrectionCheckboxComponent, type: :component do
+  subject { render_inline(described_class.new(dossier:)) }
+
+  let(:procedure) { create(:procedure) }
+  let(:dossier) { create(:dossier, :en_construction, procedure:) }
+
+  context 'when dossier has no pending correction' do
+    it 'renders nothing' do
+      expect(subject.to_html).to be_empty
+    end
+  end
+
+  context 'when dossier has pending correction' do
+    before do
+      create(:dossier_correction, dossier:)
+    end
+
+    it 'renders nothing' do
+      expect(subject.to_html).to be_empty
+    end
+
+    context 'when procedure is sva' do
+      let(:procedure) { create(:procedure, :sva) }
+
+      it 'renders a checkbox' do
+        expect(subject).to have_selector('input[type="checkbox"][name="dossier[pending_correction]"]')
+      end
+
+      context 'when there are error on checkbox' do
+        before do
+          dossier.errors.add(:pending_correction, :blank)
+        end
+
+        it 'renders the error' do
+          expect(subject).to have_content("Cochez la case")
+          expect(subject).to have_selector('.fr-checkbox-group--error')
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -567,50 +567,46 @@ describe Users::DossiersController, type: :controller do
     context "when there are pending correction" do
       let!(:correction) { create(:dossier_correction, dossier: dossier) }
 
-      subject { post :submit_en_construction, params: { id: dossier.id, dossier: { pending_correction_confirm: "1" } } }
+      subject { post :submit_en_construction, params: { id: dossier.id } }
 
-      it "resolve correction" do
+      it "resolves correction automatically" do
         expect { subject }.to change { correction.reload.resolved_at }.to be_truthy
       end
 
       context 'when procedure has sva enabled' do
         let(:procedure) { create(:procedure, :sva) }
-        let!(:dossier) { create(:dossier, :en_construction, procedure:, user:) }
+        let(:dossier) { create(:dossier, :en_construction, procedure:, user:) }
+        let!(:correction) { create(:dossier_correction, dossier: dossier) }
 
-        it 'passe automatiquement en instruction' do
-          expect(dossier.pending_correction?).to be_truthy
+        subject { post :submit_en_construction, params: { id: dossier.id, dossier: { pending_correction: pending_correction_value } } }
 
-          subject
-          dossier.reload
+        context 'when resolving correction' do
+          let(:pending_correction_value) { "1" }
+          it 'passe automatiquement en instruction' do
+            expect(dossier.pending_correction?).to be_truthy
 
-          expect(dossier).to be_en_instruction
-          expect(dossier.pending_correction?).to be_falsey
-          expect(dossier.en_instruction_at).to within(5.seconds).of(Time.current)
+            subject
+            dossier.reload
+
+            expect(dossier).to be_en_instruction
+            expect(dossier.pending_correction?).to be_falsey
+            expect(dossier.en_instruction_at).to within(5.seconds).of(Time.current)
+          end
         end
-      end
-    end
 
-    context 'when there is sva without confirming correction' do
-      let!(:correction) { create(:dossier_correction, dossier: dossier) }
+        context 'when not resolving correction' do
+          render_views
 
-      subject { post :submit_en_construction, params: { id: dossier.id } }
+          let(:pending_correction_value) { "" }
+          it 'does not passe automatiquement en instruction' do
+            subject
+            dossier.reload
 
-      it "does not resolve correction" do
-        expect { subject }.not_to change { correction.reload.resolved_at }
-      end
+            expect(dossier).to be_en_construction
+            expect(dossier.pending_correction?).to be_truthy
 
-      context 'when procedure has sva enabled' do
-        let(:procedure) { create(:procedure, :sva) }
-        let!(:dossier) { create(:dossier, :en_construction, procedure:, user:) }
-
-        it 'does not passe automatiquement en instruction' do
-          expect(dossier.pending_correction?).to be_truthy
-
-          subject
-          dossier.reload
-
-          expect(dossier).to be_en_construction
-          expect(dossier.pending_correction?).to be_truthy
+            expect(response.body).to include("Cochez la case")
+          end
         end
       end
     end


### PR DESCRIPTION
Cette case était confusante et inutile dans la plupart des cas, donc : 

- plus de case affichée
- la correction est automatiquement "résolue" à la validation des modifications

En revanche pour le SVA/SVR cette case est nécessaire (implications légales), donc : 
- la case reste
- elle est obligatoirement à valider, c'est à dire qu'on ne peut pas valider le dossier sans l'avoir cochée
- message d'erreur la case n'a pas été cochée