### PR TITLE
ETQ admin j'ai un message d'explication si j'utilise une URL déja utilisée lors de la publication d'une démarche

### DIFF
--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -3,7 +3,7 @@ module Administrateurs
     layout 'all', only: [:all, :administrateurs]
     respond_to :html, :xlsx
 
-    before_action :retrieve_procedure, only: [:champs, :annotations, :modifications, :edit, :zones, :monavis, :update_monavis, :jeton, :update_jeton, :publication, :publish, :transfert, :close, :confirmation, :allow_expert_review, :allow_expert_messaging, :experts_require_administrateur_invitation, :reset_draft, :publish_revision]
+    before_action :retrieve_procedure, only: [:champs, :annotations, :modifications, :edit, :zones, :monavis, :update_monavis, :jeton, :update_jeton, :publication, :publish, :transfert, :close, :confirmation, :allow_expert_review, :allow_expert_messaging, :experts_require_administrateur_invitation, :reset_draft, :publish_revision, :check_path]
     before_action :draft_valid?, only: [:apercu]
     after_action :reset_procedure, only: [:update]
 
@@ -280,6 +280,17 @@ module Administrateurs
         @procedure.path = @procedure.suggested_path(current_administrateur)
         @current_administrateur = current_administrateur
         @closed_procedures = current_administrateur.procedures.with_discarded.closes.map { |p| ["#{p.libelle} (#{p.id})", p.id] }.to_h
+      end
+    end
+
+    def check_path
+      @path_available = @procedure.path_available?(params[:path])
+      @other_procedure = @procedure.other_procedure_with_path(params[:path])
+      @administrateur = current_administrateur
+      respond_to do |format|
+        format.turbo_stream do
+          render :check_path
+        end
       end
     end
 

--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -286,7 +286,6 @@ module Administrateurs
     def check_path
       @path_available = @procedure.path_available?(params[:path])
       @other_procedure = @procedure.other_procedure_with_path(params[:path])
-      @administrateur = current_administrateur
       respond_to do |format|
         format.turbo_stream do
           render :check_path

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -387,7 +387,7 @@ class Procedure < ApplicationRecord
     slug = libelle&.parameterize&.first(50)
     suggestion = slug
     counter = 1
-    while !path_available?(administrateur, suggestion)
+    while !path_available?(suggestion)
       counter = counter + 1
       suggestion = "#{slug}-#{counter}"
     end
@@ -400,10 +400,8 @@ class Procedure < ApplicationRecord
       .find_by(path: path)
   end
 
-  def path_available?(administrateur, path)
-    procedure = other_procedure_with_path(path)
-
-    procedure.blank? || (administrateur.owns?(procedure) && canonical_procedure_child?(procedure))
+  def path_available?(path)
+    other_procedure_with_path(path).blank?
   end
 
   def canonical_procedure_child?(procedure)

--- a/app/views/administrateurs/procedures/_publication_form_inputs.html.haml
+++ b/app/views/administrateurs/procedures/_publication_form_inputs.html.haml
@@ -14,8 +14,11 @@
                       placeholder: t('activerecord.attributes.procedure.procedure_path_placeholder'),
                       required: true,
                       class: 'unstyled flex-1',
-                      pattern: '^[a-z0-9_-]{3,200}$',
-                      autocomplete: 'off')
+                      pattern: '[a-z0-9.\-_]{3,200}',
+                      autocomplete: 'off',
+                      data: { controller: 'turbo-input', turbo_input_url_value: admin_procedure_check_path_path })
+
+  #check_path
 
 .fr-input-group
   = label_tag :lien_site_web, class: 'fr-label' do

--- a/app/views/administrateurs/procedures/check_path.turbo_stream.haml
+++ b/app/views/administrateurs/procedures/check_path.turbo_stream.haml
@@ -1,5 +1,5 @@
 = turbo_stream.update 'check_path' do
-  - if @path_available == false && @administrateur.owns?(@other_procedure)
+  - if @path_available == false && current_administrateur.owns?(@other_procedure)
     %p.fr-error-text= t('.path_not_available.owner')
   - elsif @path_available == false
     %p.fr-error-text= t('.path_not_available.not_owner')

