### PR TITLE
ETQ instructeur: fix génération d'attestation avec une balise "nom de la commune" depuis un champ adresse

### DIFF
--- a/app/models/champs/address_champ.rb
+++ b/app/models/champs/address_champ.rb
@@ -61,7 +61,7 @@ class Champs::AddressChamp < Champs::TextChamp
 
   def commune_name
     if full_address?
-      "#{APIGeoService.commune_name(department_code, address['city_code'])} (#{address['postal_code']})"
+      "#{APIGeoService.commune_name(address.fetch('department_code'), address['city_code'])} (#{address['postal_code']})"
     end
   end
 

--- a/spec/models/champs/address_champ_spec.rb
+++ b/spec/models/champs/address_champ_spec.rb
@@ -32,6 +32,7 @@ describe Champs::AddressChamp do
     it { expect(champ.address_label).to eq('33 Rue Rébeval 75019 Paris') }
     it { expect(champ.full_address?).to be_truthy }
     it { expect(champ.commune).to eq({ name: 'Paris 19e Arrondissement', code: '75119', postal_code: '75019' }) }
+    it { expect(champ.commune_name).to eq('Paris 19e Arrondissement (75019)') }
   end
 
   context "with wrong code INSEE" do


### PR DESCRIPTION
https://demarches-simplifiees.sentry.io/issues/4949410734/