### PR TITLE
Correction : etq usager je ne vois pas le bandeau indiquant que je suis connecté avec France Connect

### DIFF
--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -338,6 +338,10 @@ ul.dropdown-items {
   color: $blue-france-500;
 }
 
-.account-btn::before {
-  content: none !important;
+.account-btn {
+  flex-wrap: wrap;
+
+  &::before {
+    content: none !important;
+  }
 }

--- a/app/views/layouts/_account_dropdown.haml
+++ b/app/views/layouts/_account_dropdown.haml
@@ -1,8 +1,11 @@
 %nav.fr-translate.fr-nav{ role: "navigation", "aria-label"=> t('menu_aria_label', scope: [:layouts]) }
   .fr-nav__item
     %button.account-btn.fr-translate__btn.fr-btn{ "aria-controls" => "account", "aria-expanded" => "false", :title => t('my_account', scope: [:layouts]) }
-      = " #{current_email}"
-      %div{ class: "fr-badge fr-badge--sm fr-ml-1w #{color_by_role(nav_bar_profile)}" }
+      %span= current_email
+      - if dossier.present? && dossier&.france_connect_information.present?
+        %span
+          &nbsp;via FranceConnect
+      %span{ class: "fr-badge fr-badge--sm fr-ml-1w #{color_by_role(nav_bar_profile)}" }
         = t("layouts.#{nav_bar_profile}")
     #account.fr-collapse.fr-menu
       %ul.fr-menu__list.max-content

--- a/app/views/layouts/_header.haml
+++ b/app/views/layouts/_header.haml
@@ -34,7 +34,7 @@
             %ul.fr-btns-group.flex.align-center
               - if instructeur_signed_in? || user_signed_in?
                 %li
-                  = render partial: 'layouts/account_dropdown', locals: { nav_bar_profile: nav_bar_profile }
+                  = render partial: 'layouts/account_dropdown', locals: { nav_bar_profile: nav_bar_profile, dossier: dossier }
               - elsif (request.path != new_user_session_path && request.path !=agent_connect_path)
                 - if request.path == new_user_registration_path
                   %li

--- a/app/views/shared/dossiers/_demande.html.haml
+++ b/app/views/shared/dossiers/_demande.html.haml
@@ -1,4 +1,4 @@
-- if dossier.france_connect_information.present?
+- if dossier.france_connect_information.present? && current_user.instructeur? && !current_user.owns_or_invite?(dossier)
   - content_for(:notice_info) do
     = render partial: "shared/dossiers/france_connect_informations_notice", locals: { user_information: dossier.france_connect_information }
 

--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -1,7 +1,6 @@
 - dossier_for_editing = dossier.en_construction? ? dossier.owner_editing_fork : dossier
 
-
-- if dossier.france_connect_information.present?
+- if dossier.france_connect_information.present? && current_user.instructeur? && !current_user.owns_or_invite?(dossier)
   - content_for(:notice_info) do
     = render partial: "shared/dossiers/france_connect_informations_notice", locals: { user_information: dossier.france_connect_information }
 

--- a/spec/views/users/dossiers/demande.html.haml_spec.rb
+++ b/spec/views/users/dossiers/demande.html.haml_spec.rb
@@ -44,8 +44,8 @@ describe 'users/dossiers/demande', type: :view do
       render
     end
 
-    it 'fills the individual with the informations from France Connect' do
-      expect(view.content_for(:notice_info)).to have_text("Le dossier a été déposé par le compte de #{france_connect_information.given_name} #{france_connect_information.family_name}, authentifié par FranceConnect le #{france_connect_information.updated_at.strftime('%d/%m/%Y')}")
+    it 'does not fill the individual with the informations from France Connect' do
+      expect(view.content_for(:notice_info)).not_to have_text("Le dossier a été déposé par le compte de #{france_connect_information.given_name} #{france_connect_information.family_name}, authentifié par FranceConnect le #{france_connect_information.updated_at.strftime('%d/%m/%Y')}")
     end
   end
 


### PR DESCRIPTION
Voir https://secure.helpscout.net/conversation/2524256972/2057286

Une usagère était perturbée par le message de warning France Connect lui indiquant qu'elle avait déposé un dossier alors que son dossier n'était qu'en brouillon.
Et comme il se trouve qu'elle était confrontée à un autre bug, et avait ouvert plusieurs brouillons, elle avait peur d'avoir déposé plusieurs dossiers.

Avant : 

![Capture d’écran du 2024-02-29 10-04-40](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/29131404/86133f0d-50f7-42de-9762-9ea24e6556a6)

Après : on n'affiche le bandeau qu'aux instructeurs 
