### PR TITLE
feat(api): add champs.champDescriptorId so champRepetitions.rows[x] has a uniq id

### DIFF
--- a/app/graphql/api/v2/stored_query.rb
+++ b/app/graphql/api/v2/stored_query.rb
@@ -490,6 +490,7 @@ class API::V2::StoredQuery
 
   fragment ChampFragment on Champ {
     id
+    champDescriptorId
     __typename
     label
     stringValue

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -72,6 +72,11 @@ type Address {
 
 type AddressChamp implements Champ {
   address: Address
+
+  """
+  L'identifiant du champDescriptor de ce champ
+  """
+  champDescriptorId: String!
   commune: Commune
   departement: Departement
   id: ID!
@@ -230,6 +235,10 @@ type COJOChampDescriptor implements ChampDescriptor {
 }
 
 type CarteChamp implements Champ {
+  """
+  L'identifiant du champDescriptor de ce champ
+  """
+  champDescriptorId: String!
   geoAreas: [GeoArea!]!
   id: ID!
 
@@ -279,6 +288,10 @@ type CarteChampDescriptor implements ChampDescriptor {
 }
 
 interface Champ {
+  """
+  L'identifiant du champDescriptor de ce champ
+  """
+  champDescriptorId: String!
   id: ID!
 
   """
@@ -327,6 +340,10 @@ interface ChampDescriptor {
 }
 
 type CheckboxChamp implements Champ {
+  """
+  L'identifiant du champDescriptor de ce champ
+  """
+  champDescriptorId: String!
   id: ID!
 
   """
@@ -405,6 +422,10 @@ enum Civilite {
 }
 
 type CiviliteChamp implements Champ {
+  """
+  L'identifiant du champDescriptor de ce champ
+  """
+  champDescriptorId: String!
   id: ID!
 
   """
@@ -499,6 +520,10 @@ type Commune {
 }
 
 type CommuneChamp implements Champ {
+  """
+  L'identifiant du champDescriptor de ce champ
+  """
+  champDescriptorId: String!
   commune: Commune
   departement: Departement
   id: ID!
@@ -640,6 +665,11 @@ type CreateDirectUploadPayload {
 
 type DateChamp implements Champ {
   """
+  L'identifiant du champDescriptor de ce champ
+  """
+  champDescriptorId: String!
+
+  """
   La valeur du champ formaté en ISO8601 (Date).
   """
   date: ISO8601Date
@@ -697,6 +727,11 @@ type DateChampDescriptor implements ChampDescriptor {
 
 type DatetimeChamp implements Champ {
   """
+  L'identifiant du champDescriptor de ce champ
+  """
+  champDescriptorId: String!
+
+  """
   La valeur du champ formaté en ISO8601 (DateTime).
   """
   datetime: ISO8601DateTime
@@ -748,6 +783,10 @@ type DatetimeChampDescriptor implements ChampDescriptor {
 }
 
 type DecimalNumberChamp implements Champ {
+  """
+  L'identifiant du champDescriptor de ce champ
+  """
+  champDescriptorId: String!
   id: ID!
 
   """
@@ -1239,6 +1278,10 @@ type Departement {
 }
 
 type DepartementChamp implements Champ {
+  """
+  L'identifiant du champDescriptor de ce champ
+  """
+  champDescriptorId: String!
   departement: Departement
   id: ID!
 
@@ -1677,6 +1720,10 @@ type DossierEnvoyerMessagePayload {
 }
 
 type DossierLinkChamp implements Champ {
+  """
+  L'identifiant du champDescriptor de ce champ
+  """
+  champDescriptorId: String!
   dossier: Dossier
   id: ID!
 
@@ -2213,6 +2260,11 @@ type EngagementJuridique {
 
 type EngagementJuridiqueChamp implements Champ {
   """
+  L'identifiant du champDescriptor de ce champ
+  """
+  champDescriptorId: String!
+
+  """
   Montant engagé et payé de l'EJ.
   """
   engagementJuridique: EngagementJuridique
@@ -2315,6 +2367,10 @@ type Epci {
 }
 
 type EpciChamp implements Champ {
+  """
+  L'identifiant du champDescriptor de ce champ
+  """
+  champDescriptorId: String!
   departement: Departement
   epci: Epci
   id: ID!
@@ -2873,6 +2929,10 @@ type IbanChampDescriptor implements ChampDescriptor {
 }
 
 type IntegerNumberChamp implements Champ {
+  """
+  L'identifiant du champDescriptor de ce champ
+  """
+  champDescriptorId: String!
   id: ID!
 
   """
@@ -2922,6 +2982,10 @@ type IntegerNumberChampDescriptor implements ChampDescriptor {
 }
 
 type LinkedDropDownListChamp implements Champ {
+  """
+  L'identifiant du champDescriptor de ce champ
+  """
+  champDescriptorId: String!
   id: ID!
 
   """
@@ -3015,6 +3079,10 @@ type Message {
 }
 
 type MultipleDropDownListChamp implements Champ {
+  """
+  L'identifiant du champDescriptor de ce champ
+  """
+  champDescriptorId: String!
   id: ID!
 
   """
@@ -3366,6 +3434,10 @@ type Pays {
 }
 
 type PaysChamp implements Champ {
+  """
+  L'identifiant du champDescriptor de ce champ
+  """
+  champDescriptorId: String!
   id: ID!
 
   """
@@ -3487,6 +3559,10 @@ type PhoneChampDescriptor implements ChampDescriptor {
 }
 
 type PieceJustificativeChamp implements Champ {
+  """
+  L'identifiant du champDescriptor de ce champ
+  """
+  champDescriptorId: String!
   file: File @deprecated(reason: "Utilisez le champ `files` à la place.")
   files: [File!]!
   id: ID!
@@ -3637,6 +3713,10 @@ type RNA {
 }
 
 type RNAChamp implements Champ {
+  """
+  L'identifiant du champDescriptor de ce champ
+  """
+  champDescriptorId: String!
   commune: Commune
   departement: Departement
   id: ID!
@@ -3694,6 +3774,10 @@ type RNF {
 }
 
 type RNFChamp implements Champ {
+  """
+  L'identifiant du champDescriptor de ce champ
+  """
+  champDescriptorId: String!
   commune: Commune
   departement: Departement
   id: ID!
@@ -3750,6 +3834,10 @@ type Region {
 }
 
 type RegionChamp implements Champ {
+  """
+  L'identifiant du champDescriptor de ce champ
+  """
+  champDescriptorId: String!
   id: ID!
 
   """
@@ -3804,6 +3892,10 @@ type RegionChampDescriptor implements ChampDescriptor {
 }
 
 type RepetitionChamp implements Champ {
+  """
+  L'identifiant du champDescriptor de ce champ
+  """
+  champDescriptorId: String!
   champs: [Champ!]! @deprecated(reason: "Utilisez le champ `rows` à la place.")
   id: ID!
 
@@ -3906,6 +3998,10 @@ type Service {
 }
 
 type SiretChamp implements Champ {
+  """
+  L'identifiant du champDescriptor de ce champ
+  """
+  champDescriptorId: String!
   etablissement: PersonneMorale
   id: ID!
 
@@ -3955,6 +4051,10 @@ type SiretChampDescriptor implements ChampDescriptor {
 }
 
 type TextChamp implements Champ {
+  """
+  L'identifiant du champDescriptor de ce champ
+  """
+  champDescriptorId: String!
   id: ID!
 
   """
@@ -4032,6 +4132,10 @@ type TextareaChampDescriptor implements ChampDescriptor {
 }
 
 type TitreIdentiteChamp implements Champ {
+  """
+  L'identifiant du champDescriptor de ce champ
+  """
+  champDescriptorId: String!
   filled: Boolean!
   grantType: TitreIdentiteGrantType!
   id: ID!

--- a/app/graphql/types/champ_type.rb
+++ b/app/graphql/types/champ_type.rb
@@ -3,6 +3,7 @@ module Types
     include Types::BaseInterface
 
     global_id_field :id
+    field :champ_descriptor_id, String, "L'identifiant du champDescriptor de ce champ", null: false
     field :label, String, "Libellé du champ.", null: false, method: :libelle
     field :string_value, String, "La valeur du champ sous forme texte.", null: true, method: :for_api_v2
     field :updated_at, GraphQL::Types::ISO8601DateTime, "Date de dernière modification du champ.", null: false

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -134,6 +134,10 @@ class Champ < ApplicationRecord
     :value
   end
 
+  def champ_descriptor_id
+    type_de_champ.to_typed_id
+  end
+
   def to_typed_id
     if row_id.present?
       GraphQL::Schema::UniqueWithinType.encode('Champ', "#{stable_id}|#{row_id}")


### PR DESCRIPTION
crisp: https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_71f4d6c6-34c6-4b63-aff3-9f51cb94c3f0/

C'est un problème / situation que nous avons aussi rencontré lors d'un echange avec le sgar.

# problème

Sur l'api
Pour un dossier, ayant des répétitions. 
Ces répétitions exposent des rows. 
Ces rows exposent les champs. 

Cependant dans l'API `champs.id` est le stable_id du type de champ.
Or, dans l'API, pour un enfant d'une répétition, le `champs.id` est [stable_id|row_id](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/blob/main/app/models/champ.rb#L137). 
Résultat, on n'avait plus l'id du champDescriptor. Ce qui est problématique pour les consommateurs d'API qui ne peuvent pas faire le mapping champDescriptor / row.id.

# solution

on ajoute un champDescriptorId a tous les champs. Deux raisons : ca explicite nos relations avec les revisions. Ça permet d'identifier le type de champ d'un enfant d'une répétition