### PR TITLE
ETQ utilisateur, je voudrais que le format affiché pour les champs de date corresponde au format du champ de saisie

### DIFF
--- a/app/components/editable_champ/champ_label_content_component/champ_label_content_component.html.haml
+++ b/app/components/editable_champ/champ_label_content_component/champ_label_content_component.html.haml
@@ -18,7 +18,7 @@
     = t('.check_content_rebased')
 
 - if hint?
-  %span.fr-hint-text= hint
+  %span.fr-hint-text{ data: { controller: 'date-input-hint' } }= hint
 
 - if @champ.description.present?
   %span.fr-hint-text{ id: @champ.describedby_id }= render SimpleFormatComponent.new(@champ.description, allow_a: true)

--- a/app/components/editable_champ/date_component/date_component.html.haml
+++ b/app/components/editable_champ/date_component/date_component.html.haml
@@ -3,4 +3,4 @@
   aria: { describedby: @champ.describedby_id },
   value: @champ.value,
   required: @champ.required?,
-  placeholder: 'aaaa-mm-jj', class: "width-33-desktop")
+  class: "width-33-desktop")

--- a/app/javascript/controllers/date_input_hint_controller.ts
+++ b/app/javascript/controllers/date_input_hint_controller.ts
@@ -1,0 +1,49 @@
+import { ApplicationController } from './application_controller';
+
+const DATE_PLACEHOLDER_REGEXP = /[jJmMdD]{2}\/[jJmMdD]{2}\/[aAyY]{4}/;
+const DATE_EXAMPLE_REGEXP = /\d{1,2}\/\d{1,2}\/\d{4}/;
+const PARTS = {
+  fr: {
+    '15': 'JJ',
+    '10': 'MM',
+    '2022': 'AAAA'
+  },
+  en: {
+    '15': 'dd',
+    '10': 'mm',
+    '2022': 'yyyy'
+  }
+};
+
+export class DateInputHintController extends ApplicationController {
+  connect() {
+    this.fixDateFormat(this.element);
+  }
+
+  private fixDateFormat(input: Element) {
+    const text = input.textContent ?? '';
+    const match = text.match(DATE_PLACEHOLDER_REGEXP);
+
+    if (match) {
+      const [placeholder, example] = this.translatePlaceholder();
+      // This component behaviour can be had to test and debug. We keep a (debug) log here to help.
+      console.debug(`Replace ${match[0]} with ${placeholder} and ${example}`);
+      input.textContent = text
+        .replace(DATE_PLACEHOLDER_REGEXP, placeholder)
+        .replace(DATE_EXAMPLE_REGEXP, example);
+    }
+  }
+
+  private translatePlaceholder() {
+    const locale = document.documentElement.lang as 'fr' | 'en';
+    const parts = PARTS[locale];
+    const example = new Date(2022, 9, 15).toLocaleDateString();
+    return [
+      Object.entries(parts).reduce(
+        (text, [part, str]) => text.replace(part, str),
+        example
+      ),
+      example
+    ];
+  }
+}


### PR DESCRIPTION
Nous recevons des retours au support car l'affichage du format est parfois trompeur actuellement.

> Pour la date d'arrivée en anglais (daytime), le bon format anglais est indiqué : MM/DD/YYYY, cependant cela est ensuite inversé côté service instructeur. J'ai fait un test en mettant 07/12/2024 en date d'arrivée en anglais et dans mon format instructeur en version EN et FR, ça me donne Décembre 07 2024

Le problème vient du fait que les inputs natifs date/datetime ne peuvent pas être configurés. Ils utilisent toujours la locale du navigateur, et la locale du navigateur dépend des préférences du navigateur et, pour certains navigateurs, de l'OS. Par exemple, sur mon OS, la langue est anglais mais la localisation est française. En ce qui concerne les navigateurs, personne n'est d'accord : Safari suit l'OS, Chrome suit sa propre configuration pour la langue, mais pour la localisation, il suit le système, et Firefox suit à la fois la langue et la localisation en fonction de sa propre configuration.

En plus de tout cela, nous avons notre propre cookie qui configure la langue de l'interface, mais bien sûr, cela n'a pas d'impact sur les contrôles natifs.

avant :

en (ds) / fr (system)
<img width="436" alt="bad" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/12428/2de164c1-d2b2-4149-92da-b3586a987099">

après :

en (ds) / en (system)
<img width="457" alt="en / en" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/12428/d9fe4862-5294-4b48-b109-1b56b60a26ae">

en (ds) / fr (system)
<img width="436" alt="en / fr" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/12428/78af4e7f-e686-4563-bd9f-9eabf3b8f307">

fr (ds) / fr (system)
<img width="436" alt="fr / fr" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/12428/0d8c5306-5cf3-4a40-ac3b-76e883cd7f77">

fr (ds) / en (system)
<img width="436" alt="fr / en" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/12428/abd500f2-e937-40bb-bf40-f0eafbc639aa">
