### PR TITLE
Tech : met à jours les conditions et règles de routage suite à l'ajout de nouveaux opérateurs

### DIFF
--- a/app/tasks/maintenance/update_conditions_based_on_commune_or_epci_champ_task.rb
+++ b/app/tasks/maintenance/update_conditions_based_on_commune_or_epci_champ_task.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class UpdateConditionsBasedOnCommuneOrEpciChampTask < MaintenanceTasks::Task
+    include Logic
+
+    def collection
+      ProcedureRevision.all
+    end
+
+    def process(revision)
+      tdc_to_update_ids = []
+
+      tdcs = revision.types_de_champ_public
+
+      tdcs.where.not(condition: nil).pluck(:condition, :id).each do |condition, id|
+        if tdcs.where(stable_id: condition.sources, type_champ: ["communes", "epci"]).present?
+          tdc_to_update_ids << id
+        end
+      end
+
+      tdc_to_update_ids.each do |id|
+        tdc = tdcs.find_by(id:)
+
+        condition = tdc.condition
+
+        if condition.is_a?(And)
+          new_operands = new_operands_from(tdcs, condition)
+          tdc.update!(condition: ds_and(new_operands))
+        elsif condition.is_a?(Or)
+          new_operands = new_operands_from(tdcs, condition)
+          tdc.update!(condition: ds_or(new_operands))
+        elsif condition.is_a?(NotEq)
+          tdc.update!(condition: ds_not_in_departement(condition.left, condition.right))
+        elsif condition.is_a?(Eq)
+          tdc.update!(condition: ds_in_departement(condition.left, condition.right))
+        end
+      end
+    end
+
+    def count
+      collection.count
+    end
+
+    private
+
+    def new_operands_from(tdcs, condition)
+      condition.operands.map do |sub_condition|
+        if tdcs.where(stable_id: sub_condition.sources, type_champ: ["communes", "epci"]).present?
+          if sub_condition.is_a?(NotEq)
+            ds_not_in_departement(sub_condition.left, sub_condition.right)
+          elsif sub_condition.is_a?(Eq)
+            ds_in_departement(sub_condition.left, sub_condition.right)
+          else
+            sub_condition
+          end
+        else
+          sub_condition
+        end
+      end
+    end
+  end
+end

--- a/app/tasks/maintenance/update_routing_rules_based_on_commune_or_epci_champ_task.rb
+++ b/app/tasks/maintenance/update_routing_rules_based_on_commune_or_epci_champ_task.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class UpdateRoutingRulesBasedOnCommuneOrEpciChampTask < MaintenanceTasks::Task
+    include Logic
+
+    def collection
+      GroupeInstructeur
+        .joins(:procedure)
+        .where(procedures: { routing_enabled: true })
+    end
+
+    def process(gi)
+      routing_rule = gi.routing_rule
+
+      if routing_rule.present?
+        tdcs = gi.procedure.active_revision.types_de_champ_public
+
+        if tdcs.where(stable_id: routing_rule.sources, type_champ: ["communes", "epci"]).present?
+          if routing_rule.is_a?(And)
+            new_operands = new_operands_from(tdcs, routing_rule)
+            gi.update!(routing_rule: ds_and(new_operands))
+          elsif routing_rule.is_a?(Or)
+            new_operands = new_operands_from(tdcs, routing_rule)
+            gi.update!(routing_rule: ds_or(new_operands))
+          elsif routing_rule.is_a?(NotEq)
+            gi.update!(routing_rule: ds_not_in_departement(routing_rule.left, routing_rule.right))
+          elsif routing_rule.is_a?(Eq)
+            gi.update!(routing_rule: ds_in_departement(routing_rule.left, routing_rule.right))
+          end
+        end
+      end
+    end
+
+    def count
+      collection.count
+    end
+
+    private
+
+    def new_operands_from(tdcs, condition)
+      condition.operands.map do |sub_condition|
+        if tdcs.where(stable_id: sub_condition.sources, type_champ: ["communes", "epci"]).present?
+          if sub_condition.is_a?(NotEq)
+            ds_not_in_departement(sub_condition.left, sub_condition.right)
+          elsif sub_condition.is_a?(Eq)
+            ds_in_departement(sub_condition.left, sub_condition.right)
+          else
+            sub_condition
+          end
+        else
+          sub_condition
+        end
+      end
+    end
+  end
+end

--- a/spec/tasks/maintenance/update_routing_rules_based_on_commune_or_epci_champ_task_spec.rb
+++ b/spec/tasks/maintenance/update_routing_rules_based_on_commune_or_epci_champ_task_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  describe UpdateRoutingRulesBasedOnCommuneOrEpciChampTask do
+    include Logic
+    describe "#process" do
+      subject(:process) { described_class.process(groupe_defaut) }
+
+      let(:procedure) { create(:procedure, :published, :routee, types_de_champ_public: [{ type: :communes }, { type: :epci }, { type: :drop_down_list, libelle: 'Votre choix', options: ['Choix 1', 'Choix 2', 'Choix 3'] }, { type: :text }]) }
+
+      let(:commune_tdc) { procedure.active_revision.types_de_champ_public.where(type_champ: 'communes').first }
+      let(:epci_tdc) { procedure.active_revision.types_de_champ_public.where(type_champ: 'epci').first }
+      let(:drop_down_list_tdc) { procedure.active_revision.types_de_champ_public.where(type_champ: 'drop_down_list').first }
+
+      let(:groupe_defaut) { procedure.defaut_groupe_instructeur }
+
+      context "with a routing rule based on commune and epci" do
+        before { groupe_defaut.update(routing_rule: ds_and([ds_eq(champ_value(commune_tdc.stable_id), constant('11')), ds_not_eq(champ_value(epci_tdc.stable_id), constant('84'))])) }
+
+        it "updates routing rule" do
+          subject
+          expect(groupe_defaut.routing_rule).to eq ds_and([ds_in_departement(champ_value(commune_tdc.stable_id), constant('11')), ds_not_in_departement(champ_value(epci_tdc.stable_id), constant('84'))])
+        end
+      end
+
+      context "with a routing rule based on a dropdown list" do
+        before { groupe_defaut.update(routing_rule: ds_eq(champ_value(drop_down_list_tdc.stable_id), constant('Choix 2'))) }
+
+        it "does not update routing rule" do
+          subject
+          expect(groupe_defaut.routing_rule).to eq ds_eq(champ_value(drop_down_list_tdc.stable_id), constant('Choix 2'))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Nouveaux opérateurs pour le conditionnel PR 3/3**
Rattrapage des données : toutes les conditions et toutes les règles de routage dont un des champs cibles est un champ commune ou epci sont mis à jour  : 
l'opérateur "Est" devient "Est dans le département" et l'opérateur "N'est pas" devient "N'est pas dans le département".

_PR à déployer en même temps que #9798 (et lancer la maintenance task si pas de problème suite à l'ajout des nouveaux opérateurs)_