### PR TITLE
Correctif : supprime les closing attributes lors du clonage d'une démarche

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -544,6 +544,10 @@ class Procedure < ApplicationRecord
     procedure.canonical_procedure = nil
     procedure.replaced_by_procedure = nil
     procedure.service = nil
+    procedure.closing_reason = nil
+    procedure.closing_details = nil
+    procedure.closing_notification_brouillon = false
+    procedure.closing_notification_en_cours = false
 
     if !procedure.valid?
       procedure.errors.attribute_names.each do |attribute|


### PR DESCRIPTION
Remontée au support d'une démarche en brouillon ne pouvant pas être publiée à cause de ça : https://secure.helpscout.net/conversation/2547638610/2063209?folderId=1653799
Une maintenance task a permis de corriger les démarches concernées : https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/10181
Avec cette PR, on évite que ça arrive à nouveau

Reminder : relancer la maintenance task une fois cette PR déployée