### PR TITLE
ETQ usager je vois les informations de contact de mon groupe instructeur (si elles existent) dans mon attestation de dépôt

### DIFF
--- a/app/models/contact_information.rb
+++ b/app/models/contact_information.rb
@@ -21,4 +21,7 @@ class ContactInformation < ApplicationRecord
       "tel:#{telephone.gsub(/[[:blank:]]/, '')}"
     end
   end
+
+  def organisme
+  end
 end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -891,11 +891,11 @@ class Dossier < ApplicationRecord
       .passer_en_construction
       .processed_at
     save!
+    RoutingEngine.compute(self)
     MailTemplatePresenterService.create_commentaire_for_state(self, Dossier.states.fetch(:en_construction))
     NotificationMailer.send_en_construction_notification(self).deliver_later
     NotificationMailer.send_notification_for_tiers(self).deliver_later if self.for_tiers?
     procedure.compute_dossiers_count
-    RoutingEngine.compute(self)
   end
 
   def submit_en_construction!

--- a/app/views/users/dossiers/papertrail.pdf.prawn
+++ b/app/views/users/dossiers/papertrail.pdf.prawn
@@ -75,7 +75,7 @@ prawn_document(margin: [top_margin, right_margin, bottom_margin, left_margin], p
       pdf.text t('.dossier_state') + ' : ' + papertrail_dossier_state(@dossier), size: 10, character_spacing: -0.2, align: :justify
     end
 
-    service = @dossier.procedure.service
+    service = @dossier.service
     if service.present?
       pdf.fill_color black
       pdf.pad_top(30) { pdf.text t('.administrative_service'), size: 14, character_spacing: -0.2, align: :justify }


### PR DESCRIPTION
Sur une procédure routée, avec des groupes instructeurs ayant des informations de contact, l'attestation de dépôt mentionnait les coordonnées du service de la procédure.
-> si le groupe instructeur a des informations de contact, on les affiche à la place

voir https://secure.helpscout.net/conversation/2529161115/2059049/