### PR TITLE
ETQ usager, améliore le footer dans les emails de démarche avec un petit espace supplémentaire

### DIFF
--- a/app/views/layouts/mailers/_service_footer.html.haml
+++ b/app/views/layouts/mailers/_service_footer.html.haml
@@ -19,7 +19,7 @@
           = t('.email_sent_to')
           %br
           = dossier.user_email_for(:notification)
-      %td{ width: "50%", valign: "top" }
+      %td{ width: "50%", valign: "top", style: "padding-left:10px;" }
         %p
           %strong
             = t('.ask_question')


### PR DESCRIPTION
Suite à une remontée sur HelpScout : https://secure.helpscout.net/conversation/2497013653/2054318?folderId=1653799

**APRES**
<img width="638" alt="Capture d’écran 2024-02-07 à 17 06 58" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/8c2bd724-834b-4146-8840-a1658d76b56d">

**AVANT**
<img width="592" alt="Capture d’écran 2024-02-07 à 17 07 40" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/4798d9a7-fd8a-45e2-ae85-8020c6d07161">
