### PR TITLE
Tech: cache le bouton de c/c lorsque le navigateur bloque l'accès au clipboard

### DIFF
--- a/app/javascript/controllers/clipboard_controller.ts
+++ b/app/javascript/controllers/clipboard_controller.ts
@@ -14,6 +14,13 @@ export class ClipboardController extends Controller {
 
   #timer?: ReturnType<typeof setTimeout>;
 
+  connect(): void {
+    // some extensions or browsers block clipboard
+    if (!navigator.clipboard) {
+      this.element.classList.add('hidden');
+    }
+  }
+
   disconnect(): void {
     clearTimeout(this.#timer);
   }


### PR DESCRIPTION
sinon en plus d'être inopérant, ça provoque des erreurs en console ` TypeError: can't access property "writeText", navigator.clipboard is undefined`