### PR TITLE
ETQ expert, je veux pouvoir gérer les notifications que je reçois depuis mon interface

### DIFF
--- a/app/controllers/concerns/create_avis_concern.rb
+++ b/app/controllers/concerns/create_avis_concern.rb
@@ -59,7 +59,9 @@ module CreateAvisConcern
       persisted.each do |avis|
         avis.dossier.demander_un_avis!(avis)
         if avis.dossier == dossier
-          AvisMailer.avis_invitation(avis).deliver_later
+          if avis.experts_procedure.notify_on_new_avis?
+            AvisMailer.avis_invitation(avis).deliver_later
+          end
           sent_emails_addresses << avis.expert.email
           # the email format is already verified, we update value to nil
           avis.update_column(:email, nil)

--- a/app/controllers/experts/avis_controller.rb
+++ b/app/controllers/experts/avis_controller.rb
@@ -68,7 +68,7 @@ module Experts
     end
 
     def expert_procedure
-      ExpertsProcedure.find_by(expert_id: current_expert.id, procedure_id: @procedure.id)
+      ExpertsProcedure.find_by!(expert_id: current_expert.id, procedure_id: @procedure.id)
     end
 
     def notification_settings
@@ -188,7 +188,7 @@ module Experts
     end
 
     def set_procedure
-      @procedure = current_expert.procedures.find_by(id: params[:procedure_id])
+      @procedure = current_expert.procedures.find(params[:procedure_id])
     end
 
     def check_messaging_allowed

--- a/app/controllers/experts/avis_controller.rb
+++ b/app/controllers/experts/avis_controller.rb
@@ -4,10 +4,11 @@ module Experts
     include Zipline
 
     before_action :authenticate_expert!, except: [:sign_up, :update_expert]
-    before_action :check_if_avis_revoked, except: [:index, :procedure]
+    before_action :check_if_avis_revoked, except: [:index, :procedure, :notification_settings, :update_notification_settings]
     before_action :redirect_if_no_sign_up_needed, only: [:sign_up, :update_expert]
     before_action :set_avis_and_dossier, only: [:show, :instruction, :avis_list, :avis_new, :messagerie, :create_commentaire, :delete_commentaire, :update, :telecharger_pjs]
     before_action :check_messaging_allowed, only: [:messagerie, :create_commentaire]
+    before_action :set_procedure, only: [:notification_settings, :update_notification_settings]
 
     A_DONNER_STATUS = 'a-donner'
     DONNES_STATUS   = 'donnes'
@@ -64,6 +65,20 @@ module Experts
     end
 
     def avis_list
+    end
+
+    def expert_procedure
+      ExpertsProcedure.find_by(expert_id: current_expert.id, procedure_id: @procedure.id)
+    end
+
+    def notification_settings
+      @expert_procedure = expert_procedure
+    end
+
+    def update_notification_settings
+      expert_procedure.update!(expert_procedure_params)
+      flash.notice = 'Vos notifications sont enregistrées.'
+      redirect_to procedure_expert_avis_index_path(@procedure)
     end
 
     def avis_new
@@ -166,6 +181,15 @@ module Experts
     end
 
     private
+
+    def expert_procedure_params
+      params.require(:experts_procedure)
+        .permit(:notify_on_new_avis, :notify_on_new_message)
+    end
+
+    def set_procedure
+      @procedure = current_expert.procedures.find_by(id: params[:procedure_id])
+    end
 
     def check_messaging_allowed
       if !@avis.procedure.allow_expert_messaging

--- a/app/models/commentaire.rb
+++ b/app/models/commentaire.rb
@@ -120,7 +120,8 @@ class Commentaire < ApplicationRecord
     experts_contactes = Set.new
 
     dossier.avis.includes(:expert).find_each do |avis|
-      if avis.expert.present?
+      expert_procedure = avis.expert.experts_procedures.find_by(procedure_id: dossier.procedure.id)
+      if expert_procedure.notify_on_new_message? && avis.expert.present?
         expert_id = avis.expert.id
         if !experts_contactes.include?(expert_id)
           AvisMailer.notify_new_commentaire_to_expert(dossier, avis, avis.expert).deliver_later

--- a/app/views/experts/avis/notification_settings.html.haml
+++ b/app/views/experts/avis/notification_settings.html.haml
@@ -8,7 +8,7 @@
     .procedure-header
       %h1.fr-h3= procedure_libelle @procedure
 
