### PR TITLE
ETQ usager : Champ choix multiple, ajouter une aide a a la saisie

### DIFF
--- a/app/components/editable_champ/multiple_drop_down_list_component/multiple_drop_down_list_component.en.yml
+++ b/app/components/editable_champ/multiple_drop_down_list_component/multiple_drop_down_list_component.en.yml
@@ -1,0 +1,3 @@
+---
+en:
+  prompt: "Select"

--- a/app/components/editable_champ/multiple_drop_down_list_component/multiple_drop_down_list_component.fr.yml
+++ b/app/components/editable_champ/multiple_drop_down_list_component/multiple_drop_down_list_component.fr.yml
@@ -1,0 +1,3 @@
+---
+fr:
+  prompt: "Sélectionner"

--- a/app/components/editable_champ/multiple_drop_down_list_component/multiple_drop_down_list_component.html.haml
+++ b/app/components/editable_champ/multiple_drop_down_list_component/multiple_drop_down_list_component.html.haml
@@ -11,7 +11,7 @@
   - else
     %div{ 'data-turbo-focus-group': true }
       - if @champ.selected_options.present?
-        .fr-mb-2w{ "data-turbo": "true" }
+        .fr-mb-2w.fr-mt-2w{ "data-turbo": "true" }
           - @champ.selected_options.each do |option|
             = render NestedForms::OwnedButtonComponent.new(formaction: champs_options_path(@champ.id, option:), http_method: :delete, opt: { aria: {pressed: true }, class: 'fr-tag fr-tag-bug fr-mb-1w fr-mr-1w', id: @champ.checkbox_id(option) }) do
               = option

--- a/app/components/editable_champ/multiple_drop_down_list_component/multiple_drop_down_list_component.html.haml
+++ b/app/components/editable_champ/multiple_drop_down_list_component/multiple_drop_down_list_component.html.haml
@@ -16,4 +16,4 @@
             = render NestedForms::OwnedButtonComponent.new(formaction: champs_options_path(@champ.id, option:), http_method: :delete, opt: { aria: {pressed: true }, class: 'fr-tag fr-tag-bug fr-mb-1w fr-mr-1w', id: @champ.checkbox_id(option) }) do
               = option
       - if @champ.unselected_options.present?
-        = @form.select :value, @champ.unselected_options, { selected: '', include_blank: '' }, id: @champ.input_id, aria: { describedby: @champ.describedby_id }, class: 'fr-select fr-mt-2v'
+        = @form.select :value, @champ.unselected_options, { selected: '', include_blank: false, prompt: t('.prompt') }, id: @champ.input_id, aria: { describedby: @champ.describedby_id }, class: 'fr-select fr-mt-2v'

--- a/config/locales/models/champs/multiple_drop_down_list/en.yml
+++ b/config/locales/models/champs/multiple_drop_down_list/en.yml
@@ -1,0 +1,6 @@
+en:
+  activerecord:
+    attributes:
+      champs/multiple_drop_down_list_champ:
+        hints:
+          value: "You can select one or more options."

--- a/config/locales/models/champs/multiple_drop_down_list/fr.yml
+++ b/config/locales/models/champs/multiple_drop_down_list/fr.yml
@@ -1,0 +1,6 @@
+fr:
+  activerecord:
+    attributes:
+      champs/multiple_drop_down_list_champ:
+        hints:
+          value: "Vous pouvez séléctionner un ou plusieurs choix."

--- a/config/locales/models/champs/multiple_drop_down_list/fr.yml
+++ b/config/locales/models/champs/multiple_drop_down_list/fr.yml
@@ -3,4 +3,4 @@ fr:
     attributes:
       champs/multiple_drop_down_list_champ:
         hints:
-          value: "Vous pouvez séléctionner un ou plusieurs choix."
+          value: "Vous pouvez sélectionner un ou plusieurs choix."


### PR DESCRIPTION
fix: https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/10185

* Ajout d'une aide à la saisie pour les champs à choix multiple.
* Ajout d'un espace vertical au-dessus de la liste des choix sélectionnés.
* Ajout d'une option par défaut : "Sélectionner".

_Après :_
<img width="1073" alt="" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/da23a737-f637-4591-bce9-caaaf9263c1d">


_Avant :_
<img width="1069" alt="" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/84e20a25-6f06-4d09-aa49-888f8306a3a4">

