### PR TITLE
Tech: réduit l'impact de Flipper sur la base

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'dotenv-rails', require: 'dotenv/rails-now' # dotenv should always be loaded
 gem 'dry-monads'
 gem 'flipper'
 gem 'flipper-active_record'
+gem 'flipper-active_support_cache_store'
 gem 'flipper-ui'
 gem 'fugit'
 gem 'geocoder'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,6 +237,9 @@ GEM
     flipper-active_record (1.2.2)
       activerecord (>= 4.2, < 8)
       flipper (~> 1.2.2)
+    flipper-active_support_cache_store (1.2.2)
+      activesupport (>= 4.2, < 8)
+      flipper (~> 1.2.2)
     flipper-ui (1.2.2)
       erubi (>= 1.0.0, < 2.0.0)
       flipper (~> 1.2.2)
@@ -833,6 +836,7 @@ DEPENDENCIES
   factory_bot
   flipper
   flipper-active_record
+  flipper-active_support_cache_store
   flipper-ui
   fugit
   geo_coord

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -561,9 +561,10 @@ class Procedure < ApplicationRecord
     procedure.update!(defaut_groupe_instructeur: new_defaut_groupe)
 
     Flipper.features.each do |feature|
-      if feature_enabled?(feature.key)
-        Flipper.enable(feature.key, procedure)
-      end
+      next if feature.enabled? # don't clone features globally enabled
+      next unless feature_enabled?(feature.key)
+
+      Flipper.enable(feature.key, procedure)
     end
 
     procedure

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -2,11 +2,12 @@
 # we can add new features from the Web UI. However when the new DB is created
 # this will immediately migrate the default features to be controlled.
 def setup_features(features)
-  features.each do |feature|
-    if !Flipper.exist?(feature)
-      # Disable feature by default
-      Flipper.disable(feature)
-    end
+  existing = Flipper.preload(features).map { _1.name.to_sym }
+  missing = features - existing
+
+  missing.each do |feature|
+    # Feature is disabled by default
+    Flipper.add(feature.to_s)
   end
 end
 
@@ -14,13 +15,17 @@ end
 features = [
   :administrateur_web_hook,
   :api_particulier,
-  :dossier_pdf_vide,
-  :hide_instructeur_email,
-  :procedure_routage_api,
-  :groupe_instructeur_api_hack,
+  :attestation_v2,
+  :blocking_pending_correction,
   :cojo_type_de_champ,
+  :dossier_pdf_vide,
+  :engagement_juridique_type_de_champ,
+  :export_order_by_revision,
+  :expression_reguliere_type_de_champ,
+  :groupe_instructeur_api_hack,
+  :hide_instructeur_email,
   :sva,
-  :blocking_pending_correction
+  :switch_domain
 ]
 
 def database_exists?
@@ -34,4 +39,8 @@ ActiveSupport.on_load(:active_record) do
   if database_exists? && ActiveRecord::Base.connection.data_source_exists?('flipper_features')
     setup_features(features)
   end
+end
+
+Rails.application.configure do
+  config.flipper.strict = Rails.env.development?
 end

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -56,5 +56,7 @@ Flipper.configure do |config|
 end
 
 Rails.application.configure do
+  # don't preload features for /assets/* but do for everything else
+  config.flipper.preload = -> (request) { !request.path.start_with?('/assets/', '/ping') }
   config.flipper.strict = Rails.env.development?
 end

