### PR TITLE
ETQ admin: petites corrections de style dans l'éditeur

### DIFF
--- a/app/assets/stylesheets/_colors.scss
+++ b/app/assets/stylesheets/_colors.scss
@@ -23,5 +23,4 @@ $light-yellow: #FFFFDE;
 $blue-france-700: #00006D;
 $blue-france-500: #000091;
 $blue-france-400: #7F7FC8;
-$blue-cumulus-950: #E6EEFE;
 $g700: #383838;

--- a/app/assets/stylesheets/procedure_champs_editor.scss
+++ b/app/assets/stylesheets/procedure_champs_editor.scss
@@ -19,7 +19,7 @@
 
     .type-de-champ-container {
       width: 100%;
-      border: 1px solid $border-grey;
+      border: 1px solid var(--border-default-grey);
       border-radius: 5px;
       margin-bottom: $default-padding;
       box-shadow: 0px 2px 4px -4px;
@@ -55,7 +55,7 @@
 
     &.type-header-section {
       .head {
-        background-color: $blue-cumulus-950;
+        background-color: var(--background-contrast-blue-cumulus);
       }
     }
 

--- a/app/assets/stylesheets/procedure_champs_editor.scss
+++ b/app/assets/stylesheets/procedure_champs_editor.scss
@@ -33,10 +33,11 @@
       }
     }
 
-    .delete {
+    .right {
       flex-grow: 1;
       display: flex;
       justify-content: flex-end;
+      align-items: center;
     }
 
     &.first .move-up {

--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
@@ -5,13 +5,12 @@
       %button.fr-btn.fr-btn--tertiary-no-outline.fr-icon-arrow-up-line.move-up{ move_button_options(:up) }
       %button.fr-btn.fr-btn--tertiary-no-outline.fr-icon-arrow-down-line.move-down{ move_button_options(:down) }
 
-      - if coordinate.used_by_routing_rules?
-        .flex.align-center
+      .flex.right
+        - if coordinate.used_by_routing_rules?
           %span
             utilisé pour
             = link_to('le routage', admin_procedure_groupe_instructeurs_path(revision.procedure_id, anchor: 'routing-rules'))
-      - else
-        .flex.justify-start.delete
+        - else
           = button_to type_de_champ_path, class: 'fr-btn fr-btn--tertiary-no-outline fr-icon-delete-line', title: "Supprimer le champ", method: :delete, form: { data: { turbo_confirm: 'Êtes vous sûr de vouloir supprimer ce champ ?' } } do
             %span.sr-only Supprimer
 


### PR DESCRIPTION
- thème sombre pour les titres de section & bordures
- alignement sur le tdc  utilisé par le routage

## APRES

![Capture d’écran 2024-01-08 à 18 12 52](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/222ab2e3-17f4-4441-964c-cfcd84aed6b6)


![Capture d’écran 2024-01-08 à 18 12 23](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/bfd2d054-155d-4d6a-be30-4b6d6828bf39)


## AVANT
![Capture d’écran 2024-01-08 à 18 14 09](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/1b1f6526-9e5f-4370-a1e2-b27dd04e0c99)


![Capture d’écran 2024-01-08 à 18 14 24](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/522ff931-8a41-4039-a8ea-e6d66d560be8)

