### PR TITLE
task(procedure): fix open procedures with closing reason

### DIFF
--- a/app/tasks/maintenance/fix_open_procedures_with_closing_reason_task.rb
+++ b/app/tasks/maintenance/fix_open_procedures_with_closing_reason_task.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class FixOpenProceduresWithClosingReasonTask < MaintenanceTasks::Task
+    def collection
+      Procedure
+        .with_discarded
+        .where
+        .not(aasm_state: [:close, :depubliee])
+        .where
+        .not(closing_reason: nil)
+    end
+
+    def process(procedure)
+      procedure.update!(closing_reason: nil)
+    end
+  end
+end

--- a/spec/tasks/maintenance/fix_open_procedures_with_closing_reason_task_spec.rb
+++ b/spec/tasks/maintenance/fix_open_procedures_with_closing_reason_task_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe FixOpenProceduresWithClosingReasonTask do
+    describe "#process" do
+      subject(:process) { described_class.process(procedure) }
+      let(:procedure) { create(:procedure, :published) }
+
+      before do
+        procedure.update_column(:closing_reason, 'internal_procedure')
+      end
+
+      it do
+        subject
+        expect(procedure.closing_reason).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Il y a 55 procedures en brouillon qui ont une `closing_reason` non nulles. Ça les empêche d'être publié

Notamment cette démarche : https://secure.helpscout.net/conversation/2547638610/2063209?folderId=1653799 