### PR TITLE
ETQ instructeur, ma demande de correction est supprimée lorsque je supprime son message associé

### DIFF
--- a/app/components/dossiers/message_component.rb
+++ b/app/components/dossiers/message_component.rb
@@ -17,8 +17,20 @@ class Dossiers::MessageComponent < ApplicationComponent
 
   private
 
+  def soft_deletable?
+    commentaire.soft_deletable?(connected_user)
+  end
+
   def show_reply_button?
     @show_reply_button
+  end
+
+  def delete_button_text
+    if commentaire.dossier_correction&.pending?
+      t('.delete_with_correction_button')
+    else
+      t('.delete_button')
+    end
   end
 
   def highlight_if_unseen_class

--- a/app/components/dossiers/message_component/message_component.en.yml
+++ b/app/components/dossiers/message_component/message_component.en.yml
@@ -3,6 +3,7 @@ en:
   reply: Reply
   guest: Guest
   delete_button: Delete this message
+  delete_with_correction_button: Delete the correction and this message
   confirm: Are you sure you want to delete this message ?
   automatic_email: Automatic email
   you: You

--- a/app/components/dossiers/message_component/message_component.fr.yml
+++ b/app/components/dossiers/message_component/message_component.fr.yml
@@ -3,6 +3,7 @@ fr:
   reply: Répondre
   guest: Invité
   delete_button: Supprimer le message
+  delete_with_correction_button: Supprimer la demande de correction et ce message
   confirm: Êtes-vous sûr de vouloir supprimer ce message ?
   automatic_email: Email automatique
   you: Vous

--- a/app/components/dossiers/message_component/message_component.html.haml
+++ b/app/components/dossiers/message_component/message_component.html.haml
@@ -13,7 +13,7 @@
       = commentaire_date
   .rich-text
     - if commentaire.discarded?
-      %p= t('.deleted_body')
+      %p= "(#{t('.deleted_body')})"
     - elsif commentaire.sent_by_system?
       = sanitize(commentaire.body, scrubber: Sanitizers::MailScrubber.new)
     - else
@@ -21,9 +21,9 @@
 
 
   .message-extras.flex.justify-start
-    - if commentaire.soft_deletable?(connected_user)
+    - if soft_deletable?
       = button_to instructeur_commentaire_path(commentaire.dossier.procedure, commentaire.dossier, commentaire), method: :delete,  class: 'fr-btn fr-btn--sm fr-btn--tertiary fr-icon-delete-line fr-btn--icon-left fr-text-default--warning', form: { data: { turbo: true, turbo_confirm: t('.confirm') } } do
-        = t('.delete_button')
+        = delete_button_text
 
     - if commentaire.piece_jointe.attached?
       .fr-ml-2w

--- a/app/models/commentaire.rb
+++ b/app/models/commentaire.rb
@@ -74,9 +74,13 @@ class Commentaire < ApplicationRecord
   end
 
   def soft_delete!
+    transaction do
+      discard!
+      dossier_correction&.resolve!
+      update! body: ''
+    end
+
     piece_jointe.purge_later if piece_jointe.attached?
-    discard!
-    update! body: ''
   end
 
   def flagged_pending_correction?

--- a/app/models/concerns/dossier_correctable_concern.rb
+++ b/app/models/concerns/dossier_correctable_concern.rb
@@ -41,9 +41,7 @@ module DossierCorrectableConcern
     end
 
     def resolve_pending_correction
-      return if pending_correction.nil?
-
-      pending_correction.resolved_at = Time.current
+      pending_correction&.resolve
     end
 
     def resolve_pending_correction!

--- a/app/models/dossier_correction.rb
+++ b/app/models/dossier_correction.rb
@@ -15,4 +15,15 @@ class DossierCorrection < ApplicationRecord
   def resolved?
     resolved_at.present?
   end
+
+  def resolve
+    self.resolved_at = Time.current
+  end
+
+  def resolve!
+    resolve
+    save!
+  end
+
+  def pending? = !resolved?
 end

--- a/app/views/instructeurs/commentaires/destroy.turbo_stream.haml
+++ b/app/views/instructeurs/commentaires/destroy.turbo_stream.haml
@@ -1,3 +1,6 @@
 - if @commentaire.discarded?
   = turbo_stream.update @commentaire do
     = render Dossiers::MessageComponent.new(commentaire: @commentaire, connected_user: @commentaire.instructeur || @commentaire.expert)
+
+  - if current_user.instructeur? && @commentaire.dossier_correction.present?
+    = turbo_stream.replace 'header-top', partial: 'instructeurs/dossiers/header_top', locals: { dossier: @commentaire.dossier }

--- a/spec/components/dossiers/message_component_spec.rb
+++ b/spec/components/dossiers/message_component_spec.rb
@@ -69,7 +69,10 @@ RSpec.describe Dossiers::MessageComponent, type: :component do
       context 'on a procedure where commentaire had been written by connected instructeur' do
         let(:commentaire) { create(:commentaire, instructeur: instructeur, body: 'Second message') }
 
-        it { is_expected.to have_selector("form[action=\"#{form_url}\"]") }
+        it do
+          is_expected.to have_selector("form[action=\"#{form_url}\"]")
+          is_expected.to have_button(component.t('.delete_button'))
+        end
       end
 
       context 'on a procedure where commentaire had been written by connected instructeur and discarded' do
@@ -95,6 +98,13 @@ RSpec.describe Dossiers::MessageComponent, type: :component do
         let(:commentaire) { create(:commentaire, instructeur: create(:instructeur), body: 'Second message') }
 
         it { is_expected.not_to have_selector("form[action=\"#{form_url}\"]") }
+      end
+
+      context 'when commentaire is a correction' do
+        let(:commentaire) { create(:commentaire, instructeur:, body: 'Please fix this') }
+        before { create(:dossier_correction, commentaire:, dossier:) }
+
+        it { is_expected.to have_button(component.t('.delete_with_correction_button')) }
       end
     end
 

--- a/spec/controllers/instructeurs/commentaires_controller_spec.rb
+++ b/spec/controllers/instructeurs/commentaires_controller_spec.rb
@@ -20,6 +20,29 @@ describe Instructeurs::CommentairesController, type: :controller do
           expect(subject.body).to include('Message supprimé')
           expect(subject.body).to include('alert-success')
           expect(subject.body).to include('Votre message a été supprimé')
+          expect(commentaire.reload).to be_discarded
+          expect(commentaire.body).to be_empty
+        end
+
+        context 'when instructeur is not owner' do
+          let(:commentaire) { create(:commentaire, dossier: dossier) }
+
+          it 'does not delete the message' do
+            expect(subject.body).to include('alert-danger')
+            expect(commentaire.reload).not_to be_discarded
+            expect(commentaire.body).not_to be_empty
+          end
+        end
+
+        context 'when a correction is attached' do
+          let!(:correction) { create(:dossier_correction, commentaire:, dossier:) }
+
+          it 'removes the correction' do
+            expect(subject).to have_http_status(:ok)
+            expect(subject.body).to include('en construction') # update the header
+            expect(subject.body).not_to include('en attente')
+            expect(correction.reload).to be_resolved
+          end
         end
       end
 


### PR DESCRIPTION
Cf #9731 (première partie)

quand un instructeur supprime le message de sa demande de correction, on résout la correction associée (j'en profite pour petit refacto et meilleure couverture de tests à ce sujet)

(Seul l'instructeur à l'origine de la correction peut supprimer son message, et donc la correction associée.)

![Capture d’écran 2023-12-07 à 15 43 25](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/160add59-58e8-4335-9914-19e12e94ac80)

