### PR TITLE
ETQ admin, je veux que le message de fin de dépot d'une démarche déclarative soit correct

### DIFF
--- a/app/views/users/dossiers/_merci.html.haml
+++ b/app/views/users/dossiers/_merci.html.haml
@@ -11,7 +11,7 @@
       %strong= t('views.users.dossiers.merci.dossier_acces_l2')
     %p.m-2
       = t('views.users.dossiers.merci.dossier_edit_l1')
-      - if !dossier&.read_only?
+      - if !dossier&.read_only? && !procedure.declarative_accepte? && !procedure.sva_svr_enabled?
         %strong= t('views.users.dossiers.merci.dossier_edit_l2')
         = t('views.users.dossiers.merci.dossier_edit_l3')
       %strong= t('views.users.dossiers.merci.dossier_edit_l4')

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -75,6 +75,8 @@ RSpec.describe ApplicationMailer, type: :mailer do
     let(:user1) { create(:user) }
     let(:user2) { create(:user, email: "your@email.com") }
 
+    before { freeze_time }
+
     it 'creates a new EmailEvent record with the correct information' do
       expect { UserMailer.ask_for_merge(user1, user2.email).deliver_now }.to change { EmailEvent.count }.by(2)
       event = EmailEvent.last
@@ -83,7 +85,7 @@ RSpec.describe ApplicationMailer, type: :mailer do
       expect(event.to).to eq("your@email.com")
       expect(event.method).to eq("test")
       expect(event.subject).to eq('Fusion de compte')
-      expect(event.processed_at).to be_within(1.second).of(Time.zone.now)
+      expect(event.processed_at).to eq(Time.current)
       expect(event.status).to eq('dispatched')
     end
   end


### PR DESCRIPTION
closes #9899 

le message de la partial "merci" se basait sur le dossier donc il était correct pour l'usager mais par pour l'admin dont l'aperçu n'avait pas de dossier.

**Maintenant les 2 sont raccords :** 

<img width="1098" alt="Capture d’écran 2024-02-07 à 16 49 09" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/94075d3d-2f16-4e05-b57c-81c6b99a26f7">
<img width="1130" alt="Capture d’écran 2024-02-07 à 16 49 33" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/a6689d1b-9098-49fd-9416-96d52ecf84ad">


