### PR TITLE
ETQ instructeur, je vois un badge Corrigé lorsque le dossier a été corrigé

### DIFF
--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -103,8 +103,8 @@ module DossierHelper
     tag.span(Dossier.human_attribute_name("pending_correction.#{for_profile}"), class: ['fr-badge fr-badge--sm fr-badge--warning super', html_class], role: 'status')
   end
 
-  def correction_resolved_badge
-    tag.span(Dossier.human_attribute_name("pending_correction.resolved"), class: ['fr-badge fr-badge--sm fr-badge--success super'], role: 'status')
+  def correction_resolved_badge(html_class: nil)
+    tag.span(Dossier.human_attribute_name("pending_correction.resolved"), class: ['fr-badge fr-badge--sm fr-badge--success super', html_class], role: 'status')
   end
 
   def demandeur_dossier(dossier)

--- a/app/models/concerns/dossier_correctable_concern.rb
+++ b/app/models/concerns/dossier_correctable_concern.rb
@@ -40,6 +40,10 @@ module DossierCorrectableConcern
       pending_corrections.exists?
     end
 
+    def last_correction_resolved?
+      corrections.last&.resolved?
+    end
+
     def resolve_pending_correction
       pending_correction&.resolve
     end

--- a/app/services/dossier_projection_service.rb
+++ b/app/services/dossier_projection_service.rb
@@ -5,6 +5,12 @@ class DossierProjectionService
 
         corrections.any? { _1[:resolved_at].nil? }
       end
+
+      def resolved_corrections?
+        return false if corrections.blank?
+
+        corrections.all? { _1[:resolved_at].present? }
+      end
     end
   end
 

--- a/app/views/instructeurs/dossiers/_header_top.html.haml
+++ b/app/views/instructeurs/dossiers/_header_top.html.haml
@@ -9,7 +9,10 @@
         = procedure_badge(dossier.procedure)
 
         = status_badge(dossier.state)
-        = pending_correction_badge(:for_instructeur) if dossier.pending_correction?
+        - if dossier.pending_correction?
+          = pending_correction_badge(:for_instructeur)
+        - elsif dossier.en_construction? && dossier.last_correction_resolved?
+          = correction_resolved_badge
         = render Instructeurs::SVASVRDecisionBadgeComponent.new(projection_or_dossier: dossier, procedure: dossier.procedure, with_label: true)
 
 

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -175,7 +175,10 @@
 
                   %td.status-col
                     - status = [status_badge(p.state)]
-                    - status << pending_correction_badge(:for_instructeur, html_class: "fr-mt-1v") if p.pending_correction?
+                    - if p.pending_correction?
+                      - status << pending_correction_badge(:for_instructeur, html_class: "fr-mt-1v")
+                    - elsif p.state.to_sym == :en_construction && p.resolved_corrections?
+                      - status << correction_resolved_badge(html_class: "fr-mt-1v")
                     = link_to_if(p.hidden_by_administration_at.blank?, safe_join(status), path, class: class_names("cell-link": true, "fr-py-0": status.many?))
 
                   - if @procedure.sva_svr_enabled?

--- a/spec/services/dossier_projection_service_spec.rb
+++ b/spec/services/dossier_projection_service_spec.rb
@@ -258,16 +258,19 @@ describe DossierProjectionService do
           before { create(:dossier_correction, dossier:) }
 
           it { expect(subject.pending_correction?).to be(true) }
+          it { expect(subject.resolved_corrections?).to eq(false) }
         end
 
         context "when dossier has a resolved correction" do
           before { create(:dossier_correction, :resolved, dossier:) }
 
           it { expect(subject.pending_correction?).to eq(false) }
+          it { expect(subject.resolved_corrections?).to eq(true) }
         end
 
         context "when dossier has no correction at all" do
           it { expect(subject.pending_correction?).to eq(false) }
+          it { expect(subject.resolved_corrections?).to eq(false) }
         end
       end
     end

--- a/spec/views/instructeur/dossiers/show.html.haml_spec.rb
+++ b/spec/views/instructeur/dossiers/show.html.haml_spec.rb
@@ -70,6 +70,10 @@ describe 'instructeurs/dossiers/show', type: :view do
 
       it { expect(subject).to have_button('Passer en instruction', disabled: false) }
 
+      it 'shows the correction badge' do
+        expect(subject).to have_selector('.fr-badge--warning', text: "en attente")
+      end
+
       context 'with procedure blocking pending correction' do
         before { Flipper.enable(:blocking_pending_correction, dossier.procedure) }
 
@@ -77,6 +81,14 @@ describe 'instructeurs/dossiers/show', type: :view do
           expect(subject).to have_button('Passer en instruction', disabled: true)
           expect(subject).to have_content('Le passage en instruction est impossible')
         end
+      end
+    end
+
+    context 'with resolved correction' do
+      before { create(:dossier_correction, dossier:, resolved_at: 1.minute.ago) }
+
+      it 'shows the resolved badge' do
+        expect(subject).to have_selector('.fr-badge--success', text: "corrigé")
       end
     end
   end


### PR DESCRIPTION
Closes #9928

Je l'ai pas mis lorsque le dossier est en instruction pour pas faire trop sapin de noel, mais je sais pas si c'est une bonne idée, (et donc invisible pour les démarche déclaratives en instruction mais qui utilisent sûrement moins cette feature)

![Capture d’écran 2024-01-24 à 17 28 06](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/02a62bfd-1252-49a2-b7ab-83a4a2b51ab5)
![Capture d’écran 2024-01-24 à 17 27 50](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/3f90eee9-bcd6-4dfb-83fc-5c12f42a0d16)
