### PR TITLE
[Nitpick] Adjust vertical spacing in segmented-control-item

### DIFF
--- a/app/assets/stylesheets/stats.scss
+++ b/app/assets/stylesheets/stats.scss
@@ -90,6 +90,7 @@ $segmented-control-item-border-radius: 2 * $default-space;
   font-size: 15px;
   border: 2px solid $blue-france-700;
   margin-right: -2px;
+  padding-top: var(--li-bottom);
   padding-left: $segmented-control-item-horizontal-padding;
   padding-right: $segmented-control-item-horizontal-padding;
   color: $blue-france-700;


### PR DESCRIPTION
This small fix adjusts vertical spacing for the text inside `segmented-control-item`.   
Padding before: `0 15 4 15`, padding after: `4 15`. 

- The `.segmented-control-item` class is only used on the stats page, so there won't be any unwanted side-effects. 
- Also, since the same variable is used for top and bottom, any change to the `--li-bottom` variable won't break vertical alignment.

![before-after-vertical-alignment-change](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/419086/66d87916-6e0d-43f3-8a2e-dd2b2361e7fa)