### PR TITLE
ETQ utilisateur avec plusieurs rôles, je m'y retrouve plus facilement

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -88,6 +88,7 @@ class ApplicationController < ActionController::Base
       gestionnaire: current_gestionnaire,
       administrateur: current_administrateur,
       instructeur: current_instructeur,
+      expert: current_expert,
       user: current_user
     }.compact
   end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -16,6 +16,9 @@ class Users::SessionsController < Devise::SessionsController
     end
 
     super
+    if current_account.count > 1
+      flash[:notice] = t("devise.sessions.signed_in_multiple_profile", roles: current_account.keys.map { |role| t("layouts.#{role}") }.join(', '))
+    end
   end
 
   def reset_link_sent

--- a/app/helpers/release_notes_helper.rb
+++ b/app/helpers/release_notes_helper.rb
@@ -1,6 +1,12 @@
 module ReleaseNotesHelper
   def announce_category_badge(category)
-    color_class = case category.to_sym
+    color_class = color_by_role(category)
+
+    content_tag(:span, ReleaseNote.human_attribute_name("categories.#{category}"), class: "fr-badge #{color_class}")
+  end
+
+  def color_by_role(role)
+    case role.to_sym
     when :administrateur
       'fr-badge--blue-cumulus'
     when :instructeur
@@ -12,8 +18,6 @@ module ReleaseNotesHelper
     when :api
       'fr-badge--pink-macaron'
     end
-
-    content_tag(:span, ReleaseNote.human_attribute_name("categories.#{category}"), class: "fr-badge #{color_class}")
   end
 
   def infer_default_announce_categories

--- a/app/views/layouts/_account_dropdown.haml
+++ b/app/views/layouts/_account_dropdown.haml
@@ -1,7 +1,8 @@
 %nav.fr-translate.fr-nav{ role: "navigation", "aria-label"=> t('menu_aria_label', scope: [:layouts]) }
   .fr-nav__item
     %button.account-btn.fr-translate__btn.fr-btn{ "aria-controls" => "account", "aria-expanded" => "false", :title => t('my_account', scope: [:layouts]) }
-      &nbsp;
+      %div{ class: "fr-badge fr-badge--sm fr-mr-1w #{color_by_role(nav_bar_profile)}"}
+        = t("layouts.#{nav_bar_profile}")
       = " #{current_email}"
     #account.fr-collapse.fr-menu
       %ul.fr-menu__list.max-content

--- a/app/views/layouts/_account_dropdown.haml
+++ b/app/views/layouts/_account_dropdown.haml
@@ -1,9 +1,9 @@
 %nav.fr-translate.fr-nav{ role: "navigation", "aria-label"=> t('menu_aria_label', scope: [:layouts]) }
   .fr-nav__item
     %button.account-btn.fr-translate__btn.fr-btn{ "aria-controls" => "account", "aria-expanded" => "false", :title => t('my_account', scope: [:layouts]) }
-      %div{ class: "fr-badge fr-badge--sm fr-mr-1w #{color_by_role(nav_bar_profile)}" }
-        = t("layouts.#{nav_bar_profile}")
       = " #{current_email}"
+      %div{ class: "fr-badge fr-badge--sm fr-ml-1w #{color_by_role(nav_bar_profile)}" }
+        = t("layouts.#{nav_bar_profile}")
     #account.fr-collapse.fr-menu
       %ul.fr-menu__list.max-content
         - if multiple_devise_profile_connect?

--- a/app/views/layouts/_account_dropdown.haml
+++ b/app/views/layouts/_account_dropdown.haml
@@ -1,7 +1,7 @@
 %nav.fr-translate.fr-nav{ role: "navigation", "aria-label"=> t('menu_aria_label', scope: [:layouts]) }
   .fr-nav__item
     %button.account-btn.fr-translate__btn.fr-btn{ "aria-controls" => "account", "aria-expanded" => "false", :title => t('my_account', scope: [:layouts]) }
-      %div{ class: "fr-badge fr-badge--sm fr-mr-1w #{color_by_role(nav_bar_profile)}"}
+      %div{ class: "fr-badge fr-badge--sm fr-mr-1w #{color_by_role(nav_bar_profile)}" }
         = t("layouts.#{nav_bar_profile}")
       = " #{current_email}"
     #account.fr-collapse.fr-menu

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -3,3 +3,5 @@ en:
     passwords:
       new:
         request_new_password: Request new password
+    sessions:
+      signed_in_multiple_profile: "You are connected ! You can switch between your multiple profiles : %{roles}."

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -3,3 +3,5 @@ fr:
     passwords:
       new:
         request_new_password: Demander un nouveau mot de passe
+    sessions:
+      signed_in_multiple_profile: "Vous êtes connecté(e) ! Vous pouvez à tout moment alterner entre vos différents profils : %{roles}."

--- a/spec/system/experts/expert_spec.rb
+++ b/spec/system/experts/expert_spec.rb
@@ -36,7 +36,7 @@ describe 'Inviting an expert:' do
         visit new_user_session_path
         sign_in_with avis.expert.email, password
 
-        expect(page).to have_content('Connecté(e).')
+        expect(page).to have_content('Vous pouvez à tout moment alterner entre vos différents profils : expert, usager.')
         expect(page).to have_current_path(expert_all_avis_path)
       end
     end

--- a/spec/system/sessions/sign_in_spec.rb
+++ b/spec/system/sessions/sign_in_spec.rb
@@ -12,6 +12,22 @@ describe 'Signin in:' do
 
     sign_in_with user.email, password
     expect(page).to have_current_path dossiers_path
+    expect(page).to have_content('Connecté(e).')
+    expect(page).not_to have_content('Vous pouvez à tout moment alterner')
+  end
+
+  context 'user has multiple profiles' do
+    let!(:instructeur) { create(:instructeur,    user: user) }
+    let!(:admin)       { create(:administrateur, user: user, instructeur: instructeur) }
+
+    scenario 'he can sign-in and he is notified in flash' do
+      visit root_path
+      click_on 'Se connecter', match: :first
+
+      sign_in_with user.email, password
+      expect(page).to have_current_path admin_procedures_path
+      expect(page).to have_content('Vous êtes connecté(e) ! Vous pouvez à tout moment alterner entre vos différents profils : administrateur, instructeur, usager.')
+    end
   end
 
   scenario 'an existing user can lock its account' do


### PR DESCRIPTION
Suite au forum ouvert et à différentes remontées, on souhaite mettre en avant le profil sur lequel on est connecté et la possibilité de changer de profil.

Dans cette PR : 
- on ajoute le badge du profil actif dans le header
- on ajoute un message dans le flash à la connexion

<img width="1277" alt="Capture d’écran 2023-12-19 à 11 18 48" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/0bcea5aa-fc40-4109-971c-84d23138a248">

