### PR TITLE
chore(browser): mark samsung browser as supported browser

### DIFF
--- a/app/services/browser_support.rb
+++ b/app/services/browser_support.rb
@@ -6,7 +6,8 @@ class BrowserSupport
       browser.firefox? && browser.version.to_i >= 67 && !browser.platform.ios?,
       browser.opera? && browser.version.to_i >= 50,
       browser.safari? && browser.version.to_i >= 12,
-      browser.platform.ios? && browser.platform.version.to_i >= 12
+      browser.platform.ios? && browser.platform.version.to_i >= 12,
+      browser.samsung_browser? && browser.version.to_i >= 12
     ].any?
   end
 end

--- a/app/tasks/maintenance/samsung_browser_is_supported_task.rb
+++ b/app/tasks/maintenance/samsung_browser_is_supported_task.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class SamsungBrowserIsSupportedTask < MaintenanceTasks::Task
+    def collection
+      Traitement.where(browser_name: 'Samsung Browser', browser_version: 12..)
+    end
+
+    def process(traitement)
+      traitement.update_column(:browser_supported, true)
+    end
+  end
+end


### PR DESCRIPTION
C'est un navigateur très utilisé et bien maintenu. On n'a pas de raison de le marquer comme non supporté.