### PR TITLE
ETQ uager, fix sélection d'un choix multiple qui commence par `[`

### DIFF
--- a/app/models/champs/multiple_drop_down_list_champ.rb
+++ b/app/models/champs/multiple_drop_down_list_champ.rb
@@ -90,7 +90,7 @@ class Champs::MultipleDropDownListChamp < Champ
     values = if value.is_a?(Array)
       value
     elsif value.starts_with?('[')
-      JSON.parse(value)
+      JSON.parse(value) rescue selected_options + [value] # value may start by [ without being a real JSON value
     else
       selected_options + [value]
     end.uniq.without('')

--- a/spec/models/champs/multiple_drop_down_list_champ_spec.rb
+++ b/spec/models/champs/multiple_drop_down_list_champ_spec.rb
@@ -1,5 +1,5 @@
 describe Champs::MultipleDropDownListChamp do
-  let(:type_de_champ) { build(:type_de_champ_multiple_drop_down_list, drop_down_list_value: "val1\r\nval2\r\nval3") }
+  let(:type_de_champ) { build(:type_de_champ_multiple_drop_down_list, drop_down_list_value: "val1\r\nval2\r\nval3\r\n[brackets] val4") }
   let(:value) { nil }
   subject { build(:champ_multiple_drop_down_list, type_de_champ:, value:) }
 
@@ -41,6 +41,8 @@ describe Champs::MultipleDropDownListChamp do
           expect(subject.value).to eq("[\"val1\",\"val2\"]")
           subject.value = ''
           expect(subject.value).to eq("[\"val1\",\"val2\"]")
+          subject.value = "[brackets] val4"
+          expect(subject.value).to eq("[\"val1\",\"val2\",\"[brackets] val4\"]")
           subject.value = nil
           expect(subject.value).to be_nil
           subject.value = ["val1"]


### PR DESCRIPTION
Il y a des choix qui commencent par des `[]` sans être du json, par exemple `[Toiture] Pose d'une isolation` dans des démarches FV.

https://demarches-simplifiees.sentry.io/issues/4905767507

https://secure.helpscout.net/conversation/2515388532/2056236?folderId=1653799