### PR TITLE
ETQ usager: connexion par token & secret

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -776,6 +776,8 @@ Rails/DynamicFindBy:
   Enabled: true
   Exclude:
     - spec/system/**/*.rb
+  AllowedMethods:
+    - find_by_authenticable_token
 
 Rails/EagerEvaluationLogMessage:
   Enabled: true

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   include TrustedDeviceConcern
   include Pundit::Authorization
   include Devise::StoreLocationExtension
+  include ApplicationController::AuthenticateByToken
   include ApplicationController::LongLivedAuthenticityToken
   include ApplicationController::ErrorHandling
 

--- a/app/controllers/application_controller/authenticate_by_token.rb
+++ b/app/controllers/application_controller/authenticate_by_token.rb
@@ -1,0 +1,24 @@
+module ApplicationController::AuthenticateByToken
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :authenticate_by_token!
+
+    protected
+
+    def authenticate_by_token!
+      return if params[:authenticable_token].blank?
+
+      user = User.find_by_authenticable_token(params[:authenticable_token])
+
+      if user.present?
+        user.clear_sign_in_secret!
+        sign_in(user)
+      end
+
+      # Don't let the token in url, wheter authentication was successfull or not
+      # If not authenticated, next request will redirect to signin with notice
+      redirect_to url_for(params.except(:authenticable_token).to_unsafe_h), status: 302
+    end
+  end
+end

--- a/app/models/concerns/token_authenticable_concern.rb
+++ b/app/models/concerns/token_authenticable_concern.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module TokenAuthenticableConcern
+  extend ActiveSupport::Concern
+
+  included do
+    AUTHENTICABLE_TOKEN_LIFETIME = 5.minutes
+
+    def authenticable_token
+      secret = sign_in_secret.presence || reset_sign_in_secret!
+
+      payload = {
+        user_id: id,
+        sign_in_secret: secret
+      }
+
+      self.class.token_authenticable_verifier.generate(payload, expires_in: AUTHENTICABLE_TOKEN_LIFETIME)
+    end
+
+    def reset_sign_in_secret!
+      update!(sign_in_secret: SecureRandom.base64(32))
+      sign_in_secret
+    end
+
+    def clear_sign_in_secret!
+      update!(sign_in_secret: nil)
+    end
+  end
+
+  class_methods do
+    def token_authenticable_verifier
+      Rails.application.message_verifier(:token_authenticable)
+    end
+
+    def find_by_authenticable_token(token)
+      decoded_token = decode_authenticable_token(token)
+
+      return if decoded_token.blank?
+
+      find_by(id: decoded_token.fetch(:user_id),
+              sign_in_secret: decoded_token.fetch(:sign_in_secret))
+    end
+
+    def decode_authenticable_token(token)
+      token_authenticable_verifier.verify(token)
+    rescue ActiveSupport::MessageVerifier::InvalidSignature
+      {}.freeze
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   include EmailSanitizableConcern
   include PasswordComplexityConcern
+  include TokenAuthenticableConcern
 
   enum loged_in_with_france_connect: {
     particulier: 'particulier',

--- a/db/migrate/20240223092711_add_sign_in_secret_to_users.rb
+++ b/db/migrate/20240223092711_add_sign_in_secret_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSignInSecretToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :sign_in_secret, :string, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1141,6 +1141,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_18_134256) do
     t.datetime "reset_password_sent_at", precision: nil
     t.string "reset_password_token"
     t.integer "sign_in_count", default: 0, null: false
+    t.string "sign_in_secret"
     t.string "siret"
     t.boolean "team_account", default: false
     t.text "unconfirmed_email"

