### PR TITLE
tech(specs): safer and cleaner API to create procedure with tdcs

### DIFF
--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -264,12 +264,11 @@ class ProcedureRevision < ApplicationRecord
   end
 
   def next_position_for(siblings:, after_coordinate: nil)
-    if siblings.to_a.empty? # first element of the list, starts at 0
+    # either we are at the beginning of the list or after another item
+    if after_coordinate.nil? # first element of the list, starts at 0
       0
-    elsif after_coordinate # middle of the list, between two items
+    else # after another item
       after_coordinate.position + 1
-    else # last element of the list, end with last position + 1
-      siblings.to_a.last.position + 1
     end
   end
 

--- a/spec/components/types_de_champ_editor/explication_component_spec.rb
+++ b/spec/components/types_de_champ_editor/explication_component_spec.rb
@@ -1,7 +1,7 @@
 describe TypesDeChampEditor::ChampComponent, type: :component do
   describe 'render by type' do
     context 'explication' do
-      let(:procedure) { create(:procedure, :with_explication) }
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :explication }]) }
       let(:tdc) { procedure.active_revision.types_de_champ_public.first }
       let(:coordinate) { procedure.draft_revision.coordinate_for(tdc) }
       let(:component) { described_class.new(coordinate: coordinate, upper_coordinates: []) }

--- a/spec/controllers/administrateurs/attestation_templates_controller_spec.rb
+++ b/spec/controllers/administrateurs/attestation_templates_controller_spec.rb
@@ -185,7 +185,7 @@ describe Administrateurs::AttestationTemplatesController, type: :controller do
     end
 
     context 'when procedure is published' do
-      let(:procedure) { create(:procedure, :with_type_de_champ, types_de_champ_count: 3, administrateur: admin, attestation_template: attestation_template) }
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :text }, { type: :text }, { type: :text }], administrateur: admin, attestation_template: attestation_template) }
       let(:dossier) {}
       let(:attestation_template) { build(:attestation_template, title: 'a') }
       let(:attestation_params) do
@@ -208,11 +208,12 @@ describe Administrateurs::AttestationTemplatesController, type: :controller do
         procedure.publish!
         procedure.reload
         procedure.draft_revision.remove_type_de_champ(removed_and_published_type_de_champ.stable_id)
-        procedure.draft_revision.add_type_de_champ(libelle: 'new type de champ', type_champ: 'text')
+        procedure.draft_revision.add_type_de_champ(libelle: 'new type de champ', type_champ: 'text', after_stable_id: procedure.draft_revision.types_de_champ_public.last.stable_id)
         procedure.publish_revision!
         procedure.reload
         procedure.draft_revision.remove_type_de_champ(removed_type_de_champ.stable_id)
-        procedure.draft_revision.add_type_de_champ(libelle: 'draft type de champ', type_champ: 'text')
+        procedure.draft_revision.reload
+        procedure.draft_revision.add_type_de_champ(libelle: 'draft type de champ', type_champ: 'text', after_stable_id: procedure.draft_revision.types_de_champ_public.last.stable_id)
 
         dossier
 

--- a/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
+++ b/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
@@ -1,11 +1,14 @@
 describe Administrateurs::TypesDeChampController, type: :controller do
   let(:procedure) do
-    create(:procedure).tap do |p|
-      p.draft_revision.add_type_de_champ(type_champ: :integer_number, libelle: 'l1')
-      p.draft_revision.add_type_de_champ(type_champ: :integer_number, libelle: 'l2')
-      p.draft_revision.add_type_de_champ(type_champ: :drop_down_list, libelle: 'l3')
-      p.draft_revision.add_type_de_champ(type_champ: :yes_no, libelle: 'bon dossier', private: true)
-    end
+    create(:procedure,
+           types_de_champ_public: [
+             { type: :integer_number, libelle: 'l1' },
+             { type: :integer_number, libelle: 'l2' },
+             { type: :drop_down_list, libelle: 'l3' }
+           ],
+           types_de_champ_private: [
+             { type: :yes_no, libelle: 'bon dossier', private: true }
+           ])
   end
 
   def first_coordinate = procedure.draft_revision.revision_types_de_champ_public.first

