### PR TITLE
En tant que superadmin, je peux transférer un dossier d'un utilistateur à un autre

### DIFF
--- a/app/controllers/manager/dossiers_controller.rb
+++ b/app/controllers/manager/dossiers_controller.rb
@@ -21,7 +21,7 @@ module Manager
     end
 
     def transfer
-      transfer = DossierTransfer.create(email: params[:email], dossiers: [Dossier.find(params[:id])])
+      transfer = DossierTransfer.create(email: params[:email], dossiers: [Dossier.find(params[:id])], from_support: true)
       if transfer.persisted?
         flash[:success] = "Une invitation de transfert a été envoyée à #{params[:email]}"
       else

--- a/app/controllers/manager/dossiers_controller.rb
+++ b/app/controllers/manager/dossiers_controller.rb
@@ -31,6 +31,12 @@ module Manager
       redirect_to manager_dossier_path(params[:id])
     end
 
+    def transfer_destroy
+      dossier = Dossier.find(params[:id])
+      dossier.transfer.destroy_and_nullify
+      redirect_to manager_dossier_path(dossier), notice: t("users.dossiers.transferer.destroy")
+    end
+
     private
 
     def unfiltered_list?

--- a/app/controllers/manager/dossiers_controller.rb
+++ b/app/controllers/manager/dossiers_controller.rb
@@ -16,6 +16,21 @@ module Manager
       end
     end
 
+    def transfer_edit
+      @dossier = Dossier.find params[:id]
+    end
+
+    def transfer
+      transfer = DossierTransfer.create(email: params[:email], dossiers: [Dossier.find(params[:id])])
+      if transfer.persisted?
+        flash[:success] = "Une invitation de transfert a été envoyée à #{params[:email]}"
+      else
+        flash[:alert] = transfer.errors.full_messages.join("<br>")
+      end
+
+      redirect_to manager_dossier_path(params[:id])
+    end
+
     private
 
     def unfiltered_list?

--- a/app/models/dossier_transfer.rb
+++ b/app/models/dossier_transfer.rb
@@ -29,6 +29,7 @@ class DossierTransfer < ApplicationRecord
         {
           dossier: dossier,
           from: dossier.user.email,
+          from_support: transfer.from_support,
           to: transfer.email
         }
       end)

--- a/app/views/manager/dossiers/show.html.erb
+++ b/app/views/manager/dossiers/show.html.erb
@@ -26,6 +26,13 @@ as well as a link to its edit page.
       (Supprimé)
     <% end %>
   </h1>
+  <div>
+    <%= link_to(
+      "Transférer le dossier",
+      [:transfer_edit, namespace, page.resource],
+      class: "button",
+    ) if valid_action? :transfer_edit %>
+  </div>
 </header>
 
 <section class="main-content__body">

--- a/app/views/manager/dossiers/show.html.erb
+++ b/app/views/manager/dossiers/show.html.erb
@@ -36,6 +36,15 @@ as well as a link to its edit page.
 </header>
 
 <section class="main-content__body">
+  <div>
+    <% if dossier.transfer&.from_support %>
+      <p>
+        <%= t('views.users.dossiers.transfers.sender_demande_en_cours_from_support', id: dossier.id, email: dossier.transfer.email) %>
+        <br>
+        <%= link_to t('views.users.dossiers.transfers.revoke'), transfer_destroy_manager_dossier_path(dossier), class: 'fr-link', method: :delete %>
+      </p>
+    <% end %>
+  </div>
   <dl>
     <% page.attributes.each do |attribute| %>
       <dt class="attribute-label" id="<%= attribute.name %>">