--- a/app/views/administrateurs/procedures/check_path.turbo_stream.haml
+++ b/app/views/administrateurs/procedures/check_path.turbo_stream.haml
@@ -1,0 +1,6 @@
+= turbo_stream.update 'check_path' do
+  - if @path_available == false && @administrateur.owns?(@other_procedure)
+    %p.fr-error-text= t('.path_not_available.owner')
+  - elsif @path_available == false
+    %p.fr-error-text= t('.path_not_available.not_owner')
+  - else

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -650,8 +650,7 @@ en:
           attributes:
             path:
               taken: is already used for procedure. You cannot use it because it belongs to another administrator.
-              taken_can_be_claimed: Is the same as another of your procedure. If you publish this procedure, the other one will be unpublished
-              invalid: is not valid. It must countain between 3 and 50 characters among a-z, 0-9, '_' and '-'.
+              invalid: is not valid. It must countain between 3 and 200 characters among a-z, 0-9, '_' and '-'.
         "dossier/champs":
           format: "%{message}"
           attributes:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -652,8 +652,7 @@ fr:
           attributes:
             path:
               taken: est déjà utilisé par une démarche. Vous ne pouvez pas l’utiliser car il appartient à un autre administrateur.
-              taken_can_be_claimed: est identique à celui d’une autre de vos démarches publiées. Si vous publiez cette démarche, l’ancienne sera dépubliée et ne sera plus accessible au public. Les utilisateurs qui ont commencé un brouillon vont pouvoir le déposer.
-              invalid: n’est pas valide. Il doit comporter au moins 3 caractères, au plus 50 caractères et seuls les caractères a-z, 0-9, '_' et '-' sont autorisés.
+              invalid: n’est pas valide. Il doit comporter au moins 3 caractères, au plus 200 caractères et seuls les caractères a-z, 0-9, '_' et '-' sont autorisés.
         "dossier/champs":
           format: "%{message}"
           attributes:

--- a/config/locales/views/administrateurs/procedures/en.yml
+++ b/config/locales/views/administrateurs/procedures/en.yml
@@ -51,6 +51,10 @@ en:
         dpd_part_4: How to do ? You can either send him the link to the procedure on test stage by email, or name him "administrator". In any case, publish your approach only after having had his opinion.
         back_to_procedure: 'Cancel and return to the procedure page'
         submit: Publish
+      check_path:
+        path_not_available:
+          owner: This URL is identical to another of your published procedures. If you publish this procedure, the old one will be unpublished and will no longer be accessible to the public.
+          not_owner: This URL is identical to another procedure, you must modify it.
     autosave_notice:
       form_saved: "Form saved"
       form_error: "Form in error"

--- a/config/locales/views/administrateurs/procedures/fr.yml
+++ b/config/locales/views/administrateurs/procedures/fr.yml
@@ -51,6 +51,10 @@ fr:
         dpd_part_4: Comment faire ? Vous pouvez soit lui communiquer par email le lien vers la démarche en test, ou bien le nommer « administrateur ». Dans tous les cas, ne publiez votre démarche qu’après avoir eu son avis.
         back_to_procedure: 'Annuler et revenir à la page de la démarche'
         submit: Publier
+      check_path:
+        path_not_available:
+          owner: Cette url est identique à celle d’une autre de vos démarches publiées. Si vous publiez cette démarche, l’ancienne sera dépubliée et ne sera plus accessible au public.
+          not_owner: Cette url est identique à celle d’une autre démarche, vous devez la modifier afin de pouvoir publier votre démarche.
     autosave_notice:
       form_saved: "Formulaire enregistré"
       form_error: "Formulaire en erreur"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -595,6 +595,7 @@ Rails.application.routes.draw do
       put 'clone'
       put 'archive'
       get 'publication' => 'procedures#publication', as: :publication
+      get 'check_path' => 'procedures#check_path', as: :check_path
       put 'publish' => 'procedures#publish', as: :publish
       put 'reset_draft' => 'procedures#reset_draft', as: :reset_draft
       put 'publish_revision' => 'procedures#publish_revision', as: :publish_revision

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -1317,7 +1317,7 @@ describe Procedure do
         create(:procedure, aasm_state: :publiee, path: 'inscription-au-college', administrateurs: procedure.administrateurs, zones: [create(:zone)])
       end
 
