### PR TITLE
ETQ usager, pas d'erreur 500 lorsque j'accède à une démarche "fermée" qui n'existe pas

### DIFF
--- a/app/controllers/users/commencer_controller.rb
+++ b/app/controllers/users/commencer_controller.rb
@@ -80,6 +80,9 @@ module Users
 
     def closing_details
       @procedure = Procedure.find_by(path: params[:path])
+
+      return procedure_not_found if @procedure.blank?
+
       render 'closing_details', layout: 'closing_details'
     end
 

--- a/app/views/users/commencer/closing_details.html.haml
+++ b/app/views/users/commencer/closing_details.html.haml
@@ -3,7 +3,7 @@
 .fr-container
   .fr-grid-row
     .fr-col-12
-      %h1= t('commencer.closing_details.page_title', libelle: @procedure.libelle, closed_at: @procedure.closed_at.strftime('%d/%m/%Y'))
+      %h1= t('commencer.closing_details.page_title', libelle: @procedure.libelle, closed_at: l(@procedure.closed_at.to_date, format: :long))
       %p
         = format_text_value(@procedure.closing_details)
 


### PR DESCRIPTION
https://demarches-simplifiees.sentry.io/issues/5059497565

visiblement des gens qui jouent avec les urls pour trouver des démarches en changeant l'année ou un suffixe