### PR TITLE
Correctif : supprime l'information de contact à la suppression du groupe instructeur

### DIFF
--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -13,7 +13,7 @@ class GroupeInstructeur < ApplicationRecord
   has_and_belongs_to_many :bulk_messages, dependent: :destroy
 
   has_one :defaut_procedure, -> { with_discarded }, class_name: 'Procedure', foreign_key: :defaut_groupe_instructeur_id, dependent: :nullify, inverse_of: :defaut_groupe_instructeur
-  has_one :contact_information
+  has_one :contact_information, dependent: :destroy
 
   has_one_attached :signature
 

--- a/spec/models/groupe_instructeur_spec.rb
+++ b/spec/models/groupe_instructeur_spec.rb
@@ -129,6 +129,21 @@ describe GroupeInstructeur, type: :model do
     end
   end
 
+  describe 'destroy' do
+    context 'with contact information' do
+      let(:defaut_group) { procedure.defaut_groupe_instructeur }
+      let(:second_group) { create(:groupe_instructeur, procedure:) }
+
+      before do
+        second_group.update(contact_information: create(:contact_information))
+      end
+
+      it 'works' do
+        expect { second_group.destroy! }.not_to raise_error
+      end
+    end
+  end
+
   private
 
   def assign(procedure_to_assign, instructeur_assigne: instructeur)


### PR DESCRIPTION
Évite une erreur 500 à la suppression d'un groupe instructeur qui a des informations de contact

Voir https://demarches-simplifiees.sentry.io/issues/4739032972