### PR TITLE
Perf chargement de dossier: fix N+1 sur les champs répétitions non obligatoires

### DIFF
--- a/app/models/dossier_preloader.rb
+++ b/app/models/dossier_preloader.rb
@@ -97,7 +97,10 @@ class DossierPreloader
   end
 
   def load_champs(parent, name, champs, dossier, children_by_parent)
-    return if champs.empty?
+    if champs.empty?
+      parent.association(name).target = [] # tells to Rails association has been loaded
+      return
+    end
 
     champs.each do |champ|
       champ.association(:dossier).target = dossier

--- a/spec/models/dossier_preloader_spec.rb
+++ b/spec/models/dossier_preloader_spec.rb
@@ -2,12 +2,14 @@ describe DossierPreloader do
   let(:types_de_champ) do
     [
       { type: :text },
-      { type: :repetition, mandatory: true, children: [{ type: :text }] }
+      { type: :repetition, mandatory: true, children: [{ type: :text }] },
+      { type: :repetition, mandatory: false, children: [{ type: :text }] }
     ]
   end
   let(:procedure) { create(:procedure, types_de_champ_public: types_de_champ) }
   let(:dossier) { create(:dossier, procedure: procedure) }
   let(:repetition) { subject.champs_public.second }
+  let(:repetition_optional) { subject.champs_public.third }
   let(:first_child) { subject.champs_public.second.champs.first }
 
   describe 'all' do
@@ -37,6 +39,8 @@ describe DossierPreloader do
         expect(subject.champs_public.first.conditional?).to eq(false)
 
         expect(first_child.parent).to eq(repetition)
+        expect(repetition.champs.first).to eq(first_child)
+        expect(repetition_optional.champs).to be_empty
       end
 
       expect(count).to eq(0)


### PR DESCRIPTION
- un champ répétition n'est pas obligatoire
- on ne créé pas de champ (row) par défaut (contrairement à une répétition obligatoire)
- jusqu'à cette PR, on ne disait pas à AR que l'association était connue, bien que vide
- AR déclenchait une requête sur 'champ_repetition.champs