--- a/spec/controllers/api/v1/dossiers_controller_spec.rb
+++ b/spec/controllers/api/v1/dossiers_controller_spec.rb
@@ -269,7 +269,7 @@ describe API::V1::DossiersController do
           end
 
           describe 'departement' do
-            let(:procedure) { create(:procedure, :with_departement, administrateur: admin) }
+            let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :departements }], administrateur: admin) }
             let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, procedure: procedure) }
 
             subject { super() }
@@ -281,7 +281,7 @@ describe API::V1::DossiersController do
           end
 
           describe 'repetition' do
-            let(:procedure) { create(:procedure, :with_repetition, administrateur: admin) }
+            let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :repetition, children: [{ type: :text }, { type: :integer_number }] }], administrateur: admin) }
             let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, procedure: procedure) }
 
             subject { super().first[:rows] }

--- a/spec/controllers/champs/piece_justificative_controller_spec.rb
+++ b/spec/controllers/champs/piece_justificative_controller_spec.rb
@@ -1,6 +1,6 @@
 describe Champs::PieceJustificativeController, type: :controller do
   let(:user) { create(:user) }
-  let(:procedure) { create(:procedure, :published, :with_piece_justificative) }
+  let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }]) }
   let(:dossier) { create(:dossier, user: user, procedure: procedure) }
   let(:champ) { dossier.champs_public.first }
 

--- a/spec/controllers/champs/rna_controller_spec.rb
+++ b/spec/controllers/champs/rna_controller_spec.rb
@@ -1,6 +1,6 @@
 describe Champs::RNAController, type: :controller do
   let(:user) { create(:user) }
-  let(:procedure) { create(:procedure, :published, :with_rna) }
+  let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :rna }]) }
 
   describe '#show' do
     let(:dossier) { create(:dossier, user: user, procedure: procedure) }

--- a/spec/controllers/champs/siret_controller_spec.rb
+++ b/spec/controllers/champs/siret_controller_spec.rb
@@ -1,6 +1,6 @@
 describe Champs::SiretController, type: :controller do
   let(:user) { create(:user) }
-  let(:procedure) { create(:procedure, :published, :with_siret) }
+  let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :siret }]) }
 
   describe '#show' do
     let(:dossier) { create(:dossier, user: user, procedure: procedure) }

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -915,7 +915,7 @@ describe Instructeurs::DossiersController, type: :controller do
       it { expect(response).to render_template 'dossiers/show' }
 
       context 'empty champs commune' do
-        let(:procedure) { create(:procedure, :published, :with_commune, instructeurs:) }
+        let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :communes }], instructeurs:) }
         let(:dossier) { create(:dossier, :accepte, procedure:) }
 
         it { expect(response).to render_template 'dossiers/show' }

--- a/spec/controllers/manager/procedures_controller_spec.rb
+++ b/spec/controllers/manager/procedures_controller_spec.rb
@@ -40,7 +40,7 @@ describe Manager::ProceduresController, type: :controller do
   describe '#show' do
     render_views
 
-    let(:procedure) { create(:procedure, :published, :with_repetition) }
+    let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :repetition, children: [{ type: :text, libelle: 'sub type de champ' }] }]) }
 
     before do
       get :show, params: { id: procedure.id }

--- a/spec/controllers/recherche_controller_spec.rb
+++ b/spec/controllers/recherche_controller_spec.rb
@@ -1,12 +1,9 @@
 describe RechercheController, type: :controller do
   let(:procedure) {
-    create(:procedure,
-                           :published,
-                           :for_individual,
-                           :with_type_de_champ,
-                           :with_type_de_champ_private,
-                           types_de_champ_count: 2,
-                           types_de_champ_private_count: 2)
+    create(:procedure, :published,
+                       :for_individual,
+                       types_de_champ_public: [{ type: :text }, { type: :text }],
+                       types_de_champ_private: [{ type: :text }, { type: :text }])
   }
   let(:dossier) { create(:dossier, :en_construction, :with_individual, procedure: procedure) }
   let(:instructeur) { create(:instructeur) }

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -90,10 +90,7 @@ FactoryBot.define do
       published
 
       for_individual { true }
