### PR TITLE
ETQ instructeur je peux de nouveau passer en correction un dossier avec corrections en attente

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -568,7 +568,7 @@ class Dossier < ApplicationRecord
   end
 
   def can_passer_en_instruction?
-    return false if pending_correction?
+    return false if procedure.feature_enabled?(:blocking_pending_correction) && pending_correction?
 
     true
   end
@@ -579,7 +579,7 @@ class Dossier < ApplicationRecord
 
     return false if !can_passer_en_instruction?
     return true if declarative_triggered_at.nil? && procedure.declarative_en_instruction?
-    return true if procedure.sva_svr_enabled? && sva_svr_decision_triggered_at.nil?
+    return true if procedure.sva_svr_enabled? && sva_svr_decision_triggered_at.nil? && !pending_correction?
 
     false
   end
@@ -931,6 +931,8 @@ class Dossier < ApplicationRecord
       .passer_en_instruction(instructeur: instructeur)
       .processed_at
     save!
+
+    resolve_pending_correction!
 
     MailTemplatePresenterService.create_commentaire_for_state(self, Dossier.states.fetch(:en_instruction))
     if !disable_notification

--- a/app/models/procedure_flipper_actor.rb
+++ b/app/models/procedure_flipper_actor.rb
@@ -1,0 +1,7 @@
+# Use this when we want to check feature flags on a procedure whithout loading the all procedure
+class ProcedureFlipperActor < Struct.new(:procedure_id) do
+    def flipper_id
+      "Procedure;#{procedure_id}"
+    end
+  end
+end

--- a/app/views/instructeurs/dossiers/_header_actions.html.haml
+++ b/app/views/instructeurs/dossiers/_header_actions.html.haml
@@ -9,6 +9,7 @@
               close_to_expiration: dossier.close_to_expiration?,
               hidden_by_administration: dossier.hidden_by_administration?,
               has_pending_correction: dossier.pending_correction?,
+              has_blocking_pending_correction: dossier.procedure.feature_enabled?(:blocking_pending_correction) && dossier.pending_correction?,
               turbo: true,
               with_menu: true }
 

--- a/app/views/instructeurs/procedures/_dossier_actions.html.haml
+++ b/app/views/instructeurs/procedures/_dossier_actions.html.haml
@@ -45,10 +45,10 @@
   - if Dossier.states[:en_construction] == state
     %li{ 'data-turbo': turbo ? 'true' : 'false' }
       = button_to passer_en_instruction_instructeur_dossier_path(procedure_id, dossier_id), method: :post, class: 'fr-btn fr-icon-edit-line',
-        disabled: has_pending_correction, "aria-describedby" => has_pending_correction ? "tooltip-passer-en-instruction" : nil do
+        disabled: has_blocking_pending_correction, "aria-describedby" => has_blocking_pending_correction ? "tooltip-passer-en-instruction" : nil do
         = t('views.instructeurs.dossiers.passer_en_instruction')
 
-      - if has_pending_correction
+      - if has_blocking_pending_correction
         %span#tooltip-passer-en-instruction.fr-tooltip.fr-placement{ role: :tooltip, "aria-hidden" => "true" }
           = t('views.instructeurs.dossiers.passer_en_instruction_blocked_by_pending_correction')
 

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -193,7 +193,7 @@
                                   close_to_expiration: @statut == 'expirant',
                                   hidden_by_administration: @statut == 'supprimes_recemment',
                                   sva_svr: @procedure.sva_svr_enabled?,
-                                  has_pending_correction: p.pending_correction?,
+                                  has_blocking_pending_correction: @procedure.feature_enabled?(:blocking_pending_correction) && p.pending_correction?,
                                   turbo: false,
                                   with_menu: false }
 

--- a/app/views/recherche/index.html.haml
+++ b/app/views/recherche/index.html.haml
@@ -105,7 +105,7 @@
                                                                       close_to_expiration: nil,
                                                                       hidden_by_administration: nil,
                                                                       sva_svr: p.sva_svr_decision_on.present?,
-                                                                      has_pending_correction: p.pending_correction?,
+                                                                      has_blocking_pending_correction: p.pending_correction? && Flipper.enabled?(:blocking_pending_correction, ProcedureFlipperActor.new(procedure_id)),
                                                                       turbo: false,
                                                                       with_menu: false }
 

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -19,7 +19,8 @@ features = [
   :procedure_routage_api,
   :groupe_instructeur_api_hack,
   :cojo_type_de_champ,
-  :sva
+  :sva,
+  :blocking_pending_correction
 ]
 
 def database_exists?

--- a/spec/jobs/process_stalled_declarative_dossier_job_spec.rb
+++ b/spec/jobs/process_stalled_declarative_dossier_job_spec.rb
@@ -31,18 +31,6 @@ RSpec.describe ProcessStalledDeclarativeDossierJob, type: :job do
 
           it { expect(subject.state).to eq('en_construction') }
         end
-
-        context 'with pending correction' do
-          let!(:correction) { create(:dossier_correction, dossier:) }
-
-          it { expect(subject.state).to eq('en_construction') }
-        end
-
-        context 'with resolved correction' do
-          let!(:correction) { create(:dossier_correction, :resolved, dossier:) }
-
-          it { expect(subject.state).to eq('en_instruction') }
-        end
       end
 
       context 'dossier already en_instruction' do

--- a/spec/views/instructeur/dossiers/show.html.haml_spec.rb
+++ b/spec/views/instructeur/dossiers/show.html.haml_spec.rb
@@ -68,9 +68,15 @@ describe 'instructeurs/dossiers/show', type: :view do
     context 'with pending correction' do
       before { create(:dossier_correction, dossier:) }
 
-      it 'disable the instruction button' do
-        expect(subject).to have_button('Passer en instruction', disabled: true)
-        expect(subject).to have_content('Le passage en instruction est impossible')
+      it { expect(subject).to have_button('Passer en instruction', disabled: false) }
+
+      context 'with procedure blocking pending correction' do
+        before { Flipper.enable(:blocking_pending_correction, dossier.procedure) }
+
+        it 'disable the instruction button' do
+          expect(subject).to have_button('Passer en instruction', disabled: true)
+          expect(subject).to have_content('Le passage en instruction est impossible')
+        end
       end
     end
   end


### PR DESCRIPTION
Des administrations ont besoin de cette flexibilité pour certaines façons de traiter des dossiers, c'est donc un rollback partiel de #9821 (exception du SVA/SVR pour lesquelles c'est tjs bloquant)

A la place, pour le moment on rend les corrections bloquantes par feature flags uniquement pour les Fonds Verts.
On verra sur le moyen terme si on garde ce feature flag ou on trouve autre chose.