### PR TITLE
correctif(tags): ETQ admin, les champs contenant deux '-' successif ne pouvaient etre utilisé dans les attestations & mail

### DIFF
--- a/app/models/concerns/tags_substitution_concern.rb
+++ b/app/models/concerns/tags_substitution_concern.rb
@@ -19,6 +19,7 @@ module TagsSubstitutionConcern
         .sub(/[[:space:]]+$/, '')
         .gsub(/[[:space:]]/, ' ')
         .gsub('&nbsp;', ' ')
+        .gsub(/--/, '__')
     end
 
     define_combinator :doc do

--- a/spec/models/concern/tags_substitution_concern_spec.rb
+++ b/spec/models/concern/tags_substitution_concern_spec.rb
@@ -211,7 +211,7 @@ describe TagsSubstitutionConcern, type: :model do
       end
 
       context 'and they are used in the template' do
-        let(:template) { "--bon pote -- c'est top--" }
+        let(:template) { "--bon pote __ c'est top--" }
 
         context 'and their value in the dossier are not nil' do
           before do

--- a/spec/models/concern/tags_substitution_concern_spec.rb
+++ b/spec/models/concern/tags_substitution_concern_spec.rb
@@ -203,6 +203,28 @@ describe TagsSubstitutionConcern, type: :model do
       end
     end
 
+    context 'when the procedure has a type de champ with double dash (--)' do
+      let(:types_de_champ_public) do
+        [
+          { libelle: "bon pote -- c'est top" }
+        ]
+      end
+
+      context 'and they are used in the template' do
+        let(:template) { "--bon pote -- c'est top--" }
+
+        context 'and their value in the dossier are not nil' do
+          before do
+            dossier.champs_public
+              .find { |champ| champ.libelle == "bon pote -- c'est top" }
+              .update(value: 'ceci est mon évènement')
+          end
+
+          it { is_expected.to eq('ceci est mon évènement') }
+        end
+      end
+    end
+
     context 'when the procedure has a type de champ repetition' do
       let(:template) { '--Répétition--' }
       let(:types_de_champ_public) { [{ type: :repetition, libelle: 'Répétition', mandatory: true, children: [{ libelle: 'Nom' }, { libelle: 'Prénom' }] }] }


### PR DESCRIPTION
crisp: https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_b512ae9a-d59d-463f-a410-5800c40efe67/