### PR TITLE
Améliorer l'affichage des couleurs pour la page nouveautés

### DIFF
--- a/app/helpers/release_notes_helper.rb
+++ b/app/helpers/release_notes_helper.rb
@@ -2,15 +2,15 @@ module ReleaseNotesHelper
   def announce_category_badge(category)
     color_class = case category.to_sym
     when :administrateur
-      'fr-background-flat--blue-france fr-text-inverted--blue-france'
+      'fr-badge--blue-cumulus'
     when :instructeur
-      'fr-background-contrast--yellow-tournesol'
+      'fr-badge--yellow-tournesol'
     when :expert
-      'fr-background-contrast--purple-glycine'
+      'fr-badge--purple-glycine'
     when :usager
-      'fr-background-contrast--green-emeraude'
+      'fr-badge--green-emeraude'
     when :api
-      'fr-background-contrast--blue-ecume'
+      'fr-badge--pink-macaron'
     end
 
     content_tag(:span, ReleaseNote.human_attribute_name("categories.#{category}"), class: "fr-badge #{color_class}")


### PR DESCRIPTION
vu avec @colinux 
Amélioration des couleurs pour le thême sombre et couleur du badge admin plus "équilibré" avec les autres.

**APRES**
<img width="579" alt="Capture d’écran 2023-12-13 à 11 53 04" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/972d71f2-ea5a-4cc6-8b0c-82dc77b87622">
<img width="634" alt="Capture d’écran 2023-12-13 à 11 52 55" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/871fdef0-2fbb-4d3f-9c57-a1b3a682e68d">

**AVANT**
<img width="918" alt="Capture d’écran 2023-12-13 à 12 10 19" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/05c7b040-0f21-4850-b234-f5e9e2c0d8ab">
<img width="918" alt="Capture d’écran 2023-12-13 à 12 10 11" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/d3d9dfc8-6d3f-48d4-a941-0a2676caf4e3">

