### PR TITLE
Correctif: Le noms des EPCIs changent, ce qui bloque la validation et ou demande a resaisir le champs

### DIFF
--- a/app/models/champs/epci_champ.rb
+++ b/app/models/champs/epci_champ.rb
@@ -1,6 +1,7 @@
 class Champs::EpciChamp < Champs::TextChamp
   store_accessor :value_json, :code_departement, :code_region
   before_validation :on_departement_change
+  before_validation :on_epci_name_changes
 
   validate :code_departement_in_departement_codes, unless: -> { code_departement.nil? }
   validate :external_id_in_departement_epci_codes, unless: -> { code_departement.nil? || external_id.nil? }
@@ -98,5 +99,14 @@ class Champs::EpciChamp < Champs::TextChamp
     return if value.in?(APIGeoService.epcis(code_departement).pluck(:name))
 
     errors.add(:value, :not_in_departement_epci_names)
+  end
+
+  def on_epci_name_changes
+    return if external_id.nil? || code_departement.nil?
+    return if value.in?(APIGeoService.epcis(code_departement).pluck(:name))
+
+    if external_id.in?(APIGeoService.epcis(code_departement).pluck(:code))
+      self.value = (external_id)
+    end
   end
 end

--- a/spec/models/champs/epci_champ_spec.rb
+++ b/spec/models/champs/epci_champ_spec.rb
@@ -110,10 +110,10 @@ describe Champs::EpciChamp, type: :model do
           it { is_expected.to be_valid }
         end
 
-        context 'when value is empty' do
-          let(:value) { '' }
+        context 'when value is in departement epci names' do
+          let(:value) { 'CA Haut - Bugey Agglomération' }
 
-          it { is_expected.not_to be_valid }
+          it { is_expected.to be_valid }
         end
 
         context 'when value is in departement epci names' do
@@ -122,10 +122,22 @@ describe Champs::EpciChamp, type: :model do
           it { is_expected.to be_valid }
         end
 
-        context 'when value is not in departement epci names' do
+        context 'when epci name had been renamed' do
           let(:value) { 'totoro' }
 
-          it { is_expected.not_to be_valid }
+          it 'is valid and updates its own value' do
+            expect(subject).to be_valid
+            expect(subject.value).to eq('CA Haut - Bugey Agglomération')
+          end
+        end
+
+        context 'when value is not in departement epci names nor in departement epci codes' do
+          let(:value) { 'totoro' }
+
+          it 'is invalid' do
+            allow(APIGeoService).to receive(:epcis).with(champ.code_departement).and_return([])
+            expect(subject).not_to be_valid
+          end
         end
       end
     end


### PR DESCRIPTION
hs: https://secure.helpscout.net/conversation/2445777524/2047866?folderId=5935139
hs: https://secure.helpscout.net/conversation/2456448493/2048726/

# Probleme : impossible de MAJ les annotations privées d'un dossier

## constat :

Pour l'un des **champs public** du dossier, Le nom de son EPCI a été renommé `CC de la Région de Blain` -> `CC Pays de Blain communauté`. 
Nous avons un validateur qui bloque la dessus.

## la data :
En db en prod nous avons 
```
{
  "id"=>461566047,
  "value"=>"CC de la Région de Blain",
  "type_de_champ_id"=>3020399,
  "dossier_id"=>XXX,
  "type"=>"Champs::EpciChamp",
  "parent_id"=>461081494,
  "external_id"=>"244400453",
  "value_json"=>{"code_departement"=>"44"},
}
```

Lorsqu'on requete les APIs de geo pour le departement du champ
```
APIGeoService.epcis(44)
[
  { ... },
  { :name => "CC Pays de Blain communauté", :code => "244400453" },
  { ... }
]
```

## solution. 
on remap quand ça arrive
