### PR TITLE
ETQ admin: correction du cache de la liste des PJ d'une démarche en brouillon

### DIFF
--- a/app/views/shared/_procedure_description.html.haml
+++ b/app/views/shared/_procedure_description.html.haml
@@ -24,7 +24,7 @@
 
 - unless @no_description
   .fr-accordions-group.fr-mb-3w
-    - cache [I18n.locale, procedure, "description"] do
+    - cache_unless(procedure.brouillon?, [I18n.locale, procedure, "description"]) do
       %section.fr-accordion
         %h2.fr-accordion__title
           %button.fr-accordion__btn{ "aria-controls" => "accordion-114", "aria-expanded" => "true" }

--- a/spec/views/shared/_procedure_description.html.haml_spec.rb
+++ b/spec/views/shared/_procedure_description.html.haml_spec.rb
@@ -124,5 +124,19 @@ describe 'shared/_procedure_description', type: :view do
       render partial: 'shared/procedure_description', locals: { procedure: }
       expect(rendered).to have_text('new pj')
     end
+
+    context 'draft procedure' do
+      let(:procedure) { create(:procedure, :draft) }
+
+      it 'respect revision changes on brouillon' do
+        render partial: 'shared/procedure_description', locals: { procedure: }
+        expect(rendered).not_to have_text('new pj')
+
+        procedure.draft_revision.add_type_de_champ(type_champ: :piece_justificative, libelle: 'new pj')
+
+        render partial: 'shared/procedure_description', locals: { procedure: }
+        expect(rendered).to have_text('new pj')
+      end
+    end
   end
 end


### PR DESCRIPTION
Des changements de champs PJ d'une démarche en brouillon ne mettent pas à jour la cache_key de la procedure (pas de publication), donc au fait au plus simple pour éviter un cache stale dans ces cas là : désactivation du cache.