-
-      after(:build) do |procedure, _evaluator|
-        build(:type_de_champ, libelle: 'Texte obligatoire', mandatory: true, procedure: procedure)
-      end
+      types_de_champ_public { [{ type: :text, libelle: 'Texte obligatoire', mandatory: true }] }
     end
 
     trait :with_bulk_message do
@@ -144,164 +141,11 @@ FactoryBot.define do
     end
 
     trait :with_type_de_champ do
-      transient do
-        types_de_champ_count { 1 }
-      end
-
-      after(:build) do |procedure, evaluator|
-        evaluator.types_de_champ_count.times do |position|
-          build(:type_de_champ, procedure: procedure, position: position)
-        end
-      end
+      types_de_champ_public { [{ type: :text }] }
     end
 
     trait :with_type_de_champ_private do
-      transient do
-        types_de_champ_private_count { 1 }
-      end
-
-      after(:build) do |procedure, evaluator|
-        evaluator.types_de_champ_private_count.times do |position|
-          build(:type_de_champ, :private, procedure: procedure, position: position)
-        end
-      end
-    end
-
-    trait :with_type_de_champ_mandatory do
-      after(:build) do |procedure, _evaluator|
-        build(:type_de_champ, mandatory: true, procedure: procedure)
-      end
-    end
-
-    trait :with_datetime do
-      after(:build) do |procedure, _evaluator|
-        build(:type_de_champ_datetime, mandatory: true, procedure: procedure)
-      end
-    end
-
-    trait :with_dossier_link do
-      after(:build) do |procedure, _evaluator|
-        build(:type_de_champ_dossier_link, procedure: procedure)
-      end
-    end
-
-    trait :with_siret do
-      after(:build) do |procedure, _evaluator|
-        build(:type_de_champ_siret, procedure: procedure)
-      end
-    end
-
-    trait :with_yes_no do
-      after(:build) do |procedure, _evaluator|
-        build(:type_de_champ_yes_no, procedure: procedure)
-      end
-    end
-
-    trait :with_commune do
-      after(:build) do |procedure, _evaluator|
-        build(:type_de_champ_communes, procedure: procedure)
-      end
-    end
-
-    trait :with_departement do
-      after(:build) do |procedure, _evaluator|
-        build(:type_de_champ_departements, procedure: procedure)
-      end
-    end
-
-    trait :with_region do
-      after(:build) do |procedure, _evaluator|
-        build(:type_de_champ_regions, procedure: procedure)
-      end
-    end
-
-    trait :with_piece_justificative do
-      after(:build) do |procedure, _evaluator|
-        build(:type_de_champ_piece_justificative, procedure: procedure)
-      end
-    end
-
-    trait :with_titre_identite do
-      after(:build) do |procedure, _evaluator|
-        build(:type_de_champ_titre_identite, procedure: procedure)
-      end
-    end
-
-    trait :with_repetition do
-      after(:build) do |procedure, _evaluator|
-        build(:type_de_champ_repetition, :with_types_de_champ, procedure: procedure)
-      end
-    end
-
-    trait :with_private_repetition do
-      after(:build) do |procedure, _evaluator|
-        build(:type_de_champ_repetition, :private, procedure: procedure)
-      end
-    end
-
-    trait :with_number do
-      after(:build) do |procedure, _evaluator|
-        build(:type_de_champ_number, procedure: procedure)
-      end
-    end
-
-    trait :with_phone do
-      after(:build) do |procedure, _evaluator|
-        build(:type_de_champ_phone, procedure: procedure)
-      end
-    end
-
-    trait :with_drop_down_list do
-      after(:build) do |procedure, _evaluator|
-        build(:type_de_champ_drop_down_list, :with_other, procedure: procedure)
-      end
-    end
-
-    trait :with_address do
-      after(:build) do |procedure, _evaluator|
-        build(:type_de_champ_address, procedure: procedure)
-      end
-    end
-
-    trait :with_cnaf do
-      after(:build) do |procedure, _evaluator|
-        build(:type_de_champ_cnaf, procedure: procedure)
-      end
-    end
-
-    trait :with_rna do
-      after(:build) do |procedure, _evaluator|
-        build(:type_de_champ_rna, procedure: procedure)
-      end
-    end
-
-    trait :with_dgfip do
-      after(:build) do |procedure, _evaluator|
-        build(:type_de_champ_dgfip, procedure: procedure)
-      end
-    end
-
-    trait :with_pole_emploi do
-      after(:build) do |procedure, _evaluator|
-        build(:type_de_champ_pole_emploi, procedure: procedure)
-      end
-    end
-
-    trait :with_mesri do
-      after(:build) do |procedure, _evaluator|
-        build(:type_de_champ_mesri, procedure: procedure)
-      end
-    end
-
-    trait :with_explication do
-      after(:build) do |procedure, _evaluator|
-        build(:type_de_champ_explication, procedure: procedure)
-      end
-    end
-    trait :with_carte do
-      after(:build) do |procedure, _evaluator|
-        build(:type_de_champ_carte, procedure: procedure)
-      end
+      types_de_champ_private { [{ type: :text }] }
     end
 
     trait :draft do
