### PR TITLE
correctif(attestation): ETQ usager, je ne souhaite pas voir apparaitre des balaises HTML dans mon attestation au format pdf

### DIFF
--- a/app/views/administrateurs/attestation_templates/show.pdf.prawn
+++ b/app/views/administrateurs/attestation_templates/show.pdf.prawn
@@ -20,7 +20,7 @@ max_logo_height = 50.mm
 max_signature_size = 50.mm
 
 def normalize_pdf_text(text)
-  text&.tr("\t", '  ')
+  strip_tags(text&.tr("\t", '  '))
 end
 
 title = normalize_pdf_text(@attestation.fetch(:title))


### PR DESCRIPTION
cf: https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_3698937a-90e0-4f57-8860-ffb0cbcc32a9/

# probleme 
dans le [app/models/concerns/tags_substitution_concern.rb](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/blob/1024557081fbb958b660a62825188efcc86337db/app/models/concerns/tags_substitution_concern.rb#L69), nous faisons un `simple_format(motivation)`, ce qui englobe le contenu dans une balise `<p>#{motivation}</p>`. Résultat cette balise HTML se retrouve dans l'attestation.

# solution 
on souhaite eviter que des tags se retrouvent dans l'attestion, de fait on `strip_tags(content)` dans notre normalizer de text pour pdf.