-.container
+.fr-container
   %h1.fr-h3
     = t('.title')
 
@@ -16,7 +16,7 @@
     = render Dsfr::AlertComponent.new(state: :info, size: :sm, extra_class_names: 'fr-mb-2w') do |c|
       - c.with_body do
         %p
-          = t('.subtitle', procedure_libelle: @procedure.libelle)
+          = t('.subtitle')
 
     %fieldset.fr-fieldset
       %legend.fr-fieldset__legend
@@ -55,6 +55,6 @@
           %label.fr-label{ for: 'notify_on_new_message_false' }
             = t('.utils.negative')
 
-    .send-wrapper
-      = link_to t('.buttons.back_to_procedure', procedure_id: @procedure.id), procedure_expert_avis_index_path(@procedure), class: 'fr-btn fr-btn--secondary fr-mr-2w'
-      = form.submit t('.buttons.save'), class: "fr-btn"
+    %ul.fr-btns-group.fr-btns-group--inline
+      %li= form.submit t('.buttons.save'), class: "fr-btn"
+      %li= link_to t('.buttons.back_to_procedure', procedure_id: @procedure.id), procedure_expert_avis_index_path(@procedure), class: 'fr-btn fr-btn--secondary'

--- a/app/views/experts/avis/notification_settings.html.haml
+++ b/app/views/experts/avis/notification_settings.html.haml
@@ -1,0 +1,60 @@
+
+.sub-header
+  .fr-container.flex
+
+    .procedure-logo{ style: "background-image: url(#{@procedure.logo_url})",
+      role: 'img', 'aria-label': "logo de la démarche #{@procedure.libelle}" }
+
+    .procedure-header
+      %h1.fr-h3= procedure_libelle @procedure
+
+.container
+  %h1.fr-h3
+    = t('.title')
+
+  = form_for @expert_procedure, url: update_notification_settings_expert_procedure_path(@procedure), html: { class: 'form' } do |form|
+    = render Dsfr::AlertComponent.new(state: :info, size: :sm, extra_class_names: 'fr-mb-2w') do |c|
+      - c.with_body do
+        %p
+          = t('.subtitle', procedure_libelle: @procedure.libelle)
+
+    %fieldset.fr-fieldset
+      %legend.fr-fieldset__legend
+        = t(".for_each_avis_submitted.title")
+        %span.fr-hint-text= t('.for_each_avis_submitted.notice_1')
+        %span.fr-hint-text= t('.for_each_avis_submitted.notice_2')
+      .fr-fieldset__element.fr-fieldset__element--inline
+        .fr-radio-group
+          = form.radio_button :notify_on_new_avis, true, id: 'notify_on_new_avis_true'
+          %label.fr-label{ for: 'notify_on_new_avis_true' }
+            = t('.utils.positive')
+
+
+      .fr-fieldset__element.fr-fieldset__element--inline
+        .fr-radio-group
+          = form.radio_button :notify_on_new_avis, false, id: 'notify_on_new_avis_false'
+          %label.fr-label{ for: 'notify_on_new_avis_false' }
+            = t('.utils.negative')
+
+
+    %fieldset.fr-fieldset
+      %legend.fr-fieldset__legend
+        = t(".for_each_message_submitted.title")
+        %span.fr-hint-text= t('.for_each_message_submitted.notice_1')
+        %span.fr-hint-text= t('.for_each_message_submitted.notice_2')
+      .fr-fieldset__element.fr-fieldset__element--inline
+        .fr-radio-group
+          = form.radio_button :notify_on_new_message, true, id: 'notify_on_new_message_true'
+          %label.fr-label{ for: 'notify_on_new_message_true' }
+            = t('.utils.positive')
+
+
+      .fr-fieldset__element.fr-fieldset__element--inline
+        .fr-radio-group
+          = form.radio_button :notify_on_new_message, false, id: 'notify_on_new_message_false'
+          %label.fr-label{ for: 'notify_on_new_message_false' }
+            = t('.utils.negative')
+
+    .send-wrapper
+      = link_to t('.buttons.back_to_procedure', procedure_id: @procedure.id), procedure_expert_avis_index_path(@procedure), class: 'fr-btn fr-btn--secondary fr-mr-2w'
+      = form.submit t('.buttons.save'), class: "fr-btn"

--- a/app/views/experts/avis/procedure.html.haml
+++ b/app/views/experts/avis/procedure.html.haml
@@ -10,6 +10,9 @@
 
       .procedure-header
         %h1.fr-h3= procedure_libelle @procedure
