### PR TITLE
refactor(champs): update champs by public_id

### DIFF
--- a/app/components/editable_champ/carte_component/carte_component.html.haml
+++ b/app/components/editable_champ/carte_component/carte_component.html.haml
@@ -4,7 +4,7 @@
   = react_component("MapEditor",
     { featureCollection: @champ.to_feature_collection,
     champId: @champ.input_id,
-    url: champs_carte_features_path(@champ),
+    url: champs_carte_features_path(@champ.dossier, @champ.stable_id, row_id: @champ.row_id),
     options: @champ.render_options,
     autocompleteAnnounceTemplateId: @autocomplete_component.announce_template_id,
     autocompleteScreenReaderInstructions: t("combo_search_component.screen_reader_instructions") },

--- a/app/components/editable_champ/editable_champ_component.rb
+++ b/app/components/editable_champ/editable_champ_component.rb
@@ -54,9 +54,9 @@ class EditableChamp::EditableChampComponent < ApplicationComponent
 
   def turbo_poll_url_value
     if @champ.private?
-      annotation_instructeur_dossier_path(@champ.dossier.procedure, @champ.dossier, @champ)
+      annotation_instructeur_dossier_path(@champ.dossier.procedure, @champ.dossier, @champ.stable_id, row_id: @champ.row_id)
     else
-      champ_dossier_path(@champ.dossier, @champ)
+      champ_dossier_path(@champ.dossier, @champ.stable_id, row_id: @champ.row_id)
     end
   end
 

--- a/app/components/editable_champ/editable_champ_component/editable_champ_component.html.haml
+++ b/app/components/editable_champ/editable_champ_component/editable_champ_component.html.haml
@@ -7,4 +7,4 @@
 
     = render Dsfr::InputStatusMessageComponent.new(errors_on_attribute: champ_component.errors_on_attribute?, error_full_messages: champ_component.error_full_messages, described_by: @champ.describedby_id, champ: @champ)
 
-    = @form.hidden_field :id, value: @champ.id
+    = @form.hidden_field :with_public_id, value: 'true'

--- a/app/components/editable_champ/multiple_drop_down_list_component/multiple_drop_down_list_component.html.haml
+++ b/app/components/editable_champ/multiple_drop_down_list_component/multiple_drop_down_list_component.html.haml
@@ -13,7 +13,7 @@
       - if @champ.selected_options.present?
         .fr-mb-2w.fr-mt-2w{ "data-turbo": "true" }
           - @champ.selected_options.each do |option|
-            = render NestedForms::OwnedButtonComponent.new(formaction: champs_options_path(@champ.id, option:), http_method: :delete, opt: { aria: {pressed: true }, class: 'fr-tag fr-tag-bug fr-mb-1w fr-mr-1w', id: @champ.checkbox_id(option) }) do
+            = render NestedForms::OwnedButtonComponent.new(formaction: champs_options_path(@champ.dossier, @champ.stable_id, row_id: @champ.row_id, option:), http_method: :delete, opt: { aria: {pressed: true }, class: 'fr-tag fr-tag-bug fr-mb-1w fr-mr-1w', id: @champ.checkbox_id(option) }) do
               = option
       - if @champ.unselected_options.present?
         = @form.select :value, @champ.unselected_options, { selected: '', include_blank: false, prompt: t('.prompt') }, id: @champ.input_id, aria: { describedby: @champ.describedby_id }, class: 'fr-select fr-mt-2v'

--- a/app/components/editable_champ/rna_component/rna_component.html.haml
+++ b/app/components/editable_champ/rna_component/rna_component.html.haml
@@ -1,4 +1,4 @@
-= @form.text_field(:value, input_opts( id: @champ.input_id, aria: { describedby: @champ.describedby_id }, data: { controller: 'turbo-input', turbo_input_load_on_connect_value: @champ.prefilled? && @champ.value.present? && @champ.data.blank?, turbo_input_url_value: champs_rna_path(@champ.id) }, required: @champ.required?, pattern: "W[0-9]{9}", title: t(".title"), class: "width-33-desktop", maxlength: 10))
+= @form.text_field(:value, input_opts( id: @champ.input_id, aria: { describedby: @champ.describedby_id }, data: { controller: 'turbo-input', turbo_input_load_on_connect_value: @champ.prefilled? && @champ.value.present? && @champ.data.blank?, turbo_input_url_value: champs_rna_path(@champ.dossier, @champ.stable_id, row_id: @champ.row_id) }, required: @champ.required?, pattern: "W[0-9]{9}", title: t(".title"), class: "width-33-desktop", maxlength: 10))
 
 .rna-info{ id: dom_id(@champ, :rna_info) }
   = render 'shared/champs/rna/association', champ: @champ, error: nil

--- a/app/components/editable_champ/siret_component/siret_component.html.haml
+++ b/app/components/editable_champ/siret_component/siret_component.html.haml
@@ -1,4 +1,4 @@
-= @form.text_field(:value, input_opts(id: @champ.input_id, aria: { describedby: @champ.describedby_id }, data: { controller: 'turbo-input', turbo_input_load_on_connect_value: @champ.prefilled? && @champ.value.present? && @champ.etablissement.blank?, turbo_input_url_value: champs_siret_path(@champ.id) }, required: @champ.required?, pattern: "[0-9]{14}", title: t(".title"), class: "width-33-desktop", maxlength: 14))
+= @form.text_field(:value, input_opts(id: @champ.input_id, aria: { describedby: @champ.describedby_id }, data: { controller: 'turbo-input', turbo_input_load_on_connect_value: @champ.prefilled? && @champ.value.present? && @champ.etablissement.blank?, turbo_input_url_value: champs_siret_path(@champ.dossier, @champ.stable_id, row_id: @champ.row_id) }, required: @champ.required?, pattern: "[0-9]{14}", title: t(".title"), class: "width-33-desktop", maxlength: 14))
 .siret-info{ id: dom_id(@champ, :siret_info) }
   - if @champ.etablissement.present?
     = render EditableChamp::EtablissementTitreComponent.new(etablissement: @champ.etablissement)

--- a/app/controllers/champs/champ_controller.rb
+++ b/app/controllers/champs/champ_controller.rb
@@ -1,0 +1,22 @@
+class Champs::ChampController < ApplicationController
+  before_action :authenticate_logged_user!
+  before_action :set_champ
+
+  private
+
+  def find_champ
+    if params[:champ_id].present?
+      policy_scope(Champ)
+        .includes(:type_de_champ, dossier: :champs)
+        .find(params[:champ_id])
+    else
+      dossier = policy_scope(Dossier).includes(:champs, revision: [:types_de_champ]).find(params[:dossier_id])
+      type_de_champ = dossier.revision.types_de_champ.find_by!(stable_id: params[:stable_id])
+      dossier.champ_for_update(type_de_champ, params[:row_id])
+    end
+  end
+
+  def set_champ
+    @champ = find_champ
+  end
+end

--- a/app/controllers/champs/options_controller.rb
+++ b/app/controllers/champs/options_controller.rb
@@ -1,13 +1,9 @@
-class Champs::OptionsController < ApplicationController
+class Champs::OptionsController < Champs::ChampController
   include TurboChampsConcern
 
-  before_action :authenticate_logged_user!
-
   def remove
-    champ = policy_scope(Champ).includes(:champs).find(params[:champ_id])
-    champ.remove_option([params[:option]].compact, true)
-    champs = champ.private? ? champ.dossier.champs_private_all : champ.dossier.champs_public_all
-    @dossier = champ.private? ? nil : champ.dossier
-    @to_show, @to_hide, @to_update = champs_to_turbo_update({ params[:champ_id] => true }, champs)
+    @champ.remove_option([params[:option]].compact, true)
+    @dossier = @champ.private? ? nil : @champ.dossier
+    @to_show, @to_hide, @to_update = champs_to_turbo_update({ @champ.public_id => true }, @champ.dossier.champs)
   end
 end

--- a/app/controllers/champs/piece_justificative_controller.rb
+++ b/app/controllers/champs/piece_justificative_controller.rb
@@ -1,7 +1,4 @@
-class Champs::PieceJustificativeController < ApplicationController
-  before_action :authenticate_logged_user!
-  before_action :set_champ
-
+class Champs::PieceJustificativeController < Champs::ChampController
   def show
     respond_to do |format|
       format.turbo_stream
@@ -22,10 +19,6 @@ class Champs::PieceJustificativeController < ApplicationController
   end
 
   private
-
-  def set_champ
-    @champ = policy_scope(Champ).find(params[:champ_id])
-  end
 
   def attach_piece_justificative
     save_succeed = nil

--- a/app/controllers/champs/repetition_controller.rb
+++ b/app/controllers/champs/repetition_controller.rb
@@ -1,8 +1,5 @@
-class Champs::RepetitionController < ApplicationController
-  before_action :authenticate_logged_user!
-
+class Champs::RepetitionController < Champs::ChampController
   def add
-    @champ = find_champ
     row = @champ.add_row(@champ.dossier.revision)
     @first_champ_id = row.map(&:focusable_input_id).compact.first
     @row_id = row.first&.row_id
@@ -10,21 +7,16 @@ class Champs::RepetitionController < ApplicationController
   end
 
   def remove
-    @champ = find_champ
-    @champ.champs.where(row_id: params[:row_id]).destroy_all
-    @champ.reload
-    @row_id = params[:row_id]
+    @champ.remove_row(params[:row_id])
+    @to_remove = "safe-row-selector-#{params[:row_id]}"
+    @to_focus = @champ.focusable_input_id || helpers.dom_id(@champ, :create_repetition)
   end
 
   private
 
   def find_champ
-    if params[:champ_id].present?
-      policy_scope(Champ).includes(:champs).find(params[:champ_id])
-    else
-      policy_scope(Champ)
-        .includes(:champs, :type_de_champ)
-        .find_by!(dossier_id: params[:dossier_id], type_de_champ: { stable_id: params[:stable_id] })
-    end
+    dossier = policy_scope(Dossier).includes(:champs, revision: [:types_de_champ]).find(params[:dossier_id])
+    type_de_champ = dossier.revision.types_de_champ.find_by!(stable_id: params[:stable_id])
+    dossier.champ_for_update(type_de_champ, nil)
   end
 end

--- a/app/controllers/champs/rna_controller.rb
+++ b/app/controllers/champs/rna_controller.rb
@@ -1,8 +1,5 @@
-class Champs::RNAController < ApplicationController
-  before_action :authenticate_logged_user!
-
+class Champs::RNAController < Champs::ChampController
   def show
-    @champ = policy_scope(Champ).find(params[:champ_id])
     rna = read_param_value(@champ.input_name, 'value')
 
     unless @champ.fetch_association!(rna)

--- a/app/controllers/champs/siret_controller.rb
+++ b/app/controllers/champs/siret_controller.rb
@@ -1,9 +1,5 @@
-class Champs::SiretController < ApplicationController
-  before_action :authenticate_logged_user!
-
+class Champs::SiretController < Champs::ChampController
   def show
-    @champ = policy_scope(Champ).find(params[:champ_id])
-
     if @champ.fetch_etablissement!(read_param_value(@champ.input_name, 'value'), current_user)
       @siret = @champ.etablissement.siret
     else

--- a/app/controllers/concerns/turbo_champs_concern.rb
+++ b/app/controllers/concerns/turbo_champs_concern.rb
@@ -4,9 +4,14 @@ module TurboChampsConcern
   private
 
   def champs_to_turbo_update(params, champs)
-    champ_ids = params.keys.map(&:to_i)
+    to_update = if params.values.filter { _1.key?(:with_public_id) }.empty?
+                  champ_ids = params.keys.map(&:to_i)
+                  champs.filter { _1.id.in?(champ_ids) }
+                else
+                  champ_public_ids = params.keys
+                  champs.filter { _1.public_id.in?(champ_public_ids) }
+                end.filter { _1.refresh_after_update? || _1.forked_with_changes? }
 
-    to_update = champs.filter { _1.id.in?(champ_ids) && (_1.refresh_after_update? || _1.forked_with_changes?) }
     to_show, to_hide = champs.filter(&:conditional?)
       .partition(&:visible?)
       .map { champs_to_one_selector(_1 - to_update) }

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -277,7 +277,7 @@ module Users
           end
 
           format.turbo_stream do
-            @to_show, @to_hide, @to_update = champs_to_turbo_update(champs_public_params.fetch(:champs_public_all_attributes), dossier.champs_public_all)
+            @to_show, @to_hide, @to_update = champs_to_turbo_update(champs_public_params.fetch(:champs_public_all_attributes), dossier.champs.filter(&:public?))
             render :update, layout: false
           end
         end
@@ -291,7 +291,7 @@ module Users
 
       respond_to do |format|
         format.turbo_stream do
-          @to_show, @to_hide, @to_update = champs_to_turbo_update(champs_public_params.fetch(:champs_public_all_attributes), dossier.champs_public_all)
+          @to_show, @to_hide, @to_update = champs_to_turbo_update(champs_public_params.fetch(:champs_public_all_attributes), dossier.champs.filter(&:public?))
           render :update, layout: false
         end
       end
@@ -303,7 +303,8 @@ module Users
 
     def champ
       @dossier = dossier_with_champs(pj_template: false)
-      champ = @dossier.champs_public_all.find(params[:champ_id])
+      type_de_champ = @dossier.find_public_type_de_champ!(params[:stable_id])
+      champ = @dossier.project_champ(type_de_champ, params[:row_id])
 
       respond_to do |format|
         format.turbo_stream do
@@ -471,7 +472,7 @@ module Users
     end
 
     def champs_public_params
-      champs_params = params.require(:dossier).permit(champs_public_attributes: [
+      champ_attributes = [
         :id,
         :value,
         :value_other,
@@ -489,8 +490,12 @@ module Users
         :accreditation_number,
         :accreditation_birthdate,
         :feature,
+        :with_public_id,
         value: []
-      ])
+      ]
+      public_ids = params.dig(:dossier, :champs_public_attributes)&.keys || []
+      champs_attributes = public_ids.map { [_1, champ_attributes] }.to_h
+      champs_params = params.require(:dossier).permit(champs_public_attributes: champs_attributes)
       champs_params[:champs_public_all_attributes] = champs_params.delete(:champs_public_attributes) || {}
       champs_params
     end
@@ -525,8 +530,8 @@ module Users
     end
 
     def update_dossier_and_compute_errors
-      @dossier.assign_attributes(champs_public_params)
-      if @dossier.champs_public_all.any?(&:changed_for_autosave?)
+      @dossier.update_champs_public(champs_public_params[:champs_public_all_attributes])
+      if @dossier.champs.any?(&:changed_for_autosave?) || @dossier.champs_public_all.any?(&:changed_for_autosave?) # TODO remove second condition after one deploy
         @dossier.last_champ_updated_at = Time.zone.now
       end
 

--- a/app/graphql/mutations/dossier_modifier_annotation.rb
+++ b/app/graphql/mutations/dossier_modifier_annotation.rb
@@ -39,10 +39,12 @@ module Mutations
 
     def find_annotation(dossier, annotation_id)
       stable_id, row_id = Champ.decode_typed_id(annotation_id)
+      type_de_champ = dossier.revision.types_de_champ
+        .private_only
+        .find_by(type_champ: annotation_type_champ, stable_id:)
 
-      Champ.joins(:type_de_champ).find_by(type_de_champ: {
-        type_champ: annotation_type_champ, stable_id:, private: true
-      }, private: true, row_id:, dossier:)
+      return nil if type_de_champ.nil?
+      dossier.champ_for_update(type_de_champ, row_id)
     end
 
     def annotation_type_champ

--- a/app/graphql/mutations/dossier_modifier_annotation_ajouter_ligne.rb
+++ b/app/graphql/mutations/dossier_modifier_annotation_ajouter_ligne.rb
@@ -26,11 +26,13 @@ module Mutations
     private
 
     def find_annotation(dossier, annotation_id)
-      stable_id, row_id = Champ.decode_typed_id(annotation_id)
+      stable_id, _row_id = Champ.decode_typed_id(annotation_id)
+      type_de_champ = dossier.revision.types_de_champ
+        .private_only
+        .find_by(type_champ: TypeDeChamp.type_champs.fetch(:repetition), stable_id:)
 
-      Champ.joins(:type_de_champ).find_by(type_de_champ: {
-        type_champ: TypeDeChamp.type_champs.fetch(:repetition), stable_id:, private: true
-      }, private: true, row_id:, dossier:)
+      return nil if type_de_champ.nil?
+      dossier.project_champ(type_de_champ, nil)
     end
   end
 end

--- a/app/helpers/champ_helper.rb
+++ b/app/helpers/champ_helper.rb
@@ -9,7 +9,7 @@ module ChampHelper
 
   def auto_attach_url(object, params = {})
     if object.is_a?(Champ)
-      champs_attach_piece_justificative_url(object.id, params)
+      champs_piece_justificative_url(object.dossier, object.stable_id, params.merge(row_id: object.row_id))
     elsif object.is_a?(TypeDeChamp) && object.piece_justificative?
       piece_justificative_template_admin_procedure_type_de_champ_url(stable_id: object.stable_id, procedure_id: object.procedure.id, **params)
     elsif object.is_a?(TypeDeChamp) && object.explication?

--- a/app/javascript/components/MapEditor/hooks.ts
+++ b/app/javascript/components/MapEditor/hooks.ts
@@ -137,7 +137,7 @@ export function useFeatureCollection(
         for (const feature of features) {
           const id = feature.properties?.id;
           if (id) {
-            await httpRequest(`${url}/${id}`, {
+            await httpRequest(endpointWithId(url, id), {
               method: 'patch',
               json: { feature }
             }).json();
@@ -174,7 +174,9 @@ export function useFeatureCollection(
         const deletedFeatures = [];
         for (const feature of features) {
           const id = feature.properties?.id;
-          await httpRequest(`${url}/${id}`, { method: 'delete' }).json();
+          await httpRequest(endpointWithId(url, id), {
+            method: 'delete'
+          }).json();
           deletedFeatures.push(feature);
         }
         removeFeatures(deletedFeatures, external);
@@ -211,4 +213,12 @@ function useError(): [string | undefined, (message: string) => void] {
   }, [error]);
 
   return [error, onError];
+}
+
+// We need this because endoint can have query params. For example with /champs/123?row_id=abc we can't juste concatanate id.
+// We want /champs/123/456?row_id=abc not /champs/123?row_id=abc/456
+function endpointWithId(endpoint: string, id: string) {
+  const url = new URL(endpoint, document.baseURI);
+  url.pathname = `${url.pathname}/${id}`;
+  return url.toString();
 }

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -174,13 +174,13 @@ class Champ < ApplicationRecord
   # However the field index makes it difficult to render a single field, independent from the ordering of the others.
   #
   # Luckily, this is only used to make the name unique, but the actual value is ignored when Rails parses nested
-  # attributes. So instead of the field index, this method uses the champ id; which gives us an independent and
+  # attributes. So instead of the field index, this method uses the champ public_id; which gives us an independent and
   # predictable input name.
   def input_name
     if private?
-      "dossier[champs_private_attributes][#{id}]"
+      "dossier[champs_private_attributes][#{public_id}]"
     else
-      "dossier[champs_public_attributes][#{id}]"
+      "dossier[champs_public_attributes][#{public_id}]"
     end
   end
 

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -1,6 +1,9 @@
 class Champ < ApplicationRecord
   include ChampConditionalConcern
 
+  # TODO: remove after one deploy
+  attr_writer :with_public_id
+
   belongs_to :dossier, inverse_of: false, touch: true, optional: false
   belongs_to :type_de_champ, inverse_of: :champ, optional: false
   belongs_to :parent, class_name: 'Champ', optional: true

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -53,7 +53,6 @@ class Champ < ApplicationRecord
     :siret?,
     :carte?,
     :datetime?,
-    :stable_id,
     :mandatory?,
     :prefillable?,
     :refresh_after_update?,

--- a/app/models/champs/repetition_champ.rb
+++ b/app/models/champs/repetition_champ.rb
@@ -25,6 +25,15 @@ class Champs::RepetitionChamp < Champ
     added_champs
   end
 
+  def remove_row(row_id)
+    dossier.champs.where(row_id:).destroy_all
+    dossier.champs.reload
+  end
+
+  def focusable_input_id
+    rows.last&.first&.focusable_input_id
+  end
+
   def blank?
     champs.empty?
   end

--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -1,0 +1,150 @@
+module DossierChampsConcern
+  extend ActiveSupport::Concern
+
+  def find_public_type_de_champ!(stable_id)
+    revision.types_de_champ.public_only.find_by!(stable_id:)
+  end
+
+  def find_private_type_de_champ!(stable_id)
+    revision.types_de_champ.private_only.find_by!(stable_id:)
+  end
+
+  def project_champ(type_de_champ, row_id)
+    champ = champs_by_public_id[type_de_champ.public_id(row_id)]
+    if champ.nil?
+      type_de_champ.build_champ(dossier: self, row_id:)
+    else
+      champ
+    end
+  end
+
+  # Get all the champs values for the types de champ in the final list.
+  # Dossier might not have corresponding champ – display nil.
+  # To do so, we build a virtual champ when there is no value so we can call for_export with all indexes
+  def champs_for_export(types_de_champ, row_id = nil)
+    types_de_champ.flat_map do |type_de_champ|
+      champ = champ_for_export(type_de_champ, row_id)
+
+      # nil => [nil]
+      # text => [text]
+      # [commune, insee, departement] => [commune, insee, departement]
+      wrapped_exported_values = [champ.for_export].flatten
+
+      wrapped_exported_values.map.with_index do |champ_value, index|
+        [type_de_champ.libelle_for_export(index), champ_value]
+      end
+    end
+  end
+
+  def champs_for_prefill(stable_ids)
+    revision
+      .types_de_champ
+      .filter { _1.stable_id.in?(stable_ids) }
+      .filter { !revision.child?(_1) }
+      .map { champ_for_update(_1, nil) }
+  end
+
+  def champ_for_update(type_de_champ, row_id)
+    champ, attributes = champ_with_attributes_for_update(type_de_champ, row_id)
+    champ.assign_attributes(attributes)
+    champ
+  end
+
+  def champs_for_revision(scope: nil, root: false)
+    champs_index = champs.group_by(&:stable_id)
+      # Due to some bad data we can have multiple copies of the same champ. Ignore extra copy.
+      .transform_values { _1.sort_by(&:id).uniq(&:row_id) }
+
+    if scope.is_a?(TypeDeChamp)
+      revision
+        .children_of(scope)
+        .flat_map { champs_index[_1.stable_id] || [] }
+        .filter(&:child?) # TODO: remove once bad data (child champ without a row id) is cleaned
+    else
+      revision
+        .types_de_champ_for(scope:, root:)
+        .flat_map { champs_index[_1.stable_id] || [] }
+    end
+  end
+
+  def update_champs_public(attributes)
+    # TODO: remove after one deploy
+    if attributes.present? && attributes.values.filter { _1.key?(:with_public_id) }.empty?
+      assign_attributes(champs_public_all_attributes: attributes)
+      @champs_by_public_id = nil
+      return
+    end
+
+    champs_attributes = attributes
+      .keys
+      .map do
+        stable_id, row_id = _1.split('-')
+        type_de_champ = revision.types_de_champ.public_only.find_by!(stable_id:)
+        champ_with_attributes_for_update(type_de_champ, row_id).last.merge(attributes[_1])
+      end
+
+    assign_attributes(champs_attributes:)
+  end
+
+  def update_champs_private(attributes)
+    # TODO: remove after one deploy
+    if attributes.present? && attributes.values.filter { _1.key?(:with_public_id) }.empty?
+      assign_attributes(champs_private_all_attributes: attributes)
+      @champs_by_public_id = nil
+      return
+    end
+
+    champs_attributes = attributes
+      .keys
+      .map do
+        stable_id, row_id = _1.split('-')
+        type_de_champ = revision.types_de_champ.private_only.find_by!(stable_id:)
+        champ_with_attributes_for_update(type_de_champ, row_id).last.merge(attributes[_1])
+      end
+
+    assign_attributes(champs_attributes:)
+  end
+
+  private
+
+  def champs_by_public_id
+    @champs_by_public_id ||= champs.sort_by(&:id).index_by(&:public_id)
+  end
+
+  def champ_for_export(type_de_champ, row_id)
+    champ = champs_by_public_id[type_de_champ.public_id(row_id)]
+    if champ.blank? || !champ.visible?
+      nil
+    else
+      champ
+    end
+  end
+
+  def champ_with_attributes_for_update(type_de_champ, row_id)
+    attributes = type_de_champ.params_for_champ
+    # TODO: Once we have the right index in place, we should change this to use `create_or_find_by` instead of `find_or_create_by`
+    champ = champs
+      .create_with(type_de_champ:, **attributes)
+      .find_or_create_by(stable_id: type_de_champ.stable_id, row_id:)
+
+    attributes[:id] = champ.id
+
+    if champ.type != attributes[:type]
+      attributes[:value] = nil
+      attributes[:value_json] = nil
+      attributes[:external_id] = nil
+      attributes[:data] = nil
+    end
+
+    parent = revision.parent_of(type_de_champ)
+    if parent.present?
+      attributes[:parent] = champs.find { _1.type_de_champ_id == parent.id }
+    else
+      attributes[:parent] = nil
+    end
+
+    @champs_by_public_id = nil
+
+    return champ, attributes
+  end
+end

--- a/app/models/concerns/dossier_prefillable_concern.rb
+++ b/app/models/concerns/dossier_prefillable_concern.rb
@@ -13,8 +13,4 @@ module DossierPrefillableConcern
     assign_attributes(attributes)
     save(validate: false)
   end
-
-  def find_champs_by_stable_ids(stable_ids)
-    champs.joins(:type_de_champ).where(types_de_champ: { stable_id: stable_ids.compact.uniq })
-  end
 end

--- a/app/models/prefill_champs.rb
+++ b/app/models/prefill_champs.rb
@@ -23,7 +23,7 @@ class PrefillChamps
       .to_h
 
     dossier
-      .find_champs_by_stable_ids(value_by_stable_id.keys)
+      .champs_for_prefill(value_by_stable_id.keys)
       .map { |champ| [champ, value_by_stable_id[champ.stable_id]] }
       .map { |champ, value| PrefillValue.new(champ:, value:, dossier:) }
   end

--- a/app/models/types_de_champ/prefill_repetition_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_repetition_type_de_champ.rb
@@ -54,14 +54,17 @@ class TypesDeChamp::PrefillRepetitionTypeDeChamp < TypesDeChamp::PrefillTypeDeCh
     def to_assignable_attributes
       return unless repetition.is_a?(Hash)
 
-      row = champ.rows[index] || champ.add_row(champ.dossier_revision)
+      row = champ.rows[index] || champ.add_row(revision)
+      row_id = row.first.row_id
 
       repetition.map do |key, value|
         next unless key.is_a?(String) && key.starts_with?("champ_")
 
-        subchamp = row.find { |champ| champ.stable_id == Champ.stable_id_from_typed_id(key) }
-        next unless subchamp
+        stable_id = Champ.stable_id_from_typed_id(key)
+        type_de_champ = revision.types_de_champ.find_by(stable_id:)
+        next unless type_de_champ
 
+        subchamp = champ.dossier.champ_for_update(type_de_champ, row_id)
         TypesDeChamp::PrefillTypeDeChamp.build(subchamp.type_de_champ, revision).to_assignable_attributes(subchamp, value)
       end.compact
     end

--- a/app/policies/dossier_policy.rb
+++ b/app/policies/dossier_policy.rb
@@ -1,0 +1,39 @@
+class DossierPolicy < ApplicationPolicy
+  # Scope for WRITING to a dossier.
+  #
+  # (If the need for a scope to READ a dossier emerges, we can implement another scope
+  # in this file, following this example: https://github.com/varvet/pundit/issues/368#issuecomment-196111115)
+  class Scope < ApplicationScope
+    def resolve
+      if user.blank?
+        return scope.none
+      end
+
+      # The join must be the same for all elements of the WHERE clause.
+      #
+      # NB: here we want to do `.left_outer_joins(:invites, { :groupe_instructeur: :instructeurs })`,
+      # but for some reasons ActiveRecord <= 5.2 generates bogus SQL. Hence the manual version of it below.
+      joined_scope = scope
+        .joins('LEFT OUTER JOIN invites ON invites.dossier_id = dossiers.id OR invites.dossier_id = dossiers.editing_fork_origin_id')
+        .joins('LEFT OUTER JOIN groupe_instructeurs ON groupe_instructeurs.id = dossiers.groupe_instructeur_id')
+        .joins('LEFT OUTER JOIN assign_tos ON assign_tos.groupe_instructeur_id = groupe_instructeurs.id')
+        .joins('LEFT OUTER JOIN instructeurs ON instructeurs.id = assign_tos.instructeur_id')
+
+      # Users can access public champs on their own dossiers.
+      resolved_scope = joined_scope.where(user_id: user.id)
+
+      # Invited users can access public champs on dossiers they are invited to
+      invite_clause = joined_scope.where('invites.user_id': user.id)
+      resolved_scope = resolved_scope.or(invite_clause)
+
+      if instructeur.present?
+        # Additionnaly, instructeurs can access private champs
+        # on dossiers they are allowed to instruct.
+        instructeur_clause = joined_scope.where('instructeurs.id': instructeur.id)
+        resolved_scope = resolved_scope.or(instructeur_clause)
+      end
+
+      resolved_scope.or(joined_scope.where(for_procedure_preview: true))
+    end
+  end
+end

--- a/app/views/champs/repetition/remove.turbo_stream.haml
+++ b/app/views/champs/repetition/remove.turbo_stream.haml
@@ -1,6 +1,2 @@
-= turbo_stream.remove "safe-row-selector-#{@row_id}"
-
-- if @champ.rows.size > 0 && @champ.rows.last&.first&.present?
-  = turbo_stream.focus @champ.rows.last&.first.focusable_input_id
-- else
-  = turbo_stream.focus dom_id(@champ, :create_repetition)
+= turbo_stream.remove @to_remove
+= turbo_stream.focus @to_focus

--- a/app/views/shared/_piece_justificative_template.html.haml
+++ b/app/views/shared/_piece_justificative_template.html.haml
@@ -1,1 +1,1 @@
-= render Dsfr::DownloadComponent.new(attachment: champ.type_de_champ.piece_justificative_template, url: champs_piece_justificative_template_path(champ), name: "Modèle à télécharger", ephemeral_link: administrateur_signed_in? )
+= render Dsfr::DownloadComponent.new(attachment: champ.type_de_champ.piece_justificative_template, url: champs_piece_justificative_template_path(champ.dossier, champ.stable_id, row_id: champ.row_id), name: "Modèle à télécharger", ephemeral_link: administrateur_signed_in? )

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -195,21 +195,33 @@ Rails.application.routes.draw do
   namespace :champs do
     post ':dossier_id/:stable_id/repetition', to: 'repetition#add', as: :repetition
     delete ':dossier_id/:stable_id/repetition', to: 'repetition#remove'
-    post ':champ_id/repetition', to: 'repetition#add'
-    delete ':champ_id/repetition', to: 'repetition#remove'
 
-    get ':champ_id/siret', to: 'siret#show', as: :siret
-    get ':champ_id/rna', to: 'rna#show', as: :rna
-    delete ':champ_id/options', to: 'options#remove', as: :options
+    get ':dossier_id/:stable_id/siret', to: 'siret#show', as: :siret
+    get ':dossier_id/:stable_id/rna', to: 'rna#show', as: :rna
+    delete ':dossier_id/:stable_id/options', to: 'options#remove', as: :options
 
-    get ':champ_id/carte/features', to: 'carte#index', as: :carte_features
+    get ':dossier_id/:stable_id/carte/features', to: 'carte#index', as: :carte_features
+    post ':dossier_id/:stable_id/carte/features', to: 'carte#create'
+    patch ':dossier_id/:stable_id/carte/features/:id', to: 'carte#update', as: :carte_feature
+    delete ':dossier_id/:stable_id/carte/features/:id', to: 'carte#destroy'
+
+    get ':dossier_id/:stable_id/piece_justificative', to: 'piece_justificative#show', as: :piece_justificative
+    put ':dossier_id/:stable_id/piece_justificative', to: 'piece_justificative#update'
+    get ':dossier_id/:stable_id/piece_justificative/template', to: 'piece_justificative#template', as: :piece_justificative_template
+
+    # TODO: remove after one deploy
+    get ':champ_id/siret', to: 'siret#show'
+    get ':champ_id/rna', to: 'rna#show'
+    delete ':champ_id/options', to: 'options#remove'
+
+    get ':champ_id/carte/features', to: 'carte#index'
     post ':champ_id/carte/features', to: 'carte#create'
     patch ':champ_id/carte/features/:id', to: 'carte#update'
     delete ':champ_id/carte/features/:id', to: 'carte#destroy'
 
-    get ':champ_id/piece_justificative', to: 'piece_justificative#show', as: :piece_justificative
-    put ':champ_id/piece_justificative', to: 'piece_justificative#update', as: :attach_piece_justificative
-    get ':champ_id/piece_justificative/template', to: 'piece_justificative#template', as: :piece_justificative_template
+    get ':champ_id/piece_justificative', to: 'piece_justificative#show'
+    put ':champ_id/piece_justificative', to: 'piece_justificative#update'
+    get ':champ_id/piece_justificative/template', to: 'piece_justificative#template'
   end
 
   resources :attachments, only: [:show, :destroy]
@@ -360,7 +372,7 @@ Rails.application.routes.draw do
         get 'modifier', to: 'dossiers#modifier'
         post 'modifier', to: 'dossiers#submit_en_construction'
         patch 'modifier', to: 'dossiers#modifier_legacy'
-        get 'champs/:champ_id', to: 'dossiers#champ', as: :champ
+        get 'champs/:stable_id', to: 'dossiers#champ', as: :champ
         get 'merci'
         get 'demande'
         get 'messagerie'
@@ -483,7 +495,7 @@ Rails.application.routes.draw do
             get 'avis'
             get 'avis_new'
             get 'personnes-impliquees' => 'dossiers#personnes_impliquees'
-            get 'annotations/:annotation_id', to: 'dossiers#annotation', as: :annotation
+            get 'annotations/:stable_id', to: 'dossiers#annotation', as: :annotation
             patch 'follow'
             patch 'unfollow'
             patch 'archive'

--- a/spec/controllers/champs/repetition_controller_spec.rb
+++ b/spec/controllers/champs/repetition_controller_spec.rb
@@ -5,8 +5,9 @@ describe Champs::RepetitionController, type: :controller do
 
     before { sign_in dossier.user }
     it 'removes repetition' do
-      rows, repetitions = dossier.champs.partition { _1.parent_id.present? }
-      expect { delete :remove, params: { champ_id: repetitions.first.id, row_id: rows.first.row_id }, format: :turbo_stream }
+      rows, repetitions = dossier.champs.partition(&:child?)
+      repetition = repetitions.first
+      expect { delete :remove, params: { dossier_id: repetition.dossier, stable_id: repetition.stable_id, row_id: rows.first.row_id }, format: :turbo_stream }
         .to change { dossier.reload.champs.size }.from(3).to(1)
     end
   end

--- a/spec/controllers/champs/rna_controller_spec.rb
+++ b/spec/controllers/champs/rna_controller_spec.rb
@@ -7,8 +7,8 @@ describe Champs::RNAController, type: :controller do
     let(:champ) { dossier.champs_public.first }
 
     let(:champs_public_attributes) do
-      champ_attributes = []
-      champ_attributes[champ.id] = { value: rna }
+      champ_attributes = {}
+      champ_attributes[champ.public_id] = { value: rna }
       champ_attributes
     end
     let(:params) do

--- a/spec/controllers/champs/siret_controller_spec.rb
+++ b/spec/controllers/champs/siret_controller_spec.rb
@@ -7,8 +7,8 @@ describe Champs::SiretController, type: :controller do
     let(:champ) { dossier.champs_public.first }
 
     let(:champs_public_attributes) do
-      champ_attributes = []
-      champ_attributes[champ.id] = { value: siret }
+      champ_attributes = {}
+      champ_attributes[champ.public_id] = { value: siret }
       champ_attributes
     end
     let(:params) do

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -975,25 +975,25 @@ describe Instructeurs::DossiersController, type: :controller do
             dossier_id: dossier.id,
             dossier: {
               champs_private_attributes: {
-                '0': {
-                  id: champ_multiple_drop_down_list.id,
+                champ_multiple_drop_down_list.public_id => {
+                  with_public_id: true,
                   value: ['', 'val1', 'val2']
                 },
-                '1': {
-                  id: champ_datetime.id,
+                champ_datetime.public_id => {
+                  with_public_id: true,
                   value: '2019-12-21T13:17'
                 },
-                '2': {
-                  id: champ_linked_drop_down_list.id,
+                champ_linked_drop_down_list.public_id => {
+                  with_public_id: true,
                   primary_value: 'primary',
                   secondary_value: 'secondary'
                 },
-                '3': {
-                  id: champ_repetition.champs.first.id,
+                champ_repetition.champs.first.public_id => {
+                  with_public_id: true,
                   value: 'text'
                 },
-                '4': {
-                  id: champ_drop_down_list.id,
+                champ_drop_down_list.public_id => {
+                  with_public_id: true,
                   value: '__other__',
                   value_other: 'other value'
                 }
@@ -1044,12 +1044,11 @@ describe Instructeurs::DossiersController, type: :controller do
       end
     end
 
-    context 'with invalid champs_public (DecimalNumberChamp)' do
-      let(:types_de_champ_public) do
-        [
-          { type: :decimal_number }
-        ]
-      end
+    after do
+      Timecop.return
+    end
+
+    context "with new values for champs_private (legacy)" do
       let(:params) do
         {
           procedure_id: procedure.id,
@@ -1066,8 +1065,62 @@ describe Instructeurs::DossiersController, type: :controller do
       end
 
       it 'update champs_private' do
+        patch :update_annotations, params: params, format: :turbo_stream
+        champ_datetime.reload
+        expect(champ_datetime.value).to eq(Time.zone.parse('2024-03-30T07:03:00').iso8601)
+      end
+    end
+
+    context "without new values for champs_private" do
+      let(:params) do
+        {
+          procedure_id: procedure.id,
+          dossier_id: dossier.id,
+          dossier: {
+            champs_private_attributes: {},
+            champs_public_attributes: {
+              champ_multiple_drop_down_list.public_id => {
+                with_public_id: true,
+                value: ['', 'val1', 'val2']
+              }
+            }
+          }
+        }
+      end
+
+      it {
+        expect(dossier.reload.last_champ_private_updated_at).to eq(nil)
+        expect(response).to have_http_status(200)
+      }
+    end
+
+    context "with invalid champs_public (DecimalNumberChamp)" do
+      let(:types_de_champ_public) do
+        [
+          { type: :decimal_number }
+        ]
+      end
+
+      let(:champ_decimal_number) { dossier.champs_public.first }
+
+      let(:params) do
+        {
+          procedure_id: procedure.id,
+          dossier_id: dossier.id,
+          dossier: {
+            champs_private_attributes: {
+              champ_datetime.public_id => {
+                with_public_id: true,
+                value: '2024-03-30T07:03'
+              }
+            }
+          }
+        }
+      end
+
+      it 'update champs_private' do
         too_long_float = '3.1415'
-        dossier.champs_public.first.update_column(:value, too_long_float)
+        champ_decimal_number.update_column(:value, too_long_float)
         patch :update_annotations, params: params, format: :turbo_stream
         champ_datetime.reload
         expect(champ_datetime.value).to eq(Time.zone.parse('2024-03-30T07:03:00').iso8601)

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -674,12 +674,12 @@ describe Users::DossiersController, type: :controller do
         dossier: {
           groupe_instructeur_id: dossier.groupe_instructeur_id,
           champs_public_attributes: {
-            first_champ.id => {
-              id: first_champ.id,
+            first_champ.public_id => {
+              with_public_id: true,
               value: value
             },
-            piece_justificative_champ.id => {
-              id: piece_justificative_champ.id,
+            piece_justificative_champ.public_id => {
+              with_public_id: true,
               piece_justificative_file: file
             }
           }
@@ -719,7 +719,7 @@ describe Users::DossiersController, type: :controller do
           {
             id: dossier.id,
             dossier: {
-              champs_public_attributes: { first_champ.id => { id: first_champ.id } }
+              champs_public_attributes: { first_champ.public_id => { with_public_id: true } }
             }
           }
         end
@@ -747,7 +747,7 @@ describe Users::DossiersController, type: :controller do
         {
           id: dossier.id,
           dossier: {
-            champs_public_attributes: { first_champ.id => { id: first_champ.id, value: value } }
+            champs_public_attributes: { first_champ.public_id => { with_public_id: true, value: value } }
           }
         }
       end
@@ -790,12 +790,12 @@ describe Users::DossiersController, type: :controller do
         dossier: {
           groupe_instructeur_id: dossier.groupe_instructeur_id,
           champs_public_attributes: {
-            first_champ.id => {
-              id: first_champ.id,
+            first_champ.public_id => {
+              with_public_id: true,
               value: value
             },
-            piece_justificative_champ.id => {
-              id: piece_justificative_champ.id,
+            piece_justificative_champ.public_id => {
+              with_public_id: true,
               piece_justificative_file: file
             }
           }
@@ -855,8 +855,8 @@ describe Users::DossiersController, type: :controller do
             id: dossier.id,
             dossier: {
               champs_public_attributes: {
-                piece_justificative_champ.id => {
-                  id: piece_justificative_champ.id,
+                piece_justificative_champ.public_id => {
+                  with_public_id: true,
                   piece_justificative_file: file
                 }
               }
@@ -951,8 +951,8 @@ describe Users::DossiersController, type: :controller do
           id: dossier.id,
           dossier: {
             champs_public_attributes: {
-              first_champ.id => {
-                id: first_champ.id,
+              first_champ.public_id => {
+                with_public_id: true,
                 value: value
               }
             }

--- a/spec/models/champ_spec.rb
+++ b/spec/models/champ_spec.rb
@@ -496,41 +496,6 @@ describe Champ do
         expect(champ_text_row_1.dossier_id).to eq(champ.dossier_id)
       end
     end
-
-    context 'when updating using nested attributes' do
-      subject do
-        dossier.update!(champs_public_attributes: [
-          {
-            id: champ.id,
-            champs_attributes: [champ_text_attrs]
-          }
-        ])
-        champ.reload
-        dossier.reload
-      end
-
-      it 'associates nested champs to the parent dossier' do
-        subject
-
-        expect(dossier.champs_public.size).to eq(2)
-        expect(champ.rows.size).to eq(2)
-        second_row = champ.reload.rows.second
-        expect(second_row.size).to eq(1)
-        expect(second_row.first.dossier).to eq(dossier)
-
-        champ.champs << champ_integer
-        first_row = champ.reload.rows.first
-        expect(first_row.size).to eq(2)
-        expect(first_row.second).to eq(champ_integer)
-
-        champ.champs << champ_text
-        first_row = champ.reload.rows.first
-        expect(first_row.size).to eq(2)
-        expect(first_row.first).to eq(champ_text)
-
-        expect(champ.rows.size).to eq(2)
-      end
-    end
   end
 
   describe '#log_fetch_external_data_exception' do

--- a/spec/models/champ_spec.rb
+++ b/spec/models/champ_spec.rb
@@ -572,21 +572,21 @@ describe Champ do
 
   describe "#input_name" do
     let(:champ) { create(:champ_text) }
-    it { expect(champ.input_name).to eq "dossier[champs_public_attributes][#{champ.id}]" }
+    it { expect(champ.input_name).to eq "dossier[champs_public_attributes][#{champ.public_id}]" }
 
     context "when private" do
       let(:champ) { create(:champ_text, private: true) }
-      it { expect(champ.input_name).to eq "dossier[champs_private_attributes][#{champ.id}]" }
+      it { expect(champ.input_name).to eq "dossier[champs_private_attributes][#{champ.public_id}]" }
     end
 
     context "when has parent" do
       let(:champ) { create(:champ_text, parent: create(:champ_text)) }
-      it { expect(champ.input_name).to eq "dossier[champs_public_attributes][#{champ.id}]" }
+      it { expect(champ.input_name).to eq "dossier[champs_public_attributes][#{champ.public_id}]" }
     end
 
     context "when has private parent" do
       let(:champ) { create(:champ_text, private: true, parent: create(:champ_text, private: true)) }
-      it { expect(champ.input_name).to eq "dossier[champs_private_attributes][#{champ.id}]" }
+      it { expect(champ.input_name).to eq "dossier[champs_private_attributes][#{champ.public_id}]" }
     end
   end
 

--- a/spec/models/champs/carte_champ_spec.rb
+++ b/spec/models/champs/carte_champ_spec.rb
@@ -21,7 +21,7 @@ describe Champs::CarteChamp do
     let(:feature_collection) {
       {
         type: 'FeatureCollection',
-        id: champ.type_de_champ.stable_id,
+        id: champ.stable_id,
         bbox: champ.bounding_box,
         features: features
       }

--- a/spec/models/concern/dossier_champs_concern_spec.rb
+++ b/spec/models/concern/dossier_champs_concern_spec.rb
@@ -1,0 +1,294 @@
+RSpec.describe DossierChampsConcern do
+  let(:procedure) do
+    create(:procedure, types_de_champ_public:, types_de_champ_private:)
+  end
+  let(:types_de_champ_public) do
+    [
+      { type: :text, libelle: "Un champ text", stable_id: 99 },
+      { type: :text, libelle: "Un autre champ text", stable_id: 991 },
+      { type: :yes_no, libelle: "Un champ yes no", stable_id: 992 },
+      { type: :repetition, libelle: "Un champ répétable", stable_id: 993, mandatory: true, children: [{ type: :text, libelle: 'Nom', stable_id: 994 }] }
+    ]
+  end
+  let(:types_de_champ_private) do
+    [
+      { type: :text, libelle: "Une annotation", stable_id: 995 }
+    ]
+  end
+  let(:dossier) { create(:dossier, procedure:) }
+
+  describe "#find_public_type_de_champ!" do
+    subject { dossier.find_public_type_de_champ!(992) }
+
+    it { is_expected.to be_truthy }
+  end
+
+  describe "#find_private_type_de_champ!" do
+    subject { dossier.find_private_type_de_champ!(995) }
+
+    it { is_expected.to be_truthy }
+  end
+
+  describe "#project_champ" do
+    let(:type_de_champ_repetition) { dossier.find_public_type_de_champ!(993) }
+    let(:type_de_champ_public) { dossier.find_public_type_de_champ!(99) }
+    let(:type_de_champ_private) { dossier.find_private_type_de_champ!(995) }
+    let(:row_ids) { dossier.project_champ(type_de_champ_repetition, nil).row_ids }
+
+    context "public champ" do
+      let(:row_id) { nil }
+      subject { dossier.project_champ(type_de_champ_public, row_id) }
+
+      it { expect(subject.persisted?).to be_truthy }
+
+      context "in repetition" do
+        let(:type_de_champ_public) { dossier.find_public_type_de_champ!(994) }
+        let(:row_id) { row_ids.first }
+
+        it {
+          expect(subject.persisted?).to be_truthy
+          expect(subject.row_id).to eq(row_id)
+          expect(subject.parent_id).not_to be_nil
+        }
+      end
+
+      context "missing champ" do
+        before { dossier; Champs::TextChamp.destroy_all }
+
+        it {
+          expect(subject.new_record?).to be_truthy
+          expect(subject.is_a?(Champs::TextChamp)).to be_truthy
+        }
+
+        context "in repetition" do
+          let(:type_de_champ_public) { dossier.find_public_type_de_champ!(994) }
+          let(:row_id) { row_ids.first }
+
+          it {
+            expect(subject.new_record?).to be_truthy
+            expect(subject.is_a?(Champs::TextChamp)).to be_truthy
+            expect(subject.row_id).to eq(row_id)
+          }
+        end
+      end
+    end
+
+    context "private champ" do
+      subject { dossier.project_champ(type_de_champ_private, nil) }
+
+      it { expect(subject.persisted?).to be_truthy }
+
+      context "missing champ" do
+        before { dossier; Champs::TextChamp.destroy_all }
+
+        it {
+          expect(subject.new_record?).to be_truthy
+          expect(subject.is_a?(Champs::TextChamp)).to be_truthy
+        }
+      end
+    end
+  end
+
+  describe "#champs_for_export" do
+    subject { dossier.champs_for_export(dossier.revision.types_de_champ_public) }
+
+    it { expect(subject.size).to eq(4) }
+    it { expect(subject.first).to eq(["Un champ text", nil]) }
+  end
+
+  describe "#champs_for_prefill" do
+    subject { dossier.champs_for_prefill([991, 995]) }
+
+    it {
+      expect(subject.size).to eq(2)
+      expect(subject.map(&:libelle)).to eq(["Une annotation", "Un autre champ text"])
+      expect(subject.all?(&:persisted?)).to be_truthy
+    }
+
+    context "missing champ" do
+      before { dossier; Champs::TextChamp.destroy_all }
+
+      it {
+        expect(subject.size).to eq(2)
+        expect(subject.map(&:libelle)).to eq(["Une annotation", "Un autre champ text"])
+        expect(subject.all?(&:persisted?)).to be_truthy
+      }
+    end
+  end
+
+  describe "#champ_for_update" do
+    let(:type_de_champ_repetition) { dossier.find_public_type_de_champ!(993) }
+    let(:type_de_champ_public) { dossier.find_public_type_de_champ!(99) }
+    let(:type_de_champ_private) { dossier.find_private_type_de_champ!(995) }
+    let(:row_ids) { dossier.project_champ(type_de_champ_repetition, nil).row_ids }
+    let(:row_id) { nil }
+
+    context "public champ" do
+      subject { dossier.champ_for_update(type_de_champ_public, row_id) }
+
+      it {
+        expect(subject.persisted?).to be_truthy
+        expect(subject.row_id).to eq(row_id)
+      }
+
+      context "in repetition" do
+        let(:type_de_champ_public) { dossier.find_public_type_de_champ!(994) }
+        let(:row_id) { row_ids.first }
+
+        it {
+          expect(subject.persisted?).to be_truthy
+          expect(subject.row_id).to eq(row_id)
+          expect(subject.parent_id).not_to be_nil
+        }
+      end
+
+      context "missing champ" do
+        before { dossier; Champs::TextChamp.destroy_all }
+
+        it {
+          expect(subject.persisted?).to be_truthy
+          expect(subject.is_a?(Champs::TextChamp)).to be_truthy
+        }
+
+        context "in repetition" do
+          let(:type_de_champ_public) { dossier.find_public_type_de_champ!(994) }
+          let(:row_id) { row_ids.first }
+
+          it {
+            expect(subject.persisted?).to be_truthy
+            expect(subject.is_a?(Champs::TextChamp)).to be_truthy
+            expect(subject.row_id).to eq(row_id)
+            expect(subject.parent_id).not_to be_nil
+          }
+        end
+      end
+    end
+
+    context "private champ" do
+      subject { dossier.champ_for_update(type_de_champ_private, row_id) }
+
+      it {
+        expect(subject.persisted?).to be_truthy
+        expect(subject.row_id).to eq(row_id)
+      }
+    end
+  end
+
+  describe "#update_champs_public" do
+    let(:type_de_champ_repetition) { dossier.find_public_type_de_champ!(993) }
+    let(:row_ids) { dossier.project_champ(type_de_champ_repetition, nil).row_ids }
+    let(:row_id) { row_ids.first }
+
+    let(:attributes) do
+      {
+        "99" => { value: "Hello", with_public_id: true },
+        "991" => { value: "World", with_public_id: true },
+        "994-#{row_id}" => { value: "Greer", with_public_id: true }
+      }
+    end
+
+    let(:champ_99) { dossier.project_champ(dossier.find_public_type_de_champ!(99), nil) }
+    let(:champ_991) { dossier.project_champ(dossier.find_public_type_de_champ!(991), nil) }
+    let(:champ_994) { dossier.project_champ(dossier.find_public_type_de_champ!(994), row_id) }
+
+    subject { dossier.update_champs_public(attributes) }
+
+    it {
+      subject
+      expect(dossier.champs.any?(&:changed_for_autosave?)).to be_truthy
+      expect(champ_99.changed?).to be_truthy
+      expect(champ_991.changed?).to be_truthy
+      expect(champ_994.changed?).to be_truthy
+      expect(champ_99.value).to eq("Hello")
+      expect(champ_991.value).to eq("World")
+      expect(champ_994.value).to eq("Greer")
+    }
+
+    context "missing champs" do
+      before { dossier; Champs::TextChamp.destroy_all; }
+
+      it {
+        subject
+        expect(dossier.champs.any?(&:changed_for_autosave?)).to be_truthy
+        expect(champ_99.changed?).to be_truthy
+        expect(champ_991.changed?).to be_truthy
+        expect(champ_994.changed?).to be_truthy
+        expect(champ_99.value).to eq("Hello")
+        expect(champ_991.value).to eq("World")
+        expect(champ_994.value).to eq("Greer")
+      }
+    end
+
+    context 'legacy attributes' do
+      let(:attributes) do
+        {
+          champ_99.id => { value: "Hello", id: champ_99.id },
+          champ_991.id => { value: "World", id: champ_991.id },
+          champ_994.id => { value: "Greer", id: champ_994.id }
+        }
+      end
+
+      let(:champ_99_updated) { dossier.project_champ(dossier.find_public_type_de_champ!(99), nil) }
+      let(:champ_991_updated) { dossier.project_champ(dossier.find_public_type_de_champ!(991), nil) }
+      let(:champ_994_updated) { dossier.project_champ(dossier.find_public_type_de_champ!(994), row_id) }
+
+      it {
+        subject
+        expect(dossier.champs_public_all.any?(&:changed_for_autosave?)).to be_truthy
+        dossier.save
+        dossier.reload
+        expect(champ_99_updated.value).to eq("Hello")
+        expect(champ_991_updated.value).to eq("World")
+        expect(champ_994_updated.value).to eq("Greer")
+      }
+    end
+  end
+
+  describe "#update_champs_private" do
+    let(:attributes) do
+      {
+        "995" => { value: "Hello", with_public_id: true }
+      }
+    end
+
+    let(:annotation_995) { dossier.project_champ(dossier.find_private_type_de_champ!(995), nil) }
+
+    subject { dossier.update_champs_private(attributes) }
+
+    it {
+      subject
+      expect(dossier.champs.any?(&:changed_for_autosave?)).to be_truthy
+      expect(annotation_995.changed?).to be_truthy
+      expect(annotation_995.value).to eq("Hello")
+    }
+
+    context "missing champs" do
+      before { dossier; Champs::TextChamp.destroy_all; }
+
+      it {
+        subject
+        expect(dossier.champs.any?(&:changed_for_autosave?)).to be_truthy
+        expect(annotation_995.changed?).to be_truthy
+        expect(annotation_995.value).to eq("Hello")
+      }
+    end
+
+    context 'legacy attributes' do
+      let(:attributes) do
+        {
+          annotation_995.id => { value: "Hello", id: annotation_995.id }
+        }
+      end
+
+      let(:annotation_995_updated) { dossier.project_champ(dossier.find_private_type_de_champ!(995), nil) }
+
+      it {
+        subject
+        expect(dossier.champs_private_all.any?(&:changed_for_autosave?)).to be_truthy
+        dossier.save
+        dossier.reload
+        expect(annotation_995_updated.value).to eq("Hello")
+      }
+    end
+  end
+end

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -2183,41 +2183,6 @@ describe Dossier, type: :model do
     end
   end
 
-  describe '#find_champs_by_stable_ids' do
-    let(:procedure) { create(:procedure, :published) }
-    let(:dossier) { create(:dossier, :brouillon, procedure: procedure) }
-
-    subject { dossier.find_champs_by_stable_ids(stable_ids) }
-
-    context 'when stable_ids is empty' do
-      let(:stable_ids) { [] }
-
-      it { expect(subject).to match([]) }
-    end
-
-    context 'when stable_ids contains nil or blank values' do
-      let(:stable_ids) { [nil, ""] }
-
-      it { expect(subject).to match([]) }
-    end
-
-    context 'when stable_ids contains present values' do
-      context 'when the dossier has no champ with the given stable ids' do
-        let(:stable_ids) { ['My Neighbor Totoro', 'Miyazaki'] }
-
-        it { expect(subject).to match([]) }
-      end
-
-      context 'when the dossier has champs with the given stable ids' do
-        let!(:type_de_champ_1) { create(:type_de_champ_text, procedure: procedure) }
-        let!(:type_de_champ_2) { create(:type_de_champ_textarea, procedure: procedure) }
-        let(:stable_ids) { [type_de_champ_1.stable_id, type_de_champ_2.stable_id] }
-
-        it { expect(subject).to match_array(dossier.champs_public.joins(:type_de_champ).where(types_de_champ: { stable_id: stable_ids })) }
-      end
-    end
-  end
-
   describe 'BatchOperation' do
     subject { build(:dossier) }
     it { is_expected.to belong_to(:batch_operation).optional }


### PR DESCRIPTION
Cette PR bascule le référencement des champs de `id` vers `[dossier_id, stable_id, row_id]`

- [ ] Avant de merger cette PR, il faut attendre la fin de la tâche qui ajoute les `stable_id` à tous les champs