### PR TITLE
Tech: ne plante plus le job de purge des dossiers supprimés par l'usager lorsqu'un seul dossier échoue

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -1349,6 +1349,8 @@ class Dossier < ApplicationRecord
       DeletedDossier.create_from_dossier(self, hidden_by_reason)
       dossier_operation_logs.purge_discarded
       destroy
+    rescue => e
+      Sentry.capture_exception(e, extra: { dossier: id })
     end
   end
 


### PR DESCRIPTION
On a encore un cas de dossier qui n'a pas de `hidden_by_reason` pour une raison mystérieuse, ce qui empêche le job de traiter toute la file de dossiers à supprimer (et provoque d'autres bugs en cascade)

https://demarches-simplifiees.sentry.io/issues/4581099175/?project=1429550

Cette PR fait en sorte de ne plus planter toute la file.
