### PR TITLE
ETQ instructeur: j'accède à la page d'agent connect depuis un button dédié sur la page d'accueil

### DIFF
--- a/app/views/layouts/_header.haml
+++ b/app/views/layouts/_header.haml
@@ -31,7 +31,7 @@
         .fr-header__tools
           .fr-header__tools-links.relative
 
-            %ul.fr-btns-group
+            %ul.fr-btns-group.flex.align-center
               - if instructeur_signed_in? || user_signed_in?
                 %li
                   = render partial: 'layouts/account_dropdown', locals: { nav_bar_profile: nav_bar_profile }

--- a/app/views/layouts/_header.haml
+++ b/app/views/layouts/_header.haml
@@ -39,6 +39,7 @@
                 - if request.path == new_user_registration_path
                   %li
                     .fr-hidden-sm.fr-unhidden-lg.fr-link--sm= t('views.shared.account.already_user_question')
+                %li= link_to 'Agent', agent_connect_path, class: "fr-btn fr-btn--tertiary fr-icon-government-fill fr-btn--icon-left"
                 %li= link_to t('views.shared.account.signin'), new_user_session_path, class: "fr-btn fr-btn--tertiary fr-icon-account-circle-fill fr-btn--icon-left"
 
               %li


### PR DESCRIPTION
J'en profite pour aligner les buttons et les liens.

![Screenshot 2023-12-11 at 12-25-26 Effectuer une démarche administrative en ligne · demarches-simplifiees fr](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/907405/26b4ede1-dc8f-4bc6-b4b0-4531dc8c1804)

Du coté usager :
je ne pense pas que cet ajout perturbe le processus dans la mesure où :
- ils ne sont pas sensés atterrir sur la page d'accueil mais directement sur la page de leurs démarches ou dossiers
- le terme `se connecter` semble plus attirant que `agent`

Du coté instructeur :
Il  est légitime que les agents passent par la page demarches-simplifiees.fr pour se connecter