### PR TITLE
ETQ usager les emails de gestion de compte sont disponibles en anglais

### DIFF
--- a/app/mailers/devise_user_mailer.rb
+++ b/app/mailers/devise_user_mailer.rb
@@ -18,7 +18,23 @@ class DeviseUserMailer < Devise::Mailer
     opts[:from] = NO_REPLY_EMAIL
     @procedure = opts[:procedure_after_confirmation] || nil
     @prefill_token = opts[:prefill_token]
-    super
+    I18n.with_locale(record&.locale || I18n.default_locale) { super }
+  end
+
+  def reset_password_instructions(record, token, opts = {})
+    I18n.with_locale(record&.locale || I18n.default_locale) { super }
+  end
+
+  def unlock_instructions(record, token, opts = {})
+    I18n.with_locale(record&.locale || I18n.default_locale) { super }
+  end
+
+  def email_changed(record, opts = {})
+    I18n.with_locale(record&.locale || I18n.default_locale) { super }
+  end
+
+  def password_change(record, opts = {})
+    I18n.with_locale(record&.locale || I18n.default_locale) { super }
   end
 
   def self.critical_email?(action_name)

--- a/app/views/devise_mailer/reset_password_instructions.en.html.haml
+++ b/app/views/devise_mailer/reset_password_instructions.en.html.haml
@@ -5,6 +5,8 @@
 
 = round_button 'Change the password', edit_password_url(@resource, reset_password_token: @token), :primary
 
+%p This email invalidate similar previous emails.
+
 %p
   If you didn't request this, please ignore this email. Your password won't change.
 

--- a/spec/mailers/devise_user_mailer_spec.rb
+++ b/spec/mailers/devise_user_mailer_spec.rb
@@ -1,8 +1,9 @@
 RSpec.describe DeviseUserMailer, type: :mailer do
-  let(:user) { create(:user) }
+  let(:user) { build(:user) }
   let(:token) { SecureRandom.hex }
+
   describe '.confirmation_instructions' do
-    subject { described_class.confirmation_instructions(user, token, opts = {}) }
+    subject { described_class.confirmation_instructions(user, token) }
 
     context 'without SafeMailer configured' do
       it { expect(subject[BalancerDeliveryMethod::FORCE_DELIVERY_METHOD_HEADER]&.value).to eq(nil) }
@@ -15,9 +16,96 @@ RSpec.describe DeviseUserMailer, type: :mailer do
     end
 
     context 'when perform_later is called' do
+      let(:user) { create(:user) }
       it 'enqueues email in default queue for high priority delivery' do
-  expect { subject.deliver_later }.to have_enqueued_job.on_queue(Rails.application.config.action_mailer.deliver_later_queue_name)
-end
+        expect { subject.deliver_later }.to have_enqueued_job.on_queue(Rails.application.config.action_mailer.deliver_later_queue_name)
+      end
+    end
+
+    context 'when user.locale is fr' do
+      let(:user) { build(:user, locale: :fr) }
+
+      it 'enqueues email in default queue for high priority delivery' do
+        expect(subject.subject).to eq('Instructions de confirmation')
+      end
+    end
+
+    context 'when user.locale is en' do
+      let(:user) { build(:user, locale: :en) }
+
+      it 'i18n content' do
+        expect(subject.subject).to eq("Confirmation instructions")
+      end
+    end
+  end
+
+  describe '.reset_password_instructions' do
+    subject { DeviseUserMailer.reset_password_instructions(user, 'faketoken') }
+
+    context 'with user.locale fr' do
+      let(:user) { build(:user, locale: 'fr') }
+      it 'uses fr subject' do
+        expect(subject.subject).to eq("Instructions pour changer le mot de passe")
+      end
+    end
+
+    context 'with user.locale en' do
+      let(:user) { build(:user, locale: 'en') }
+      it 'uses fr subject' do
+        expect(subject.subject).to eq("Reset password instructions")
+      end
+    end
+  end
+
+  describe '.unlock_instructions' do
+    subject { DeviseUserMailer.unlock_instructions(user, 'faketoken') }
+    context 'with user.locale fr' do
+      let(:user) { build(:user, locale: 'fr') }
+      it 'uses fr subject' do
+        expect(subject.subject).to eq('Instructions pour déverrouiller le compte')
+      end
+    end
+    context 'with user.locale en' do
+      let(:user) { build(:user, locale: 'en') }
+      it 'uses fr subject' do
+        expect(subject.subject).to eq('Unlock instructions')
+      end
+    end
+  end
+
+  describe '.email_changed' do
+    subject { DeviseUserMailer.email_changed(user) }
+
+    context 'with user.locale fr' do
+      let(:user) { build(:user, locale: 'fr') }
+      it 'uses fr subject' do
+        expect(subject.subject).to eq('Courriel modifié')
+      end
+    end
+
+    context 'with user.locale en' do
+      let(:user) { build(:user, locale: 'en') }
+      it 'uses fr subject' do
+        expect(subject.subject).to eq('Email Changed')
+      end
+    end
+  end
+
+  describe '.password_change' do
+    subject { DeviseUserMailer.password_change(user) }
+
+    context 'with user.locale fr' do
+      let(:user) { build(:user, locale: 'fr') }
+      it 'uses fr subject' do
+        expect(subject.subject).to eq('Mot de passe modifié')
+      end
+    end
+
+    context 'with user.locale en' do
+      let(:user) { build(:user, locale: 'en') }
+      it 'uses fr subject' do
+        expect(subject.subject).to eq('Password Changed')
+      end
     end
   end
 end

--- a/spec/mailers/previews/devise_user_mailer_preview.rb
+++ b/spec/mailers/previews/devise_user_mailer_preview.rb
@@ -16,10 +16,22 @@ class DeviseUserMailerPreview < ActionMailer::Preview
     DeviseUserMailer.reset_password_instructions(user, "faketoken", {})
   end
 
+  def unlock_instructions
+    DeviseUserMailer.unlock_instructions(user, "faketoken", {})
+  end
+
+  def email_changed
+    DeviseUserMailer.email_changed(user, {})
+  end
+
+  def password_change
+    DeviseUserMailer.password_change(user, {})
+  end
+
   private
 
   def user
-    User.new(id: 10, email: "usager@example.com")
+    User.new(id: 10, email: "usager@example.com", locale: ['en', 'fr'].sample)
   end
 
   def procedure


### PR DESCRIPTION
hs: https://secure.helpscout.net/conversation/2493665220/2053945?folderId=1653799

etait deja la : les templates.en.haml av quasiment le bon wording ! :D 

done: 
* certains mails devise n'avaient pas de preview, c'est plus le cas
* certains mails de device n'avaient pas de test, c'est plus le cas
* les mails de device n'etaient pas i18nable. c'est plus le cas