### PR TITLE
ETQ usager, je ne vois plus le statut "antivirus en cours" lorsque j'envoie un PJ 

### DIFF
--- a/app/components/attachment/edit_component/edit_component.html.haml
+++ b/app/components/attachment/edit_component/edit_component.html.haml
@@ -14,7 +14,7 @@
           .fr-py-1v
             %span.attachment-filename.fr-mr-1w= link_to_if(viewable?, attachment.filename.to_s, helpers.url_for(attachment.blob), title: t(".open_file", filename: attachment.filename), **helpers.external_link_attributes)
 
-          = render Attachment::ProgressComponent.new(attachment: attachment)
+          = render Attachment::ProgressComponent.new(attachment: attachment, ignore_antivirus: true)
 
       - if error?
         %p.fr-error-text= error_message

--- a/app/components/attachment/pending_poll_component.rb
+++ b/app/components/attachment/pending_poll_component.rb
@@ -36,6 +36,6 @@ class Attachment::PendingPollComponent < ApplicationComponent
   private
 
   def pending_attachment?(attachment)
-    attachment.virus_scanner.pending? || attachment.watermark_pending?
+    attachment.watermark_pending?
   end
 end

--- a/app/components/attachment/pending_poll_component/pending_poll_component.en.yml
+++ b/app/components/attachment/pending_poll_component/pending_poll_component.en.yml
@@ -2,6 +2,6 @@
 en:
   reload: Reload
   explanation:
-    one: Scanning for viruses and processing your attachment takes longer than expected.
-    other: Scanning for viruses and processing your attachments takes longer than expected.
+    one: Processing your attachment takes longer than expected.
+    other: Processing your attachments takes longer than expected.
   dossier_submittable: This does not prevent you from submitting your file if you wish.

--- a/app/components/attachment/pending_poll_component/pending_poll_component.fr.yml
+++ b/app/components/attachment/pending_poll_component/pending_poll_component.fr.yml
@@ -2,7 +2,7 @@
 fr:
   reload: Recharger
   explanation:
-    one: L’analyse antivirus et le traitement de votre pièce jointe prend plus de temps que prévu.
-    other: L’analyse antivirus et le traitement de vos pièces jointes prend plus de temps que prévu.
+    one: Le traitement de votre pièce jointe prend plus de temps que prévu.
+    other: Le traitement de vos pièces jointes prend plus de temps que prévu.
 
   dossier_submittable: Cela ne vous empêche pas de déposer votre dossier si vous le souhaitez.

--- a/app/components/attachment/progress_component.rb
+++ b/app/components/attachment/progress_component.rb
@@ -1,13 +1,15 @@
 class Attachment::ProgressComponent < ApplicationComponent
   attr_reader :attachment
+  attr_reader :ignore_antivirus
 
-  def initialize(attachment:)
+  def initialize(attachment:, ignore_antivirus: false)
     @attachment = attachment
+    @ignore_antivirus = ignore_antivirus
   end
 
   def progress_label
     case
-    when attachment.virus_scanner.pending?
+    when !ignore_antivirus && attachment.virus_scanner.pending?
       t(".antivirus_pending")
     when attachment.watermark_pending?
       t(".watermark_pending")

--- a/app/views/root/patron.html.haml
+++ b/app/views/root/patron.html.haml
@@ -332,8 +332,8 @@
     %h1.fr-mt-4w Attachment::EditComponent
     %span.fr-hint-text Note: direct upload, suppression ne marchent pas comme attendu ici.
 
-    - champ = @dossier.champs_public.first
-    - tdc = @dossier.champs_public.find { _1.type_champ == TypeDeChamp.type_champs.fetch(:piece_justificative) }.type_de_champ
+    - champ = @dossier.champs_public.find { _1.type_champ == TypeDeChamp.type_champs.fetch(:piece_justificative) }
+    - tdc = champ.type_de_champ
     - avis = Avis.new
 
     - if attachment = ActiveStorage::Attachment.last
@@ -346,16 +346,6 @@
 
       %h3.fr-mt-4w Existing attachment, user can not destroy
       = render Attachment::EditComponent.new(champ:, attached_file: champ.piece_justificative_file, attachment:, user_can_destroy: false)
-
-      %h3.fr-mt-4w Existing attachment, antivirus in progress
-      - attachment.blob.metadata[:virus_scan_result] = ActiveStorage::VirusScanner::PENDING
-      - attachment.created_at = Time.zone.now
-      = render Attachment::EditComponent.new(champ:, attached_file: Champ.new.piece_justificative_file, attachment:)
-
-      %h3.fr-mt-4w Existing attachment, antivirus in progress since long time
-      - attachment.blob.metadata[:virus_scan_result] = ActiveStorage::VirusScanner::PENDING
-      - attachment.created_at = 2.minutes.ago
-      = render Attachment::EditComponent.new(champ:, attached_file: Champ.new.piece_justificative_file, attachment:)
 
       %h3.fr-mt-4w Existing attachment, error
       - attachment.blob.metadata[:virus_scan_result] = ActiveStorage::VirusScanner::INFECTED

--- a/spec/components/attachment/edit_component_spec.rb
+++ b/spec/components/attachment/edit_component_spec.rb
@@ -130,28 +130,6 @@ RSpec.describe Attachment::EditComponent, type: :component do
       champ.piece_justificative_file[0].blob.update(virus_scan_result:)
     end
 