@@ -398,6 +242,7 @@ FactoryBot.define do
       end
     end
 
+    # TODO: rewrite with types_de_champ_private
     trait :with_all_annotations do
       after(:build) do |procedure, _evaluator|
         TypeDeChamp.type_champs.map.with_index do |(libelle, type_champ), index|

--- a/spec/factories/type_de_champ.rb
+++ b/spec/factories/type_de_champ.rb
@@ -218,6 +218,7 @@ FactoryBot.define do
         revision.save
       end
 
+      # TODO: drop
       trait :with_types_de_champ do
         after(:build) do |type_de_champ_repetition, evaluator|
           revision = evaluator.procedure.active_revision

--- a/spec/helpers/procedure_helper_spec.rb
+++ b/spec/helpers/procedure_helper_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe ProcedureHelper, type: :helper do
     subject { estimated_fill_duration_minutes(procedure.reload) }
 
     context 'with champs' do
-      let(:procedure) { create(:procedure, :with_yes_no, :with_piece_justificative) }
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :yes_no }, { type: :piece_justificative }]) }
 
       it 'rounds up the duration to the minute' do
         expect(subject).to eq(2)

--- a/spec/lib/data_fixer/dossier_champs_missing_spec.rb
+++ b/spec/lib/data_fixer/dossier_champs_missing_spec.rb
@@ -1,6 +1,6 @@
 describe DataFixer::DossierChampsMissing do
   describe '#fix' do
-    let(:procedure) { create(:procedure, :with_datetime, :with_dossier_link) }
+    let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :datetime }, { type: :dossier_link }]) }
     let(:dossier) { create(:dossier, procedure:) }
 
     context 'when dossier does not have a fork' do
@@ -34,7 +34,7 @@ describe DataFixer::DossierChampsMissing do
     end
 
     context 'when dossier have missing champ on repetition' do
-      let(:procedure) { create(:procedure, :with_repetition) }
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :repetition, children: [{ type: :text }, { type: :decimal_number }] }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
       let(:champ_repetition) { dossier.champs_public.first }
       let(:initial_champ_count) { dossier.champs.count }

--- a/spec/models/concern/dossier_rebase_concern_spec.rb
+++ b/spec/models/concern/dossier_rebase_concern_spec.rb
@@ -573,11 +573,7 @@ describe DossierRebaseConcern do
 
     context 'with a procedure with 2 tdc' do
       let!(:procedure) do
-        create(:procedure).tap do |p|
-          p.draft_revision.add_type_de_champ(type_champ: :text, libelle: 'l1')
-          p.draft_revision.add_type_de_champ(type_champ: :text, libelle: 'l2')
-          p.publish!
-        end
+        create(:procedure, :published, types_de_champ_public: [{ type: :text, libelle: 'l1' }, { type: :text, libelle: 'l2' }])
       end
       let!(:dossier) { create(:dossier, procedure: procedure) }
 
@@ -656,25 +652,34 @@ describe DossierRebaseConcern do
 
     context 'with a procedure with a repetition' do
       let!(:procedure) do
