### PR TITLE
En tant que consommateur de l'API DS, je peux récupérer les infos RNF

### DIFF
--- a/app/graphql/api/v2/schema.rb
+++ b/app/graphql/api/v2/schema.rb
@@ -63,6 +63,7 @@ class API::V2::Schema < GraphQL::Schema
     Types::Champs::DepartementChampType,
     Types::Champs::DossierLinkChampType,
     Types::Champs::EpciChampType,
+    Types::Champs::RNFChampType,
     Types::Champs::IntegerNumberChampType,
     Types::Champs::LinkedDropDownListChampType,
     Types::Champs::MultipleDropDownListChampType,

--- a/app/graphql/api/v2/stored_query.rb
+++ b/app/graphql/api/v2/stored_query.rb
@@ -564,6 +564,11 @@ class API::V2::StoredQuery
         ...PersonneMoraleFragment
       }
     }
+    ... on RNFChamp {
+      rnf {
+        ...RNFFragment
+      }
+    }
   }
 
   fragment PersonneMoraleFragment on PersonneMorale {
@@ -664,6 +669,14 @@ class API::V2::StoredQuery
     name
     code
     postalCode
+  }
+
+  fragment RNFFragment on RNF {
+    id
+    title
+    address {
+      ...AddressFragment
+    }
   }
 
   fragment PageInfoFragment on PageInfo {

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -3581,6 +3581,33 @@ type RNAChampDescriptor implements ChampDescriptor {
   type: TypeDeChamp! @deprecated(reason: "Utilisez le champ `__typename` à la place.")
 }
 
+type RNF {
+  address: Address
+  id: String!
+  title: String
+}
+
+type RNFChamp implements Champ {
+  id: ID!
+
+  """
+  Libellé du champ.
+  """
+  label: String!
+  prefilled: Boolean!
+  rnf: RNF
+
+  """
+  La valeur du champ sous forme texte.
+  """
+  stringValue: String
+
+  """
+  Date de dernière modification du champ.
+  """
+  updatedAt: ISO8601DateTime!
+}
+
 type RNFChampDescriptor implements ChampDescriptor {
   """
   Description des champs d’un bloc répétable.

--- a/app/graphql/types/champ_type.rb
+++ b/app/graphql/types/champ_type.rb
@@ -75,6 +75,8 @@ module Types
           Types::Champs::TitreIdentiteChampType
         when ::Champs::EpciChamp
           Types::Champs::EpciChampType
+        when ::Champs::RNFChamp
+          Types::Champs::RNFChampType
         else
           Types::Champs::TextChampType
         end

--- a/app/graphql/types/champs/rnf_champ_type.rb
+++ b/app/graphql/types/champs/rnf_champ_type.rb
@@ -1,0 +1,45 @@
+module Types::Champs
+  class RNFChampType < Types::BaseObject
+    implements Types::ChampType
+
+    class RNFType < Types::BaseObject
+      field :id, String, null: false
+      field :title, String, null: true
+      field :address, Types::AddressType, null: true
+
+      def id
+        object.value
+      end
+
+      def title
+        object.data["title"]
+      end
+
+      def address
+        address = object.data["address"]
+        if address
+          {
+            label: address["label"],
+            type: address["type"],
+            street_address: address["streetAddress"],
+            street_number: address["streetNumber"],
+            street_name: address["streetName"],
+            postal_code: address["postalCode"],
+            city_name: address["cityName"],
+            city_code: address["cityCode"],
+            department_name: address["departmentName"],
+            department_code: address["departmentCode"],
+            region_name: address["regionName"],
+            region_code: address["regionCode"]
+          }
+        end
+      end
+    end
+
+    field :rnf, RNFType, null: true
+
+    def rnf
+      object if object.external_id.present?
+    end
+  end
+end

--- a/app/models/champs/rnf_champ.rb
+++ b/app/models/champs/rnf_champ.rb
@@ -5,6 +5,10 @@ class Champs::RNFChamp < Champ
     external_id
   end
 
+  def value
+    rnf_id
+  end
+
   def fetch_external_data
     RNFService.new.(rnf_id:)
   end


### PR DESCRIPTION
Cette PR expose les infos RNF suivantes pour chaque dossier ayant un champ RNF : 
- string_value : l'identifiant RNF
- le titre  de la fondation
- l'adresse de la fondation

Exemple : 

```
          "rnf": {
            "id": "000-XXX-00001-01
            "title": "Fondation SFR",
            "address": {
              "label": "16 Rue du Général de Boissieu 75015 Paris",
              "type": "housenumber",
              "streetAddress": "16 Rue du Général de Boissieu",
              "streetNumber": "16",
              "streetName": "Rue du Général de Boissieu",
              "postalCode": "75015",
              "cityName": "Paris",
              "cityCode": "75115",
              "departmentName": "Paris",
              "departmentCode": "75",
              "regionName": "Île-de-France",
              "regionCode": "11"
            }

```