### PR TITLE
fix: Image#data is not supported on MiniMagick

### DIFF
--- a/app/controllers/concerns/uninterlace_png_concern.rb
+++ b/app/controllers/concerns/uninterlace_png_concern.rb
@@ -14,6 +14,6 @@ module UninterlacePngConcern
 
   def interlaced?(png_path)
     png = MiniMagick::Image.open(png_path)
-    png.data["interlace"] != "None"
+    png.details["interlace"] != "None"
   end
 end


### PR DESCRIPTION
Corrige une erreur 500 lors d'un dépôt de png lors de la modification d'un template d'attestation, backtrace:

```
Nov 28 22:01:48 compute01 ds-fr[5758]: F, [2023-11-28T22:01:48.533359 #5758] FATAL -- :
Nov 28 22:01:48 compute01 ds-fr[5758]: MiniMagick::Error (MiniMagick::Image#data isn't supported on GraphicsMagick. Use MiniMagick::Image#details instead.):
Nov 28 22:01:48 compute01 ds-fr[5758]:   
Nov 28 22:01:48 compute01 ds-fr[5758]: app/controllers/concerns/uninterlace_png_concern.rb:17:in `interlaced?'
Nov 28 22:01:48 compute01 ds-fr[5758]: app/controllers/concerns/uninterlace_png_concern.rb:7:in `uninterlace_png'
Nov 28 22:01:48 compute01 ds-fr[5758]: app/controllers/administrateurs/attestation_templates_controller.rb:68:in `activated_attestation_params'
Nov 28 22:01:48 compute01 ds-fr[5758]: app/controllers/administrateurs/attestation_templates_controller.rb:19:in `update'
Nov 28 22:01:48 compute01 ds-fr[5758]: app/controllers/application_controller.rb:376:in `switch_locale'
```