### PR TITLE
[Bug] Fix des placeholders et des icones du dropdown instruction (actions multiples)

### DIFF
--- a/app/assets/stylesheets/motivation.scss
+++ b/app/assets/stylesheets/motivation.scss
@@ -18,6 +18,7 @@
 
   textarea {
     margin-bottom: $default-spacer;
+    min-height: 10em;
   }
 
   .help {

--- a/app/components/dossiers/batch_operation_component.rb
+++ b/app/components/dossiers/batch_operation_component.rb
@@ -64,24 +64,27 @@ class Dossiers::BatchOperationComponent < ApplicationComponent
                                 label: t(".operations.accepter"),
                                 operation_description: t(".operations.accepter_description"),
                                 operation: BatchOperation.operations.fetch(:accepter),
-                                operation_class_name: 'accept',
-                                placeholder: t(".placeholders.accepter")
-                              },
-
-                              {
-                                label: t(".operations.refuser"),
-                                operation_description: t(".operations.refuser_description"),
-                                operation: BatchOperation.operations.fetch(:refuser),
-                                operation_class_name: 'refuse',
-                                placeholder: t(".placeholders.refuser")
+                                operation_class_name: 'fr-icon-checkbox-circle-fill fr-text-default--success',
+                                placeholder: t(".placeholders.accepter"),
+                                instruction_operation: 'accept'
                               },
 
                               {
                                 label: t(".operations.classer_sans_suite"),
                                 operation_description: t(".operations.classer_sans_suite_description"),
                                 operation: BatchOperation.operations.fetch(:classer_sans_suite),
-                                operation_class_name: 'without-continuation',
-                                placeholder: t(".placeholders.classer_sans_suite")
+                                operation_class_name: 'fr-icon-intermediate-circle-fill fr-text-mention--grey',
+                                placeholder: t(".placeholders.classer_sans_suite"),
+                                instruction_operation: 'without-continuation'
+                              },
+
+                              {
+                                label: t(".operations.refuser"),
+                                operation_description: t(".operations.refuser_description"),
+                                operation: BatchOperation.operations.fetch(:refuser),
+                                operation_class_name: 'fr-icon-close-circle-fill fr-text-default--warning',
+                                placeholder: t(".placeholders.refuser"),
+                                instruction_operation: 'refuse'
                               }
                             ]
             },

--- a/app/components/dossiers/batch_operation_component/batch_operation_component.fr.yml
+++ b/app/components/dossiers/batch_operation_component/batch_operation_component.fr.yml
@@ -16,5 +16,5 @@ fr:
     confirm: Confirmez-vous le traitement multiple des dossiers sélectionnés ?
   placeholders:
     accepter: "Expliquez aux demandeurs pourquoi leur dossier est accepté (facultatif)"
-    refuser: "Expliquez aux demandeurs pourquoi leur dossier est accepté (obligatoire)"
-    classer_sans_suite: "Expliquez aux demandeurs pourquoi leur dossier est accepté (obligatoire)"
+    refuser: "Expliquez aux demandeurs pourquoi leur dossier est refusé (obligatoire)"
+    classer_sans_suite: "Expliquez aux demandeurs pourquoi leur dossier est classé sans suite (obligatoire)"

--- a/app/components/dossiers/batch_operation_inline_buttons_component/batch_operation_inline_buttons_component.html.haml
+++ b/app/components/dossiers/batch_operation_inline_buttons_component/batch_operation_inline_buttons_component.html.haml
@@ -5,13 +5,13 @@
 
       - opt[:instruction].each do |opt|
         - menu.with_item do
-          = link_to('#', onclick: "DS.showMotivation(event, '#{opt[:operation_class_name]}');", role: 'menuitem') do
+          = link_to('#', onclick: "DS.showMotivation(event, '#{opt[:instruction_operation]}');", role: 'menuitem') do
             %span{ class: "icon #{opt[:operation_class_name]}" }
             .dropdown-description
               %h4= opt[:label]
               = opt[:operation_description]
 
         - menu.with_item(class: "hidden inactive form-inside fr-pt-1v") do
-          = render partial: 'instructeurs/dossiers/instruction_button_motivation_batch', locals: { instruction_operation: opt[:operation_class_name], form:, opt: }
+          = render partial: 'instructeurs/dossiers/instruction_button_motivation_batch', locals: { instruction_operation: opt[:instruction_operation], form:, opt: }
 - else
   = form.button opt[:label], class: ['fr-btn fr-btn--sm fr-btn--icon-left fr-ml-1w', icons[opt[:operation].to_sym]], disabled: true, name: "#{form.object_name}[operation]", value: opt[:operation], data: { operation: opt[:operation] }


### PR DESCRIPTION
Avec la mise en place des icones DSFR, ça a fait sauter les icones du côté du dropdown action multiples.
Ça a également révélé un probleme de trad.
J'en ai profité pour mettre les actions dans le mm sens que sur la vue dossier : accepter/classer sans suite/refuser

Et j'ai aussi profité de cette PR pour agrandir un peu ce champ texte car depuis qu'il y a les sauts de ligne compris dedans, ça vaut le coup de laisser un peu plus de place pour motiver une décision.

**APRES**
<img width="694" alt="Capture d’écran 2023-12-06 à 16 56 11" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/f554491b-a002-42af-b866-73019982818d">

**AVANT**
<img width="607" alt="Capture d’écran 2023-12-06 à 16 58 14" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/344cc835-cdac-4873-9774-9e20eeceb3a1">