+        = link_to t('.management', procedure_id: @procedure.id), notification_settings_expert_procedure_path(@procedure), class: 'header-link'
+
+
 
         %nav.fr-tabs
           %ul.fr-tabs__list{ role: 'tablist' }

--- a/config/locales/views/experts/avis/en.yml
+++ b/config/locales/views/experts/avis/en.yml
@@ -2,13 +2,13 @@ en:
   experts:
     avis:
       procedure:
-        management: notification management of the procedure %{procedure_id}
+        management: Notification management of the procedure
       notification_settings:
         utils:
           positive: Yes
           negative: No
         title: Email Notifications
-        subtitle: "Configure on this page the notifications you wish to receive by email for: %{procedure_libelle}"
+        subtitle: Configure on this page the notifications you wish to receive by email
         for_each_avis_submitted:
           title: Receive a notification for each avis requested from you
           notice_1: This email alerts you that an avis is requested from you.
@@ -18,5 +18,5 @@ en:
           notice_1: This email notifies you that a new message is available in the messaging system.
           notice_2: It is sent every time an instructor or user sends a message.
         buttons:
-          back_to_procedure: Return to the procedure notices %{procedure_id}
+          back_to_procedure: Return to the procedure notices
           save: Save

--- a/config/locales/views/experts/avis/en.yml
+++ b/config/locales/views/experts/avis/en.yml
@@ -1,0 +1,22 @@
+en:
+  experts:
+    avis:
+      procedure:
+        management: notification management of the procedure %{procedure_id}
+      notification_settings:
+        utils:
+          positive: Yes
+          negative: No
+        title: Email Notifications
+        subtitle: "Configure on this page the notifications you wish to receive by email for: %{procedure_libelle}"
+        for_each_avis_submitted:
+          title: Receive a notification for each avis requested from you
+          notice_1: This email alerts you that an avis is requested from you.
+          notice_2: It is sent each time an instructor asks you for an avis.
+        for_each_message_submitted:
+          title: Receive a notification for each message received
+          notice_1: This email notifies you that a new message is available in the messaging system.
+          notice_2: It is sent every time an instructor or user sends a message.
+        buttons:
+          back_to_procedure: Return to the procedure notices %{procedure_id}
+          save: Save

--- a/config/locales/views/experts/avis/fr.yml
+++ b/config/locales/views/experts/avis/fr.yml
@@ -1,0 +1,22 @@
+fr:
+  experts:
+    avis:
+      procedure:
+        management: gestion des notifications de la démarche %{procedure_id}
+      notification_settings:
+        utils:
+          positive: Oui
+          negative: Non
+        title: Notifications par email
+        subtitle: "Configurez sur cette page les notifications que vous souhaitez recevoir par email pour : %{procedure_libelle}"
+        for_each_avis_submitted:
+          title: Recevoir une notification à chaque avis qui vous est demandé
+          notice_1: Cet email vous signale qu'un avis vous est demandé.
+          notice_2: Il est envoyé à chaque fois qu’un instructeur vous demande un avis.
+        for_each_message_submitted:
+          title: Recevoir une notification à chaque message reçu
+          notice_1: Cet email vous signale qu'un nouveau message est disponible dans la messagerie.
+          notice_2: Il est envoyé à chaque fois qu’un instructeur ou usager envoie un message.
+        buttons:
+          back_to_procedure: Revenir sur les avis de la démarche %{procedure_id}
+          save: Enregistrer

--- a/config/locales/views/experts/avis/fr.yml
+++ b/config/locales/views/experts/avis/fr.yml
@@ -2,13 +2,13 @@ fr:
   experts:
     avis:
       procedure:
-        management: gestion des notifications de la démarche %{procedure_id}
+        management: Gestion des notifications de la démarche
       notification_settings:
         utils:
           positive: Oui
           negative: Non
         title: Notifications par email
-        subtitle: "Configurez sur cette page les notifications que vous souhaitez recevoir par email pour : %{procedure_libelle}"
+        subtitle: Configurez sur cette page les notifications que vous souhaitez recevoir par email
         for_each_avis_submitted:
           title: Recevoir une notification à chaque avis qui vous est demandé
           notice_1: Cet email vous signale qu'un avis vous est demandé.
