### PR TITLE
ETQ Usager : légères améliorations de lisibilité et d'espacement sur le formulaire

### DIFF
--- a/app/assets/stylesheets/02_utils.scss
+++ b/app/assets/stylesheets/02_utils.scss
@@ -145,9 +145,11 @@
 
 // who known
 .highlighted {
-  background-color: var(--background-contrast-yellow-moutarde); // from fr-badge--new
-  color: var(--text-action-high-grey);
-  background-clip: content-box;
+  background-color: var(
+    --background-contrast-yellow-moutarde
+  ); // from fr-badge--new
+  color: var(--text-label-yellow-tournesol);
+  padding: 0 0.5rem;
 }
 
 .overflow-y-visible {

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -50,7 +50,12 @@
   }
 
   // Don't cumulate margin-bottoms for inlined elements (radio...), because .fr-fieldset has already its own
-  .fr-fieldset__element > .fr-fieldset > .fr-fieldset__element.fr-fieldset__element--inline {
+  // This is important because of multilpe conditional hidden elements to not take additional space,
+  // but we need the usual margin when there are an error or conditional spinner is visible.
+  // scss-lint:disable SingleLinePerSelector
+  .fr-fieldset__element
+    > .fr-fieldset:not(.fr-fieldset--error):not(:has(+ .spinner))
+    > .fr-fieldset__element.fr-fieldset__element--inline {
     margin-bottom: 0;
   }
 

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -72,13 +72,6 @@
     border-bottom: 2px solid $border-grey;
   }
 
-  @mixin notice-text-style {
-    font-size: 16px;
-    color: $dark-grey;
-  }
-
-
-
   label:not(.fr-label),
   legend.form-label {
     font-size: 18px;
@@ -101,9 +94,9 @@
   }
 
   .notice {
-    @include notice-text-style;
     margin-top: - $default-spacer;
     margin-bottom: $default-padding;
+    color: var(--text-mention-grey);
 
     p {
       margin-bottom: $default-spacer;
@@ -118,7 +111,7 @@
     position: relative;
 
     .updated-at {
-      @include notice-text-style;
+      font-size: 0.875rem;
       float: right;
       margin-left: $default-spacer;
       visibility: hidden;
@@ -127,6 +120,7 @@
     &:hover .updated-at,
     .updated-at.highlighted {
       visibility: visible;
+      margin-bottom: 4px;
     }
 
     &.editable-champ-checkbox {
@@ -493,15 +487,6 @@
 
   .justify-content--space-between {
     justify-content: space-between;
-  }
-
-  .send-notice {
-    @include notice-text-style;
-    margin-bottom: $default-padding;
-  }
-
-  .send-wrapper + .send-notice {
-    margin-top: - $default-padding;
   }
 
   .inline-champ {

--- a/app/components/editable_champ/champ_label_content_component/champ_label_content_component.en.yml
+++ b/app/components/editable_champ/champ_label_content_component/champ_label_content_component.en.yml
@@ -2,6 +2,6 @@
 en:
   changes_to_save: "modifications to submit"
   modified_at: "modified on %{datetime}"
-  check_content_rebased: The type of this field or its description has been modified by the administration. Check its content.
+  check_content_rebased: "Information: field updated by administration. Check its content."
   optional_champ: (optional)
   recommended_size: The recommended maximum size is %{size} characters.

--- a/app/components/editable_champ/champ_label_content_component/champ_label_content_component.fr.yml
+++ b/app/components/editable_champ/champ_label_content_component/champ_label_content_component.fr.yml
@@ -2,6 +2,6 @@
 fr:
   changes_to_save: "modification à déposer"
   modified_at: "modifié le %{datetime}"
-  check_content_rebased: Le type de ce champ ou sa description ont été modifiés par l'administration. Vérifier son contenu.
+  check_content_rebased: "Information : champ actualisé par l'administration. Vérifier son contenu."
   optional_champ: (facultatif)
   recommended_size: La taille maximale conseillée est de %{size} caractères.

--- a/app/components/editable_champ/checkbox_component/checkbox_component.html.haml
+++ b/app/components/editable_champ/checkbox_component/checkbox_component.html.haml
@@ -5,4 +5,5 @@
       'true',
       'false'
     %label.fr-label{ for: @champ.input_id, id: @champ.labelledby_id }
-      = render EditableChamp::ChampLabelContentComponent.new form: @form, champ: @champ, seen_at: @seen_at
+      %span
+        = render EditableChamp::ChampLabelContentComponent.new form: @form, champ: @champ, seen_at: @seen_at


### PR DESCRIPTION
- Le message quand un champ a été modifié( rebasé) était lourd et débordait sur mobile. Je l'ai simplifié, et j'ai adapté son style pour le rapprocher un peu plus d'un badge sans en être un (j'ai essayé d'y caller une alerte, mais c'est trop proéminent surtout qu'on est dans le `<label>`. Il faudrait d'ailleurs l'enlever de ce label, mais c'est pas si simple. (ça Améliore aussi le thème sombre.)
- le changement de style sur `.highlighlited` a un impact mineur sur la messagerie, et sur `.notice` sur quelques  pages instructeurs qu'il faut de toute façuon migrer au dsfr
- amélioration spacing pour les radios inline en erreur ou avec conditionnel
- maintenant qu'on met `*` sur les checkbox, autant bien la positionner quand le texte est sur plusieurs lignes
- 
Chemin faisant j'ai supprimé un peu de css obsolète. 


## APRES
![Capture d’écran 2024-02-21 à 17 15 32](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/7af4ddd2-dab2-44d1-9314-1a03eb33655f)
![Capture d’écran 2024-02-21 à 14 20 56](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/485512eb-48b4-47a1-b8bf-0c1c1b1eef53)
![Capture d’écran 2024-02-21 à 17 56 50](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/ac57d1b6-5a24-48f8-a4de-fe34a9bdeef7)


## AVANT
![Capture d’écran 2024-02-21 à 17 15 56](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/a8ced30c-b379-473d-a982-99c8b4c6b95a)
![Capture d’écran 2024-02-21 à 17 30 32](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/5d633f4a-113c-42e2-a6cc-ea515ec8a564)
![Capture d’écran 2024-02-21 à 18 00 13](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/f0b9302d-9478-4e26-b6dc-12807fe0c7d6)
