### PR TITLE
ETQ developpeur, je veux trouver facilement la doc sur Graphql

### DIFF
--- a/config/locales/links.en.yml
+++ b/config/locales/links.en.yml
@@ -33,7 +33,7 @@ en:
       api_doc:
         label: "API Documentation"
         title: "API Documentation"
-        url: "https://doc.demarches-simplifiees.fr/pour-aller-plus-loin/graphql"
+        url: "https://doc.demarches-simplifiees.fr/api-graphql"
       dinum:
         title: "The DINUM website - Government"
         url: "https://www.numerique.gouv.fr/dinum/"

--- a/config/locales/links.fr.yml
+++ b/config/locales/links.fr.yml
@@ -35,7 +35,7 @@ fr:
       api_doc:
         label: "Documentation de l’API"
         title: "Documentation graphql de l’API"
-        url: "https://doc.demarches-simplifiees.fr/pour-aller-plus-loin/graphql"
+        url: "https://doc.demarches-simplifiees.fr/api-graphql"
       dinum:
         title: "Le site de la DINUM — Gouvernement"
         url: "https://www.numerique.gouv.fr/dinum/"


### PR DESCRIPTION
Cette PR corrige le lien cassé du pied de page pour accéder à la doc Graphql.