### PR TITLE
Super-Admins: évite que le géocodage des services tombe sur une mauvaise commune

### DIFF
--- a/app/jobs/api_entreprise/service_job.rb
+++ b/app/jobs/api_entreprise/service_job.rb
@@ -5,14 +5,19 @@ class APIEntreprise::ServiceJob < APIEntreprise::Job
     service_params = APIEntreprise::ServiceAdapter.new(service.siret, service_id).to_params
     service.etablissement_infos = service_params
 
-    point = Geocoder.search(service_params[:adresse]).first
-
-    service.etablissement_lat = point&.latitude
-    service.etablissement_lng = point&.longitude
-
     code_insee = service.etablissement_infos['code_insee_localite']
-    if code_insee
+    if code_insee.present?
       service.departement = CodeInsee.new(code_insee).to_departement
+    end
+
+    if service_params[:adresse].present?
+      point = Geocoder.search(service_params[:adresse], params: { citycode: code_insee, limit: 1 }).first
+
+      service.etablissement_lat = point&.latitude
+      service.etablissement_lng = point&.longitude
+    else
+      service.etablissement_lat = nil
+      service.etablissement_lng = nil
     end
 
     service.save!

--- a/app/tasks/maintenance/update_service_etablissement_infos_task.rb
+++ b/app/tasks/maintenance/update_service_etablissement_infos_task.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class UpdateServiceEtablissementInfosTask < MaintenanceTasks::Task
+    # No more 20 geocoding by 10 seconds window
+    THROTTLE_LIMIT = 20
+    THROTTLE_PERIOD = 10.seconds
+
+    @@request_count = 0
+    @@period_start = Time.current
+
+    throttle_on(backoff: THROTTLE_LIMIT) do
+      if Time.current - @@period_start > THROTTLE_PERIOD
+        @@request_count = 0
+        @@period_start = Time.current
+      end
+
+      @@request_count += 1
+      @@request_count > THROTTLE_LIMIT
+    end
+
+    def collection
+      Service.where.not(siret: nil)
+    end
+
+    def process(service)
+      APIEntreprise::ServiceJob.perform_now(service.id)
+    end
+
+    def count
+      collection.count
+    end
+  end
+end

--- a/spec/jobs/api_entreprise/service_job_spec.rb
+++ b/spec/jobs/api_entreprise/service_job_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe APIEntreprise::ServiceJob, type: :job do
 
     Geocoder.configure(lookup: :ban_data_gouv_fr, use_https: true)
 
-    stub_request(:get, "https://api-adresse.data.gouv.fr/search/?q=#{adresse}")
+    stub_request(:get, "https://api-adresse.data.gouv.fr/search/?citycode=75112&limit=1&q=#{adresse}")
       .to_return(body: geocoder_body, status: status)
   end
 
@@ -67,7 +67,7 @@ RSpec.describe APIEntreprise::ServiceJob, type: :job do
       geocoder_response = JSON.parse(geocoder_body)
       geocoder_response["features"] = []
 
-      stub_request(:get, "https://api-adresse.data.gouv.fr/search/?q=#{adresse}")
+      stub_request(:get, "https://api-adresse.data.gouv.fr/search/?citycode=75112&limit=1&q=#{adresse}")
         .to_return(body: JSON.generate(geocoder_response), status: status)
 
       subject


### PR DESCRIPTION
Parfois mis sur une mauvaise commune, donc sur une suggestion de Christian on filtre par code INSEE.
Cf tchap