--- a/spec/controllers/application_controller/authenticate_by_token_spec.rb
+++ b/spec/controllers/application_controller/authenticate_by_token_spec.rb
@@ -1,0 +1,62 @@
+RSpec.describe ApplicationController::AuthenticateByToken, type: :controller do
+  controller do
+    include ApplicationController::AuthenticateByToken
+
+    def index
+      render plain: "Hello, world!"
+    end
+  end
+
+  before do
+    Rails.application.routes.draw do
+      get '/authenticated' => 'anonymous#index'
+    end
+
+    allow(controller).to receive(:sign_in).with(user)
+  end
+
+  describe '#authentication_user! with token' do
+    let(:user) { create(:user) }
+
+    subject { get :index, params: { authenticable_token: token } }
+
+    context "when authenticable_token is present in params" do
+      let(:token) { user.authenticable_token }
+
+      it "authenticates the user with the token" do
+        subject
+        expect(controller).to have_received(:sign_in).with(user)
+        expect(user.reload.sign_in_secret).to be_nil
+        expect(flash).to be_empty
+        expect(response).to redirect_to("/authenticated")
+      end
+
+      context "when token has expired" do
+        let(:token) { travel_to(20.minutes.ago) { user.authenticable_token } }
+
+        it "does not authenticate the user" do
+          subject
+          expect(controller).not_to have_received(:sign_in)
+          expect(response).to redirect_to("/authenticated")
+        end
+      end
+
+      context "when token is invalid" do
+        let(:token) { "invalid_token" }
+
+        it "redirects without signing in the user" do
+          subject
+          expect(controller).not_to have_received(:sign_in)
+          expect(response).to redirect_to("/authenticated")
+        end
+      end
+    end
+
+    context "when authenticable_token is not present" do
+      it "calls the original Devise authenticate_user!" do
+        get :index
+        expect(controller).not_to have_received(:sign_in)
+      end
+    end
+  end
+end

--- a/spec/models/concern/token_authenticable_concern_spec.rb
+++ b/spec/models/concern/token_authenticable_concern_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+RSpec.describe TokenAuthenticableConcern, type: :model do
+    let(:user) { create(:user, sign_in_secret: secret) }
+    let(:secret) { nil }
+
+    describe '#authenticable_token' do
+      it 'generates a valid cross domain token' do
+        token = user.authenticable_token
+
+        expect(user.sign_in_secret).not_to be_nil
+
+        decoded_payload = User.token_authenticable_verifier.verify(token)
+        expect(decoded_payload[:user_id]).to eq(user.id)
+        expect(decoded_payload[:sign_in_secret]).to eq(user.sign_in_secret)
+      end
+
+      context 'with an existing secret' do
+        let(:secret) { "abc" }
+
+        it 'reuses the same secret' do
+          expect { user.authenticable_token }.not_to change(user, :sign_in_secret)
+        end
+      end
+    end
+
+    describe '#reset_sign_in_secret!' do
+      let(:secret) { "abc" }
+
+      it do
+        expect { user.reset_sign_in_secret! }.to change(user, :sign_in_secret).from("abc").to(String)
+      end
+    end
+
+    describe '#clear_sign_in_secret!' do
+      let(:secret) { "abc" }
+
+      it do
+        expect { user.clear_sign_in_secret! }.to change(user, :sign_in_secret).to(nil)
+      end
+    end
+
+    describe '.find_by_authenticable_token' do
+      it 'finds the user with a valid token' do
+        token = user.authenticable_token
+        travel_to 1.minute.from_now
+
+        expect(User.find_by_authenticable_token(token)).to eq(user)
+      end
+
+      it 'ignore expired tokens' do
+        token = user.authenticable_token
+        travel_to 2.hours.from_now
+        expect(User.find_by_authenticable_token(token)).to be_nil
+      end
+
+      it 'returns nil with an invalid token' do
+        expect(User.find_by_authenticable_token('invalid.token')).to be_nil
+      end
+    end
+  end


### PR DESCRIPTION
La PR est fonctionnelle, avait été envisagée pour la migration de domaine, mais finalement on souhaite pas l'activer.
On garde le code sous le code au cas où pour plus tard