--- a/app/views/manager/dossiers/transfer_edit.html.erb
+++ b/app/views/manager/dossiers/transfer_edit.html.erb
@@ -1,0 +1,46 @@
+<% content_for(:title) { "Transfert d'un dossier vers un autre utilisateur" } %>
+
+<header class="main-content__header" role="banner">
+  <h1 class="main-content__page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+</header>
+
+<section class="main-content__body">
+  <dl>
+    <dt class="attribute-label" id="user">User</dt>
+
+    <dd class="attribute-data attribute-data--belongs-to">
+      <%= link_to @dossier.user.email, manager_user_path(@dossier.user) %>
+    </dd>
+
+    <dt class="attribute-label" id="text_summary">Text summary</dt>
+
+    <dd class="attribute-data attribute-data--string">
+        <%= @dossier.text_summary %>
+    </dd>
+
+    <dt class="attribute-label" id="state">State</dt>
+
+    <dd class="attribute-data attribute-data--enum">
+      <%= dossier_display_state(@dossier) %>
+    </dd>
+  </dl>
+</section>
+<section>
+  <%= form_for([namespace, DossierTransfer.new], method: :post, url: transfer_manager_dossier_path(@dossier), html: { class: "form" }) do |f| %>
+    <div class="field-unit field-unit--string field-unit--optional">
+      <div class="field-unit__label">
+        <label for="user_email">A qui souhaitez-vous transferer le dossier ?</label>
+      </div>
+      <div class="field-unit__field">
+        <input type="text" name="email"  required placeholder="chouette.gars@laposte.net">
+      </div>
+
+    </div>
+    <div class="form-actions">
+      <%= f.submit "Transférer le dossier" %>
+    </div>
+  <% end %>
+</section>

--- a/app/views/users/dossiers/_dossiers_list.html.haml
+++ b/app/views/users/dossiers/_dossiers_list.html.haml
@@ -68,7 +68,10 @@
           = render Dsfr::AlertComponent.new(state: :info, size: :sm) do |c|
             - c.body do
               %p
-                = t('views.users.dossiers.transfers.receiver_demande_en_cours', id: dossier.id, email: dossier.user.email)
+                - if dossier.transfer.from_support?
+                  = t('views.users.dossiers.transfers.receiver_demande_en_cours_from_support', id: dossier.id, email: dossier.user.email)
+                - else
+                  = t('views.users.dossiers.transfers.receiver_demande_en_cours', id: dossier.id, email: dossier.user.email)
               %p
                 = link_to t('views.users.dossiers.transfers.accept'), transfer_path(dossier.transfer), class: "fr-link fr-mr-1w", method: :put
                 = link_to t('views.users.dossiers.transfers.reject'), transfer_path(dossier.transfer), class: "fr-link", method: :delete
@@ -76,7 +79,10 @@
           = render Dsfr::AlertComponent.new(state: :info, size: :sm, extra_class_names: "fr-mb-2w") do |c|
             - c.body do
               %p
-                = t('views.users.dossiers.transfers.sender_demande_en_cours', id: dossier.id, email: dossier.transfer.email)
+                - if dossier.transfer.from_support?
+                  = t('views.users.dossiers.transfers.sender_demande_en_cours_from_support', id: dossier.id, email: dossier.transfer.email)
+                - else
+                  = t('views.users.dossiers.transfers.sender_demande_en_cours', id: dossier.id, email: dossier.transfer.email)
               %p
                 = link_to t('views.users.dossiers.transfers.revoke'), transfer_path(dossier.transfer), class: 'fr-link', method: :delete
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -479,7 +479,9 @@ en:
           deleted_badge: Deleted
         transfers:
           sender_demande_en_cours: "A transfer request is pending on file Nº %{id} to %{email}"
+          sender_demande_en_cours: "A transfer request from technical support is pending on file Nº %{id} to %{email}"
           receiver_demande_en_cours: "Transfer request on file Nº %{id} sent by %{email}"
+          receiver_demande_en_cours_from_support: "Transfer request from technical support on file Nº %{id} of %{email}"
           revoke: Revoke this request
           accept: Accept
           reject: Reject

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -493,7 +493,9 @@ fr:
           other_actions: "Autres actions"
         transfers:
           sender_demande_en_cours: "Une demande de transfert est en cours sur le dossier Nº %{id} pour %{email}"
+          sender_demande_en_cours_from_support: "Une demande de transfert par le support technique est en cours sur le dossier Nº %{id} pour %{email}"
           receiver_demande_en_cours: "Demande de transfert pour le dossier Nº %{id} envoyé par %{email}"
+          receiver_demande_en_cours_from_support: "Demande de transfert par le support technique pour le dossier Nº %{id} de %{email}"
           revoke: Révoquer cette demande
           accept: Accepter
           reject: Rejeter

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,7 +69,10 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :dossiers, only: [:show]
+    resources :dossiers, only: [:show] do
+      get 'transfer_edit', on: :member
+      post 'transfer', on: :member
+    end
 
     resources :bill_signatures, only: [:index]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,7 @@ Rails.application.routes.draw do
     resources :dossiers, only: [:show] do
       get 'transfer_edit', on: :member
       post 'transfer', on: :member
