### PR TITLE
Correctif API Entreprise: transmet l'APPLICATION_NAME en `context`

### DIFF
--- a/app/lib/api_entreprise/api.rb
+++ b/app/lib/api_entreprise/api.rb
@@ -163,7 +163,7 @@ class APIEntreprise::API
 
   def base_params(siret_or_siren)
     {
-      context: Current.application_name,
+      context: APPLICATION_NAME,
       recipient: recipient_for(siret_or_siren),
       non_diffusables: true
     }

--- a/spec/lib/api_entreprise/api_spec.rb
+++ b/spec/lib/api_entreprise/api_spec.rb
@@ -120,7 +120,8 @@ describe APIEntreprise::API do
   describe '.etablissement' do
     subject { described_class.new(procedure_id).etablissement(siret) }
     before do
-      stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v3\/insee\/sirene\/etablissements\/#{siret}?.*non_diffusables=true/)
+      stub_request(:get, "https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/#{siret}")
+        .with(query: { "non_diffusables" => "true", "context" => APPLICATION_NAME, "object" => "procedure_id: #{procedure_id}", "recipient" => ENV.fetch("API_ENTREPRISE_DEFAULT_SIRET") })
         .to_return(status: status, body: body)
       allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
     end


### PR DESCRIPTION
`Current` n'est pas entièrement défini dans les jobs