-        create(:procedure).tap do |p|
-          repetition = p.draft_revision.add_type_de_champ(type_champ: :repetition, libelle: 'p1', mandatory: true)
-          p.draft_revision.add_type_de_champ(type_champ: :text, libelle: 'c1', parent_stable_id: repetition.stable_id)
-          p.draft_revision.add_type_de_champ(type_champ: :text, libelle: 'c2', parent_stable_id: repetition.stable_id)
-          p.publish!
-        end
+        create(:procedure, :published, types_de_champ_public: [
+          {
+            type: :repetition,
+            libelle: 'p1',
+            mandatory: true,
+            children: [
+              { type: :text, libelle: 'c1' },
+              { type: :text, libelle: 'c2' }
+            ]
+          }
+        ])
       end
       let!(:dossier) { create(:dossier, procedure: procedure) }
-      let(:repetition_stable_id) { procedure.draft_revision.types_de_champ.find(&:repetition?) }
+      let(:repetition) { procedure.draft_revision.types_de_champ.find(&:repetition?) }
 
       def child_libelles = dossier.champs_public.first.champs.map(&:libelle)
 
       context 'when a child tdc is added in the middle' do
         before do
-          added_tdc = procedure.draft_revision.add_type_de_champ(type_champ: :text, libelle: 'c3', parent_stable_id: repetition_stable_id)
+          last_child = procedure.draft_revision.children_of(repetition).last
+          added_tdc = procedure.draft_revision.add_type_de_champ(type_champ: :text, libelle: 'c3', parent_stable_id: repetition.stable_id, after_stable_id: last_child)
           procedure.draft_revision.move_type_de_champ(added_tdc.stable_id, 1)
+          # procedure.publish_revision!
         end
 
-        it { expect { subject }.to change { child_libelles }.from(['c1', 'c2']).to(['c1', 'c3', 'c2']) }
+        it 'does somehting' do
+          expect { subject }.to change { child_libelles }.from(['c1', 'c2']).to(['c1', 'c3', 'c2'])
+        end
       end
 
       context 'when the first child tdc is removed' do

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1979,7 +1979,7 @@ describe Dossier, type: :model do
       end
 
       context "when procedure brouillon" do
-        let(:procedure) { create(:procedure, :with_type_de_champ, :with_explication) }
+        let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :text }, { type: :explication }]) }
 
         it "should not contain non-exportable types de champ" do
           expect(dossier_champs_for_export.map { |(libelle)| libelle }).to eq([text_type_de_champ.libelle])

--- a/spec/models/instructeur_spec.rb
+++ b/spec/models/instructeur_spec.rb
@@ -262,7 +262,6 @@ describe Instructeur, type: :model do
     let(:seen_at_instructeur2) { now - 1.hour }
 
     before do
-      gi_p1.instructeurs << instructeur
       instructeur_2.followed_dossiers << dossier
       Timecop.freeze(now)
     end

--- a/spec/models/procedure_presentation_and_revisions_spec.rb
+++ b/spec/models/procedure_presentation_and_revisions_spec.rb
@@ -3,30 +3,25 @@ describe ProcedurePresentation do
     subject { procedure.types_de_champ_for_procedure_presentation.not_repetition.pluck(:libelle) }
 
     context 'for a draft procedure' do
-      let(:procedure) { create(:procedure) }
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :number, libelle: 'libelle 1' }]) }
 
       context 'when there are one tdc on a draft revision' do
-        let!(:tdc) { { type_champ: :number, libelle: 'libelle 1' } }
-
-        before { procedure.draft_revision.add_type_de_champ(tdc) }
-
         it { is_expected.to match(['libelle 1']) }
       end
     end
 
     context 'for a published procedure' do
-      let(:procedure) { create(:procedure, :published) }
-      let(:tdc) { { type_champ: :number, libelle: 'libelle 1' } }
+      let(:procedure) { create(:procedure, :published, types_de_champ_public: []) }
+      let!(:tdc) { procedure.draft_revision.add_type_de_champ({ type_champ: :number, libelle: 'libelle 1' }) }
 
       before do
-        procedure.draft_revision.add_type_de_champ(tdc)
         procedure.publish_revision!
       end
 
       it { is_expected.to match(['libelle 1']) }
 
       context 'when there is another published revision with an added tdc' do
-        let(:added_tdc) { { type_champ: :number, libelle: 'libelle 2' } }
+        let(:added_tdc) { { type_champ: :number, libelle: 'libelle 2', after_stable_id: tdc.stable_id } }
 
         before do
           procedure.draft_revision.add_type_de_champ(added_tdc)

