### PR TITLE
API: une demande de correction de dossier peut être de type "outdated"

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -568,6 +568,11 @@ enum CorrectionReason {
   Le dossier n’est pas valide et nécessite une correction
   """
   incorrect
+
+  """
+  Le dossier doit être mis à jour et revalidé
+  """
+  outdated
 }
 
 """

--- a/app/models/dossier_correction.rb
+++ b/app/models/dossier_correction.rb
@@ -6,7 +6,11 @@ class DossierCorrection < ApplicationRecord
 
   scope :pending, -> { where(resolved_at: nil) }
 
-  enum reason: { incorrect: 'incorrect', incomplete: 'incomplete' }, _prefix: :dossier
+  enum reason: {
+    incorrect: 'incorrect',
+    incomplete: 'incomplete',
+    outdated: 'outdated'
+  }, _prefix: :dossier
 
   def resolved?
     resolved_at.present?

--- a/config/locales/models/dossier_correction/en.yml
+++ b/config/locales/models/dossier_correction/en.yml
@@ -5,3 +5,4 @@ en:
         reasons:
           incorrect: "The file is invalid and needs to be corrected"
           incomplete: "The file is incomplete and needs to be completed"
+          outdated: "The file needs to be updated and revalidated"

--- a/config/locales/models/dossier_correction/fr.yml
+++ b/config/locales/models/dossier_correction/fr.yml
@@ -5,3 +5,4 @@ fr:
         reasons:
           incorrect: "Le dossier n’est pas valide et nécessite une correction"
           incomplete: "Le dossier est incomplet et nécessite d’être complété"
+          outdated: "Le dossier doit être mis à jour et revalidé"


### PR DESCRIPTION
Première étape pour améliorer plus tard le wording usager quand une correction concerne plutôt une demande de mise à jour/reconfirmation du dossier, plutôt qu'une correction spécifique.

Cf #9485 pour les détails