### PR TITLE
ETQ admin je peux faire un routage simple à partir d'un type de champ communes ou epci

### DIFF
--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -773,6 +773,46 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
         expect(procedure3.routing_enabled).to be_truthy
       end
     end
+
+    context 'with a communes type de champ' do
+      let!(:procedure3) do
+        create(:procedure,
+               types_de_champ_public: [{ type: :communes }],
+               administrateurs: [admin])
+      end
+
+      let!(:communes_tdc) { procedure3.draft_revision.types_de_champ.first }
+
+      before { post :create_simple_routing, params: { procedure_id: procedure3.id, create_simple_routing: { stable_id: communes_tdc.stable_id } } }
+
+      it do
+        expect(response).to redirect_to(admin_procedure_groupe_instructeurs_path(procedure3))
+        expect(flash.notice).to eq 'Les groupes instructeurs ont été ajoutés'
+        expect(procedure3.groupe_instructeurs.pluck(:label)).to include("01 – Ain")
+        expect(procedure3.reload.defaut_groupe_instructeur.routing_rule).to eq(ds_in_departement(champ_value(communes_tdc.stable_id), constant('01')))
+        expect(procedure3.routing_enabled).to be_truthy
+      end
+    end
+
+    context 'with an epci type de champ' do
+      let!(:procedure3) do
+        create(:procedure,
+               types_de_champ_public: [{ type: :epci }],
+               administrateurs: [admin])
+      end
+
+      let!(:epci_tdc) { procedure3.draft_revision.types_de_champ.first }
+
+      before { post :create_simple_routing, params: { procedure_id: procedure3.id, create_simple_routing: { stable_id: epci_tdc.stable_id } } }
+
+      it do
+        expect(response).to redirect_to(admin_procedure_groupe_instructeurs_path(procedure3))
+        expect(flash.notice).to eq 'Les groupes instructeurs ont été ajoutés'
+        expect(procedure3.groupe_instructeurs.pluck(:label)).to include("01 – Ain")
+        expect(procedure3.reload.defaut_groupe_instructeur.routing_rule).to eq(ds_in_departement(champ_value(epci_tdc.stable_id), constant('01')))
+        expect(procedure3.routing_enabled).to be_truthy
+      end
+    end
   end
 
   describe '#wizard' do


### PR DESCRIPTION
La fonctionnalité n'était qu'à moitié codée. Maintenant en faisant un routage simple à partir d'un champ communes ou epci, on crée un groupe par département avec une règle de routage du type "Ma commune est dans le département..."