--- a/lib/tasks/deployment/20240301223646_clean_old_gates2024.rake
+++ b/lib/tasks/deployment/20240301223646_clean_old_gates2024.rake
@@ -1,0 +1,29 @@
+namespace :after_party do
+  desc 'Deployment task: clean_old_gates2024'
+  task clean_old_gates2024: :environment do
+    puts "Running deploy task 'clean_old_gates2024'"
+
+    keys = [
+      'admin_affect_experts_to_avis',
+      'chorus',
+      'disable_label_optional_champ_2023_06_29',
+      'expert_not_allowed_to_invite',
+      'instructeur_bypass_email_login_token',
+      'multi_line_routing',
+      'opendata',
+      'procedure_conditional',
+      'procedure_routage_api',
+      'rerouting',
+      'routing_rules',
+      'zonage'
+    ]
+
+    Flipper::Adapters::ActiveRecord::Gate.where(feature_key: keys).delete_all
+    Flipper::Adapters::ActiveRecord::Feature.where(key: keys).delete_all
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -871,21 +871,33 @@ describe Procedure do
     describe 'feature flag' do
       context 'with a feature flag enabled' do
         before do
-          Flipper.enable(:procedure_routage_api, procedure)
+          Flipper.enable(:dossier_pdf_vide, procedure)
         end
 
         it 'should enable feature' do
-          expect(subject.feature_enabled?(:procedure_routage_api)).to be true
+          expect(subject.feature_enabled?(:dossier_pdf_vide)).to be true
+          expect(Flipper.feature(:dossier_pdf_vide).enabled_gate_names).to include(:actor)
+        end
+      end
+
+      context 'with feature flag is fully enabled' do
+        before do
+          Flipper.enable(:dossier_pdf_vide)
+        end
+
+        it 'should not clone feature for actor' do
+          expect(subject.feature_enabled?(:dossier_pdf_vide)).to be true
+          expect(Flipper.feature(:dossier_pdf_vide).enabled_gate_names).not_to include(:actor)
         end
       end
 
       context 'with a feature flag disabled' do
         before do
-          Flipper.disable(:procedure_routage_api, procedure)
+          Flipper.disable(:dossier_pdf_vide, procedure)
         end
 
         it 'should not enable feature' do
-          expect(subject.feature_enabled?(:procedure_routage_api)).to be false
+          expect(subject.feature_enabled?(:dossier_pdf_vide)).to be false
         end
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -121,10 +121,6 @@ RSpec.configure do |config|
     end
   end
 
-  config.before(:each, type: Proc.new { |type| type != :system }) do
-    Flipper.instance = Flipper.new(Flipper::Adapters::Memory.new)
-  end
-
   config.include ActiveSupport::Testing::TimeHelpers
   config.include Shoulda::Matchers::ActiveRecord, type: :model
   config.include Shoulda::Matchers::ActiveModel, type: :model


### PR DESCRIPTION
Cette PR adresse quelques problèmes et améliore certains aspects autour de Flipper (en suivant les recommandations de la doc), ce qui soulagera considérablement l'impact sur la base.

- Correction d'un bug lors du clone des démarches: depuis le 29/11 on conserve les features lors du clone, mais cela **clonait aussi les 4 features activées globalement** (non spécifique à la démarche). Ce qui signifie qu'à chaque démarche clonée on crééait 4 entrées (environ 1800 par semaine). Or, l'ensemble des features étant préloadées à chaque hit, on arrivait à 20K rows chargées et conservées en mémoire (environ ~1 Mo de données renvoyées par pg)
- active le mode strict en dev: une feature "testée" non déclarée dans l'initializer ni activée déclenche une requête malgré le preload. Le mode strict provoque une erreur si c'est le cas (pas applicable en test à cause du reset avant chaque test)
- supprime toutes les features obsolètes (certaines n'avaient pas été supprimées correctement), y compris les 4 clonées inutilement par démarche
- Ne charge plus les features pour charger les assets et /ping
- utilise le cache RAM à très courte durée de vie: on va économiser 1 query/hit, donc environ ~ 30 queries/sec


Eventuellement plus tard on pourrait :  
- passer par redis
- ne plus faire de préload, et faire du cache rails pour team_on_strike nécessaire à chaque page

Cependant sorti du bug on est dans le genre de volumétrie recommandé pour le preload, avec un impact quasi nul sur la base grâce au cache en RAM