### PR TITLE
Remove user_email input autofocus on agent page

### DIFF
--- a/app/views/agent_connect/agent/index.html.haml
+++ b/app/views/agent_connect/agent/index.html.haml
@@ -41,7 +41,7 @@
                 %p.fr-text--sm= t('utils.mandatory_champs')
 
               .fr-fieldset__element
-                = render Dsfr::InputComponent.new(form: f, attribute: :email, input_type: :email_field, opts: { autocomplete: 'email', autofocus: true }) do |c|
+                = render Dsfr::InputComponent.new(form: f, attribute: :email, input_type: :email_field, opts: { autocomplete: 'email' }) do |c|
                   - c.with_label { t('.pro_email') }
 
               .fr-fieldset__element


### PR DESCRIPTION
This avoid automatic scroll on page load so the AgentConnect button is visible.