### PR TITLE
fix(combobox): some old procedure still have options with trailing white spaces. ensure to trim selected value as well as options.value for better comparison

### DIFF
--- a/app/javascript/shared/combobox.ts
+++ b/app/javascript/shared/combobox.ts
@@ -105,7 +105,7 @@ export class Combobox {
     }
 
     const option = this.#visibleOptions.find(
-      (option) => option.value == maybeValue
+      (option) => option.value.trim() == maybeValue.trim()
     );
     if (!option) return false;
 


### PR DESCRIPTION
hs: https://secure.helpscout.net/conversation/2469559772/2051187?folderId=1653799