### PR TITLE
refactor(dossier_vide): use types_de_champ instead of empty dossier

### DIFF
--- a/app/controllers/users/commencer_controller.rb
+++ b/app/controllers/users/commencer_controller.rb
@@ -151,7 +151,7 @@ module Users
     end
 
     def generate_empty_pdf(revision)
-      @dossier = revision.new_dossier
+      @revision = revision
       data = render_to_string(template: 'dossiers/dossier_vide', formats: [:pdf])
       send_data(data, filename: "#{revision.procedure.libelle}.pdf")
     end

--- a/app/models/champs/linked_drop_down_list_champ.rb
+++ b/app/models/champs/linked_drop_down_list_champ.rb
@@ -1,5 +1,5 @@
 class Champs::LinkedDropDownListChamp < Champ
-  delegate :primary_options, :secondary_options, to: 'type_de_champ.dynamic_type'
+  delegate :primary_options, :secondary_options, to: :type_de_champ
 
   def options?
     drop_down_list_options?

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -133,15 +133,6 @@ class ProcedureRevision < ApplicationRecord
     changes
   end
 
-  def new_dossier
-    Dossier.new(
-      revision: self,
-      champs_public: build_champs_public,
-      champs_private: build_champs_private,
-      groupe_instructeur: procedure.defaut_groupe_instructeur
-    )
-  end
-
   def dossier_for_preview(user)
     dossier = Dossier
       .create_with(autorisation_donnees: true)

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -167,6 +167,8 @@ class TypeDeChamp < ApplicationRecord
 
   attr_reader :dynamic_type
 
+  delegate :primary_options, :secondary_options, to: :dynamic_type
+
   scope :public_only, -> { where(private: false) }
   scope :private_only, -> { where(private: true) }
   scope :repetition, -> { where(type_champ: type_champs.fetch(:repetition)) }

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -1366,26 +1366,6 @@ describe Procedure do
     it { expect(Procedure.default_sort).to eq({ "table" => "self", "column" => "id", "order" => "desc" }) }
   end
 
-  describe '#new_dossier' do
-    let(:procedure) do
-      create(:procedure,
-        types_de_champ_public: [{}, { type: :number }],
-        types_de_champ_private: [{ type: :textarea }])
-    end
-
-    let(:dossier) { procedure.active_revision.new_dossier }
-
-    it { expect(dossier.procedure).to eq(procedure) }
-
-    it { expect(dossier.champs_public.size).to eq(2) }
-    it { expect(dossier.champs_public.first.type).to eq("Champs::TextChamp") }
-
-    it { expect(dossier.champs_private.size).to eq(1) }
-    it { expect(dossier.champs_private.first.type).to eq("Champs::TextareaChamp") }
-
-    it { expect(Champ.count).to eq(0) }
-  end
-
   describe "#organisation_name" do
     subject { procedure.organisation_name }
     context 'when the procedure has a service (and no organization)' do

--- a/spec/views/dossiers/dossier_vide.pdf.prawn_spec.rb
+++ b/spec/views/dossiers/dossier_vide.pdf.prawn_spec.rb
@@ -1,10 +1,9 @@
 describe 'dossiers/dossier_vide', type: :view do
   let(:procedure) { create(:procedure, :with_all_champs) }
-  let(:dossier) { create(:dossier, procedure: procedure) }
 
   before do
     assign(:procedure, procedure)
-    assign(:dossier, dossier)
+    assign(:revision, procedure.draft_revision)
   end
 
   subject { render }


### PR DESCRIPTION
- On arrête de créer des dossiers en mémoire (source de bugs)
- On render les champs dans le bon ordre