### PR TITLE
ETQ usager je dois voir de vraies apostrophes à la place de `&#39;` dans les sujets d'email

### DIFF
--- a/app/models/concerns/mail_template_concern.rb
+++ b/app/models/concerns/mail_template_concern.rb
@@ -10,7 +10,7 @@ module MailTemplateConcern
   end
 
   def subject_for_dossier(dossier)
-    replace_tags(subject, dossier).presence || replace_tags(self.class::DEFAULT_SUBJECT, dossier)
+    replace_tags(subject, dossier, escape: false).presence || replace_tags(self.class::DEFAULT_SUBJECT, dossier, escape: false)
   end
 
   def body_for_dossier(dossier)

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -140,9 +140,9 @@ RSpec.describe NotificationMailer, type: :mailer do
 
     subject(:mail) { described_class.send_en_instruction_notification(dossier) }
 
-    context "subject has a special character" do
+    context "subject has a special character should not be escaped" do
       let(:subject) { '--libellé démarche--' }
-      it { expect(mail.subject).to eq("Mon titre avec l&#39;apostrophe") }
+      it { expect(mail.subject).to eq("Mon titre avec l'apostrophe") }
     end
   end
 end


### PR DESCRIPTION
Régression depuis quelques semaines où on escape tout ce qui vient des balises. Mais on ne devrait pas le faire pour les sujets d'email car les headers d'email ne sont pas de l'html (cf rfc 2047) et Outlook entre autre ne décode pas l'html.

