### PR TITLE
Tech: configure les CSP pour répondre à un host défini par `APP_HOST_LEGACY`

### DIFF
--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -5,6 +5,11 @@ APPLICATION_NAME="demarches-simplifiees.fr"
 APPLICATION_SHORTNAME="d-s.fr"
 APPLICATION_BASE_URL="https://www.demarches-simplifiees.fr"
 
+# When migrating app to a new domain, configure APP_HOST to the new domain
+# and APP_HOST_LEGACY to the legacy domain.
+# The app will be able to answer to boths during the transition.
+# APP_HOST_LEGACY=""
+
 # If defined to "staging", tell the app that it's running on a staging instance
 DS_ENV="staging"
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -121,4 +121,5 @@ Rails.application.configure do
   # config.action_cable.disable_request_forgery_protection = true
 
   config.hosts << ENV.fetch("APP_HOST")
+  config.hosts << ENV.fetch("APP_HOST_LEGACY") if ENV.key?("APP_HOST_LEGACY")
 end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -22,6 +22,7 @@ Rails.application.config.content_security_policy do |policy|
 
   connect_whitelist = ["wss://*.crisp.chat", "*.crisp.chat", "app.franceconnect.gouv.fr", "openmaptiles.geo.data.gouv.fr", "openmaptiles.github.io", "tiles.geo.api.gouv.fr", "data.geopf.fr"]
   connect_whitelist << ENV.fetch('APP_HOST')
+  connect_whitelist << ENV.fetch('APP_HOST_LEGACY') if ENV.key?('APP_HOST_LEGACY')
   connect_whitelist << "*.amazonaws.com" if Rails.configuration.active_storage.service == :amazon
   connect_whitelist += [URI(ENV["SENTRY_DSN_JS"]).host, URI(ENV["SENTRY_DSN_RAILS"]).host].compact.uniq
   connect_whitelist << URI(DS_PROXY_URL).host if DS_PROXY_URL.present?


### PR DESCRIPTION
Après cette PR on devrait set : 

```
APP_HOST=demarches.gouv.fr
APP_HOST_LEGACY=demarches-simplifiees.fr
```

pour que les CSP / assets fonctionnent bien