### PR TITLE
ETQ admin je peux ajouter un champ carte dans un bloc répétable

### DIFF
--- a/app/components/types_de_champ_editor/champ_component.rb
+++ b/app/components/types_de_champ_editor/champ_component.rb
@@ -90,7 +90,6 @@ class TypesDeChampEditor::ChampComponent < ApplicationComponent
   end
 
   EXCLUDE_FROM_BLOCK = [
-    TypeDeChamp.type_champs.fetch(:carte),
     TypeDeChamp.type_champs.fetch(:repetition)
   ]
 

--- a/app/javascript/components/MapEditor/components/AddressInput.tsx
+++ b/app/javascript/components/MapEditor/components/AddressInput.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { fire } from '@utils';
+import type { FeatureCollection } from 'geojson';
 
 import ComboAdresseSearch from '../../ComboAdresseSearch';
 import { ComboSearchProps } from '~/components/ComboSearch';
@@ -8,7 +9,7 @@ export function AddressInput(
   comboProps: Pick<
     ComboSearchProps,
     'screenReaderInstructions' | 'announceTemplateId'
-  >
+  > & { featureCollection: FeatureCollection }
 ) {
   return (
     <div
@@ -21,7 +22,10 @@ export function AddressInput(
         placeholder="Rechercher une adresse : saisissez au moins 2 caractères"
         allowInputValues={false}
         onChange={(_, feature) => {
-          fire(document, 'map:zoom', { feature });
+          fire(document, 'map:zoom', {
+            featureCollection: comboProps.featureCollection,
+            feature
+          });
         }}
         {...comboProps}
       />

--- a/app/javascript/components/MapEditor/components/DrawLayer.tsx
+++ b/app/javascript/components/MapEditor/components/DrawLayer.tsx
@@ -6,6 +6,7 @@ import type { FeatureCollection } from 'geojson';
 import { useMapLibre } from '../../shared/maplibre/MapLibre';
 import {
   useFitBounds,
+  useFitBoundsNoFly,
   useEvent,
   useMapEvent,
   useFlyTo
@@ -117,6 +118,7 @@ function useExternalEvents(
   }
 ) {
   const fitBounds = useFitBounds();
+  const fitBoundsNoFly = useFitBoundsNoFly();
   const flyTo = useFlyTo();
 
   const onFeatureFocus = useCallback(
@@ -184,10 +186,10 @@ function useExternalEvents(
   );
 
   useEffect(() => {
-    fitBounds(featureCollection.bbox as LngLatBoundsLike);
+    fitBoundsNoFly(featureCollection.bbox as LngLatBoundsLike);
     // We only want to zoom on bbox on component mount.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fitBounds]);
+  }, [fitBoundsNoFly]);
 
   useEvent('map:feature:focus', onFeatureFocus);
   useEvent('map:feature:create', onFeatureCreate);

--- a/app/javascript/components/MapEditor/components/DrawLayer.tsx
+++ b/app/javascript/components/MapEditor/components/DrawLayer.tsx
@@ -138,12 +138,11 @@ function useExternalEvents(
 
   const onZoomFocus = useCallback(
     ({ detail }) => {
-      const { feature } = detail;
-      if (feature) {
-        flyTo(17, feature.geometry.coordinates);
+      if (detail.feature && detail.featureCollection == featureCollection) {
+        flyTo(17, detail.feature.geometry.coordinates);
       }
     },
-    [flyTo]
+    [flyTo, featureCollection]
   );
 
   const onFeatureCreate = useCallback(

--- a/app/javascript/components/MapEditor/components/PointInput.tsx
+++ b/app/javascript/components/MapEditor/components/PointInput.tsx
@@ -1,9 +1,13 @@
 import React, { useState, useId } from 'react';
 import { fire } from '@utils';
-import type { Feature } from 'geojson';
+import type { Feature, FeatureCollection } from 'geojson';
 import CoordinateInput from 'react-coordinate-input';
 
-export function PointInput() {
+export function PointInput({
+  featureCollection
+}: {
+  featureCollection: FeatureCollection;
+}) {
   const inputId = useId();
   const [value, setValue] = useState('');
   const [feature, setFeature] = useState<Feature | null>(null);
@@ -60,7 +64,7 @@ export function PointInput() {
                 properties: {}
               };
               setFeature(feature);
-              fire(document, 'map:zoom', { feature });
+              fire(document, 'map:zoom', { featureCollection, feature });
             } else {
               setFeature(null);
             }

--- a/app/javascript/components/MapEditor/index.tsx
+++ b/app/javascript/components/MapEditor/index.tsx
@@ -50,6 +50,7 @@ export default function MapEditor({
 
       <ImportFileInput featureCollection={featureCollection} {...actions} />
       <AddressInput
+        featureCollection={featureCollection}
         screenReaderInstructions={autocompleteScreenReaderInstructions}
         announceTemplateId={autocompleteAnnounceTemplateId}
       />
@@ -82,7 +83,7 @@ export default function MapEditor({
           </>
         ) : null}
       </MapLibre>
-      <PointInput />
+      <PointInput featureCollection={featureCollection} />
     </>
   );
 }

--- a/app/javascript/components/shared/maplibre/hooks.ts
+++ b/app/javascript/components/shared/maplibre/hooks.ts
@@ -26,6 +26,16 @@ export function useFitBounds() {
   );
 }
 
+export function useFitBoundsNoFly() {
+  const map = useMapLibre();
+  return useCallback(
+    (bbox: LngLatBoundsLike) => {
+      map.fitBounds(bbox, { padding: 100, linear: true, duration: 0 });
+    },
+    [map]
+  );
+}
+
 export function useFlyTo() {
   const map = useMapLibre();
   return useCallback(


### PR DESCRIPTION
# constat 

niveau perf, au chargement de 10/20 cartes vide (via les répétitions) c'est pas horrible ; mais il y a déjà quelques bémoles qu'on pourrait souhaiter améliorer 


# idée

done (et je pense suffisant pour partir en prod car pas de bug, des perfs tolérables) :
- [x] virer le panTo (le fait de scroller / zoomer la carte au chargement, ac plein de carte ça ram. juste chargeons un layer au bon endroit ac le bon zoom et on est bon ?)

pensé a todo mais pas si important
- [ ] fixer la taille des carte pour eviter un flickering [le fait de resizer un element / redimensionner la page une fois l'element chargé, en gros un simili squelette {sans partir ds les idées de visuel, juste un placeholder tenant sa place}]
- [ ] p-e delayer le chargement des cartes via un IntersectionObserver ? (autant de spinner/chargement/requete que de carte. laissons le scroll precharger les cartes au besoin non?)

# POC  (20 cartes sur un dossier)

stopper le pan to / transition jolie pour zoomer sur le point de la carte (evite de charger les tuiles de la carte)
apres : 
<img width="723" alt="Screenshot 2024-02-01 at 5 32 11 PM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/e64a53b3-90e7-4999-81ee-64eef4275601">
avant:
<img width="730" alt="Screenshot 2024-02-01 at 5 31 23 PM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/c1d3af19-0262-46bd-b13d-6f27d2e7966e">
