### PR TITLE
Tech: plus d'erreur lorsque l'email de transfert n'a plus de dossier associé

### DIFF
--- a/app/models/dossier_transfer.rb
+++ b/app/models/dossier_transfer.rb
@@ -73,6 +73,6 @@ class DossierTransfer < ApplicationRecord
   private
 
   def send_notification
-    DossierMailer.notify_transfer(self).deliver_later
+    DossierMailer.with(dossier_transfer: self).notify_transfer.deliver_later
   end
 end

--- a/app/views/users/dossiers/_dossier_actions.html.haml
+++ b/app/views/users/dossiers/_dossier_actions.html.haml
@@ -43,8 +43,8 @@
 
     - if has_delete_action
       - menu.with_item(class: 'danger') do
-        = link_to(dossier_path(dossier), role: 'menuitem', method: :delete, data: { disable: true, confirm: "En continuant, vous allez supprimer ce dossier ainsi que les informations qu’il contient. Toute suppression entraîne l’annulation de la démarche en cours.\n\nConfirmer la suppression ?" }) do
-
+        - confirm = dossier.transfer.present? ? t("views.users.dossiers.dossier_action.delete_dossier_with_transfer_confirm") : t("views.users.dossiers.dossier_action.delete_dossier_confirm")
+        = link_to(dossier_path(dossier), role: 'menuitem', method: :delete, data: { disable: true, confirm: }) do
           = dsfr_icon('fr-icon-delete-fill', :sm)
           .dropdown-description
             = t('views.users.dossiers.dossier_action.delete_dossier')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -510,6 +510,8 @@ en:
           start_other_dossier: "Start another empty file"
           clone: "Duplicate the file"
           delete_dossier: "Delete the file"
+          delete_dossier_confirm: "If you continue, you will delete this file and the information it contains. Any deletion will result in the cancellation of the current procedure.\n\nConfirm deletion?"
+          delete_dossier_with_transfer_confirm: "If you continue, you will delete this file, the information it contains and its transfer request. Any deletion will result in the cancellation of the current procedure.\n\nConfirm deletion?"
           transfer_dossier: "Transfer the file"
           edit_draft: "Keep filling"
           actions: "Actions"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -503,6 +503,8 @@ fr:
           start_other_dossier: "Commencer un autre dossier vide"
           clone: "Dupliquer ce dossier"
           delete_dossier: "Supprimer le dossier"
+          delete_dossier_confirm: "En continuant, vous allez supprimer ce dossier ainsi que les informations qu’il contient. Toute suppression entraîne l’annulation de la démarche en cours.\n\nConfirmer la suppression ?"
+          delete_dossier_with_transfer_confirm: "En continuant, vous allez supprimer ce dossier, les informations qu’il contient ainsi que sa demande de transfert. Toute suppression entraîne l’annulation de la démarche en cours.\n\nConfirmer la suppression ?"
           transfer_dossier: "Transférer le dossier"
           edit_draft: "Continuer à remplir"
           actions: "Actions"

--- a/spec/controllers/manager/dossiers_controller_spec.rb
+++ b/spec/controllers/manager/dossiers_controller_spec.rb
@@ -36,23 +36,26 @@ describe Manager::DossiersController, type: :controller do
   end
 
   describe "POST #transfer" do
-    before do
-      allow(DossierMailer).to receive(:notify_transfer).and_call_original
+    subject do
       post :transfer, params: { id: @dossier.id, email: }
     end
 
     context 'with valid email' do
       let(:email) { "chouette.gars@laposte.net" }
 
-      it { expect(flash[:success]).to eq("Une invitation de transfert a été envoyée à chouette.gars@laposte.net") }
-      it { expect(DossierMailer).to have_received(:notify_transfer) }
+      it do
+        expect { subject }.to have_enqueued_mail(DossierMailer, :notify_transfer)
+        expect(flash[:success]).to eq("Une invitation de transfert a été envoyée à chouette.gars@laposte.net")
+      end
     end
 
     context 'with invalid email' do
       let(:email) { "chouette" }
 
-      it { expect(flash[:alert]).to eq("L’adresse email est invalide") }
-      it { expect(DossierMailer).not_to have_received(:notify_transfer) }
+      it do
+        expect { subject }.not_to have_enqueued_mail
+        expect(flash[:alert]).to eq("L’adresse email est invalide")
+      end
     end
   end
 

--- a/spec/mailers/dossier_mailer_spec.rb
+++ b/spec/mailers/dossier_mailer_spec.rb
@@ -272,7 +272,7 @@ RSpec.describe DossierMailer, type: :mailer do
     let(:dossier_transfer) { create(:dossier_transfer) }
     let!(:dossier) { create(:dossier, user: user, transfer: dossier_transfer, procedure: procedure) }
 
-    subject { described_class.notify_transfer(dossier_transfer) }
+    subject { described_class.with(dossier_transfer: dossier_transfer).notify_transfer }
 
     context 'when it is a transfer of one dossier' do
       it { expect(subject.subject).to include("Vous avez une demande de transfert en attente.") }
@@ -293,6 +293,17 @@ RSpec.describe DossierMailer, type: :mailer do
 
       it { expect(subject.subject).to include("Vous avez une demande de transfert en attente.") }
       it { expect(subject.body).to include("Le support technique vous adresse une demande de transfert") }
+    end
+
+    context 'when dossiers have been dissociated from transfer' do
+      before do
+        dossier.update!(transfer: nil)
+        dossier_transfer.reload
+      end
+
+      it 'does not send an email' do
+        expect { subject.perform_now }.not_to raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
https://demarches-simplifiees.sentry.io/issues/4880772787

Quand un usager transfer un dossier, et que dans la foulée il le supprime avant que le mail soit parti, l'envoie échoue.


- [x]  prévient l'usager que la suppression entraine aussi la suppression du transfert 
- [x] fait en sorte que le mailer ne passe plus par la view et n'envoie pas le mail 🥵 