### PR TITLE
fix(dossier): safely remove child champs in apply_diff

### DIFF
--- a/app/models/concerns/dossier_clone_concern.rb
+++ b/app/models/concerns/dossier_clone_concern.rb
@@ -167,11 +167,12 @@ module DossierCloneConcern
     end
 
     champs_to_remove += diff[:removed]
-    champs_to_remove
-      .filter { !_1.child? || !champs_to_remove.include?(_1.parent) }
-      .each do |champ|
-        champ.rows.flatten.each(&:destroy!) if champ.repetition?
-        champ.destroy!
-      end
+    children_champs_to_remove, root_champs_to_remove = champs_to_remove.partition(&:child?)
+
+    children_champs_to_remove.each(&:destroy!)
+    root_champs_to_remove.each do |champ|
+      champ.rows.flatten.each(&:destroy!) if champ.repetition?
+      champ.destroy!
+    end
   end
 end


### PR DESCRIPTION
https://demarches-simplifiees.sentry.io/issues/5044598434/?project=1429550&query=is%3Aunresolved+%21has%3Adelayed_job.id+violates+foreign+key&referrer=issue-stream&sort=trends&statsPeriod=30d&stream_index=1