### PR TITLE
ETQ instructeur, n'affiche pas encore de lien vers un export quand le fichier n'est pas encore disponible

### DIFF
--- a/app/models/concerns/transient_models_with_purgeable_job_concern.rb
+++ b/app/models/concerns/transient_models_with_purgeable_job_concern.rb
@@ -41,7 +41,7 @@ module TransientModelsWithPurgeableJobConcern
     }
 
     def available?
-      generated?
+      generated? && file.url.present?
     end
 
     def compute_with_safe_stale_for_purge(&block)

--- a/app/views/instructeurs/procedures/_last_export_alert.html.haml
+++ b/app/views/instructeurs/procedures/_last_export_alert.html.haml
@@ -1,11 +1,11 @@
 - if export.present?
-  %div{ data: export.pending? ? { controller: "turbo-poll", turbo_poll_url_value: polling_last_export_instructeur_procedure_path(export_format: export.format, statut: statut), turbo_poll_interval_value: 5_000, turbo_poll_max_checks_value: 6 } : {} }
+  %div{ data: !export.available? && !export.failed? ? { controller: "turbo-poll", turbo_poll_url_value: polling_last_export_instructeur_procedure_path(export_format: export.format, statut: statut), turbo_poll_interval_value: 5_000, turbo_poll_max_checks_value: 6 } : {} }
     = render Dsfr::AlertComponent.new(state: :info, size: :sm, extra_class_names: 'fr-my-2w') do |c|
       - c.with_body do
         %p
-          - if export.pending?
-            = t('instructeurs.procedures.last_export_pending')
-          - if export.generated?
-            = t('instructeurs.procedures.last_export_available_html', file_format: export.format, file_url: export.file.url)
           - if export.failed?
             = t('instructeurs.procedures.last_export_failed', file_format: export.format)
+          - elsif export.available?
+            = t('instructeurs.procedures.last_export_available_html', file_format: export.format, file_url: export.file.url)
+          - else
+            = t('instructeurs.procedures.last_export_pending')

--- a/spec/components/dossiers/export_link_component_spec.rb
+++ b/spec/components/dossiers/export_link_component_spec.rb
@@ -63,6 +63,14 @@ RSpec.describe Dossiers::ExportLinkComponent, type: :component do
       it 'displays the current dossiers count' do
         expect(subject).to include("3 dossiers")
       end
+
+      context "when export is generated, but file not yet available" do
+        let(:export) { create(:export, :generated, groupe_instructeurs: [groupe_instructeur], procedure_presentation: procedure_presentation) }
+
+        it "displays the pending label" do
+          expect(subject).to include("demandé il y a")
+        end
+      end
     end
 
     context "when the export has failed" do

--- a/spec/controllers/instructeurs/procedures_controller_spec.rb
+++ b/spec/controllers/instructeurs/procedures_controller_spec.rb
@@ -520,6 +520,11 @@ describe Instructeurs::ProceduresController, type: :controller do
 
           it { expect(assigns(:last_export)).to eq(export) }
           it { expect(response.body).to include("Votre dernier export est en cours de création") }
+
+          context 'when export is generated but file not yet attached' do
+            let!(:export) { create(:export, :generated, groupe_instructeurs: [gi_2]) }
+            it { expect(response.body).to include("Votre dernier export est en cours de création") }
+          end
         end
 
         context 'with recent generated export' do
@@ -527,6 +532,7 @@ describe Instructeurs::ProceduresController, type: :controller do
           let!(:export) { create(:export, :generated, groupe_instructeurs: [gi_2], updated_at: 1.minute.ago) }
           render_views
           before do
+            export.file.attach(io: StringIO.new, filename: 'file')
             subject
           end
 


### PR DESCRIPTION
https://demarches-simplifiees.sentry.io/issues/4284989998 + ticket support

Scénario, tout se déroule en moins de 2-3 secondes
- un export a été généré
- l'instructeur en est rapidement informé grâce au poll XHR, avec un lien de téléchargement vers l'export
- s'il clique rapidement sur le lien, alors que le blob cible n'est pas encore attaché à l'export du point de vue de la db, on essayait de faire une redirection vers `nil` (nb: `export.file` renvoie oujours une relation, même sans blob attaché)

Le fix c'est de considérer que l'export n'est pas dispo tant que le blob/l'url n'existe pas