### PR TITLE
Correctif : supprime les démarches sans administrateur ni dossier

### DIFF
--- a/app/models/administrateur.rb
+++ b/app/models/administrateur.rb
@@ -82,6 +82,10 @@ class Administrateur < ApplicationRecord
 
       next_administrateur = procedure.administrateurs.where.not(id: self.id).first
       procedure.service.update(administrateur: next_administrateur)
+
+      if (procedure.administrateurs.count == 1 && procedure.dossiers.empty?)
+        procedure.destroy
+      end
     end
 
     services.each do |service|

--- a/app/tasks/maintenance/destroy_procedure_without_administrateur_and_without_dossier_task.rb
+++ b/app/tasks/maintenance/destroy_procedure_without_administrateur_and_without_dossier_task.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class DestroyProcedureWithoutAdministrateurAndWithoutDossierTask < MaintenanceTasks::Task
+    def collection
+      Procedure.with_discarded.where.missing(:administrateurs, :dossiers)
+    end
+
+    def process(procedure)
+      procedure.destroy!
+    end
+  end
+end

--- a/spec/tasks/maintenance/destroy_procedure_without_administrateur_and_without_dossier_task_spec.rb
+++ b/spec/tasks/maintenance/destroy_procedure_without_administrateur_and_without_dossier_task_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe DestroyProcedureWithoutAdministrateurAndWithoutDossierTask do
+    describe "#process" do
+      subject(:process) { described_class.process(procedure) }
+      let(:procedure) { create(:procedure) }
+
+      before do
+        administrateur = procedure.administrateurs.first
+        AdministrateursProcedure.where(administrateur_id: administrateur.id).delete_all
+        administrateur.destroy
+      end
+
+      it "destroys procedure" do
+        subject
+        expect(Procedure.count).to eq 0
+      end
+    end
+  end
+end


### PR DESCRIPTION
Dernier cas de démarches invalides identifié via la Maintenance Task sur les démarches closes