### PR TITLE
Style: plusieurs améliorations mineures / thème sombre

### DIFF
--- a/app/assets/images/icons/download-white.svg
+++ b/app/assets/images/icons/download-white.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="20" viewBox="0 0 16 20"><g fill="none" fill-rule="evenodd"><path d="M11.5 8H15l-7 7-7-7h3.5V1h7zM1 19h14" stroke="#FFF" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/><path d="M-4-2h24v24H-4z"/></g></svg>

--- a/app/assets/stylesheets/icons.scss
+++ b/app/assets/stylesheets/icons.scss
@@ -51,10 +51,6 @@
     background-image: image-url("icons/download.svg");
   }
 
-  &.download-white {
-    background-image: image-url("icons/download-white.svg");
-  }
-
   &.lock {
     background-image: image-url("icons/lock.svg");
   }

--- a/app/assets/stylesheets/patron.scss
+++ b/app/assets/stylesheets/patron.scss
@@ -4,9 +4,4 @@
   .patron-section {
     margin-bottom: 20px;
   }
-
-  .icon.download-white {
-    background-color: $blue-france-500;
-    box-shadow: 0px 0px 1px 2px $blue-france-500;
-  }
 }

--- a/app/views/administrateurs/procedures/_informations.html.haml
+++ b/app/views/administrateurs/procedures/_informations.html.haml
@@ -74,27 +74,36 @@
   - c.with_body do
     %p Une notice explicative est un document destiné à guider l’usager dans sa démarche. C’est un document que vous avez élaboré et qui peut prendre la forme d’un fichier doc, d’un pdf ou encore de diapositives. Le bouton pour télécharger cette notice apparaît en haut du formulaire pour l’usager.
 
-= f.label :notice, 'Notice', class: 'fr-label'
-%p.fr-hint-text
-  Formats acceptés : .doc, .odt, .pdf, .ppt, .pptx
-= render Attachment::EditComponent.new(attached_file: @procedure.notice, view_as: :download)
+.fr-mb-3w
+  = f.label :notice, 'Notice', class: 'fr-label'
+  %p.fr-hint-text
+    Formats acceptés : .doc, .odt, .pdf, .ppt, .pptx
+  = render Attachment::EditComponent.new(attached_file: @procedure.notice, view_as: :download)
 
 - if !@procedure.locked?
-  %h3.fr-h6 À qui s’adresse ma démarche ?
-  .radios.vertical
-    = f.label :for_individual, value: true do
-      = f.radio_button :for_individual, true
-      Ma démarche s’adresse à un particulier
-      %p.fr-hint-text En choisissant cette option, l’usager devra renseigner son nom et prénom avant d’accéder au formulaire
+  %fieldset.fr-fieldset{ "aria-labelledby": "for-individual-legend" }
+    %legend#for-individual-legend.fr-fieldset__legend.fr-fieldset__legend--regular À qui s’adresse ma démarche ?
+    .fr-fieldset__element
+      .fr-radio-group
+        = f.radio_button :for_individual, true
+        = f.label :for_individual, value: true, class: "fr-label" do
+          Ma démarche s’adresse à un particulier
+          %span.fr-hint-text En choisissant cette option, l’usager devra renseigner son nom et prénom avant d’accéder au formulaire
 
-    = f.label :for_individual, value: false, class: 'fr-label' do
-      = f.radio_button :for_individual, false
-      Ma démarche s’adresse à une personne morale
-      %p.fr-hint-text
-        En choisissant cette option, l’usager devra renseigner son n° SIRET.<br>Grâce à l’API Entreprise, les informations sur la personne morale (raison sociale, adresse du siège, etc.) seront automatiquement renseignées.
-  .fr-highlight
-    %p
-      Si votre démarche s’adresse indifféremment à une personne morale ou un particulier, choisissez l'option « Particuliers ». Vous pourrez ajouter un champ SIRET directement dans le formulaire.
+    .fr-fieldset__element
+      .fr-radio-group
+        = f.radio_button :for_individual, false
+        = f.label :for_individual, value: false, class: 'fr-label' do
+          Ma démarche s’adresse à une personne morale
+          %span.fr-hint-text
+            En choisissant cette option, l’usager devra renseigner son n° SIRET.<br>Grâce à l’API Entreprise, les informations sur la personne morale (raison sociale, adresse du siège, etc.) seront automatiquement renseignées.
+
+    .fr-fieldset__element
+      .fr-highlight
+        %p.fr-text--sm
+          Si votre démarche s’adresse indifféremment à une personne morale ou un particulier, choisissez l'option « Particuliers ».
+          Vous pourrez ajouter un champ SIRET directement dans le formulaire.
+
 
 = f.label :tags, 'Associez les tags à la démarche (facultatif)', class: 'fr-label'
 %p.fr-hint-text Les tags sont des mots ou des expressions que vous attribuez aux démarches pour décrire leur contenu et pour les retrouver. Les tags sont partagés avec la communauté, ce qui vous permet de voir les tags attribués aux démarches créées par les autres administrateurs.

