### PR TITLE
Perf ETQ admin: supprime plusieurs requêtes inutiles / page

### DIFF
--- a/app/models/administrateur.rb
+++ b/app/models/administrateur.rb
@@ -139,7 +139,7 @@ class Administrateur < ApplicationRecord
   end
 
   def zones
-    procedures.joins(:zones).flat_map(&:zones).uniq
+    procedures.includes(:zones).flat_map(&:zones).uniq
   end
 
   # required to display feature flags field in manager

--- a/app/models/procedures_filter.rb
+++ b/app/models/procedures_filter.rb
@@ -5,6 +5,9 @@ class ProceduresFilter
 
   def initialize(admin, params)
     @admin = admin
+
+    params[:zone_ids] = admin.zones.pluck(:id) if params[:zone_ids] == 'admin_default'
+
     @params = params.permit(:page, :libelle, :email, :from_publication_date, :service_siret, :service_departement, tags: [], zone_ids: [], statuses: [])
   end
 

--- a/app/views/administrateurs/_main_navigation.html.haml
+++ b/app/views/administrateurs/_main_navigation.html.haml
@@ -2,7 +2,7 @@
   %ul.fr-nav__list
     %li.fr-nav__item= link_to 'Mes démarches', admin_procedures_path, class:'fr-nav__link', 'aria-current': current_page?(controller: 'administrateurs/procedures', action: :index) ? 'page' : nil
     - if Rails.application.config.ds_zonage_enabled
-      %li.fr-nav__item= link_to 'Toutes les démarches', all_admin_procedures_path(zone_ids: current_administrateur.zones), class:'fr-nav__link', 'aria-current': current_page?(all_admin_procedures_path) ? 'page' : nil
+      %li.fr-nav__item= link_to 'Toutes les démarches', all_admin_procedures_path(zone_ids: :admin_default), class:'fr-nav__link', 'aria-current': current_page?(all_admin_procedures_path) ? 'page' : nil
     - if current_administrateur.groupe_gestionnaire_id
       %li.fr-nav__item= link_to 'Mon groupe gestionnaire', admin_groupe_gestionnaire_path, class:'fr-nav__link', 'aria-current': current_page?(admin_groupe_gestionnaire_path) ? 'page' : nil
 

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -116,6 +116,23 @@ describe Administrateurs::ProceduresController, type: :controller do
       expect(assigns(:procedures).any? { |p| p.id == draft_procedure.id }).to be_falsey
     end
 
+    context 'for default admin zones' do
+      let(:zone1) { create(:zone) }
+      let(:zone2) { create(:zone) }
+      let!(:procedure1) { create(:procedure, :published, zones: [zone1]) }
+      let!(:procedure2) { create(:procedure, :published, zones: [zone1, zone2]) }
+      let!(:admin_procedure) { create(:procedure, :published, zones: [zone2], administrateur: admin) }
+
+      subject { get :all, params: { zone_ids: :admin_default } }
+
+      it 'display only procedures for specified zones' do
+        subject
+        expect(assigns(:procedures).any? { |p| p.id == procedure2.id }).to be_truthy
+        expect(assigns(:procedures).any? { |p| p.id == admin_procedure.id }).to be_truthy
+        expect(assigns(:procedures).any? { |p| p.id == procedure1.id }).to be_falsey
+      end
+    end
+
     context "for specific zones" do
       let(:zone1) { create(:zone) }
       let(:zone2) { create(:zone) }


### PR DESCRIPTION
Pour la navigation, on faisait un lien vers la page _Toutes les démarches_ avec les zones de l'admin pré-sélectionnées dans l'url générée, ce qui coutait 2+(N+1) requêtes pour générer cette liste. On ne génère plus le lien vers cette liste dynamique (même si solution rapide et peu élégante), et au passage on enlève le N+1 sur cette query qui reste exécutée sur la dite page.

(il resterait encore d'autres N+1 à éliminer sur cette page, mais plus compliquées à traiter)