### PR TITLE
Correctif: un dossier peut avoir 1 à n FranceConnectInformation en passant par l'usager

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -129,7 +129,6 @@ class Dossier < ApplicationRecord
   belongs_to :batch_operation, optional: true
   has_many :dossier_batch_operations, dependent: :destroy
   has_many :batch_operations, through: :dossier_batch_operations
-  has_many :france_connect_informations, through: :user
 
   has_one :procedure, through: :revision
   has_one :attestation_template, through: :procedure
@@ -518,7 +517,7 @@ class Dossier < ApplicationRecord
   def build_default_individual
     if procedure.for_individual? && individual.blank?
       self.individual = if france_connected_with_one_identity?
-        Individual.from_france_connect(france_connect_informations.first)
+        Individual.from_france_connect(user.france_connect_informations.first)
       else
         Individual.new
       end

--- a/app/views/shared/dossiers/_demande.html.haml
+++ b/app/views/shared/dossiers/_demande.html.haml
@@ -1,6 +1,6 @@
 - if dossier.france_connected_with_one_identity? && current_user.instructeur? && !current_user.owns_or_invite?(dossier)
   - content_for(:notice_info) do
-    = render partial: "shared/dossiers/france_connect_informations_notice", locals: { user_information: dossier.france_connect_informations.first }
+    = render partial: "shared/dossiers/france_connect_informations_notice", locals: { user_information: dossier.user.france_connect_informations.first }
 
 .fr-container.counter-start-header-section.dossier-show{ class: class_names("dossier-show-instructeur" => profile =="instructeur") }
   .fr-grid-row.fr-grid-row--center

--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -2,7 +2,7 @@
 
 - if dossier.france_connected_with_one_identity?  && current_user.instructeur? && !current_user.owns_or_invite?(dossier)
   - content_for(:notice_info) do
-    = render partial: "shared/dossiers/france_connect_informations_notice", locals: { user_information: dossier.france_connect_informations.first }
+    = render partial: "shared/dossiers/france_connect_informations_notice", locals: { user_information: dossier.user.france_connect_informations.first }
 
 
 .dossier-edit.container.counter-start-header-section

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -348,10 +348,10 @@ describe User, type: :model do
         expect(dossier_termine.user).to be_nil
         expect(dossier_termine.user_email_for(:display)).to eq(user.email)
         expect(dossier_termine.valid?).to be_truthy
-        expect(dossier_termine.france_connect_informations).to be_empty
         expect { dossier_termine.user_email_for(:notification) }.to raise_error(RuntimeError)
 
         expect(User.find_by(id: user.id)).to be_nil
+        expect(FranceConnectInformation.where(user_id: user.id)).to be_empty
       end
     end
 


### PR DESCRIPTION
sntry: https://demarches-simplifiees.sentry.io/issues/5089844637/?project=1429550&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=1h&stream_index=0
pas de has_many :through, mais un delegate