@@ -18,5 +18,5 @@ fr:
           notice_1: Cet email vous signale qu'un nouveau message est disponible dans la messagerie.
           notice_2: Il est envoyé à chaque fois qu’un instructeur ou usager envoie un message.
         buttons:
-          back_to_procedure: Revenir sur les avis de la démarche %{procedure_id}
+          back_to_procedure: Revenir sur les avis de la démarche
           save: Enregistrer

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -398,6 +398,9 @@ Rails.application.routes.draw do
 
     resources :procedures, only: [], param: :procedure_id do
       member do
+        get 'notification_settings', to: 'avis#notification_settings'
+        patch 'update_notification_settings', to: 'avis#update_notification_settings'
+
         resources :avis, only: [:show, :update] do
           get '', action: 'procedure', on: :collection, as: :procedure
           member do

--- a/db/migrate/20240313122932_add_expert_notification_settings_to_experts_procedures.rb
+++ b/db/migrate/20240313122932_add_expert_notification_settings_to_experts_procedures.rb
@@ -1,0 +1,6 @@
+class AddExpertNotificationSettingsToExpertsProcedures < ActiveRecord::Migration[7.0]
+  def change
+    add_column :experts_procedures, :notify_on_new_avis, :boolean, default: true, null: false
+    add_column :experts_procedures, :notify_on_new_message, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1232,7 +1232,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_16_065520) do
   add_foreign_key "dossiers", "groupe_instructeurs"
   add_foreign_key "dossiers", "procedure_revisions", column: "revision_id"
   add_foreign_key "dossiers", "users"
-add_foreign_key "etablissements", "dossiers"
+  add_foreign_key "etablissements", "dossiers"
   add_foreign_key "experts", "users"
   add_foreign_key "experts_procedures", "experts"
   add_foreign_key "experts_procedures", "procedures"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -586,6 +586,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_16_065520) do
     t.boolean "allow_decision_access", default: false, null: false
     t.datetime "created_at", null: false
     t.bigint "expert_id", null: false
+    t.boolean "notify_on_new_avis", default: true, null: false
+    t.boolean "notify_on_new_message", default: false, null: false
     t.bigint "procedure_id", null: false
     t.datetime "revoked_at", precision: nil
     t.datetime "updated_at", null: false
@@ -1230,7 +1232,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_16_065520) do
   add_foreign_key "dossiers", "groupe_instructeurs"
   add_foreign_key "dossiers", "procedure_revisions", column: "revision_id"
   add_foreign_key "dossiers", "users"
-  add_foreign_key "etablissements", "dossiers"
+add_foreign_key "etablissements", "dossiers"
   add_foreign_key "experts", "users"
   add_foreign_key "experts_procedures", "experts"
   add_foreign_key "experts_procedures", "procedures"

--- a/spec/controllers/instructeurs/avis_controller_spec.rb
+++ b/spec/controllers/instructeurs/avis_controller_spec.rb
@@ -5,7 +5,7 @@ describe Instructeurs::AvisController, type: :controller do
     let(:now) { Time.zone.parse('01/02/2345') }
     let(:expert) { create(:expert) }
     let(:claimant) { create(:instructeur) }
-    let(:experts_procedure) { create(:experts_procedure, expert: expert, procedure: procedure) }
+    let(:experts_procedure) { create(:experts_procedure, expert: expert, procedure: procedure, notify_on_new_avis: false) }
     let(:instructeur) { create(:instructeur) }
     let(:procedure) { create(:procedure, :published, instructeurs: [instructeur]) }
     let(:dossier) { create(:dossier, :en_construction, procedure: procedure) }

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -826,6 +826,13 @@ describe Instructeurs::DossiersController, type: :controller do
         it { expect(saved_avis.expert.email).to eq("titi@titimail.com") }
       end
 
+      context 'when the expert do not want to receive notification' do
+        let(:emails) { "[\"email@a.com\"]" }
+        let(:experts_procedure) { create(:experts_procedure, expert: expert, procedure: dossier.procedure, notify_on_new_avis: false) }
+
+        before { subject }
+      end
+
       context 'with linked dossiers' do
         let(:asked_confidentiel) { false }
         let(:previous_avis_confidentiel) { false }


### PR DESCRIPTION
#10005 

Les notifications se règlent par démarche. Par défaut :

- être notifié pour les nouveaux avis : OUI
- être notifié pour les nouveaux messages des usagers dans la messagerie : NON



<img width="1512" alt="image" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/21340608/134c22fe-bd5f-4b2e-9fa6-7d1269a934a4">


