### PR TITLE
ETQ expert: lorsque je me connecte, je suis redirigé vers la page des avis, non pas vers la page de mes dossiers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -200,6 +200,7 @@ class ApplicationController < ActionController::Base
       roles = [
         current_user,
         current_instructeur,
+        current_expert,
         current_administrateur,
         current_gestionnaire,
         current_super_admin

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -6,6 +6,8 @@ class RootController < ApplicationController
       return redirect_to admin_procedures_path
     elsif instructeur_signed_in?
       return redirect_to instructeur_procedures_path
+    elsif expert_signed_in?
+      return redirect_to expert_all_avis_path
     elsif user_signed_in?
       return redirect_to dossiers_path
     elsif super_admin_signed_in?

--- a/app/controllers/targeted_user_links_controller.rb
+++ b/app/controllers/targeted_user_links_controller.rb
@@ -1,5 +1,7 @@
 class TargetedUserLinksController < ApplicationController
   def show
+    erase_user_location!
+    store_user_location! if !user_signed_in?
     if targeted_user_link.invalid_signed_in_user?(current_user)
       render
     else
@@ -10,6 +12,14 @@ class TargetedUserLinksController < ApplicationController
   end
 
   private
+
+  def store_user_location!
+    store_location_for(:user, request.fullpath)
+  end
+
+  def erase_user_location!
+    clear_stored_location_for(:user)
+  end
 
   def targeted_user_link
     @targeted_user_link ||= TargetedUserLink.find(params[:id])

--- a/spec/controllers/root_controller_spec.rb
+++ b/spec/controllers/root_controller_spec.rb
@@ -9,6 +9,16 @@ describe RootController, type: :controller do
     it { expect(subject).to redirect_to(dossiers_path) }
   end
 
+  context 'when Expert is connected' do
+    let(:expert) { create(:expert) }
+
+    before do
+      sign_in(expert.user)
+    end
+
+    it { expect(subject).to redirect_to(expert_all_avis_path) }
+  end
+
   context 'when Instructeur is connected' do
     let(:instructeur) { create(:instructeur) }
     let(:procedure) { create(:procedure, :published) }

--- a/spec/controllers/targeted_user_links_controller_spec.rb
+++ b/spec/controllers/targeted_user_links_controller_spec.rb
@@ -15,6 +15,7 @@ describe TargetedUserLinksController, type: :controller do
 
         it 'redirects to expert_avis_url' do
           expect(response).to redirect_to(expert_avis_path(target_model.procedure, target_model))
+          expect(controller.stored_location_for(:user)).to eq(controller.request.path)
         end
       end
 

--- a/spec/system/experts/expert_spec.rb
+++ b/spec/system/experts/expert_spec.rb
@@ -37,7 +37,7 @@ describe 'Inviting an expert:' do
         sign_in_with avis.expert.email, password
 
         expect(page).to have_content('Connecté(e).')
-        expect(page).to have_current_path(dossiers_path) # Ideally we'd want `expert_all_avis_path` instead
+        expect(page).to have_current_path(expert_all_avis_path)
       end
     end
 
@@ -52,9 +52,8 @@ describe 'Inviting an expert:' do
         expect(page).to have_current_path(new_user_session_path)
         login_as avis.expert.user, scope: :user
         sign_in_with(avis.expert.email, 'This is a very complicated password !')
-        click_on 'Passer en expert'
-        expect(page).to have_current_path(expert_all_avis_path)
-        expect(page).to have_text('1 avis à donner')
+        click_on 'Passer en usager'
+        expect(page).to have_current_path(dossiers_path)
       end
     end
 

--- a/spec/system/experts/expert_spec.rb
+++ b/spec/system/experts/expert_spec.rb
@@ -52,6 +52,7 @@ describe 'Inviting an expert:' do
         expect(page).to have_current_path(new_user_session_path)
         login_as avis.expert.user, scope: :user
         sign_in_with(avis.expert.email, 'This is a very complicated password !')
+        expect(page).to have_content("connecté en tant qu’expert")
         click_on 'Passer en usager'
         expect(page).to have_current_path(dossiers_path)
       end


### PR DESCRIPTION
crisp: https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_6a38035a-ca3b-4b4f-81fb-fff2c96b3d9d/ 
hs: https://secure.helpscout.net/conversation/2442913639/2047507?folderId=1653799

# prob 

ETQ expert, après m'être connecté, je suis redirigé vers la page de mes dossiers

# solution

ETQ expert, après m'être connecté, je suis redirigé vers la page des avis (a l'image des admin/instructeur/gestionnaire de groupe)