### PR TITLE
ETQ admin je suis prévenu si des erreurs sur la démarche empêchent la publication de révision

### DIFF
--- a/app/components/procedure/publication_warning_component.rb
+++ b/app/components/procedure/publication_warning_component.rb
@@ -3,6 +3,12 @@ class Procedure::PublicationWarningComponent < ApplicationComponent
     @procedure = procedure
   end
 
+  def title
+    return "Des problèmes empêchent la publication des modifications" if @procedure.publiee?
+
+    "Des problèmes empêchent la publication de la démarche"
+  end
+
   private
 
   def render?
@@ -26,7 +32,8 @@ class Procedure::PublicationWarningComponent < ApplicationComponent
     when :attestation_template
       edit_admin_procedure_attestation_template_path(@procedure)
     when :initiated_mail, :received_mail, :closed_mail, :refused_mail, :without_continuation_mail, :re_instructed_mail
-      admin_procedure_mail_templates_path(@procedure)
+      klass = "Mails::#{attribute.to_s.classify}".constantize
+      edit_admin_procedure_mail_template_path(@procedure, klass.const_get(:SLUG))
     end
   end
 end

--- a/app/components/procedure/publication_warning_component/publication_warning_component.html.haml
+++ b/app/components/procedure/publication_warning_component/publication_warning_component.html.haml
@@ -1,4 +1,4 @@
-= render Dsfr::AlertComponent.new(state: :warning, title: "Des problèmes empêchent la publication de la démarche") do |c|
+= render Dsfr::AlertComponent.new(state: :warning, title:) do |c|
   - c.body do
     - error_messages.each do |(messages, path)|
       %p.mt-2

--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -316,6 +316,8 @@ module Administrateurs
       flash.notice = "Nouvelle version de la démarche publiée"
 
       redirect_to admin_procedure_path(@procedure)
+    rescue ActiveRecord::RecordInvalid
+      redirect_to admin_procedure_publication_path(@procedure)
     end
 
     def transfert

--- a/app/views/administrateurs/procedures/show.html.haml
+++ b/app/views/administrateurs/procedures/show.html.haml
@@ -35,12 +35,14 @@
       - c.body do
         = render Procedure::RevisionChangesComponent.new changes: @procedure.revision_changes, previous_revision: @procedure.published_revision
 
+        = render Procedure::PublicationWarningComponent.new(procedure: @procedure)
+
       - c.bottom do
         %ul.fr-mt-2w.fr-btns-group.fr-btns-group--inline
           - if @procedure.publiee?
-            %li= button_to 'Publier les modifications', admin_procedure_publish_revision_path(@procedure), class: 'fr-btn', id: 'publish-procedure-link', data: { disable_with: "Publication...", confirm: 'Êtes-vous sûr de vouloir publier les modifications ?' }, disabled: !@procedure.draft_revision.valid?, method: :put
+            %li= button_to 'Publier les modifications', admin_procedure_publish_revision_path(@procedure), class: 'fr-btn', id: 'publish-procedure-link', data: { disable_with: "Publication...", confirm: 'Êtes-vous sûr de vouloir publier les modifications ?' }, disabled: !@procedure.draft_revision.valid? || @procedure.errors.present?, method: :put
           - else
-            %li= button_to 'Publier les modifications', admin_procedure_publication_path(@procedure), class: 'fr-btn', id: 'publish-procedure-link', data: { disable_with: "Publication..." }, disabled: !@procedure.draft_revision.valid?, method: :get
+            %li= button_to 'Publier les modifications', admin_procedure_publication_path(@procedure), class: 'fr-btn', id: 'publish-procedure-link', data: { disable_with: "Publication..." }, disabled: !@procedure.draft_revision.valid? || @procedure.errors.present?, method: :get
           %li= button_to "Réinitialiser les modifications", admin_procedure_reset_draft_path(@procedure), class: 'fr-btn fr-btn--secondary fr-mr-2w', data: { confirm: 'Êtes-vous sûr de vouloir réinitialiser les modifications ?' }, method: :put
 
 - if !@procedure.procedure_expires_when_termine_enabled?

--- a/spec/system/administrateurs/procedure_publish_spec.rb
+++ b/spec/system/administrateurs/procedure_publish_spec.rb
@@ -168,7 +168,7 @@ describe 'Publishing a procedure', js: true do
 
     scenario 'an error message prevents the publication' do
       visit admin_procedure_path(procedure)
-      expect(page).to have_content('Des problèmes empêchent la publication de la démarche')
+      expect(page).to have_content('Des problèmes empêchent la publication des modifications')
       expect(page).to have_link('corriger', href: edit_admin_procedure_mail_template_path(procedure, Mails::InitiatedMail::SLUG))
       expect(page).to have_button('Publier les modifications', disabled: true)
     end

--- a/spec/system/administrateurs/procedure_publish_spec.rb
+++ b/spec/system/administrateurs/procedure_publish_spec.rb
@@ -154,4 +154,23 @@ describe 'Publishing a procedure', js: true do
       expect(page).to have_selector(".dubious-champs", count: dubious_champs.size)
     end
   end
+
+  context 'when the procedure has other validation error' do
+    let(:procedure) { create(:procedure, :published, :with_service, :with_type_de_champ, administrateur:) }
+    let(:initiated_mail) { create(:initiated_mail, procedure:, body: "Hey!") }
+
+    before do
+      initiated_mail.body += "\n--invalid balise--"
+      initiated_mail.save!(validate: false)
+
+      procedure.draft_revision.add_type_de_champ(type_champ: :text, libelle: "Nouveau champ")
+    end
+
+    scenario 'an error message prevents the publication' do
+      visit admin_procedure_path(procedure)
+      expect(page).to have_content('Des problèmes empêchent la publication de la démarche')
+      expect(page).to have_link('corriger', href: edit_admin_procedure_mail_template_path(procedure, Mails::InitiatedMail::SLUG))
+      expect(page).to have_button('Publier les modifications', disabled: true)
+    end
+  end
 end


### PR DESCRIPTION
Plutôt que renvoyer une 422 avec le message "Action rejetée", on fait proactivement comme pour une démarche en brouillon: 

- réaffiche le component procedure warning
- désactive le bouton "Publier…"
- évite une 422 et affiche les erreurs si malgré tout c'est soumis (navigateur qui gère pas disabled…)
- liens directs vers les emails personnalisés

![Capture d’écran 2023-12-05 à 18 31 56](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/3d9e8554-659f-409f-b7aa-0aa8df89bee5)