--- a/spec/models/procedure_presentation_spec.rb
+++ b/spec/models/procedure_presentation_spec.rb
@@ -53,7 +53,11 @@ describe ProcedurePresentation do
 
   describe "#fields" do
     context 'when the procedure can have a SIRET number' do
-      let(:procedure) { create(:procedure, :with_type_de_champ, :with_type_de_champ_private, types_de_champ_count: 4, types_de_champ_private_count: 4) }
+      let(:procedure) do
+        create(:procedure,
+               types_de_champ_public: Array.new(4) { { type: :text } },
+               types_de_champ_private: Array.new(4) { { type: :text } })
+      end
       let(:tdc_1) { procedure.active_revision.types_de_champ_public[0] }
       let(:tdc_2) { procedure.active_revision.types_de_champ_public[1] }
       let(:tdc_private_1) { procedure.active_revision.types_de_champ_private[0] }
@@ -866,7 +870,7 @@ describe ProcedurePresentation do
     end
 
     context 'when type_de_champ yes_no' do
-      let(:procedure) { create(:procedure, :with_yes_no) }
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :yes_no }]) }
 
       it 'should transform value' do
         expect(subject).to eq("oui")
@@ -894,7 +898,7 @@ describe ProcedurePresentation do
     let(:filters) { { "suivis" => [] } }
 
     context 'when type_de_champ yes_no' do
-      let(:procedure) { create(:procedure, :with_yes_no) }
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :yes_no }]) }
 
       it 'should downcase and transform value' do
         procedure_presentation.add_filter("suivis", "type_de_champ/#{first_type_de_champ_id}", "Oui")

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -325,7 +325,7 @@ describe Procedure do
       let(:drop_down) { build(:type_de_champ_drop_down_list, :without_selectable_values, libelle: 'Civilité') }
       let(:invalid_drop_down_error_message) { 'Le champ « Civilité » doit comporter au moins un choix sélectionnable' }
 
-      let(:procedure) { create(:procedure, :with_repetition) }
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :repetition, children: [{ type: :text }, { type: :integer_number }] }]) }
       let(:draft) { procedure.draft_revision }
 
       before do

--- a/spec/models/types_de_champ/prefill_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_type_de_champ_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe TypesDeChamp::PrefillTypeDeChamp, type: :model do
       end
 
       describe 'too many possible values or not' do
-        let!(:procedure) { create(:procedure, :with_drop_down_list) }
+        let!(:procedure) { create(:procedure, types_de_champ_public: [{ type: :drop_down_list }]) }
         let(:type_de_champ) { procedure.draft_types_de_champ_public.first }
         let(:link_to_all_possible_values) {
           link_to(

--- a/spec/services/dossier_projection_service_spec.rb
+++ b/spec/services/dossier_projection_service_spec.rb
@@ -199,7 +199,7 @@ describe DossierProjectionService do
 
       context 'for type_de_champ table and value to.s' do
         let(:table) { 'type_de_champ' }
-        let(:procedure) { create(:procedure, :with_yes_no) }
+        let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :yes_no }]) }
         let(:dossier) { create(:dossier, procedure: procedure) }
         let(:column) { dossier.procedure.active_revision.types_de_champ_public.first.stable_id.to_s }
 
@@ -210,7 +210,7 @@ describe DossierProjectionService do
 
       context 'for type_de_champ table and value to.s which needs data field' do
         let(:table) { 'type_de_champ' }
-        let(:procedure) { create(:procedure, :with_address) }
+        let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :address }]) }
         let(:dossier) { create(:dossier, procedure: procedure) }
         let(:column) { dossier.procedure.active_revision.types_de_champ_public.first.stable_id.to_s }
 

--- a/spec/services/pieces_justificatives_service_spec.rb
+++ b/spec/services/pieces_justificatives_service_spec.rb
@@ -11,7 +11,7 @@ describe PiecesJustificativesService do
     end
 
     context 'with a pj champ' do
-      let(:procedure) { create(:procedure, :with_piece_justificative) }
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative }]) }
       let(:dossier) { create(:dossier, procedure: procedure) }
       let(:witness) { create(:dossier, procedure: procedure) }
 
