### PR TITLE
correctif(Champs::Civilite): ETQ usager, j'aimerais que le champs de type civilité ait le même style d'erreur que les autres

### DIFF
--- a/app/components/editable_champ/civilite_component.rb
+++ b/app/components/editable_champ/civilite_component.rb
@@ -1,2 +1,5 @@
 class EditableChamp::CiviliteComponent < EditableChamp::EditableChampBaseComponent
+  def dsfr_champ_container
+    :fieldset
+  end
 end

--- a/app/components/editable_champ/civilite_component/civilite_component.html.haml
+++ b/app/components/editable_champ/civilite_component/civilite_component.html.haml
@@ -1,13 +1,11 @@
-%fieldset.fr-fieldset
-  %legend.fr-fieldset__legend--regular.fr-fieldset__legend
-    Sélectionnez une des valeurs
-  .fr-fieldset__element.fr-fieldset__element--inline
-    .fr-radio-group
-      = @form.radio_button :value, Individual::GENDER_FEMALE, id: @champ.female_input_id
-      %label.fr-label{ for: @champ.female_input_id }
-        = Individual.human_attribute_name('gender.female')
-  .fr-fieldset__element.fr-fieldset__element--inline
-    .fr-radio-group
-      = @form.radio_button :value, Individual::GENDER_MALE, id: @champ.male_input_id
-      %label.fr-label{ for: @champ.male_input_id }
-        = Individual.human_attribute_name('gender.male')
+
+.fr-fieldset__element.fr-fieldset__element--inline
+  .fr-radio-group
+    = @form.radio_button :value, Individual::GENDER_FEMALE, id: @champ.female_input_id
+    %label.fr-label{ for: @champ.female_input_id }
+      = Individual.human_attribute_name('gender.female')
+.fr-fieldset__element.fr-fieldset__element--inline
+  .fr-radio-group
+    = @form.radio_button :value, Individual::GENDER_MALE, id: @champ.male_input_id
+    %label.fr-label{ for: @champ.male_input_id }
+      = Individual.human_attribute_name('gender.male')

--- a/app/models/champs/civilite_champ.rb
+++ b/app/models/champs/civilite_champ.rb
@@ -1,6 +1,10 @@
 class Champs::CiviliteChamp < Champ
   validates :value, inclusion: ["M.", "Mme"], allow_nil: true, allow_blank: false
 
+  def legend_label?
+    true
+  end
+
   def html_label?
     false
   end


### PR DESCRIPTION
je garde juste le fix sur le champ civilité qui n'affichait pas le rouge quand il etait pas valide

apres
<img width="391" alt="Capture d’écran 2024-03-07 à 8 40 18 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/6b694087-0579-44de-90e9-7966d279dd68">

avant
<img width="364" alt="Capture d’écran 2024-03-07 à 8 40 45 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/3727be9b-e228-4398-b5d3-f9ea74537338">
