### PR TITLE
ETQ instructeur je souhaite mieux comprendre le graph "avancée des dossiers" en changeant le terme "démarrés"

### DIFF
--- a/app/models/concerns/procedure_stats_concern.rb
+++ b/app/models/concerns/procedure_stats_concern.rb
@@ -22,7 +22,7 @@ module ProcedureStatsConcern
   def stats_dossiers_funnel
     Rails.cache.fetch("#{cache_key_with_version}/stats_dossiers_funnel", expires_in: 12.hours) do
       [
-        ['Démarrés', dossiers.visible_by_user_or_administration.count + nb_dossiers_termines_supprimes],
+        ['Tous (dont brouillon)', dossiers.visible_by_user_or_administration.count + nb_dossiers_termines_supprimes],
         ['Déposés', dossiers.visible_by_administration.count + nb_dossiers_termines_supprimes],
         ['Instruction débutée', dossiers.visible_by_administration.state_instruction_commencee.count + nb_dossiers_termines_supprimes],
         ['Traités', nb_dossiers_termines]

--- a/spec/models/concern/procedure_stats_concern_spec.rb
+++ b/spec/models/concern/procedure_stats_concern_spec.rb
@@ -14,7 +14,7 @@ describe ProcedureStatsConcern do
     it "returns the funnel stats" do
       expect(stats_dossiers_funnel).to match(
         [
-          ['Démarrés', procedure.dossiers.visible_by_user_or_administration.count],
+          ['Tous (dont brouillon)', procedure.dossiers.visible_by_user_or_administration.count],
           ['Déposés', procedure.dossiers.visible_by_administration.count],
           ['Instruction débutée', procedure.dossiers.visible_by_administration.state_instruction_commencee.count],
           ['Traités', procedure.dossiers.visible_by_administration.state_termine.count]


### PR DESCRIPTION
closes #9806 

On remplace le terme "démarrés" par "Tous (dont brouillon)"

<img width="513" alt="Capture d’écran 2024-03-18 à 10 38 20" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/7a3596c1-4ada-4dbd-b1be-360561735b22">