@@ -37,7 +37,7 @@ describe PiecesJustificativesService do
     end
 
     context 'with a pj not safe on a champ' do
-      let(:procedure) { create(:procedure, :with_piece_justificative) }
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative }]) }
       let(:dossier) { create(:dossier, procedure: procedure) }
       let(:pj_champ) { -> (d) { d.champs_public.find { |c| c.type == 'Champs::PieceJustificativeChamp' } } }
 
@@ -113,7 +113,7 @@ describe PiecesJustificativesService do
     end
 
     context 'with a identite champ pj' do
-      let(:procedure) { create(:procedure, :with_titre_identite) }
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :titre_identite }]) }
       let(:dossier) { create(:dossier, procedure: procedure) }
       let(:witness) { create(:dossier, procedure: procedure) }
 

--- a/spec/system/accessibilite/wcag_usager_spec.rb
+++ b/spec/system/accessibilite/wcag_usager_spec.rb
@@ -133,7 +133,7 @@ describe 'wcag rules for usager', js: true do
   end
 
   context "logged in, depot d'un dossier entreprise" do
-    let(:procedure) { create(:procedure, :with_type_de_champ, :with_all_champs, :with_service, :published) }
+    let(:procedure) { create(:procedure, :with_all_champs, :with_service, :published) }
 
     before do
       login_as litteraire_user, scope: :user

--- a/spec/system/administrateurs/condition_spec.rb
+++ b/spec/system/administrateurs/condition_spec.rb
@@ -3,13 +3,11 @@ describe 'As an administrateur I can edit types de champ condition', js: true do
 
   let(:administrateur) { procedure.administrateurs.first }
   let(:procedure) do
-    create(:procedure).tap do |p|
-      p.draft_revision.add_type_de_champ(type_champ: :integer_number, libelle: 'age')
-      # private
-      p.draft_revision.add_type_de_champ(type_champ: :boolean, libelle: 'bon dossier', private: true)
-
-      p.draft_revision.add_type_de_champ(type_champ: :text, libelle: 'nom du parent')
-    end
+    create(:procedure,
+           types_de_champ_public: [
+             { type: :integer_number, libelle: 'age' },
+             { type: :text, libelle: 'nom du parent' }
+           ])
   end
 
   let(:first_tdc) { procedure.draft_revision.types_de_champ.first }

--- a/spec/system/experts/expert_spec.rb
+++ b/spec/system/experts/expert_spec.rb
@@ -5,7 +5,7 @@ describe 'Inviting an expert:' do
   context 'as an invited Expert' do
     let(:expert) { create(:expert) }
     let(:instructeur) { create(:instructeur) }
-    let(:procedure) { create(:procedure, :published, :with_piece_justificative, instructeurs: [instructeur]) }
+    let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }], instructeurs: [instructeur]) }
     let(:experts_procedure) { create(:experts_procedure, expert: expert, procedure: procedure) }
     let(:dossier) { create(:dossier, :en_construction, :with_dossier_link, procedure: procedure) }
     let(:champ) { dossier.champs_public.first }

--- a/spec/system/instructeurs/instruction_spec.rb
+++ b/spec/system/instructeurs/instruction_spec.rb
@@ -198,7 +198,7 @@ describe 'Instructing a dossier:', js: true do
   end
 
   context 'A instructeur can ask for an Archive' do
-    let(:procedure) { create(:procedure, :published, :with_piece_justificative, instructeurs: [instructeur]) }
+    let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }], instructeurs: [instructeur]) }
     let(:dossier) { create(:dossier, :accepte, procedure: procedure) }
     before do
       log_in(instructeur.email, password)
@@ -212,7 +212,7 @@ describe 'Instructing a dossier:', js: true do
     end
   end
   context 'with dossiers having attached files', js: true do
-    let(:procedure) { create(:procedure, :published, :with_piece_justificative, instructeurs: [instructeur]) }
+    let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }], instructeurs: [instructeur]) }
     let(:dossier) { create(:dossier, :en_construction, procedure: procedure) }
     let(:champ) { dossier.champs_public.first }
     let(:path) { 'spec/fixtures/files/piece_justificative_0.pdf' }

