### PR TITLE
Tech: ne remonte plus que 10% des InvalidAuthenticityToken errors

### DIFF
--- a/app/controllers/application_controller/error_handling.rb
+++ b/app/controllers/application_controller/error_handling.rb
@@ -5,10 +5,12 @@ module ApplicationController::ErrorHandling
     rescue_from ActionController::InvalidAuthenticityToken do
       # When some browsers (like Safari) re-open a previously closed tab, they attempts
       # to reload the page – even if it is a POST request. But in that case, they don’t
-      # sends any of the cookies.
+      # sends any of the cookies and we don’t report this error.
       #
-      # In that case, don’t report this error.
-      if request.cookies.count > 0
+      # There are dozens of these "errors" every day,
+      # we only log them to detect massive attacks or global errors
+      # without having thousands reports.
+      if request.cookies.any? && rand(10) == 0
         log_invalid_authenticity_token_error
       end
 

--- a/spec/controllers/application_controller/error_handling_spec.rb
+++ b/spec/controllers/application_controller/error_handling_spec.rb
@@ -16,7 +16,10 @@ RSpec.describe ApplicationController::ErrorHandling, type: :controller do
       { 'some_cookie': true }
     end
 
-    before { cookies.update(request_cookies) }
+    before do
+      cookies.update(request_cookies)
+      allow(controller).to receive(:rand).and_return(0)
+    end
 
     it 'logs the error' do
       allow(Sentry).to receive(:capture_message)


### PR DESCRIPTION
https://demarches-simplifiees.sentry.io/issues/4275512708/?

Motivation : 
- ces erreurs sont la plupart du temps légitimes, on en a 100-400/jour en temps normal
- en cas d'attaque / exploration ywh, ça monte facilement à plusieurs dizaines de milliers à jour et ça nous spam
- on veut juste être alerté d'alertes légitimes d'attaques ou erreurs globales

On aurait pu laisser que 1% plutôt que 10% mais j'ai peur que si on en a 100K d'un coup en réel, on ne les regarde pas plus que ça si on en voit que 1000 sur sentry, alors que 10K ça saute quand même aux yeux.