-      it { is_expected.to eq 'inscription-au-college' }
+      it { is_expected.to eq 'inscription-au-college-2' }
     end
   end
 

--- a/spec/system/administrateurs/procedure_cloning_spec.rb
+++ b/spec/system/administrateurs/procedure_cloning_spec.rb
@@ -52,7 +52,10 @@ describe 'As an administrateur I wanna clone a procedure', js: true do
 
       # then publish
       find('#publish-procedure-link').click
-      expect(find_field('procedure_path').value).to eq 'libelle-de-la-procedure'
+      expect(find_field('procedure_path').value).to eq 'libelle-de-la-procedure-2'
+      fill_in 'procedure_path', with: 'libelle-de-la-procedure'
+      expect(page).to have_content 'Si vous publiez cette démarche, l’ancienne sera dépubliée et ne sera plus accessible au public.'
+
       fill_in 'lien_site_web', with: 'http://some.website'
       click_on 'publish'
 
@@ -87,7 +90,9 @@ describe 'As an administrateur I wanna clone a procedure', js: true do
 
       # then publish
       find('#publish-procedure-link').click
-      expect(find_field('procedure_path').value).to eq 'libelle-de-la-procedure'
+      expect(find_field('procedure_path').value).to eq 'libelle-de-la-procedure-2'
+      fill_in 'procedure_path', with: 'libelle-de-la-procedure'
+      expect(page).to have_content 'Si vous publiez cette démarche, l’ancienne sera dépubliée et ne sera plus accessible au public.'
       fill_in 'lien_site_web', with: 'http://some.website'
       click_on 'publish'
 

--- a/spec/system/administrateurs/procedure_publish_spec.rb
+++ b/spec/system/administrateurs/procedure_publish_spec.rb
@@ -4,6 +4,8 @@ describe 'Publishing a procedure', js: true do
   include ProcedureSpecHelper
 
   let(:administrateur) { create(:administrateur) }
+  let(:other_administrateur) { create(:administrateur) }
+
   let(:instructeurs) { [administrateur.user.instructeur] }
   let!(:procedure) do
     create(:procedure_with_dossiers,
@@ -13,6 +15,16 @@ describe 'Publishing a procedure', js: true do
       :with_zone,
       instructeurs: instructeurs,
       administrateur: administrateur)
+  end
+  let!(:other_procedure) do
+    create(:procedure_with_dossiers,
+      :published,
+      :with_path,
+      :with_type_de_champ,
+      :with_service,
+      :with_zone,
+      instructeurs: instructeurs,
+      administrateur: other_administrateur)
   end
 
   before do
@@ -68,6 +80,19 @@ describe 'Publishing a procedure', js: true do
         fill_in 'lien_site_web', with: 'http://some.website'
 
         expect(page).to have_button('Publier', disabled: true)
+      end
+    end
+
+    context 'when the procedure has the same path as another procedure from another admin ' do
+      scenario 'an error message prevents the publication' do
+        expect(find_field('procedure_path').value).to eq procedure.path
+        fill_in 'procedure_path', with: other_procedure.path
+        expect(page).to have_content 'vous devez la modifier afin de pouvoir publier votre démarche'
+
+        fill_in 'lien_site_web', with: 'http://some.website'
+        within('form') { click_on 'Publier' }
+
+        expect(page).to have_text('Le champ « Lien public » est déjà utilisé par une démarche.')
       end
     end
   end


### PR DESCRIPTION
closes #10105 

**Quand l'admin n'est pas "owner" de la demarche avec la meme URL**
<img width="882" alt="Capture d’écran 2024-03-14 à 17 09 42" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/384eac10-0d6d-4b4c-8561-c0f77c96a2bf">

**Quand l'admin est "owner" de la demarche avec la meme URL**
<img width="601" alt="Capture d’écran 2024-03-14 à 17 10 24" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/412e3231-4e45-481d-89f7-fa6aa2efd0de">
