### PR TITLE
Tech: pas d'erreur EmailEvent lorsque le message ne peut pas avoir plusieurs destinataires

### DIFF
--- a/app/models/email_event.rb
+++ b/app/models/email_event.rb
@@ -15,7 +15,7 @@ class EmailEvent < ApplicationRecord
 
   class << self
     def create_from_message!(message, status:)
-      to = message.to || ["unset"] # no recipients when error occurs *before* setting to: in the mailer
+      to = message.to_addrs || ["unset"] # no recipients when error occurs *before* setting to: in the mailer
 
       to.each do |recipient|
         EmailEvent.create!(


### PR DESCRIPTION
Fix majorité de ces erreurs
https://demarches-simplifiees.sentry.io/issues/4734936319

`message.to` renvoie le header tel qu'il est parsé (pas nécessairement un array contrairement à `.to_addrs`), ceci arrive lorsqu'un email contient des `<` ou d'autres caractères spéciaux qui empêchent la saisie de multiples destinataires

Cela dit la regex a été renforcée depuis