### PR TITLE
documentation(api): ou trouver l'email de l'usager qui dépose le dossier

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -1423,6 +1423,10 @@ type Dossier {
   """
   state: DossierState!
   traitements: [Traitement!]!
+
+  """
+  Profile de l'usager déposant le dossier
+  """
   usager: Profile!
 }
 
@@ -3504,7 +3508,13 @@ type PoleEmploiChampDescriptor implements ChampDescriptor {
   type: TypeDeChamp! @deprecated(reason: "Utilisez le champ `__typename` à la place.")
 }
 
+"""
+Profil d'un usager connecté (déposant un dossier, instruisant un dossier...)
+"""
 type Profile {
+  """
+  Email de l'usager
+  """
   email: String!
   id: ID!
 }

--- a/app/graphql/types/dossier_type.rb
+++ b/app/graphql/types/dossier_type.rb
@@ -49,7 +49,7 @@ module Types
     field :geojson, Types::File, "L’URL du GeoJSON contenant les données cartographiques du dossier.", null: true
     field :attestation, Types::File, "L’URL de l’attestation au format PDF.", null: true
 
-    field :usager, Types::ProfileType, null: false
+    field :usager, Types::ProfileType, "Profile de l'usager déposant le dossier", null: false
     field :groupe_instructeur, Types::GroupeInstructeurType, null: false
     field :revision, Types::RevisionType, null: false, deprecation_reason: 'Utilisez le champ `demarche.revision` à la place.'
 

--- a/app/graphql/types/profile_type.rb
+++ b/app/graphql/types/profile_type.rb
@@ -1,6 +1,8 @@
 module Types
   class ProfileType < Types::BaseObject
+    description "Profil d'un usager connecté (déposant un dossier, instruisant un dossier...)"
+
     global_id_field :id
-    field :email, String, null: false
+    field :email, String, "Email de l'usager", null: false
   end
 end


### PR DESCRIPTION
une question par mail d'un usager

> Bonjour Monsieur Fourcade,
> Je reviens vers vous car j’ai une autre question concernant l’API de Démarches simplifiées.
> Est-il possible de récupérer l’adresse email du compte DS avec laquelle le client rempli un formulaire ? Pour simplifier, l’adresse email qu’il utilise pour se connecter à Démarches simplifiées.
> Je ne trouve pas cette information dans les différentes query de la documentation.

 

Cordialement