### PR TITLE
perf(mail_template/attestation): preload procedure revisions

### DIFF
--- a/app/controllers/administrateurs/administrateur_controller.rb
+++ b/app/controllers/administrateurs/administrateur_controller.rb
@@ -26,6 +26,15 @@ module Administrateurs
       @procedure.reset!
     end
 
+    def preload_revisions
+      ProcedureRevisionPreloader.new(@procedure.revisions).all
+
+      @procedure.association(:draft_revision).target = @procedure.revisions.find { _1.id == @procedure.draft_revision.id }
+      if @procedure.published_revision
+        @procedure.association(:published_revision).target = @procedure.revisions.find { _1.id == @procedure.published_revision.id }
+      end
+    end
+
     def ensure_not_super_admin!
       if administrateur_as_manager?
         redirect_back fallback_location: root_url, alert: "Interdit aux super admins", status: 403

--- a/app/controllers/administrateurs/attestation_templates_controller.rb
+++ b/app/controllers/administrateurs/attestation_templates_controller.rb
@@ -3,6 +3,7 @@ module Administrateurs
     include UninterlacePngConcern
 
     before_action :retrieve_procedure
+    before_action :preload_revisions
 
     def show
       redirect_to edit_admin_procedure_attestation_template_path(@procedure)

--- a/app/controllers/administrateurs/mail_templates_controller.rb
+++ b/app/controllers/administrateurs/mail_templates_controller.rb
@@ -1,6 +1,8 @@
 module Administrateurs
   class MailTemplatesController < AdministrateurController
     include ActionView::Helpers::SanitizeHelper
+    before_action :retrieve_procedure
+    before_action :preload_revisions
 
     def index
       @mail_templates = mail_templates
@@ -15,7 +17,7 @@ module Administrateurs
     end
 
     def show
-      redirect_to edit_admin_procedure_mail_template_path(procedure.id, params[:id])
+      redirect_to edit_admin_procedure_mail_template_path(@procedure.id, params[:id])
     end
 
     def update
@@ -35,11 +37,11 @@ module Administrateurs
 
     def preview
       mail_template = find_mail_template_by_slug(params[:id])
-      dossier = procedure.active_revision.dossier_for_preview(current_user)
+      dossier = @procedure.active_revision.dossier_for_preview(current_user)
 
       @dossier = dossier
-      @logo_url = procedure.logo_url
-      @service = procedure.service
+      @logo_url = @procedure.logo_url
+      @service = @procedure.service
       @rendered_template = sanitize(mail_template.body_for_dossier(dossier), scrubber: Sanitizers::MailScrubber.new)
       @actions = mail_template.actions_for_dossier(dossier)
 
@@ -48,18 +50,14 @@ module Administrateurs
 
     private
 
-    def procedure
-      @procedure ||= current_administrateur.procedures.find(params[:procedure_id])
-    end
-
     def mail_templates
       [
-        procedure.passer_en_construction_email_template,
-        procedure.passer_en_instruction_email_template,
-        procedure.accepter_email_template,
-        procedure.refuser_email_template,
-        procedure.classer_sans_suite_email_template,
-        procedure.repasser_en_instruction_email_template
+        @procedure.passer_en_construction_email_template,
+        @procedure.passer_en_instruction_email_template,
+        @procedure.accepter_email_template,
+        @procedure.refuser_email_template,
+        @procedure.classer_sans_suite_email_template,
+        @procedure.repasser_en_instruction_email_template
       ]
     end
 


### PR DESCRIPTION
crisp: https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_b512ae9a-d59d-463f-a410-5800c40efe67/

# contexte : 

testé sur la démarche 39943, 134 champs, 220 annotations.
on avait des n+1 qui trainaient sur l'attestation & j'ai checké l'email template.

**avant: 735 requetes**
**apres: 28 requetes**
± pareil sur l'index des mail, la vue des mails, et l'edition/update de attestation





