### PR TITLE
[accessibilité] Améliore la lisibilité du site en mode Contraste élevé de Windows

### DIFF
--- a/app/assets/stylesheets/dsfr.scss
+++ b/app/assets/stylesheets/dsfr.scss
@@ -138,3 +138,25 @@ button.fr-tag-bug {
     align-items: flex-end;
   }
 }
+
+
+// improve readability in Windows High Contrast Mode
+@media screen and (forced-colors: active) {
+  .fr-input,
+  .fr-select,
+  .fr-btn {
+    border: 2px solid var(--border-action-high-grey);
+  }
+
+  .fr-radio-group input[type="radio"] {
+    opacity: 1;
+  }
+
+  .fr-tabs__tab[aria-selected=true]:not(:disabled) {
+    border: 5px solid var(--border-action-high-grey);
+  }
+
+  .fr-tabs__tab {
+    border: 2px solid var(--border-action-high-grey);
+  }
+}


### PR DESCRIPTION
Lorsque le site est utilisé avec le mode contraste élevé de Windows, il devient inutilisable. Cette PR permet d'améliorer un peu la lisibilité.

**APRES**
<img width="728" alt="Capture d’écran 2023-11-27 à 15 49 13" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/f3736cb4-5561-4398-b8b8-7529db66b80f">
**AVANT**
<img width="762" alt="Capture d’écran 2023-11-27 à 15 49 35" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/223bb3e4-b54b-41d9-851f-24eb3d686921">

Pour en savoir plus, un exemple d'article qui parle du mode contraste élevé de Windows :
https://www.smashingmagazine.com/2022/06/guide-windows-high-contrast-mode/