### PR TITLE
Admin: corrige un bug ou un message d'erreur d expression regulière apparaissait plusieurs fois

### DIFF
--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -649,6 +649,9 @@ class TypeDeChamp < ApplicationRecord
   end
 
   def invalid_regexp?
+    self.errors.delete(:expression_reguliere)
+    self.errors.delete(:expression_reguliere_exemple_text)
+
     return false if expression_reguliere.blank?
     return false if expression_reguliere_exemple_text.blank?
     return false if expression_reguliere_exemple_text.match?(Regexp.new(expression_reguliere, timeout: ExpressionReguliereValidator::TIMEOUT))

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -174,9 +174,13 @@ describe TypeDeChamp do
       let(:expression_reguliere_exemple_text) { "01234567" }
       let(:expression_reguliere) { "[A-Z]+" }
 
-      it "should add error message" do
+      it "should add only one error message" do
         expect(subject).to be_truthy
-        expect(tdc.errors.messages[:expression_reguliere_exemple_text]).to be_present
+        expect(tdc.errors.messages[:expression_reguliere_exemple_text].size).to eq(1)
+
+        tdc.invalid_regexp?
+
+        expect(tdc.errors.messages[:expression_reguliere_exemple_text].size).to eq(1)
       end
     end
 


### PR DESCRIPTION
voir https://secure.helpscout.net/conversation/2532984418/2060777?folderId=1653799

A chaque fois qu'on calcule si la regexp est valide, on remplit le model errors.
Fix: on nettoie avant de le re remplir. 