--- a/app/views/root/patron.html.haml
+++ b/app/views/root/patron.html.haml
@@ -25,7 +25,6 @@
     %span.icon.preview
     %span.icon.retry
     %span.icon.download
-    %span.icon.download-white
     %span.icon.frown
     %span.icon.meh
     %span.icon.smile

--- a/app/views/users/dossiers/index.html.haml
+++ b/app/views/users/dossiers/index.html.haml
@@ -17,7 +17,7 @@
               = text_field_tag "q", "#{@search_terms if @search_terms.present?}", placeholder: t('views.users.dossiers.search.search_file'), class: "fr-input"
               %button.fr-btn.fr-btn--sm
                 = t('views.users.dossiers.search.simple')
-      - if @procedures_for_select.present?
+      - if @procedures_for_select.size > 1
         .fr-col
           = render Dossiers::UserProcedureFilterComponent.new(procedures_for_select: @procedures_for_select)
 

--- a/app/views/users/dossiers/show/_status_overview.html.haml
+++ b/app/views/users/dossiers/show/_status_overview.html.haml
@@ -68,8 +68,7 @@
 
           - if dossier.attestation.present?
             .action
-              = link_to attestation_dossier_path(dossier), target: '_blank', rel: 'noopener', class: 'button primary' do
-                %span.icon.download-white
+              = link_to attestation_dossier_path(dossier), class: "fr-btn fr-icon-download-line fr-btn--icon-left", target: '_blank', rel: 'noopener' do
                 = t('views.users.dossiers.show.status_overview.accepte_attestation')
 
 

--- a/spec/views/users/dossiers/index.html.haml_spec.rb
+++ b/spec/views/users/dossiers/index.html.haml_spec.rb
@@ -19,6 +19,7 @@ describe 'users/dossiers/index', type: :view do
     assign(:dossier_transferes, Kaminari.paginate_array([]).page(1))
     assign(:dossiers_close_to_expiration, Kaminari.paginate_array([]).page(1))
     assign(:dossiers, Kaminari.paginate_array(user_dossiers).page(1))
+    assign(:procedures_for_select, user_dossiers.map(&:procedure))
     assign(:statut, statut)
     assign(:filter, filter)
     assign(:all_dossiers_uniq_procedures_count, 0)


### PR DESCRIPTION
### Usager: bouton de téléchargement de l'attestation compatible thème sombre/dsfr
**APRES**
![Capture d’écran 2023-12-12 à 17 30 40](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/1e42c1e4-fabe-45da-910b-f6910895bd43)

**AVANT**
![Capture d’écran 2023-12-13 à 16 11 50](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/8882ee93-2c2d-48a0-9224-24fab3173581)

### usager: n'affiche plus un filtre de démarche trop large et inutile lorsqu'il n'y a qu'une seule démarche (1 seul dossier)
**APRES**
![Capture d’écran 2023-12-13 à 15 59 28](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/e651ccfa-3e46-40d5-914c-6063bb59be38)

**AVANT**
![Capture d’écran 2023-12-13 à 15 52 25](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/ed8a3294-4880-4ebe-9c24-601d986346fe)


### Admin: radios choix particulier/personne morale au dsfr, mieux espacés, et mieux pour le thème sombre
**APRES**
![Capture d’écran 2023-12-13 à 11 03 29](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/049b64a5-d391-4fd4-8b8a-f23f44a7ddc4)


**AVANT**
![Capture d’écran 2023-12-13 à 16 11 13](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/88c0890e-a584-4c5d-b377-f36c9ea58019)

