### PR TITLE
ETQ instructeur, message d'erreur plutôt que crash lorsqu'on ajoute un filtre trop long (plus de 100 caractères)

### DIFF
--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -148,7 +148,9 @@ module Instructeurs
     end
 
     def add_filter
-      procedure_presentation.add_filter(statut, params[:field], params[:value])
+      if !procedure_presentation.add_filter(statut, params[:field], params[:value])
+        flash.alert = procedure_presentation.errors.full_messages
+      end
 
       redirect_back(fallback_location: instructeur_procedure_url(procedure))
     end

--- a/app/models/procedure_presentation.rb
+++ b/app/models/procedure_presentation.rb
@@ -319,7 +319,7 @@ class ProcedurePresentation < ApplicationRecord
         'value' => value
       }
 
-      update!(filters: updated_filters)
+      update(filters: updated_filters)
     end
   end
 
@@ -457,11 +457,11 @@ class ProcedurePresentation < ApplicationRecord
   end
 
   def check_filters_max_length
-    individual_filters = filters.values.flatten.filter { |f| f.is_a?(Hash) }
-    individual_filters.each do |filter|
-      if filter['value']&.length.to_i > FILTERS_VALUE_MAX_LENGTH
-        errors.add(:filters, :too_long)
-      end
+    filters.values.flatten.each do |filter|
+      next if !filter.is_a?(Hash)
+      next if filter['value']&.length.to_i <= FILTERS_VALUE_MAX_LENGTH
+
+      errors.add(:base, "Le filtre #{filter['label']} est trop long (maximum: #{FILTERS_VALUE_MAX_LENGTH} caractères)")
     end
   end
 

--- a/spec/controllers/instructeurs/procedures_controller_spec.rb
+++ b/spec/controllers/instructeurs/procedures_controller_spec.rb
@@ -830,4 +830,24 @@ describe Instructeurs::ProceduresController, type: :controller do
       it { is_expected.to have_http_status(:forbidden) }
     end
   end
+
+  describe '#add_filter' do
+    let(:instructeur) { create(:instructeur) }
+    let(:procedure) { create(:procedure, :for_individual) }
+
+    before do
+      create(:assign_to, instructeur:, groupe_instructeur: build(:groupe_instructeur, procedure:))
+
+      sign_in(instructeur.user)
+    end
+
+    subject do
+      post :add_filter, params: { procedure_id: procedure.id, field: "individual/nom", value: "n" * 110, statut: "a-suivre" }
+    end
+
+    it 'should render the error' do
+      subject
+      expect(flash.alert[0]).to include("Le filtre Nom est trop long (maximum: 100 caractères)")
+    end
+  end
 end


### PR DESCRIPTION
Malgré le maxlength sur l'input des navigateurs soumettent des valeurs trop longues et on n'interceptait pas l'erreur

https://demarches-simplifiees.sentry.io/issues/4586755699/

![Capture d’écran 2024-02-21 à 11 35 59](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/0b9632f6-0220-45d0-886d-06f792406622)
