### PR TITLE
ETQ usager la liste des pièces justificatives à fournir inclut les PJ des blocs répétables

### DIFF
--- a/app/controllers/users/commencer_controller.rb
+++ b/app/controllers/users/commencer_controller.rb
@@ -25,8 +25,6 @@ module Users
         @preview_dossiers = @dossiers.take(3)
       end
 
-      @usual_traitement_time = @procedure.stats_usual_traitement_time
-
       render 'commencer/show'
     end
 

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -944,11 +944,15 @@ class Procedure < ApplicationRecord
   end
 
   def pieces_jointes_list_without_conditionnal
-    active_revision.types_de_champ_public.not_condition.filter(&:piece_justificative?)
+    pieces_jointes_list do |base_scope|
+      base_scope.where(types_de_champ: { condition: nil })
+    end
   end
 
   def pieces_jointes_list_with_conditionnal
-    active_revision.types_de_champ_public.where.not(condition: nil).filter(&:piece_justificative?)
+    pieces_jointes_list do |base_scope|
+      base_scope.where.not(types_de_champ: { condition: nil })
+    end
   end
 
   def toggle_routing
@@ -960,6 +964,22 @@ class Procedure < ApplicationRecord
   end
 
   private
+
+  def pieces_jointes_list
+    scope = yield active_revision.revision_types_de_champ_public
+      .includes(:type_de_champ, revision_types_de_champ: :type_de_champ)
+      .where(types_de_champ: { type_champ: ['repetition', 'piece_justificative', 'titre_identite'] })
+
+    scope.each_with_object([]) do |rtdc, list|
+      if rtdc.type_de_champ.repetition?
+        rtdc.revision_types_de_champ.each do |rtdc_in_repetition|
+          list << [rtdc_in_repetition.type_de_champ, rtdc.type_de_champ] if rtdc_in_repetition.type_de_champ.piece_justificative?
+        end
+      else
+        list << [rtdc.type_de_champ]
+      end
+    end
+  end
 
   def validate_auto_archive_on_in_the_future
     return if auto_archive_on.nil?

--- a/app/views/shared/_procedure_description.html.haml
+++ b/app/views/shared/_procedure_description.html.haml
@@ -24,53 +24,54 @@
 
 - unless @no_description
   .fr-accordions-group.fr-mb-3w
-    %section.fr-accordion
-      %h2.fr-accordion__title
-        %button.fr-accordion__btn{ "aria-controls" => "accordion-114", "aria-expanded" => "true" }
-          = t('activerecord.attributes.procedure.description')
-      #accordion-114.fr-collapse
-        = h render SimpleFormatComponent.new(procedure.description, allow_a: true)
-
-    - if procedure.description_target_audience.present?
+    - cache [procedure, "description"] do
       %section.fr-accordion
         %h2.fr-accordion__title
-          %button.fr-accordion__btn{ "aria-controls" => "accordion-115", "aria-expanded" => "false" }
-            = t('activerecord.attributes.procedure.description_target_audience')
-        #accordion-115.fr-collapse
-          = h render SimpleFormatComponent.new(procedure.description_target_audience, allow_a: true)
+          %button.fr-accordion__btn{ "aria-controls" => "accordion-114", "aria-expanded" => "true" }
+            = t('activerecord.attributes.procedure.description')
+        #accordion-114.fr-collapse
+          = h render SimpleFormatComponent.new(procedure.description, allow_a: true)
 
-    - if procedure.description_pj.present?
-      %section.fr-accordion.pieces_jointes
-        %h2.fr-accordion__title
-          %button.fr-accordion__btn{ "aria-controls" => "accordion-116", "aria-expanded" => "false" }
-            = t('shared.procedure_description.pieces_jointes')
-        #accordion-116.fr-collapse
-          = h render SimpleFormatComponent.new(procedure.description_pj, allow_a: true)
+      - if procedure.description_target_audience.present?
+        %section.fr-accordion
+          %h2.fr-accordion__title
+            %button.fr-accordion__btn{ "aria-controls" => "accordion-115", "aria-expanded" => "false" }
+              = t('activerecord.attributes.procedure.description_target_audience')
+          #accordion-115.fr-collapse
+            = h render SimpleFormatComponent.new(procedure.description_target_audience, allow_a: true)
 
-    - elsif procedure.pieces_jointes_list?
-      %section.fr-accordion.pieces_jointes
-        %h2.fr-accordion__title
-          %button.fr-accordion__btn{ "aria-controls" => "accordion-116", "aria-expanded" => "false" }
-            = t('shared.procedure_description.pieces_jointes')
-        #accordion-116.fr-collapse
-          - if procedure.pieces_jointes_list_without_conditionnal.present?
-            %ul
-              = render partial: "shared/procedure_pieces_jointes_list", collection: procedure.pieces_jointes_list_without_conditionnal, as: :pj
+      - if procedure.description_pj.present?
+        %section.fr-accordion.pieces_jointes
+          %h2.fr-accordion__title
+            %button.fr-accordion__btn{ "aria-controls" => "accordion-116", "aria-expanded" => "false" }
+              = t('shared.procedure_description.pieces_jointes')
+          #accordion-116.fr-collapse
+            = h render SimpleFormatComponent.new(procedure.description_pj, allow_a: true)
 
