### PR TITLE
Tech: document STRICT_EMAIL_VALIDATION_STARTS_ON env var

### DIFF
--- a/config/env.example
+++ b/config/env.example
@@ -155,3 +155,10 @@ CLAMAV_ENABLED="disabled"
 
 # Siret number used for API Entreprise, by default we use SIRET from dinum
 API_ENTREPRISE_DEFAULT_SIRET="put_your_own_siret"
+
+# Date from which email validation requires a TLD in email adresses.
+# This change had been introduced by : cc53946d221d6f64c365ad6c6c4c544802eb94b4
+# Records (users, …) created before this date won't be affected. See #9978
+# To set a date, we recommend using *the day after* you have deployed this commit,
+# so existing records won't be invalid.
+STRICT_EMAIL_VALIDATION_STARTS_ON="2024-02-19"

--- a/spec/mailers/groupe_gestionnaire_mailer_spec.rb
+++ b/spec/mailers/groupe_gestionnaire_mailer_spec.rb
@@ -2,20 +2,20 @@ RSpec.describe GroupeGestionnaireMailer, type: :mailer do
   describe '#notify_removed_gestionnaire' do
     let(:groupe_gestionnaire) { create(:groupe_gestionnaire) }
 
-    let(:gestionnaire_to_remove) { create(:gestionnaire, email: 'int3@g') }
+    let(:gestionnaire_to_remove) { create(:gestionnaire, email: 'int3@g.fr') }
 
     let(:current_super_admin_email) { 'toto@email.com' }
 
     subject { described_class.notify_removed_gestionnaire(groupe_gestionnaire, gestionnaire_to_remove.email, current_super_admin_email) }
 
     it { expect(subject.body).to include('Vous venez d’être supprimé(e) du groupe gestionnaire') }
-    it { expect(subject.to).to match_array(['int3@g']) }
+    it { expect(subject.to).to match_array(['int3@g.fr']) }
   end
 
   describe '#notify_added_gestionnaires' do
     let(:groupe_gestionnaire) { create(:groupe_gestionnaire) }
 
-    let(:gestionnaires_to_add) { [create(:gestionnaire, email: 'int3@g'), create(:gestionnaire, email: 'int4@g')] }
+    let(:gestionnaires_to_add) { [create(:gestionnaire, email: 'int3@g.fr'), create(:gestionnaire, email: 'int4@g.fr')] }
 
     let(:current_super_admin_email) { 'toto@email.com' }
 
@@ -24,26 +24,26 @@ RSpec.describe GroupeGestionnaireMailer, type: :mailer do
     before { gestionnaires_to_add.each { groupe_gestionnaire.add_gestionnaire(_1) } }
 
     it { expect(subject.body).to include('Vous venez d’être nommé gestionnaire du groupe gestionnaire') }
-    it { expect(subject.bcc).to match_array(['int3@g', 'int4@g']) }
+    it { expect(subject.bcc).to match_array(['int3@g.fr', 'int4@g.fr']) }
   end
 
   describe '#notify_removed_administrateur' do
     let(:groupe_gestionnaire) { create(:groupe_gestionnaire) }
 
-    let(:administrateur_to_remove) { create(:administrateur, email: 'int3@g') }
+    let(:administrateur_to_remove) { create(:administrateur, email: 'int3@g.fr') }
 
     let(:current_super_admin_email) { 'toto@email.com' }
 
     subject { described_class.notify_removed_administrateur(groupe_gestionnaire, administrateur_to_remove.email, current_super_admin_email) }
 
     it { expect(subject.body).to include('Vous venez d’être supprimé(e) du groupe gestionnaire') }
-    it { expect(subject.to).to match_array(['int3@g']) }
+    it { expect(subject.to).to match_array(['int3@g.fr']) }
   end
 
   describe '#notify_added_administrateurs' do
     let(:groupe_gestionnaire) { create(:groupe_gestionnaire) }
 
-    let(:administrateurs_to_add) { [create(:administrateur, email: 'int3@g'), create(:administrateur, email: 'int4@g')] }
+    let(:administrateurs_to_add) { [create(:administrateur, email: 'int3@g.fr'), create(:administrateur, email: 'int4@g.fr')] }
 
     let(:current_super_admin_email) { 'toto@email.com' }
 
@@ -52,13 +52,13 @@ RSpec.describe GroupeGestionnaireMailer, type: :mailer do
     before { administrateurs_to_add.each { groupe_gestionnaire.add_administrateur(_1) } }
 
     it { expect(subject.body).to include('Vous venez d’être nommé administrateur du groupe gestionnaire') }
-    it { expect(subject.bcc).to match_array(['int3@g', 'int4@g']) }
+    it { expect(subject.bcc).to match_array(['int3@g.fr', 'int4@g.fr']) }
   end
 
   describe '#notify_new_commentaire_groupe_gestionnaire' do
     let(:groupe_gestionnaire) { create(:groupe_gestionnaire) }
 
-    let(:gestionnaire) { create(:gestionnaire, email: 'int3@g') }
+    let(:gestionnaire) { create(:gestionnaire, email: 'int3@g.fr') }
 
     let(:admin) { create(:administrateur, email: 'toto@email.com') }
 
@@ -69,6 +69,6 @@ RSpec.describe GroupeGestionnaireMailer, type: :mailer do
     subject { described_class.notify_new_commentaire_groupe_gestionnaire(groupe_gestionnaire, commentaire, admin.email, gestionnaire.email, commentaire_url) }
 
     it { expect(subject.body).to include('Vous avez un nouveau message dans le groupe gestionnaire') }
