### PR TITLE
fix(maintenance task): pass a collection instead of an array

### DIFF
--- a/app/tasks/maintenance/backfill_bulk_messages_with_procedure_id_task.rb
+++ b/app/tasks/maintenance/backfill_bulk_messages_with_procedure_id_task.rb
@@ -3,7 +3,7 @@
 module Maintenance
   class BackfillBulkMessagesWithProcedureIdTask < MaintenanceTasks::Task
     def collection
-      BulkMessage.all.filter { |bm| bm.procedure.nil? && bm.groupe_instructeurs.present? }
+      BulkMessage.where(procedure: nil).where.missing(:groupe_instructeurs)
     end
 
     def process(element)

--- a/app/tasks/maintenance/destroy_incomplete_bulk_messages_task.rb
+++ b/app/tasks/maintenance/destroy_incomplete_bulk_messages_task.rb
@@ -3,7 +3,7 @@
 module Maintenance
   class DestroyIncompleteBulkMessagesTask < MaintenanceTasks::Task
     def collection
-      BulkMessage.all.filter { |bm| bm.procedure.nil? && bm.groupe_instructeurs.blank? }
+      BulkMessage.where(procedure: nil).where.missing(:groupe_instructeurs)
     end
 
     def process(element)


### PR DESCRIPTION
Les deux maintenance tasks de #10071 ont échoué parce que la collection passée à la tâche était un tableau d'objects Active Records.
Il faut passer une collection. C'est en discussion [ici](https://github.com/Shopify/maintenance_tasks/discussions/870)