### PR TITLE
correctif(Export.export): ETQ expert téléchargeant un dossier et toutes ses PJs, la messagerie n'est pas dans l'export quand la procedure ne l'autorise pas. L'export ne contient pas les annotations privées

### DIFF
--- a/app/controllers/api/v2/dossiers_controller.rb
+++ b/app/controllers/api/v2/dossiers_controller.rb
@@ -2,7 +2,7 @@ class API::V2::DossiersController < API::V2::BaseController
   before_action :ensure_dossier_present
 
   def pdf
-    @acls = PiecesJustificativesService.new(user_profile: Administrateur.new).acl_for_dossier_export
+    @acls = PiecesJustificativesService.new(user_profile: Administrateur.new).acl_for_dossier_export(dossier.procedure)
     render(template: 'dossiers/show', formats: [:pdf])
   end
 

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -51,7 +51,7 @@ module Instructeurs
       @is_dossier_in_batch_operation = dossier.batch_operation.present?
       respond_to do |format|
         format.pdf do
-          @acls = PiecesJustificativesService.new(user_profile: current_instructeur).acl_for_dossier_export
+          @acls = PiecesJustificativesService.new(user_profile: current_instructeur).acl_for_dossier_export(dossier.procedure)
           render(template: 'dossiers/show', formats: [:pdf])
         end
         format.all

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -92,7 +92,7 @@ module Users
       respond_to do |format|
         format.pdf do
           @dossier = dossier_with_champs(pj_template: false)
-          @acls = pj_service.acl_for_dossier_export
+          @acls = pj_service.acl_for_dossier_export(@dossier.procedure)
           render(template: 'dossiers/show', formats: [:pdf])
         end
         format.all do

--- a/app/services/pieces_justificatives_service.rb
+++ b/app/services/pieces_justificatives_service.rb
@@ -85,7 +85,7 @@ class PiecesJustificativesService
     case @user_profile
     when Expert
       {
-        include_infos_administration: true,
+        include_infos_administration: false,
         include_avis_for_expert: true,
         only_for_expert: @user_profile
       }

--- a/app/services/pieces_justificatives_service.rb
+++ b/app/services/pieces_justificatives_service.rb
@@ -46,7 +46,7 @@ class PiecesJustificativesService
       pdf = ApplicationController
         .render(template: 'dossiers/show', formats: [:pdf],
                 assigns: {
-                  acls: acl_for_dossier_export,
+                  acls: acl_for_dossier_export(procedure),
                   dossier: dossier
                 })
 
@@ -81,22 +81,25 @@ class PiecesJustificativesService
     end
   end
 
-  def acl_for_dossier_export
+  def acl_for_dossier_export(procedure)
     case @user_profile
     when Expert
       {
+        include_messagerie: procedure.allow_expert_messaging,
         include_infos_administration: false,
         include_avis_for_expert: true,
         only_for_expert: @user_profile
       }
     when Instructeur, Administrateur
       {
+        include_messagerie: true,
         include_infos_administration: true,
         include_avis_for_expert: true,
         only_for_export: false
       }
     when User
       {
+        include_messagerie: true,
         include_infos_administration: false,
         include_avis_for_expert: false, # should be true, expert can use the messagerie, why not provide avis ?
         only_for_expert: false

--- a/app/views/dossiers/show.pdf.prawn
+++ b/app/views/dossiers/show.pdf.prawn
@@ -374,7 +374,7 @@ prawn_document(page_size: "A4") do |pdf|
     end
   end
 
-  if @dossier.commentaires.present?
+  if @acls[:include_messagerie] && @dossier.commentaires.present?
     add_title(pdf, 'Messagerie')
     @dossier.commentaires.each do |commentaire|
       add_message(pdf, commentaire)

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -910,7 +910,7 @@ describe Instructeurs::DossiersController, type: :controller do
         subject
       end
 
-      it { expect(assigns(:acls)).to eq(PiecesJustificativesService.new(user_profile: instructeur).acl_for_dossier_export) }
+      it { expect(assigns(:acls)).to eq(PiecesJustificativesService.new(user_profile: instructeur).acl_for_dossier_export(dossier.procedure)) }
       it { expect(assigns(:is_dossier_in_batch_operation)).to eq(false) }
       it { expect(response).to render_template 'dossiers/show' }
 

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -1114,7 +1114,7 @@ describe Users::DossiersController, type: :controller do
       end
 
       context 'when the dossier has been submitted' do
-        it { expect(assigns(:acls)).to eq(PiecesJustificativesService.new(user_profile: user).acl_for_dossier_export) }
+        it { expect(assigns(:acls)).to eq(PiecesJustificativesService.new(user_profile: user).acl_for_dossier_export(dossier.procedure)) }
         it { expect(response).to render_template('dossiers/show') }
       end
     end


### PR DESCRIPTION
# probleme 

remonté par: https://mattermost.incubateur.net/betagouv/pl/5ksny3qwfjyemcc95aqcm5p5ry

ETQ expert, faisant un export de dossier, l'export.pdf contenait la messagerie même si l'admin avait configuré que les experts n'avaient pas access a la messagerie. Aussi un fix suite a mes changements, on intégrait aussi les annotations privées... grosse bétise sry 🙇 

