### PR TITLE
fix(data): update procedure with duree_conservation greater than max_duree

### DIFF
--- a/app/tasks/maintenance/fix_duree_conservation_greater_than_max_duree_conservation_task.rb
+++ b/app/tasks/maintenance/fix_duree_conservation_greater_than_max_duree_conservation_task.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class FixDureeConservationGreaterThanMaxDureeConservationTask < MaintenanceTasks::Task
+    def collection
+      Procedure.where('duree_conservation_dossiers_dans_ds > max_duree_conservation_dossiers_dans_ds')
+    end
+
+    def process(element)
+      max_duree = element.max_duree_conservation_dossiers_dans_ds
+      element.update!(duree_conservation_dossiers_dans_ds: max_duree)
+    end
+
+    def count
+      # Optionally, define the number of rows that will be iterated over
+      # This is used to track the task's progress
+      collection.count
+    end
+  end
+end

--- a/spec/tasks/maintenance/fix_duree_conservation_greater_than_max_duree_conservation_task_spec.rb
+++ b/spec/tasks/maintenance/fix_duree_conservation_greater_than_max_duree_conservation_task_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe FixDureeConservationGreaterThanMaxDureeConservationTask do
+    describe "#process" do
+      subject(:process) do
+        described_class.process(procedure)
+      end
+
+      let(:procedure) { create(:procedure, :published) }
+
+      before { procedure.update_column(:duree_conservation_dossiers_dans_ds, 60) }
+
+      it 'fixes invalid procedure' do
+        expect(procedure.duree_conservation_dossiers_dans_ds).to eq 60
+        expect(procedure).to be_invalid
+        subject
+        expect(procedure.duree_conservation_dossiers_dans_ds).to eq 36
+        expect(procedure).to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
18 démarches en prod sont invalides car elles ont une durée de conservation des dossiers supérieure à la durée max.
Je corrige avec cette maintenace task
Ça avait fait planter la maintenance task de cette PR https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/9930