--- a/spec/system/instructeurs/procedure_filters_spec.rb
+++ b/spec/system/instructeurs/procedure_filters_spec.rb
@@ -1,6 +1,6 @@
 describe "procedure filters" do
   let(:instructeur) { create(:instructeur) }
-  let(:procedure) { create(:procedure, :published, :with_type_de_champ, :with_departement, :with_region, :with_drop_down_list, instructeurs: [instructeur]) }
+  let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :text }, { type: :departements }, { type: :regions }, { type: :drop_down_list }], instructeurs: [instructeur]) }
   let!(:type_de_champ) { procedure.active_revision.types_de_champ_public.first }
   let!(:new_unfollow_dossier) { create(:dossier, procedure: procedure, state: Dossier.states.fetch(:en_instruction)) }
   let!(:champ) { Champ.find_by(type_de_champ_id: type_de_champ.id, dossier_id: new_unfollow_dossier.id) }

--- a/spec/system/routing/rules_full_scenario_spec.rb
+++ b/spec/system/routing/rules_full_scenario_spec.rb
@@ -2,17 +2,10 @@ describe 'The routing with rules', js: true do
   let(:password) { 'a very complicated password' }
 
   let(:procedure) do
-    create(:procedure, :with_service, :for_individual, :with_zone).tap do |p|
-      p.draft_revision.add_type_de_champ(
-        type_champ: :text,
-        libelle: 'un premier champ text'
-      )
-      p.draft_revision.add_type_de_champ(
-        type_champ: :drop_down_list,
-        libelle: 'Spécialité',
-        options: { "drop_down_other" => "0", "drop_down_options" => ["", "littéraire", "scientifique", "artistique"] }
-      )
-    end
+    create(:procedure, :with_service, :for_individual, :with_zone, types_de_champ_public: [
+      { type: :text, libelle: 'un premier champ text' },
+      { type: :drop_down_list, libelle: 'Spécialité', options: ["", "littéraire", "scientifique", "artistique"] }
+    ])
   end
   let(:administrateur) { create(:administrateur, procedures: [procedure]) }
   let(:scientifique_user) { create(:user, password: password) }

--- a/spec/system/users/en_construction_spec.rb
+++ b/spec/system/users/en_construction_spec.rb
@@ -1,6 +1,6 @@
 describe "Dossier en_construction" do
   let(:user) { create(:user) }
-  let(:procedure) { create(:simple_procedure, :with_piece_justificative, :with_titre_identite) }
+  let(:procedure) { create(:procedure, :for_individual, types_de_champ_public: [{ type: :piece_justificative }, { type: :titre_identite }]) }
   let(:dossier) { create(:dossier, :en_construction, :with_individual, :with_populated_champs, user:, procedure:) }
 
   let(:tdc) {

--- a/spec/views/dossiers/dossier_vide.pdf.prawn_spec.rb
+++ b/spec/views/dossiers/dossier_vide.pdf.prawn_spec.rb
@@ -1,5 +1,5 @@
 describe 'dossiers/dossier_vide', type: :view do
-  let(:procedure) { create(:procedure, :with_all_champs, :with_drop_down_list) }
+  let(:procedure) { create(:procedure, :with_all_champs) }
   let(:dossier) { create(:dossier, procedure: procedure) }
 
   before do

--- a/spec/views/shared/_procedure_description.html.haml_spec.rb
+++ b/spec/views/shared/_procedure_description.html.haml_spec.rb
@@ -60,7 +60,7 @@ describe 'shared/_procedure_description', type: :view do
   end
 
   context 'when the procedure has pieces jointes' do
-    let(:procedure) { create(:procedure, :draft, :with_titre_identite, :with_piece_justificative, :with_siret) }
+    let(:procedure) { create(:procedure, :draft, types_de_champ_public: [{ type: :titre_identite }, { type: :piece_justificative }, { type: :siret }]) }
     it 'shows the pieces jointes list for draft procedure' do
       subject
       expect(rendered).to have_text('Quelles sont les pièces justificatives à fournir')


### PR DESCRIPTION
le prob des factories `:with_xxx`, c'est qu'on ne gerait pas la position ds le form.
l'avantage du `types_de_champ_public|private`, c'est que ça gère automagiquement la position.

l'interet de cette PR, on tend a harmoniser la création des TDCs ds l'app 