### PR TITLE
chore: expose postgres port

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -14,6 +14,7 @@ development:
   host: <%= ENV["DB_HOST"] %>
   username: <%= ENV["DB_USERNAME"] %>
   password: <%= ENV["DB_PASSWORD"] %>
+  port: <%= ENV["DB_PORT"] || 5432 %>
   # Workaround for https://github.com/ged/ruby-pg/issues/311
   gssencmode: disable
 
@@ -23,6 +24,7 @@ test:
   host: localhost
   username: tps_test
   password: tps_test
+  port: <%= ENV["DB_PORT"] || 5432 %>
   # Workaround for https://github.com/ged/ruby-pg/issues/311
   gssencmode: disable
 
@@ -32,3 +34,4 @@ production: &production
   host: <%= ENV["DB_HOST"] %>
   username: <%= ENV["DB_USERNAME"] %>
   password: <%= ENV["DB_PASSWORD"] %>
+  port: <%= ENV["DB_PORT"] || 5432 %>

--- a/config/env.example
+++ b/config/env.example
@@ -22,6 +22,7 @@ DB_HOST="localhost"
 DB_POOL=""
 DB_USERNAME="tps_development"
 DB_PASSWORD="tps_development"
+DB_PORT=5432
 
 # Protect access to the instance with a static login/password (useful for staging environments)
 BASIC_AUTH_ENABLED="disabled"


### PR DESCRIPTION
Ajout du port de postgres a la configuration


PS: Dans le cadre de diverse demande métier nous étudions à la DSI du Sénat la mise en place d'un Démarche Simplifiée interne.