-    context 'when the anti-virus scan is pending' do
-      let(:virus_scan_result) { ActiveStorage::VirusScanner::PENDING }
-
-      it 'displays the filename, but doesn’t allow to download the file' do
-        expect(subject).to have_text(filename)
-        expect(subject).to have_no_link(text: filename)
-        expect(subject).to have_text('Analyse antivirus en cours')
-      end
-
-      it 'setup polling' do
-        expect(subject).to have_selector('[data-controller=turbo-poll]')
-      end
-
-      context "when used as multiple context" do
-        let(:kwargs) { { as_multiple: true } }
-
-        it 'does not setup polling' do
-          expect(subject).to have_no_selector('[data-controller=turbo-poll]')
-        end
-      end
-    end
-
     context 'when the file is scanned, watermarked_at, and viewed as download and safe' do
       let(:kwargs) { { view_as: :download } }
       let(:virus_scan_result) { ActiveStorage::VirusScanner::SAFE }

--- a/spec/components/attachment/pending_poll_component_spec.rb
+++ b/spec/components/attachment/pending_poll_component_spec.rb
@@ -45,15 +45,16 @@ RSpec.describe Attachment::PendingPollComponent, type: :component do
     it "does not render" do
       expect(component).not_to be_render
     end
+  end
 
-    context "when antivirus is in progress" do
-      before do
-        attachment.blob.virus_scan_result = ActiveStorage::VirusScanner::PENDING
-      end
+  context "when antivirus is in progress on pj" do
+    let(:champ) { create(:champ_piece_justificative) }
+    before do
+      attachment.blob.virus_scan_result = ActiveStorage::VirusScanner::PENDING
+    end
 
-      it "renders" do
-        expect(component).to be_render
-      end
+    it "does not render" do
+      expect(component).not_to be_render
     end
   end
 

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -100,7 +100,6 @@ describe 'The user' do
     expect(page).to have_selected_value('pays', selected: 'Australie')
     expect(page).to have_field('dossier_link', with: '123')
     expect(page).to have_text('file.pdf')
-    expect(page).to have_text('Analyse antivirus en cours')
   end
 
   scenario 'fill nothing and every error anchor links points to an existing element', js: true do
@@ -290,9 +289,9 @@ describe 'The user' do
     find_field('Pièce justificative 2').attach_file(Rails.root + 'spec/fixtures/files/RIB.pdf')
 
     # Expect the files to be uploaded immediately
-    expect(page).to have_text('Analyse antivirus en cours', count: 2, wait: 5)
     expect(page).to have_text('file.pdf')
     expect(page).to have_text('RIB.pdf')
+    expect(page).to have_button("Supprimer", title: "Supprimer le fichier RIB.pdf")
 
     # Expect the submit buttons to be enabled
     expect(page).to have_button('Déposer le dossier', disabled: false)
@@ -312,7 +311,6 @@ describe 'The user' do
     # Test invalid file type
     attach_file('Pièce justificative 1', Rails.root + 'spec/fixtures/files/invalid_file_format.json')
     expect(page).to have_no_text('La pièce justificative n’est pas d’un type accepté')
-    expect(page).to have_text('Analyse antivirus en cours', count: 1, wait: 5)
   end
 
   scenario 'retry on transcient upload error', js: true do
@@ -333,9 +331,9 @@ describe 'The user' do
 
     # Test that retrying after a failure works
     click_on('Réessayer', visible: true, wait: 5)
-    expect(page).to have_text('Analyse antivirus en cours', wait: 5)
     expect(page).to have_text('file.pdf')
     expect(page).to have_button('Déposer le dossier', disabled: false)
+    expect(page).to have_button("Supprimer", title: "Supprimer le fichier file.pdf")
 
     # Reload the current page
     visit current_path
@@ -350,7 +348,6 @@ describe 'The user' do
 
     attach_file('Pièce justificative 1', Rails.root + 'spec/fixtures/files/file.pdf')
     expect(page).to have_text('file.pdf')
-    expect(page).to have_text('Analyse antivirus en cours')
 
     attach_file('Pièce justificative 1', Rails.root + 'spec/fixtures/files/white.png')
     expect(page).to have_text('white.png')
@@ -382,7 +379,6 @@ describe 'The user' do
       _1.blob.virus_scan_result = ActiveStorage::VirusScanner::SAFE
       _1.save!
     }
-    expect(page).not_to have_text('Analyse antivirus en cours', wait: 10)
 
     visit current_path
 


### PR DESCRIPTION
On ne poll plus jusqu'à ce que l'antivirus soit passé, car d'une part l'usager s'en fiche, et d'autre part en cas de retard d'analyse ça provoque rapidement beaucoup de traffic.

Côté affichage de dossier, on garde la mention AV en cours s'il n'est pas encore passé.

Pour les filigranes pour le moment on garde ce comportement, car ça permet à l'usager de visualiser la PJ avec le filigrane. Mais à rediscuter, besoin peut-être pas légitime @LeSim 


Closes #9733

NB: en pratique, ça concerne tout formulaire qui utilise le composant de PJ, pas que le form usager. Mais les mêmes motivations restent valables.