### PR TITLE
ETQ admin: ajoute des messages manquants dans la liste des modifications d'annotations privées

### DIFF
--- a/app/components/procedure/revision_changes_component/revision_changes_component.fr.yml
+++ b/app/components/procedure/revision_changes_component/revision_changes_component.fr.yml
@@ -56,19 +56,27 @@ fr:
     update_libelle: Le libellé de l’annotation privée « %{label} » a été modifié. Le nouveau libellé est « %{to} ».
     update_description: La description de l’annotation privée « %{label} » a été modifiée. La nouvelle description est « %{to} ».
     remove_description: La description de l’annotation privée « %{label} » a été supprimée.
-    update_drop_down_secondary_libelle: Le libellé secondaire de l’annotation « %{label} » a été modifié. Le nouveau libellé est « %{to} ».
-    update_drop_down_secondary_description: La description secondaire de l’annotation « %{label} » a été modifiée. La nouvelle description est « %{to} ».
+    update_drop_down_secondary_libelle: Le libellé secondaire de l’annotation privée « %{label} » a été modifié. Le nouveau libellé est « %{to} ».
+    update_drop_down_secondary_description: La description secondaire de l’annotation privée « %{label} » a été modifiée. La nouvelle description est « %{to} ».
     update_type_champ: Le type de l’annotation privée « %{label} » a été modifié. Elle est maintenant de type « %{to} ».
     update_piece_justificative_template: Le modèle de pièce justificative de l’annotation privée « %{label} » a été modifié.
-    update_notice_explicative: La notice explicative l’annotation privée « %{label} » a été modifiée.
+    update_notice_explicative: La notice explicative de l’annotation privée « %{label} » a été modifiée.
     update_drop_down_options: "Les options de sélection de l’annotation privée « %{label} » ont été modifiées :"
-    update_carte_layers: "Les référentiels cartographiques de l’annotation privée « %{label} » ont été modifiés :"
     enable_drop_down_other: L’annotation privée « %{label} » comporte maintenant un choix « Autre ».
     disable_drop_down_other: L’annotation privée « %{label} » ne comporte plus de choix « Autre ».
-    enable_collapsible_explanation: Le texte complémentaire affichable au clic de l’annotation privée « %{label} » a été ajouté.
-    disable_collapsible_explanation: Le texte complémentaire affichable au clic de l’annotation privée « %{label} » a été supprimé.
-    update_collapsible_explanation: Le texte complémentaire affichable au clic de l’annotation privée « %{label} » a été modifié. Le nouveau texte est « %{to} ».
-    remove_collapsible_explanation: Le texte complémentaire affichable au clic de l’annotation privée « %{label} » a été supprimé.
+    update_carte_layers: "Les référentiels cartographiques de l’annotation privée « %{label} » ont été modifiés :"
+    enable_update_collapsible_explanation: Le texte complémentaire affichable au clic de l’annotation privée « %{label} » a été ajoutée.
+    disable_update_collapsible_explanation: Le texte complémentaire affichable au clic de l’annotation privée « %{label} » a été supprimé.
+    update_collapsible_explanation_text: Le texte complémentaire affichable au clic de l’annotation privée « %{label} » a été modifié. Le nouveau texte est « %{to} ».
+    remove_collapsible_explanation_text: Le texte complémentaire affichable au clic de l’annotation privée « %{label} » a été supprimé.
     add_condition: Une condition a été ajoutée sur l’annotation privée « %{label} ». La nouvelle condition est « %{to} ».
     remove_condition: La condition de l’annotation privée « %{label} » a été supprimée.
     update_condition: La condition de l’annotation privée « %{label} » a été modifiée. La nouvelle condition est « %{to} ».
+    update_character_limit: La limite de caractères de l’annotation privée texte « %{label} » a été modifiée. La nouvelle limite est « %{to} ».
+    remove_character_limit: La limite de caractères de l’annotation privée texte « %{label} » a été supprimée.
+    remove_expression_reguliere: L’expression régulière de l’annotation privée « %{label} » a été supprimée.
+    update_expression_reguliere: L’expression régulière de l’annotation privée « %{label} » a été modifiée. La nouvelle expression est « %{to} ».
+    remove_expression_reguliere_exemple_text: L’exemple d’expression régulière de l’annotation privée « %{label} » a été supprimé.
+    update_expression_reguliere_exemple_text: L’exemple d’expression régulière de l’annotation privée « %{label} » a été modifiée. Le nouvel exemple est « %{to} ».
+    remove_expression_reguliere_error_message: Le message d’erreur de l’expression régulière de l’annotation privée « %{label} » a été supprimé.
+    update_expression_reguliere_error_message: Le message d’erreur de l’expression régulière de l’annotation privée « %{label} » a été modifiée. Le nouveau message est « %{to} ».

--- a/app/components/procedure/revision_changes_component/revision_changes_component.html.haml
+++ b/app/components/procedure/revision_changes_component/revision_changes_component.html.haml
@@ -111,7 +111,7 @@
             = t(".#{prefix}.enable_collapsible_explanation", label: change.label)
         - else
           - list.with_item do
-            = t(".#{prefix}.disable_collapsible_explanation", label: change.label)
+            = t(".#{prefix}.remove_collapsible_explanation_text", label: change.label)
       - when :collapsible_explanation_text
         - list.with_item do
           - if change.to.blank?


### PR DESCRIPTION
je suis reparti de la liste complète pour les champs, en enlevant les 2-3 inutiles pour les annotations privées