### PR TITLE
Rend la signature dans les emails plus neutre

### DIFF
--- a/app/views/notification_mailer/default_templates/_signature.html.haml
+++ b/app/views/notification_mailer/default_templates/_signature.html.haml
@@ -1,4 +1,4 @@
 %p
-  Bonne journée,
+  = t(:best_regards, scope: [:views, :shared, :greetings])
   %br
   \ --nom du service--

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -326,7 +326,7 @@ fr:
         edit: Modifier
       greetings:
         hello: Bonjour,
-        best_regards: Bonne journée,
+        best_regards: Cordialement,
       dossiers:
         form:
           submitted_at: "Déposé le %{datetime}"


### PR DESCRIPTION
Suite au forum ouvert du 29/11/2023, il a été remonté que la formulation "Bonne journée" n'était pas appropriée dans certains cas.
Cette PR remplace cette formulation par *Cordialement*

