### PR TITLE
Données : suppressions et mises à jour de bulk messages

### DIFF
--- a/app/tasks/maintenance/backfill_bulk_messages_with_procedure_id_task.rb
+++ b/app/tasks/maintenance/backfill_bulk_messages_with_procedure_id_task.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class BackfillBulkMessagesWithProcedureIdTask < MaintenanceTasks::Task
+    def collection
+      BulkMessage.all.filter { |bm| bm.procedure.nil? && bm.groupe_instructeurs.present? }
+    end
+
+    def process(element)
+      element.update(procedure_id: element.groupe_instructeurs.first.procedure.id)
+    end
+  end
+end

--- a/app/tasks/maintenance/destroy_incomplete_bulk_messages_task.rb
+++ b/app/tasks/maintenance/destroy_incomplete_bulk_messages_task.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class DestroyIncompleteBulkMessagesTask < MaintenanceTasks::Task
+    def collection
+      BulkMessage.all.filter { |bm| bm.procedure.nil? && bm.groupe_instructeurs.blank? }
+    end
+
+    def process(element)
+      element.destroy
+    end
+  end
+end


### PR DESCRIPTION
Corrige les bulk messages : 
- Ajoute un procedure_id à ceux qui sont liés à au moins un groupe instructeur
- Supprime ceux qui ne sont liés ni à une procédure ni à un groupe instructeur

A faire dans la PR à suivre : 
- ajouter une clé étrangère sur `bulk_message.procedure_id`
- ajouter un `has_many :bulk_messages, dependent: :destroy` dans le modèle procedure
- enlever la relation `has_and_belongs_to_many :groupe_instructeurs, -> { order(:label) }`