### PR TITLE
ETQ gestionnaire d'admins: sépare les commentaires par origine + correctifs

### DIFF
--- a/app/components/groupe_gestionnaire/groupe_gestionnaire_administrateurs/administrateur_component.rb
+++ b/app/components/groupe_gestionnaire/groupe_gestionnaire_administrateurs/administrateur_component.rb
@@ -35,7 +35,9 @@ class GroupeGestionnaire::GroupeGestionnaireAdministrateurs::AdministrateurCompo
     button_to "Révoquer l'accès administrateur",
       gestionnaire_groupe_gestionnaire_administrateur_path(@groupe_gestionnaire, @administrateur),
       method: :delete,
+      disabled: !@administrateur.can_be_deleted?,
       class: 'fr-btn fr-btn--sm fr-btn--tertiary',
+      title: @administrateur.can_be_deleted? ? "Supprimer" : "Cet administrateur a des démarches dont il est le seul admin et ne peut être supprimé",
       form: { data: { turbo: true, turbo_confirm: "Supprimer « #{@administrateur.email} » en tant qu'administrateur ?" } }
   end
 end

--- a/app/components/groupe_gestionnaire/groupe_gestionnaire_list_commentaires/commentaire_component.rb
+++ b/app/components/groupe_gestionnaire/groupe_gestionnaire_list_commentaires/commentaire_component.rb
@@ -8,9 +8,11 @@ class GroupeGestionnaire::GroupeGestionnaireListCommentaires::CommentaireCompone
 
   def email
     if @commentaire.sender == current_gestionnaire
-      "Messages avec le groupe gestionnaire parent (#{@groupe_gestionnaire.parent.name})"
-    else
+      "Messages avec le groupe gestionnaire parent"
+    elsif @commentaire.groupe_gestionnaire_id.in?([@groupe_gestionnaire.parent_id, @groupe_gestionnaire.id])
       @commentaire.sender_email
+    else
+      "#{@commentaire.sender_email} (#{@commentaire.groupe_gestionnaire.name})"
     end
   end
 
@@ -22,10 +24,6 @@ class GroupeGestionnaire::GroupeGestionnaireListCommentaires::CommentaireCompone
     link_to 'Voir',
       @commentaire.sender == current_gestionnaire ? parent_groupe_gestionnaire_gestionnaire_groupe_gestionnaire_commentaires_path(@groupe_gestionnaire) : gestionnaire_groupe_gestionnaire_commentaire_path(@groupe_gestionnaire, @commentaire),
       class: 'fr-btn'
-  end
-
-  def groupe_gestionnaire_name
-    @commentaire.groupe_gestionnaire.name
   end
 
   def highlight?

--- a/app/components/groupe_gestionnaire/groupe_gestionnaire_list_commentaires/commentaire_component/commentaire_component.html.haml
+++ b/app/components/groupe_gestionnaire/groupe_gestionnaire_list_commentaires/commentaire_component/commentaire_component.html.haml
@@ -1,7 +1,5 @@
 %tr{ id: dom_id(@commentaire) }
   %td
-    = groupe_gestionnaire_name
-  %td
     = email
     - if highlight?
       %span.notifications{ 'aria-label': 'notifications' }

--- a/app/controllers/gestionnaires/groupe_gestionnaire_commentaires_controller.rb
+++ b/app/controllers/gestionnaires/groupe_gestionnaire_commentaires_controller.rb
@@ -9,6 +9,9 @@ module Gestionnaires
         .select("sender_id, sender_type, sender_email, groupe_gestionnaire_id, MAX(id) as id, MAX(created_at) as created_at")
         .group(:sender_id, :sender_type, :sender_email, :groupe_gestionnaire_id)
         .order("MAX(id) DESC")
+      @commentaires_parent_group = @commentaires.filter { |commentaire| commentaire.groupe_gestionnaire_id == @groupe_gestionnaire.parent_id }
+      @commentaires_children_groups = @commentaires.filter { |commentaire| commentaire.groupe_gestionnaire_id != @groupe_gestionnaire.parent_id && commentaire.groupe_gestionnaire_id != @groupe_gestionnaire.id }
+      @commentaires = @commentaires.filter { |commentaire| commentaire.groupe_gestionnaire_id == @groupe_gestionnaire.id }
     end
 
     def show

--- a/app/views/gestionnaires/_breadcrumbs.html.haml
+++ b/app/views/gestionnaires/_breadcrumbs.html.haml
@@ -5,11 +5,9 @@
         = t('show', scope: [:layouts, :breadcrumb])
       .fr-collapse#breadcrumb-1
         %ol.fr-breadcrumb__list
-          %li= link_to t('root', scope: [:layouts, :breadcrumb]), root_path, class: 'fr-breadcrumb__link'
           - steps.each.with_index do |step, i|
             - if i == steps.size - 1
-              %li{ aria: { current: "page" } }
-                %span.fr-breadcrumb__link= step[0]
+              %li= link_to step[0], '', { aria: { current: "page" } , class: 'fr-breadcrumb__link' }
             - else
               %li= link_to step[0], step[1], class: 'fr-breadcrumb__link'
     - if defined?(metadatas)

--- a/app/views/gestionnaires/groupe_gestionnaire_commentaires/_list_commentaires.html.haml
+++ b/app/views/gestionnaires/groupe_gestionnaire_commentaires/_list_commentaires.html.haml
@@ -1,0 +1,8 @@
+%table.fr-table.width-100.mt-3
+  %thead
+    %tr
+      %th= 'Adresse email'
+      %th= 'Dernier message'
+      %th
+  %tbody#commentaires
+    = render(GroupeGestionnaire::GroupeGestionnaireListCommentaires::CommentaireComponent.with_collection(commentaires, groupe_gestionnaire: groupe_gestionnaire))

