### PR TITLE
fix(export): do not cast values, otherwise decimal number with leading 0 are lost 💍 

### DIFF
--- a/app/models/champs/decimal_number_champ.rb
+++ b/app/models/champs/decimal_number_champ.rb
@@ -27,6 +27,6 @@ class Champs::DecimalNumberChamp < Champ
   def processed_value
     return unless valid_champ_value?
 
-    value&.to_f
+    value.to_s
   end
 end

--- a/app/models/champs/integer_number_champ.rb
+++ b/app/models/champs/integer_number_champ.rb
@@ -22,6 +22,6 @@ class Champs::IntegerNumberChamp < Champ
   def processed_value
     return unless valid_champ_value?
 
-    value&.to_i
+    value.to_s
   end
 end

--- a/spec/controllers/api/v1/dossiers_controller_spec.rb
+++ b/spec/controllers/api/v1/dossiers_controller_spec.rb
@@ -290,7 +290,7 @@ describe API::V1::DossiersController do
               expect(subject.size).to eq(2)
               expect(subject[0][:id]).to eq(1)
               expect(subject[0][:champs].size).to eq(2)
-              expect(subject[0][:champs].map { |c| c[:value] }).to eq(['text', 42])
+              expect(subject[0][:champs].map { |c| c[:value] }).to eq(['text', "42"])
               expect(subject[0][:champs].map { |c| c[:type_de_champ][:type_champ] }).to eq(['text', 'integer_number'])
             end
           end


### PR DESCRIPTION
https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_ce92fb59-c85b-4933-a38d-745b2d2280d6/

# problème : 

un admin utilise un champ de type decimal pour récupérer des nombres commençant par 0, ex: 0123456789.
le casting côté code vire les 0 initiaux... 

# solution 

on ne typecast pas. Par contre ça me chagrine... pske 0123456789 ca ne me semble pas etre un entier mais plutôt une chaine de caractère. il y a donc p-e debat sur l'usage du champ decimal. ça devrait être un champ texte court, limite une regexp
