### PR TITLE
ETQ instructeur, la page de gestion des groupes d'instructeur est au format du DSFR

### DIFF
--- a/app/views/administrateurs/groupe_instructeurs/_instructeurs.html.haml
+++ b/app/views/administrateurs/groupe_instructeurs/_instructeurs.html.haml
@@ -20,7 +20,7 @@
 
       = f.submit 'Affecter', class: 'fr-btn', disabled: disabled_as_super_admin
 
-  %table.table.mt-2
+  %table.fr-table.fr-mt-2w.width-100
     %thead
       %tr
         %th{ colspan: 2 }= t('.assigned_instructeur', count: instructeurs.count)

--- a/app/views/instructeurs/groupe_instructeurs/index.html.haml
+++ b/app/views/instructeurs/groupe_instructeurs/index.html.haml
@@ -5,12 +5,10 @@
                     ['Groupes d’instructeurs']] }
 
 .container.groupe-instructeur
+  %h1 Gestion des Groupes
   .card
-    .card-title Gestion des Groupes
+    %h2.fr-h3 Liste des groupes
     %table.table.mt-2
-      %thead
-        %tr
-          %th{ colspan: 2 } Liste des groupes
       %tbody
         - @groupes_instructeurs.each do |group|
           %tr

--- a/app/views/instructeurs/groupe_instructeurs/index.html.haml
+++ b/app/views/instructeurs/groupe_instructeurs/index.html.haml
@@ -4,7 +4,7 @@
   locals: { steps: [[@procedure.libelle.truncate_words(10), instructeur_procedure_path(@procedure)],
                     ['Groupes d’instructeurs']] }
 
-.container.groupe-instructeur
+.fr-container.groupe-instructeur
   %h1 Gestion des Groupes
   .card
     %h2.fr-h3 Liste des groupes

--- a/app/views/instructeurs/groupe_instructeurs/show.html.haml
+++ b/app/views/instructeurs/groupe_instructeurs/show.html.haml
@@ -21,15 +21,11 @@
       Démarche « #{@procedure.libelle} »
 
   .card.mt-2
-    .card-title Gestion des instructeurs
-    = form_for :instructeur,
-      url: { action: :add_instructeur },
-      html: { class: 'form' } do |f|
-
-      = f.label :email do
-        Affecter un nouvel instructeur
-      = f.email_field :email, placeholder: 'marie.dupont@exemple.fr', required: true
-      = f.submit 'Affecter', class: 'button primary send'
+    %h2.fr-h3 Gestion des instructeurs
+    = form_for(Instructeur.new(user: User.new), url: { action: :add_instructeur }, html: { class: 'form' }) do |f|
+      %h3.fr-h4 Affecter un nouvel instructeur 
+      = render Dsfr::InputComponent.new(form: f, attribute: :email)
+      = f.submit 'Affecter', class: 'fr-btn fr-primary'
 
     %table.table.mt-2
       %thead
@@ -40,16 +36,17 @@
           %tr
             %td= instructeur.email
             - confirmation_message = @procedure.routing_enabled? ? "Êtes-vous sûr de vouloir retirer l’instructeur « #{instructeur.email} » du groupe « #{@groupe_instructeur.label} » ?" : "Êtes-vous sûr de vouloir retirer l’instructeur « #{instructeur.email} » de la démarche ?"
-            %td.actions= button_to 'retirer',
+            %td.actions= button_to 'Retirer',
               { action: :remove_instructeur },
               { method: :delete,
                 data: { confirm: confirmation_message },
                 params: { instructeur: { id: instructeur.id }},
-                class: 'button' }
+                class: 'fr-btn fr-btn--secondary' }
 
     = paginate @instructeurs, views_prefix: 'shared'
+  
   .card.mt-2
-    .card-title Informations de contact
+    %h2.fr-h3 Informations de contact
     - service = @groupe_instructeur.contact_information
     - if service.nil?
       = "Le groupe #{@groupe_instructeur.label} n'a pas d'informations de contact. Les informations de contact affichées à l'usager seront celles du service de la procédure"

--- a/app/views/instructeurs/groupe_instructeurs/show.html.haml
+++ b/app/views/instructeurs/groupe_instructeurs/show.html.haml
@@ -13,21 +13,21 @@
     locals: { steps: [[@procedure.libelle, instructeur_procedure_path(@procedure)],
                       ['Instructeurs']] }
 
-.container.groupe-instructeur
+.fr-container.groupe-instructeur
   %h1
     - if @procedure.routing_enabled?
       Groupe « #{@groupe_instructeur.label} »
     - else
       Démarche « #{@procedure.libelle} »
 
-  .card.mt-2
+  .card.fr-mt-2w
     %h2.fr-h3 Gestion des instructeurs
     = form_for(Instructeur.new(user: User.new), url: { action: :add_instructeur }, html: { class: 'form' }) do |f|
-      %h3.fr-h4 Affecter un nouvel instructeur 
+      %h3.fr-h4 Affecter un nouvel instructeur
       = render Dsfr::InputComponent.new(form: f, attribute: :email)
       = f.submit 'Affecter', class: 'fr-btn fr-primary'
 
-    %table.table.mt-2
+    %table.fr-table.fr-mt-2w.width-100
       %thead
         %tr
           %th{ colspan: 2 } Instructeurs affectés
@@ -44,8 +44,8 @@
                 class: 'fr-btn fr-btn--secondary' }
 
     = paginate @instructeurs, views_prefix: 'shared'
-  
-  .card.mt-2
+
+  .card.fr-mt-2w
     %h2.fr-h3 Informations de contact
     - service = @groupe_instructeur.contact_information
     - if service.nil?

--- a/app/views/shared/groupe_instructeurs/_signature_form.html.haml
+++ b/app/views/shared/groupe_instructeurs/_signature_form.html.haml
@@ -1,8 +1,7 @@
 .card.mt-2
+  %h2.fr-h3 Tampon de l'attestation
   = render NestedForms::FormOwnerComponent.new
   = form_with url: { action: :add_signature }, method: :post, html: { multipart: true } do |f|
-    .card-title Tampon de l'attestation
-
     %p.fr-text--sm.fr-text-mention--grey
       Vous pouvez apposer sur l’attestation un tampon (ou signature) dédié à ce groupe d’instructeurs.
       Si vous n’en fournissez pas, celui de la démarche sera utilisé, le cas échéant.


### PR DESCRIPTION
# procedures/{procedure_id}/groupes

apres: 
> <img width="993" alt="Screenshot 2024-02-15 at 3 32 16 PM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/43d122b9-cf43-4eba-9000-d7bf5c22ef72">

avant: 
> ![Screenshot 2024-02-15 at 15-33-56 Notifications pour carte · demarches-simplifiees fr](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/9b2d4e92-d1dc-43b7-9937-67a3ad439a80)



# procedures/{procedure_id}/groupes/{groupe_instructeur_id}

apres: 
> ![Screenshot 2024-02-15 at 15-32-22 Instructeurs du groupe Deuxième choix · demarches-simplifiees fr](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/afb6beae-85f2-45c1-879b-cdfc6f6ff31f)


avant: 
> ![Screenshot 2024-02-15 at 15-33-41 Instructeurs du groupe Deuxième choix · demarches-simplifiees fr](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/99a1449f-5bfa-4017-85b2-b2d993871f0f)
