### PR TITLE
[Bug] ETQ instructeur je peux accéder à la page des dossiers supprimés

### DIFF
--- a/app/views/instructeurs/procedures/deleted_dossiers.html.haml
+++ b/app/views/instructeurs/procedures/deleted_dossiers.html.haml
@@ -11,7 +11,7 @@
 
       .procedure-actions
         - if @can_download_dossiers
-          = render Dossiers::ExportDropdownComponent.new(procedure: @procedure, exports: @exports, export_url: method(:download_export_instructeur_procedure_path))
+          = render Dossiers::ExportDropdownComponent.new(procedure: @procedure, export_url: method(:download_export_instructeur_procedure_path))
 
     .fr-container.flex= render partial: "tabs", locals: { procedure: @procedure,
         statut: @statut,


### PR DESCRIPTION
L'accès à la page "dossiers supprimés" depuis l'onglet "archivé" pour les instructeurs était cassé.

<img width="1363" alt="Capture d’écran 2023-12-07 à 10 04 52" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/7ba4ed74-1f01-4d23-ba1c-41bbb433d61f">
