### PR TITLE
Tech: bannière indiquant staging / env de test plus visible

### DIFF
--- a/app/assets/stylesheets/beta.scss
+++ b/app/assets/stylesheets/beta.scss
@@ -2,14 +2,14 @@
   text-align: center;
   text-transform: uppercase;
   position: fixed;
-  bottom: 26px;
+  top: 26px;
   right: -35px;
-  transform: rotate(-45deg);
+  transform: rotate(45deg);
   width: 150px;
   background-color: #008CBA;
   color: #FFFFFF;
   padding: 5px;
   font-size: 15px;
   font-weight: 700;
-  z-index: 10;
+  z-index: 1000;
 }


### PR DESCRIPTION
Je veux pas de nouveau perdre 1h à faire des trucs sur la dev pensant que j'étais sur la prod, donc on cale le truc en haut à droite plutôt qu'en bas

<img width="622" alt="Capture d’écran 2024-03-25 à 14 06 07" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/e69e3e12-7f2b-4988-bfd8-a5501f44b9e2">
