### PR TITLE
fix(data): avoid destroying 2M dossiers in one day due to error in Cron::ExpiredDossiersTermineDeletionJob

### DIFF
--- a/app/tasks/maintenance/spread_dossier_deletion_task.rb
+++ b/app/tasks/maintenance/spread_dossier_deletion_task.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class SpreadDossierDeletionTask < MaintenanceTasks::Task
+    ERROR_OCCURED_AT = Date.new(2024, 2, 14)
+    SPREAD_DURATION_IN_DAYS = 150
+
+    def collection
+      Dossier.where(termine_close_to_expiration_notice_sent_at: ERROR_OCCURED_AT)
+        .in_batches
+    end
+
+    def process(element)
+      element.update_all(termine_close_to_expiration_notice_sent_at: ERROR_OCCURED_AT + random_date_spread.days)
+    end
+
+    # since we do not keep track of current batch idx,
+    # delay termine_close_to_expiration_notice_sent_at using random approach
+    # should be good enough
+    def random_date_spread
+      rand(1..SPREAD_DURATION_IN_DAYS)
+    end
+  end
+end

--- a/spec/tasks/maintenance/spread_dossier_deletion_task_spec.rb
+++ b/spec/tasks/maintenance/spread_dossier_deletion_task_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe SpreadDossierDeletionTask do
+    describe "#process" do
+      let(:dossiers) { Dossier.all }
+      let(:dossier_1) { create(:dossier, termine_close_to_expiration_notice_sent_at: Date.new(2024, 2, 14)) }
+      let(:dossier_2) { create(:dossier, termine_close_to_expiration_notice_sent_at: Date.new(2024, 2, 14)) }
+      let(:dossier_3) { create(:dossier, termine_close_to_expiration_notice_sent_at: Date.new(2024, 2, 14)) }
+      let(:dossier_4) { create(:dossier, termine_close_to_expiration_notice_sent_at: Date.new(2024, 2, 14)) }
+      subject(:process) { described_class.process(dossiers) }
+
+      it "works" do
+        expect { subject }.to change { dossier_1.reload.termine_close_to_expiration_notice_sent_at }
+      end
+    end
+  end
+end


### PR DESCRIPTION
nous avons actuellement 2M dossiers qui seront supprimé le 19 mars. 
ça risque de poser quelques problèmes (quota mail, rate limiting api, charge au support etc...). 
l'idée est donc de spreader cette purge sur 150 jours (13k dossiers/jours) afin de ne pas trop solliciter l'infra/support etc..