### PR TITLE
Tech: pas de comparaison avec champ#updated_at lorsque le champ n'est pas persisté

### DIFF
--- a/app/components/dossiers/champs_rows_show_component.rb
+++ b/app/components/dossiers/champs_rows_show_component.rb
@@ -10,6 +10,7 @@ class Dossiers::ChampsRowsShowComponent < ApplicationComponent
 
   def updated_at_after_deposer(champ)
     return if champ.dossier.depose_at.blank?
+    return if champ.new_record?
 
     if champ.updated_at > champ.dossier.depose_at
       champ.updated_at

--- a/spec/views/shared/dossiers/_demande.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_demande.html.haml_spec.rb
@@ -51,4 +51,17 @@ describe 'shared/dossiers/demande', type: :view do
       end
     end
   end
+
+  context 'when a champ is freshly build' do
+    let(:procedure) { create(:procedure, :published, :with_type_de_champ) }
+    before do
+      dossier.champs_public.first.destroy
+    end
+
+    it 'renders without error' do
+      procedure.active_revision.types_de_champ.each do |tdc|
+        expect(subject).to include(tdc.libelle)
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://demarches-simplifiees.sentry.io/issues/5079592285/?project=1429550

Mais je voudrais comprendre la cause et contexte pour : 
- ne pas merger si c'est pas censé arriver et corriger les dossiers à la place
- si ça vient du build des champs rajouter les tests correspondants