### PR TITLE
Tech: quand un dossier est définitivement supprimé, on ne garde que le log (DOL) concernant sa suppression

### DIFF
--- a/app/models/dossier_operation_log.rb
+++ b/app/models/dossier_operation_log.rb
@@ -41,7 +41,9 @@ class DossierOperationLog < ApplicationRecord
 
   def self.purge_discarded
     not_deletion.destroy_all
-    with_data.each(&:move_to_cold_storage!)
+
+    supprimer.map { _1.serialized.purge_later }
+    supprimer.update_all(data: nil)
   end
 
   def self.create_and_serialize(params)

--- a/spec/models/dossier_operation_log_spec.rb
+++ b/spec/models/dossier_operation_log_spec.rb
@@ -1,0 +1,87 @@
+describe DossierOperationLog, type: :model do
+  describe '.purge_discarded' do
+    let(:dossier) { create(:dossier) }
+    let!(:witness_dossier) do
+      d = create(:dossier)
+
+      DossierOperationLog.create_and_serialize(
+        dossier: d,
+        operation: DossierOperationLog.operations[:passer_en_instruction],
+        author: instructeur
+      )
+
+      DossierOperationLog.create_and_serialize(
+        dossier: d,
+        operation: DossierOperationLog.operations[:supprimer],
+        author: instructeur
+      )
+
+      d
+    end
+
+    let(:instructeur) { create(:instructeur) }
+
+    def dols = dossier.dossier_operation_logs.reload
+    def supprimer_dol = dols.find_by(operation: 'supprimer')
+    def witness_dols = witness_dossier.dossier_operation_logs.reload
+    def witness_supprimer_dol = witness_dols.find_by(operation: 'supprimer')
+
+    it 'purges all operations but supprimer' do
+      DossierOperationLog.create_and_serialize(
+        dossier:,
+        operation: DossierOperationLog.operations[:passer_en_instruction],
+        author: instructeur
+      )
+
+      DossierOperationLog.create_and_serialize(
+        dossier:,
+        operation: DossierOperationLog.operations[:supprimer],
+        author: instructeur
+      )
+
+      expect(dols.count).to eq(2)
+
+      dols.purge_discarded
+
+      expect(dols.map(&:operation)).to match_array('supprimer')
+      expect(witness_dols.map(&:operation)).to match_array(['passer_en_instruction', 'supprimer'])
+    end
+
+    it 'destroys the serialized json from supprimer dol' do
+      DossierOperationLog.create_and_serialize(
+        dossier:,
+        operation: DossierOperationLog.operations[:supprimer],
+        author: instructeur
+      )
+
+      # serialize data attribute to json and store it to cold storage
+      perform_enqueued_jobs do
+        dols.each(&:move_to_cold_storage!)
+        witness_dols.each(&:move_to_cold_storage!)
+      end
+
+      expect(supprimer_dol.serialized.attached?).to be true
+
+      perform_enqueued_jobs { dols.purge_discarded }
+
+      expect(supprimer_dol.serialized.attached?).to be false
+      expect(witness_supprimer_dol.serialized.attached?).to be true
+    end
+
+    it 'nillifies the data attribut of not net seriaized supprimer dol' do
+      DossierOperationLog.create_and_serialize(
+        dossier:,
+        operation: DossierOperationLog.operations[:supprimer],
+        author: instructeur
+      )
+
+      expect(supprimer_dol.data).to be_present
+
+      dols.purge_discarded
+
+      expect(supprimer_dol.serialized.attached?).to be false
+      expect(supprimer_dol.data).to be_nil
+      expect(witness_supprimer_dol.data).to be_present
+    end
+  end
+end

--- a/spec/models/dossier_purge_spec.rb
+++ b/spec/models/dossier_purge_spec.rb
@@ -1,0 +1,33 @@
+describe Dossier, type: :model do
+  describe '.purge_discarded' do
+    it 'discards brouillon, en_construction and termine' do
+      [
+        :en_brouillon_expired_to_delete,
+        :en_construction_expired_to_delete,
+        :termine_expired_to_delete
+      ].each do |scope|
+        dossier = double(purge_discarded: true)
+        expect(dossier).to receive(:purge_discarded)
+
+        collection = double(find_each: true)
+        expect(collection).to receive(:find_each) { |&block| block.call(dossier) }
+
+        expect(Dossier).to receive(scope).and_return(collection)
+      end
+
+      Dossier.purge_discarded
+    end
+  end
+
+  describe '#purge_discarded' do
+    let(:dossier) { create(:dossier) }
+
+    it 'creates a deleted dossier, purge the dols and then destroy' do
+      expect(DeletedDossier).to receive(:create_from_dossier)
+      expect(dossier.dossier_operation_logs).to receive(:purge_discarded)
+      expect(dossier).to receive(:destroy)
+
+      dossier.purge_discarded
+    end
+  end
+end


### PR DESCRIPTION
Les seules dernières informations que l'on gardent sont dossier_id, automatic_operation, digest and bill_id, dol.created_at