-          - if procedure.pieces_jointes_list_with_conditionnal.present?
-            %h3.fr-text--sm.fr-mb-0.fr-mt-2w
-              = t('shared.procedure_description.pieces_jointes_conditionnal_list_title')
-            %ul
-              = render partial: "shared/procedure_pieces_jointes_list", collection: procedure.pieces_jointes_list_with_conditionnal, as: :pj
+      - elsif procedure.pieces_jointes_list?
+        %section.fr-accordion.pieces_jointes
+          %h2.fr-accordion__title
+            %button.fr-accordion__btn{ "aria-controls" => "accordion-116", "aria-expanded" => "false" }
+              = t('shared.procedure_description.pieces_jointes')
+          #accordion-116.fr-collapse
+            - if procedure.pieces_jointes_list_without_conditionnal.present?
+              %ul
+                = render partial: "shared/procedure_pieces_jointes_list", collection: procedure.pieces_jointes_list_without_conditionnal, as: :pj
 
-    - if @usual_traitement_time.present?
+            - if procedure.pieces_jointes_list_with_conditionnal.present?
+              %h3.fr-text--sm.fr-mb-0.fr-mt-2w
+                = t('shared.procedure_description.pieces_jointes_conditionnal_list_title')
+              %ul
+                = render partial: "shared/procedure_pieces_jointes_list", collection: procedure.pieces_jointes_list_with_conditionnal, as: :pj
+
+    - if procedure.stats_usual_traitement_time
       %section.fr-accordion
         %h2.fr-accordion__title
           %button.fr-accordion__btn{ "aria-controls" => "accordion-117", "aria-expanded" => "false" }
             = t('shared.procedure_description.usual_traitement_time_title')
 
         #accordion-117.fr-collapse
-          = t('shared.procedure_description.usual_traitement_time_detail_html', traitement_time: distance_of_time_in_words(@usual_traitement_time), percentile: ProcedureStatsConcern::USUAL_TRAITEMENT_TIME_PERCENTILE, days: ProcedureStatsConcern::NB_DAYS_RECENT_DOSSIERS, href: statistiques_path(procedure.path) )
+          = t('shared.procedure_description.usual_traitement_time_detail_html', traitement_time: distance_of_time_in_words(procedure.stats_usual_traitement_time), percentile: ProcedureStatsConcern::USUAL_TRAITEMENT_TIME_PERCENTILE, days: ProcedureStatsConcern::NB_DAYS_RECENT_DOSSIERS, href: statistiques_path(procedure.path) )
 
 
     - if procedure.persisted? && procedure.estimated_duration_visible?

--- a/app/views/shared/_procedure_description.html.haml
+++ b/app/views/shared/_procedure_description.html.haml
@@ -55,19 +55,13 @@
         #accordion-116.fr-collapse
           - if procedure.pieces_jointes_list_without_conditionnal.present?
             %ul
-              - procedure.pieces_jointes_list_without_conditionnal.each do |pj|
-                %li
-                  = pj.libelle
-                  = t('utils.no_mandatory') if !pj.mandatory?
+              = render partial: "shared/procedure_pieces_jointes_list", collection: procedure.pieces_jointes_list_without_conditionnal, as: :pj
 
           - if procedure.pieces_jointes_list_with_conditionnal.present?
             %h3.fr-text--sm.fr-mb-0.fr-mt-2w
               = t('shared.procedure_description.pieces_jointes_conditionnal_list_title')
             %ul
-              - procedure.pieces_jointes_list_with_conditionnal.each do |pj|
-                %li
-                  = pj.libelle
-                  = t('utils.no_mandatory') if !pj.mandatory?
+              = render partial: "shared/procedure_pieces_jointes_list", collection: procedure.pieces_jointes_list_with_conditionnal, as: :pj
 
     - if @usual_traitement_time.present?
       %section.fr-accordion

--- a/app/views/shared/_procedure_pieces_jointes_list.html.haml
+++ b/app/views/shared/_procedure_pieces_jointes_list.html.haml
@@ -1,0 +1,6 @@
+- tdc, parent_tdc = pj
+
+%li
+  = tdc.libelle
+  = "(#{parent_tdc.libelle})" if parent_tdc
+  = t('utils.no_mandatory') if !tdc.mandatory?

