### PR TITLE
Tech (CI): update apt repos before installing packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Install build dependancies
         # - fonts pickable by ImageMagick
         # - rust for YJIT support
-        run: sudo apt-get install -y gsfonts rustc redis-server
+        run: sudo apt-get update && sudo apt-get install -y gsfonts rustc redis-server
 
       - name: Setup the app runtime and dependencies
         uses: ./.github/actions/ci-setup-rails


### PR DESCRIPTION
When github runners apt's cache is out of sync, not sure what really cause this or if it happens often, `apt-get install` may try to install package versions that are no longer available in repos.