### PR TITLE
tech(procedure_revision_type_de_champ): remaniement pour ordonner les type de champs par des float (plus facile a changer la position sur de gros forms, perf)

### DIFF
--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -41,15 +41,13 @@ class ProcedureRevision < ApplicationRecord
     after_stable_id = params.delete(:after_stable_id)
     after_coordinate, _ = coordinate_and_tdc(after_stable_id)
 
-    # the collection is orderd by (position, id), so we can use after_coordinate.position
-    # if not present, a big number is used to ensure the element is at the tail
+    # TODO: position.to_f
     position = (after_coordinate&.position) || 100_000
 
     tdc = TypeDeChamp.new(params)
     if tdc.save
       h = { type_de_champ: tdc, parent_id: parent_id, position: position }
       coordinate = revision_types_de_champ.create!(h)
-
       renumber(coordinate.reload.siblings)
     end
 
@@ -250,7 +248,7 @@ class ProcedureRevision < ApplicationRecord
 
   def renumber(siblings)
     siblings.to_a.compact.each.with_index do |sibling, position|
-      sibling.update_column(:position, position)
+      sibling.update_columns(position: position, new_position: position.to_f)
     end
   end
 

--- a/db/migrate/20240112103134_add_new_position_to_procedure_revision_types_de_champ.rb
+++ b/db/migrate/20240112103134_add_new_position_to_procedure_revision_types_de_champ.rb
@@ -1,0 +1,5 @@
+class AddNewPositionToProcedureRevisionTypesDeChamp < ActiveRecord::Migration[7.0]
+  def change
+    add_column :procedure_revision_types_de_champ, :new_position, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_10_113623) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_12_103134) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -790,6 +790,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_10_113623) do
 
   create_table "procedure_revision_types_de_champ", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
+    t.float "new_position"
     t.bigint "parent_id"
     t.integer "position", null: false
     t.bigint "revision_id", null: false

--- a/lib/tasks/deployment/20240112103522_backfill_procedure_revision_types_de_champ_new_position.rake
+++ b/lib/tasks/deployment/20240112103522_backfill_procedure_revision_types_de_champ_new_position.rake
@@ -1,0 +1,13 @@
+namespace :after_party do
+  desc 'Deployment task: backfill_procedure_revision_types_de_champ_new_position'
+  task backfill_procedure_revision_types_de_champ_new_position: :environment do
+    puts "Running deploy task 'backfill_procedure_revision_types_de_champ_new_position'"
+
+    # Put your task implementation HERE.
+    ProcedureRevisionTypeDeChamp.in_batches.update_all(new_position: 'position')
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/models/procedure_revision_spec.rb
+++ b/spec/models/procedure_revision_spec.rb
@@ -30,6 +30,7 @@ describe ProcedureRevision do
         expect(draft.types_de_champ_public.last).to eq(subject)
 
         expect(last_coordinate.position).to eq(2)
+        expect(last_coordinate.new_position).to eq(2.0)
         expect(last_coordinate.type_de_champ).to eq(subject)
       end
     end


### PR DESCRIPTION
alatrello https://stackoverflow.com/questions/29791543/how-does-trello-handle-rearrangement-of-cards-lists-checklists-etc
