### PR TITLE
ETQ usager: Mentionne d'autres acteurs possibles dans la description de la co-construction

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -417,7 +417,7 @@ en:
         identite:
           legend: 'This file is:'
           self_title: Your identity
-          callout_text: "You are acting as a proxy for a principal, either professionally (such as accountant, lawyer) or personally (family). Make sure to respect the conditions of"
+          callout_text: "You are acting as a proxy for a principal, either professionally (such as accountant, lawyer, civil servant…) or personally (family). Make sure to respect the conditions of"
           callout_link: Articles 1984 and following of the Civil Code.
           callout_link_title: Articles 1984 and following of the Civil Code
           beneficiaire_title: "Identity of the beneficiary"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -419,7 +419,7 @@ fr:
         identite:
           legend: 'Ce dossier est : '
           self_title: Votre identité
-          callout_text: Vous agissez en tant que mandataire, soit professionnellement (comme expert-comptable, avocat) soit personnellement (famille). Assurez-vous de respecter les conditions
+          callout_text: Vous agissez en tant que mandataire, soit professionnellement (comme expert-comptable, avocat, agent public…) soit personnellement (famille). Assurez-vous de respecter les conditions
           callout_link: des Articles 1984 et suivants du Code civil.
           callout_link_title: Articles 1984 et suivants du Code civil
           beneficiaire_title: Identité du bénéficiaire

--- a/config/locales/models/dossier/en.yml
+++ b/config/locales/models/dossier/en.yml
@@ -13,7 +13,7 @@ en:
         mandataire_last_name: Last name
         for_tiers:
           false: For yourself
-          true: "For someone else : a family member, a relative, someone you represent"
+          true: "For someone else : a family member, a relative, a professional, someone you represent."
       dossier/state: &state
         brouillon: "Draft"
         en_construction: "In progress"

--- a/config/locales/models/dossier/fr.yml
+++ b/config/locales/models/dossier/fr.yml
@@ -13,7 +13,7 @@ fr:
         mandataire_last_name: Nom
         for_tiers:
           false: Pour vous
-          true: "Pour un bénéficiaire : membre de la famille, proche, mandant..."
+          true: "Pour un bénéficiaire : membre de la famille, proche, mandant, professionnel en charge du suivi du dossier…"
       dossier/state: &state
         brouillon: "Brouillon"
         en_construction: "En construction"

--- a/spec/system/users/dossier_creation_spec.rb
+++ b/spec/system/users/dossier_creation_spec.rb
@@ -57,7 +57,7 @@ describe 'Creating a new dossier:', js: true do
 
       context 'when individual fill dossier for a tiers' do
         it 'completes the form with email notification method selected' do
-          find('label', text: 'Pour un bénéficiaire : membre de la famille, proche, mandant...').click
+          find('label', text: 'Pour un bénéficiaire : membre de la famille, proche, mandant, professionnel en charge du suivi du dossier…').click
 
           within('.mandataire-infos') do
             fill_in('Prénom', with: 'John')
@@ -79,7 +79,7 @@ describe 'Creating a new dossier:', js: true do
         end
 
         it 'completes the form with no notification method selected' do
-          find('label', text: 'Pour un bénéficiaire : membre de la famille, proche, mandant...').click
+          find('label', text: 'Pour un bénéficiaire : membre de la famille, proche, mandant, professionnel en charge du suivi du dossier…').click
 
           within('.mandataire-infos') do
             fill_in('Prénom', with: 'John')


### PR DESCRIPTION
Suite à ce retour sur Helpscout : https://secure.helpscout.net/conversation/2457639592/2048831

Proposition d'ajouter des termes concernant les agents publics pour lever la confusion sur la fonctionnalité.
<img width="841" alt="Capture d’écran 2024-02-05 à 11 54 35" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/185663fc-bf1c-4848-92f7-e5eaa00354cd">