--- a/app/views/gestionnaires/groupe_gestionnaire_commentaires/index.html.haml
+++ b/app/views/gestionnaires/groupe_gestionnaire_commentaires/index.html.haml
@@ -6,19 +6,25 @@
 .container
   %h1 Messagerie de « #{@groupe_gestionnaire.name} »
 
-  %table.fr-table.width-100.mt-3
-    %thead
-      %tr
-        %th= 'Groupe gestionnaire'
-        %th= 'Adresse email'
-        %th= 'Dernier message'
-        %th
-    %tbody#commentaires
-      = render(GroupeGestionnaire::GroupeGestionnaireListCommentaires::CommentaireComponent.with_collection(@commentaires, groupe_gestionnaire: @groupe_gestionnaire))
-      - if @groupe_gestionnaire.parent_id && !current_gestionnaire.groupe_gestionnaires.where(id: @groupe_gestionnaire.parent_id).exists? && @last_commentaire.nil?
-        %tr
-          %td= @groupe_gestionnaire.parent.name
-          %td= "Messages avec le groupe gestionnaire parent (#{@groupe_gestionnaire.parent.name})"
-          %td
-          %td
-            = link_to 'Voir', parent_groupe_gestionnaire_gestionnaire_groupe_gestionnaire_commentaires_path(@groupe_gestionnaire), class: 'fr-btn'
+  = render partial: 'list_commentaires', locals: { commentaires: @commentaires, groupe_gestionnaire: @groupe_gestionnaire }
+
+  - if @commentaires_children_groups.present?
+    %h5 Messagerie des groupes enfants
+    = render partial: 'list_commentaires', locals: { commentaires: @commentaires_children_groups, groupe_gestionnaire: @groupe_gestionnaire }
+
+  - if @groupe_gestionnaire.parent_id
+    %h5 Messagerie du groupe parent « #{@groupe_gestionnaire.parent.name} »
+    - if @commentaires_parent_group.present?
+      = render partial: 'list_commentaires', locals: { commentaires: @commentaires_parent_group, groupe_gestionnaire: @groupe_gestionnaire }
+    - else
+      %table.fr-table.width-100.mt-3
+        %thead
+          %tr
+            %th= 'Adresse email'
+            %th= 'Dernier message'
+            %th
+          %tr
+            %td= "Messages avec le groupe gestionnaire parent"
+            %td
+            %td
+              = link_to 'Voir', parent_groupe_gestionnaire_gestionnaire_groupe_gestionnaire_commentaires_path(@groupe_gestionnaire), class: 'fr-btn'

--- a/app/views/gestionnaires/groupe_gestionnaires/index.html.haml
+++ b/app/views/gestionnaires/groupe_gestionnaires/index.html.haml
@@ -15,6 +15,8 @@
           Nombre de gestionnaires
         %th{ scope: "col" }
           Nombre d'administrateurs
+        %th{ scope: "col" }
+          Arborescence
 
     %tbody
       - @groupe_gestionnaires.order(:name).each do |groupe_gestionnaire|
@@ -25,3 +27,5 @@
             = groupe_gestionnaire.gestionnaire_ids.size
           %td
             = groupe_gestionnaire.administrateur_ids.size
+          %td
+            = link_to 'Voir', tree_structure_gestionnaire_groupe_gestionnaire_path(groupe_gestionnaire), class: 'fr-btn'

--- a/app/views/gestionnaires/groupe_gestionnaires/tree_structure.html.haml
+++ b/app/views/gestionnaires/groupe_gestionnaires/tree_structure.html.haml
@@ -7,6 +7,9 @@
   %h1 Arborescence de « #{@groupe_gestionnaire.name} »
 
   .fr-mt-4w
+    - if @groupe_gestionnaire.parent_id
+      %ul
+        %li= @groupe_gestionnaire.parent.name
     %ul
       - @tree_structure.each do |parent, children|
         %li


### PR DESCRIPTION
[#9111](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/9111)
[ETQ super-admin, déléguer la création des comptes administrateurs à des "gestionnaires de groupe - USER STORIES](https://gitlab.adullact.net/demarches-simplifiees/evolution-du-logiciel-demarches-simplifiees/-/issues/54)

## Bug

Si ETQ administrateur je crée et publie une démarche (et que je suis le seul administrateur déclaré de cette démarche) et que mon gestionnaire révoque mon accès administrateur, alors la révocation fonctionne et la démarche est supprimée de l'application.

A tester également si des dossiers créés sont supprimés également


## Tableau de bord du gestionnaire

- ajouter dans le tableau une colonne "voir l'arborescence de ce groupe" pour chaque groupe dont je suis le gestionnaire


## fil d'ariane

- enlever le lien (accessibilité web) de la page active dans le fil d'ariane

- enlever "accueil" qui renvoie vers le rôle administrateur


## Messagerie de groupe

Distinguer 3 tableau pour les 3 types de messages

    - Messagerie du groupe X

    - messagerie des groupes enfants du groupe X

    - messagerie vers le groupe parent de X


![Screenshot 2024-02-18 at 20-48-38 demarches-simplifiees syn](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/137039013/124bf4e4-aef9-4462-ae75-0a983b56e7b6)
![Screenshot 2024-02-18 at 20-28-43 demarches-simplifiees syn](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/137039013/c1de944f-60f6-48b2-94a3-41fb321e845c)


--------------------
> `trackingAdullactContrib`  `trackingAdullactARNiaContrib `