+      delete 'transfer_destroy', on: :member
     end
 
     resources :bill_signatures, only: [:index]

--- a/db/migrate/20231127102633_add_from_support_to_dossier_transfers.rb
+++ b/db/migrate/20231127102633_add_from_support_to_dossier_transfers.rb
@@ -1,0 +1,5 @@
+class AddFromSupportToDossierTransfers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :dossier_transfers, :from_support, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20231128071043_add_from_support_to_dossier_transfer_logs.rb
+++ b/db/migrate/20231128071043_add_from_support_to_dossier_transfer_logs.rb
@@ -1,0 +1,5 @@
+class AddFromSupportToDossierTransferLogs < ActiveRecord::Migration[7.0]
+  def change
+    add_column :dossier_transfer_logs, :from_support, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_27_102633) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_28_071043) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -386,6 +386,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_27_102633) do
     t.datetime "created_at", null: false
     t.bigint "dossier_id", null: false
     t.string "from", null: false
+    t.boolean "from_support", default: false, null: false
     t.string "to", null: false
     t.datetime "updated_at", null: false
     t.index ["dossier_id"], name: "index_dossier_transfer_logs_on_dossier_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_27_102633) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -395,6 +395,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_113317) do
     t.datetime "created_at", null: false
     t.string "email", null: false
     t.datetime "updated_at", null: false
+    t.boolean "from_support", default: false, null: false
     t.index ["email"], name: "index_dossier_transfers_on_email"
   end
 

--- a/spec/controllers/manager/dossiers_controller_spec.rb
+++ b/spec/controllers/manager/dossiers_controller_spec.rb
@@ -55,4 +55,14 @@ describe Manager::DossiersController, type: :controller do
       it { expect(DossierMailer).not_to have_received(:notify_transfer) }
     end
   end
+
+  describe "DELETE #transfer_destroy" do
+    before do
+      DossierTransfer.create(email: 'coucou@laposte.net', dossiers: [@dossier])
+      delete :transfer_destroy, params: { id: @dossier.id }
+    end
+
+    it { expect(@dossier.transfer).to be_nil }
+    it { expect(flash[:notice]).to eq "La demande de transfert a été supprimée avec succès" }
+  end
 end

--- a/spec/controllers/manager/dossiers_controller_spec.rb
+++ b/spec/controllers/manager/dossiers_controller_spec.rb
@@ -34,4 +34,25 @@ describe Manager::DossiersController, type: :controller do
 
     it { expect(subject).to match(%r{Nom\s+\*\s+Texte court\s+🟢\s+rempli}) }
   end
+
+  describe "POST #transfer" do
+    before do
+      allow(DossierMailer).to receive(:notify_transfer).and_call_original
+      post :transfer, params: { id: @dossier.id, email: }
+    end
+
+    context 'with valid email' do
+      let(:email) { "chouette.gars@laposte.net" }
+
+      it { expect(flash[:success]).to eq("Une invitation de transfert a été envoyée à chouette.gars@laposte.net") }
+      it { expect(DossierMailer).to have_received(:notify_transfer) }
+    end
+
+    context 'with invalid email' do
+      let(:email) { "chouette" }
+
+      it { expect(flash[:alert]).to eq("L’adresse email est invalide") }
+      it { expect(DossierMailer).not_to have_received(:notify_transfer) }
+    end
+  end
 end


### PR DESCRIPTION
close #9435 

- Dans le manager, depuis la page d'un dossier, il est possible de transférer un dossier : 

![2023-11-28-095730_836x117_scrot](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/1111966/8877e91b-1971-4c4d-91b8-1b9e3553c1a0)

- Une page spécifique pour le transfert d'un dossier s'affiche alors : 

![2023-11-28-101504_665x534_scrot](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/1111966/d97c1602-f940-4374-a2df-2336e5781370)

- L'utilisateur cible peut accepter ou rejeter la demande, et il lui est indiqué qu'elle a été initiée par le support technique : 

![2023-11-28-100352_796x433_scrot](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/1111966/7f790213-1b6e-4604-ba80-feb5771543dc)

- le superadmin peut révoquer la demande depuis la page dossier : 

![2023-11-28-100433_828x186_scrot](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/1111966/80b852c0-bca8-4cd0-912f-67d8d8cd88b4)