--- a/lib/tasks/benchmarks.rake
+++ b/lib/tasks/benchmarks.rake
@@ -78,6 +78,11 @@ namespace :benchmarks do
   #
   #     Attention : penser à refaire les étapes 1 et 2 sur la seconde branche !
   #
+  # 5.  Pour passer des paramètres d'urls, utiliser la variable d'environnement `PARAMS`
+  #     sous forme key=value, séparables par des virgules :
+  #
+  #     rake benchmarks:action[Users::CommencerController,commencer,commencer] PARAMS=path=my-demarche,other=value
+  #
   desc "Benchmark a Rails action"
   task :action, [:controller, :action1, :action2] => :environment do |_, args|
     require 'benchmark/ips'
@@ -97,6 +102,13 @@ namespace :benchmarks do
       controller.request = ActionDispatch::TestRequest.create
       controller.response = ActionDispatch::TestResponse.new
       controller.request.env['warden'] = warden
+
+      params = ENV.fetch("PARAMS") { "" }.split(",")
+      params.each do |param|
+        key, value = param.split("=")
+        controller.params[key.strip] = value.strip
+      end
+
       controller
     end
 

--- a/spec/models/procedure_revision_spec.rb
+++ b/spec/models/procedure_revision_spec.rb
@@ -770,11 +770,8 @@ describe ProcedureRevision do
       end
     end
 
-    describe 'caching behavior' do
+    describe 'caching behavior', caching: true do
       let(:procedure) { create(:procedure, :published, types_de_champ_public: types_de_champ_public) }
-
-      before { Rails.cache = ActiveSupport::Cache::MemoryStore.new }
-      after { Rails.cache = ActiveSupport::Cache::NullStore.new }
 
       context 'when a type de champ belonging to a draft revision is updated' do
         let(:draft_revision) { procedure.draft_revision }

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -1693,6 +1693,32 @@ describe Procedure do
     end
   end
 
+  describe '#pieces_jointes_list' do
+    include Logic
+    let(:procedure) { create(:procedure, types_de_champ_public:) }
+    let(:types_de_champ_public) do
+      [
+        { type: :integer_number, stable_id: 900 },
+        { type: :piece_justificative, libelle: "PJ", mandatory: true, stable_id: 910 },
+        { type: :piece_justificative, libelle: "PJ-cond", mandatory: true, stable_id: 911, condition: ds_eq(champ_value(900), constant(1)) },
+        { type: :repetition, libelle: "Répétition", stable_id: 920, children: [{ type: :piece_justificative, libelle: "PJ2", stable_id: 921 }] }
+      ]
+    end
+
+    let(:pj1) { procedure.active_revision.types_de_champ.find { _1.stable_id == 910 } }
+    let(:pjcond) { procedure.active_revision.types_de_champ.find { _1.stable_id == 911 } }
+    let(:repetition) { procedure.active_revision.types_de_champ.find { _1.stable_id == 920 } }
+    let(:pj2) { procedure.active_revision.types_de_champ.find { _1.stable_id == 921 } }
+
+    it "returns the list of pieces jointes without conditional" do
+      expect(procedure.pieces_jointes_list_without_conditionnal).to match_array([[pj1], [pj2, repetition]])
+    end
+
+    it "returns the list of pieces jointes having conditional" do
+      expect(procedure.pieces_jointes_list_with_conditionnal).to match_array([[pjcond]])
+    end
+  end
+
   private
 
   def create_dossier_with_pj_of_size(size, procedure)

--- a/spec/support/caching.rb
+++ b/spec/support/caching.rb
@@ -1,0 +1,16 @@
+RSpec.configure do |config|
+  config.around(:all, :caching) do |example|
+    caching_was = ActionController::Base.perform_caching
+    cache_store_was = Rails.cache
+
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    ActionController::Base.perform_caching = true
+    ActionController::Base.cache_store = Rails.cache
+
+    example.run
+  ensure
+    Rails.cache = cache_store_was
+    ActionController::Base.perform_caching = caching_was
+    ActionController::Base.cache_store = Rails.cache
+  end
+end


### PR DESCRIPTION
(Bug signalé au support)


C'est potentiellement pas super adapté dans les anciennes démarches qui incluent des PJ dans des blocs répétables uniquement pour pouvoir envoyer plusieurs fichiers. Mais ils ont la main : 
- pour rédiger une liste manuelle de PJ si la liste automatique ne leur convient pas
- ou pour mettre à jour leur formulaire


EDIT: comme suggéré par @LeSim j'ai ajouté du cache de fragment sur une partie de la description, ce qui accélère le chargement de cette page de 25-30%  même sur une démarche toute simple 🎉 

## APRES
![Capture d’écran 2023-11-23 à 14 46 31](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/c021dd39-09e7-429b-9f44-179bd5bcc7c0)


## AVANT
![Capture d’écran 2023-11-23 à 14 53 38](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/ff1dab32-df47-4b86-8ad0-5c3bdf7d26e9)
