### PR TITLE
Correctif : un administrateur avec une procedure discarded sans dossier peut être supprimé

### DIFF
--- a/app/models/administrateur.rb
+++ b/app/models/administrateur.rb
@@ -72,30 +72,6 @@ class Administrateur < ApplicationRecord
     procedures.with_discarded.all? { |p| p.administrateurs.count > 1 || p.dossiers.empty? }
   end
 
-  def delete_and_transfer_services
-    if !can_be_deleted?
-      fail "Impossible de supprimer cet administrateur car il a des démarches où il est le seul administrateur"
-    end
-
-    procedures.with_discarded.each do |procedure|
-      next if procedure.service.nil?
-
-      next_administrateur = procedure.administrateurs.where.not(id: self.id).first
-      procedure.service.update(administrateur: next_administrateur)
-
-      if (procedure.administrateurs.count == 1 && procedure.dossiers.empty?)
-        procedure.destroy
-      end
-    end
-
-    services.each do |service|
-      # We can't destroy a service if it has procedures, even if those procedures are archived
-      service.destroy unless service.procedures.with_discarded.any?
-    end
-    AdministrateursProcedure.where(administrateur_id: self.id).delete_all
-    destroy
-  end
-
   def merge(old_admin)
     return if old_admin.nil?
 

--- a/app/models/administrateur.rb
+++ b/app/models/administrateur.rb
@@ -69,7 +69,7 @@ class Administrateur < ApplicationRecord
   end
 
   def can_be_deleted?
-    procedures.all? { |p| p.administrateurs.count > 1 || p.dossiers.empty? }
+    procedures.with_discarded.all? { |p| p.administrateurs.count > 1 || p.dossiers.empty? }
   end
 
   def delete_and_transfer_services

--- a/app/services/administrateur_deletion_service.rb
+++ b/app/services/administrateur_deletion_service.rb
@@ -47,7 +47,7 @@ class AdministrateurDeletionService
 
   def delete_procedures_without_dossier
     procedures_without_dossier = owned_procedures.filter { _1.dossiers.empty? }
-    procedures_without_dossier.each { _1.discard_and_keep_track!(super_admin) }
+    procedures_without_dossier.each { |p| p.discard_and_keep_track!(super_admin) unless p.discarded? }
     procedures_without_dossier.each(&:purge_discarded)
   end
 

--- a/spec/models/administrateur_spec.rb
+++ b/spec/models/administrateur_spec.rb
@@ -49,47 +49,6 @@ describe Administrateur, type: :model do
     end
   end
 
-  describe '#delete_and_transfer_services' do
-    let!(:administrateur) { create(:administrateur) }
-    let!(:autre_administrateur) { create(:administrateur) }
-    let!(:procedure) { create(:procedure, :with_service, administrateurs: [administrateur, autre_administrateur]) }
-    let(:service) { procedure.service }
-
-    it "delete and transfer services to other admin" do
-      service.update(administrateur: administrateur)
-      administrateur.delete_and_transfer_services
-
-      expect(Administrateur.find_by(id: administrateur.id)).to be_nil
-      expect(service.reload.administrateur).to eq(autre_administrateur)
-    end
-
-    it "delete service if not associated to procedures" do
-      service_without_procedure = create(:service, administrateur: administrateur)
-      administrateur.delete_and_transfer_services
-
-      expect(Service.find_by(id: service_without_procedure.id)).to be_nil
-      expect(Administrateur.find_by(id: administrateur.id)).to be_nil
-    end
-
-    it "does not delete service if associated to an archived procedure" do
-      service.update(administrateur: administrateur)
-      procedure.discard!
-      administrateur.delete_and_transfer_services
-
-      expect(Service.find_by(id: procedure.service.id)).not_to be_nil
-      expect(Administrateur.find_by(id: administrateur.id)).to be_nil
-    end
-
-    context "proedure without service" do
-      let!(:procedure) { create(:procedure, :draft, administrateurs: [administrateur, autre_administrateur]) }
-
-      it "delete procedure without service" do
-        administrateur.delete_and_transfer_services
-        expect(Administrateur.find_by(id: administrateur.id)).to be_nil
-      end
-    end
-  end
-
   describe '#merge' do
     let(:new_admin) { create(:administrateur) }
     let(:old_admin) { create(:administrateur) }

--- a/spec/services/administrateur_deletion_service_spec.rb
+++ b/spec/services/administrateur_deletion_service_spec.rb
@@ -48,6 +48,17 @@ describe AdministrateurDeletionService do
       end
     end
 
+    context 'when admin has one discarded procedure without dossiers and only one admin' do
+      let(:owned_procedure_without_dossier) { create(:procedure, service: owned_procedure_service, administrateurs: [admin]) }
+
+      before { owned_procedure_without_dossier.discard! }
+
+      it "deletes admin" do
+        subject
+        expect(Administrateur.find_by(id: admin.id)).to be_nil
+      end
+    end
+
     context "when there is a failure" do
       it 'rollbacks' do
         allow_any_instance_of(Service).to receive(:update).and_return(false)


### PR DESCRIPTION
Il y avait 3 démarches sans administrateur en prod' ([86276, brouillon, 2 dossiers], [86298, close, 7 dossiers], [87980, brouillon, 0 dossiers]).
Je me suis ajouté comme admin dessus pour que ces démarches redeviennent valides.
Avant, j'avais tenté un fix [ici](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/10125) mais la requête était incorrecte et la modification concernait du code mort.
Donc là j'enlève le code mort.
Ensuite, je prends en compte les démarches discarded pour voir si un admin peut être supprimé. Mais ça ne peut pas expliquer tous les cas de démarches sans admin, car seule une des trois est discarded.

Et, 3e commit, la PR résout un autre [bug](https://demarches-simplifiees.sentry.io/issues/5087071955/) : on ne pouvait pas supprimer d'admin avec une procedure discarded sans dossier