-    it { expect(subject.to).to match_array(['int3@g']) }
+    it { expect(subject.to).to match_array(['int3@g.fr']) }
   end
 end

--- a/spec/mailers/groupe_instructeur_mailer_spec.rb
+++ b/spec/mailers/groupe_instructeur_mailer_spec.rb
@@ -3,12 +3,12 @@ RSpec.describe GroupeInstructeurMailer, type: :mailer do
     let(:procedure) { create(:procedure) }
     let(:groupe_instructeur) do
       gi = GroupeInstructeur.create(label: 'gi1', procedure: procedure)
-      gi.instructeurs << create(:instructeur, email: 'int1@g')
-      gi.instructeurs << create(:instructeur, email: 'int2@g')
+      gi.instructeurs << create(:instructeur, email: 'int1@g.fr')
+      gi.instructeurs << create(:instructeur, email: 'int2@g.fr')
       gi.instructeurs << instructeur_to_remove
       gi
     end
-    let(:instructeur_to_remove) { create(:instructeur, email: 'int3@g') }
+    let(:instructeur_to_remove) { create(:instructeur, email: 'int3@g.fr') }
 
     let(:current_instructeur_email) { 'toto@email.com' }
 
@@ -18,8 +18,8 @@ RSpec.describe GroupeInstructeurMailer, type: :mailer do
 
     context 'when instructeur is fully removed form procedure' do
       it { expect(subject.body).to include('Vous avez été désaffecté(e) de la démarche') }
-      it { expect(subject.to).to include('int3@g') }
-      it { expect(subject.to).not_to include('int1@g', 'int2@g') }
+      it { expect(subject.to).to include('int3@g.fr') }
+      it { expect(subject.to).not_to include('int1@g.fr', 'int2@g.fr') }
     end
 
     context 'when instructeur is removed from one group but still affected to procedure' do
@@ -30,15 +30,15 @@ RSpec.describe GroupeInstructeurMailer, type: :mailer do
       end
 
       it { expect(subject.body).to include('Vous avez été retiré(e) du groupe « gi1 » par « toto@email.com »') }
-      it { expect(subject.to).to include('int3@g') }
-      it { expect(subject.to).not_to include('int1@g', 'int2@g') }
+      it { expect(subject.to).to include('int3@g.fr') }
+      it { expect(subject.to).not_to include('int1@g.fr', 'int2@g.fr') }
     end
   end
 
   describe '#notify_added_instructeurs' do
     let(:procedure) { create(:procedure) }
 
-    let(:instructeurs_to_add) { [create(:instructeur, email: 'int3@g'), create(:instructeur, email: 'int4@g')] }
+    let(:instructeurs_to_add) { [create(:instructeur, email: 'int3@g.fr'), create(:instructeur, email: 'int4@g.fr')] }
 
     let(:current_instructeur_email) { 'toto@email.com' }
 
@@ -48,7 +48,7 @@ RSpec.describe GroupeInstructeurMailer, type: :mailer do
 
     context 'when there is only one group on procedure' do
       it { expect(subject.body).to include('Vous avez été affecté(e) à la démarche') }
-      it { expect(subject.bcc).to match_array(['int3@g', 'int4@g']) }
+      it { expect(subject.bcc).to match_array(['int3@g.fr', 'int4@g.fr']) }
     end
 
     context 'when there are many groups on procedure' do
@@ -56,7 +56,7 @@ RSpec.describe GroupeInstructeurMailer, type: :mailer do
         GroupeInstructeur.create(label: 'gi2', procedure: procedure)
       end
       it { expect(subject.body).to include('Vous avez été ajouté(e) au groupe') }
-      it { expect(subject.bcc).to match_array(['int3@g', 'int4@g']) }
+      it { expect(subject.bcc).to match_array(['int3@g.fr', 'int4@g.fr']) }
     end
   end
 end

--- a/spec/services/dossier_projection_service_spec.rb
+++ b/spec/services/dossier_projection_service_spec.rb
@@ -170,11 +170,11 @@ describe DossierProjectionService do
         let(:column) { 'email' }
 
         let(:dossier) { create(:dossier) }
-        let!(:follow1) { create(:follow, dossier: dossier, instructeur: create(:instructeur, email: 'b@host')) }
-        let!(:follow2) { create(:follow, dossier: dossier, instructeur: create(:instructeur, email: 'a@host')) }
-        let!(:follow3) { create(:follow, dossier: dossier, instructeur: create(:instructeur, email: 'c@host')) }
+        let!(:follow1) { create(:follow, dossier: dossier, instructeur: create(:instructeur, email: 'b@host.fr')) }
+        let!(:follow2) { create(:follow, dossier: dossier, instructeur: create(:instructeur, email: 'a@host.fr')) }
+        let!(:follow3) { create(:follow, dossier: dossier, instructeur: create(:instructeur, email: 'c@host.fr')) }
 
-        it { is_expected.to eq "a@host, b@host, c@host" }
+        it { is_expected.to eq "a@host.fr, b@host.fr, c@host.fr" }
       end
 
       context 'for type_de_champ table' do


### PR DESCRIPTION
Pas en `.optional`  car vivement recommandé, et de toute façon son absence ne casse pas l'implémentation.