### PR TITLE
ETQ instructeur, la recherche de dossiers affiche les pastilles de notifications le cas échéant

### DIFF
--- a/app/controllers/recherche_controller.rb
+++ b/app/controllers/recherche_controller.rb
@@ -35,6 +35,7 @@ class RechercheController < ApplicationController
     @dossiers_count = matching_dossiers_ids.count
     @followed_dossiers_id = current_instructeur&.followed_dossiers&.where(id: @paginated_ids)&.ids || []
     @dossier_avis_ids_h = current_expert&.avis&.where(dossier_id: @paginated_ids)&.pluck(:dossier_id, :id).to_h || {}
+    @notifications_dossier_ids = current_instructeur&.notifications_for_dossiers(@paginated_ids) || []
 
     # if an instructor search for a dossier which is in his procedures but not available to his intructor group
     # we want to display an alert in view

--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -134,12 +134,7 @@ class Instructeur < ApplicationRecord
   end
 
   def notifications_for_groupe_instructeurs(groupe_instructeurs)
-    Dossier
-      .visible_by_administration
-      .not_archived
-      .where(groupe_instructeur: groupe_instructeurs)
-      .merge(followed_dossiers)
-      .with_notifications
+    notifications_for(groupe_instructeur: groupe_instructeurs)
       .pluck(:state, :id)
       .reduce({ termines: [], en_cours: [] }) do |acc, e|
         if Dossier::TERMINE.include?(e[0])
@@ -149,6 +144,11 @@ class Instructeur < ApplicationRecord
         end
         acc
       end
+  end
+
+  def notifications_for_dossiers(dossier_ids)
+    notifications_for(id: dossier_ids)
+      .pluck(:id)
   end
 
   def procedure_ids_with_notifications(scope)
@@ -309,5 +309,14 @@ class Instructeur < ApplicationRecord
       avis: avis,
       messagerie: messagerie
     }
+  end
+
+  def notifications_for(condition)
+    Dossier
+      .visible_by_administration
+      .not_archived
+      .where(condition)
+      .merge(followed_dossiers)
+      .with_notifications
   end
 end

--- a/app/views/recherche/index.html.haml
+++ b/app/views/recherche/index.html.haml
@@ -38,6 +38,8 @@
             - if instructeur_and_expert_dossier
               %td.text-center.cell-link
                 = dsfr_icon('fr-icon-file-text-line')
+                - if @notifications_dossier_ids.include?(p.dossier_id)
+                  %span.notifications{ 'aria-label': 'notifications' }
               %td.number-col
                 .cell-link= p.dossier_id
               %td
@@ -55,6 +57,8 @@
               %td.text-center
                 %a.cell-link{ href: path }
                   = dsfr_icon('fr-icon-file-text-line')
+                  - if @notifications_dossier_ids.include?(p.dossier_id)
+                    %span.notifications{ 'aria-label': 'notifications' }
 
               %td.number-col
                 %a.cell-link{ href: path }= p.dossier_id

--- a/spec/controllers/recherche_controller_spec.rb
+++ b/spec/controllers/recherche_controller_spec.rb
@@ -140,13 +140,24 @@ describe RechercheController, type: :controller do
     describe 'by champs' do
       let(:query) { 'district A' }
 
-      before { subject }
-
       it { is_expected.to have_http_status(200) }
 
       it 'returns the expected dossier' do
+        subject
         expect(assigns(:projected_dossiers).count).to eq(1)
         expect(assigns(:projected_dossiers).first.dossier_id).to eq(dossier.id)
+      end
+
+      context 'when dossier has notification' do
+        before do
+          instructeur.follow(dossier)
+          dossier.touch(:last_commentaire_updated_at)
+        end
+
+        it 'assigns notification' do
+          subject
+          expect(assigns(:notifications_dossier_ids)).to eq([dossier.id])
+        end
       end
 
       context 'as an expert' do
@@ -156,6 +167,7 @@ describe RechercheController, type: :controller do
         it { is_expected.to have_http_status(200) }
 
         it 'returns only the dossier available to the expert' do
+          subject
           expect(assigns(:projected_dossiers).count).to eq(1)
           expect(assigns(:projected_dossiers).first.dossier_id).to eq(dossier_with_expert.id)
         end


### PR DESCRIPTION
HS: https://secure.helpscout.net/conversation/2475988027/2051745?folderId=1653799

(reste un autre bug de pastille sur les onglets à dénicher)


![Capture d’écran 2024-01-11 à 18 36 14](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/cd5d1eeb-4302-4f04-bbe2-f8eb61bd0a65)
