### PR TITLE
Tech: échappe les tags de données utilisateur dans les modèles pour email

### DIFF
--- a/app/models/attestation_template.rb
+++ b/app/models/attestation_template.rb
@@ -18,7 +18,7 @@ class AttestationTemplate < ApplicationRecord
   DOSSIER_STATE = Dossier.states.fetch(:accepte)
 
   def attestation_for(dossier)
-    attestation = Attestation.new(title: replace_tags(title, dossier))
+    attestation = Attestation.new(title: replace_tags(title, dossier, escape: false))
     attestation.pdf.attach(
       io: build_pdf(dossier),
       filename: "attestation-dossier-#{dossier.id}.pdf",
@@ -70,8 +70,8 @@ class AttestationTemplate < ApplicationRecord
 
     if dossier.present?
       attributes.merge({
-        title: replace_tags(title, dossier),
-        body: replace_tags(body, dossier),
+        title: replace_tags(title, dossier, escape: false),
+        body: replace_tags(body, dossier, escape: false),
         signature: signature_to_render(dossier.groupe_instructeur)
       })
     else

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe NotificationMailer, type: :mailer do
 
     context "subject has a special character" do
       let(:subject) { '--libellé démarche--' }
-      it { expect(mail.subject).to eq("Mon titre avec l'apostrophe") }
+      it { expect(mail.subject).to eq("Mon titre avec l&#39;apostrophe") }
     end
   end
 end

--- a/spec/models/concern/tags_substitution_concern_spec.rb
+++ b/spec/models/concern/tags_substitution_concern_spec.rb
@@ -411,6 +411,24 @@ describe TagsSubstitutionConcern, type: :model do
         end
       end
     end
+
+    context 'when data contains malicious code' do
+      let(:template) { '--libelleA-- --nom--' }
+      context 'in individual data' do
+        let(:for_individual) { true }
+        let(:individual) { create(:individual, nom: '<a href="https://oops.com">name</a>') }
+
+        it { is_expected.to eq('--libelleA-- &lt;a href=&quot;https://oops.com&quot;&gt;name&lt;/a&gt;') }
+      end
+
+      context 'in a champ' do
+        let(:types_de_champ_public) { [{ libelle: 'libelleA' }] }
+
+        before { dossier.champs_public.first.update(value: 'hey <a href="https://oops.com">anchor</a>') }
+
+        it { is_expected.to eq('hey &lt;a href=&quot;https://oops.com&quot;&gt;anchor&lt;/a&gt; --nom--') }
+      end
+    end
   end
 
   describe 'tags' do


### PR DESCRIPTION
Dans le même genre que la sanitization de données utilisateur envoyées par emails dans #9858 , cette PR sanitize les tags qui proviennent de données utilisateurs et qui sont injectés dans les emails dynamiques. Le risque est limité car les emails sont à destination des usagers eux-mêmes (sauf qu'avec les invités/transferts de dossier etc… ça pourrait impacter d'autres personnes), et comme on réaffiche aussi les messages dans les interfaces ça protège les instructeurs.

Je ne vois pas de scénario pertinent où on voudrait qu'un utilisateur puisse saisir de l'html et que ce même html soit réutilisé dans les templates d'emails SAUF peut-être dans les annotations privées pour lesquels on pourrait faire une exception?(faudrait voir la data).

## APRES
![Capture d’écran 2023-12-15 à 12 55 24](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/bd79f8dc-ce73-4ef1-96c1-b6c2ebd131d0)

![Capture d’écran 2023-12-15 à 12 54 55](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/bb756dee-5f60-4226-8b4a-d819b089827a)


## AVANT
![Capture d’écran 2023-12-15 à 12 42 09](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/69606447-6d94-437f-a72d-ba652b92eae9)
![Capture d’écran 2023-12-15 à 12 51 27](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/36e0d973-ebf7-4148-8d71-7c1815b31b00)

