### PR TITLE
Correctif : affiche correctement le lien vers la page de fermeture dans la liste des dossiers

### DIFF
--- a/app/views/users/dossiers/_dossiers_list.html.haml
+++ b/app/views/users/dossiers/_dossiers_list.html.haml
@@ -55,18 +55,17 @@
           - c.with_body do
             %p
               - if dossier.brouillon? && dossier.procedure.closing_reason_internal_procedure?
-                = I18n.t('views.users.dossiers.dossiers_list.procedure_closed.brouillon.internal_procedure_html', link: commencer_path(dossier.procedure.replaced_by_procedure.path))
+                = t('views.users.dossiers.dossiers_list.procedure_closed.brouillon.internal_procedure_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.procedure'), commencer_path(dossier.procedure.replaced_by_procedure.path), **external_link_attributes, title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.closing_details'))).html_safe)
               - elsif dossier.brouillon? && dossier.procedure.closing_reason_other?
-                = I18n.t('views.users.dossiers.dossiers_list.procedure_closed.brouillon.other_html', link: closing_details_path(dossier.procedure.path))
+                = t('views.users.dossiers.dossiers_list.procedure_closed.brouillon.other_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.here'), closing_details_path(dossier.procedure.path), **external_link_attributes, title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.closing_details'))).html_safe)
               - elsif dossier.en_construction_ou_instruction? && dossier.procedure.closing_reason_internal_procedure?
-                = I18n.t('views.users.dossiers.dossiers_list.procedure_closed.en_cours.internal_procedure_html')
+                = t('views.users.dossiers.dossiers_list.procedure_closed.en_cours.internal_procedure_html')
               - elsif dossier.en_construction_ou_instruction? && dossier.procedure.closing_reason_other?
-                = I18n.t('views.users.dossiers.dossiers_list.procedure_closed.en_cours.other_html', link: closing_details_path(dossier.procedure.path))
+                = t('views.users.dossiers.dossiers_list.procedure_closed.en_cours.other_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.here'), closing_details_path(dossier.procedure.path), **external_link_attributes, title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.closing_details'))).html_safe)
               - elsif dossier.termine? && dossier.procedure.closing_reason_internal_procedure?
-                = I18n.t('views.users.dossiers.dossiers_list.procedure_closed.termine.internal_procedure_html', link: commencer_path(dossier.procedure.replaced_by_procedure.path))
+                = t('views.users.dossiers.dossiers_list.procedure_closed.termine.internal_procedure_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.this_procedure'), commencer_path(dossier.procedure.replaced_by_procedure.path), **external_link_attributes, title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.closing_details'))).html_safe)
               - elsif dossier.termine? && dossier.procedure.closing_reason_other?
-                = I18n.t('views.users.dossiers.dossiers_list.procedure_closed.termine.other_html', link: closing_details_path(dossier.procedure.path))
-
+                = t('views.users.dossiers.dossiers_list.procedure_closed.termine.other_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.here'), closing_details_path(dossier.procedure.path), **external_link_attributes, title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.closing_details'))).html_safe)
 
       - if dossier.pending_correction?
         = render Dsfr::AlertComponent.new(state: :warning, size: :sm, extra_class_names: "fr-mb-2w") do |c|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -510,14 +510,18 @@ en:
           deleted_badge: Deleted
           procedure_closed:
             brouillon:
-              internal_procedure_html: This procedure is closed, you cannot submit this file. We invite you to submit a new one on the <a href="%{link}" target="_blank" rel="noopener noreferrer">procedure</a> which replaces it
-              other_html: This process is closed, you cannot submit this file. More information <a href="%{link}" target="_blank" rel="noopener noreferrer">here</a>
+              internal_procedure_html: This procedure is closed, you cannot submit this file. We invite you to submit a new one on the %{link} which replaces it
+              other_html: This process is closed, you cannot submit this file. More information %{link}
             en_cours:
               internal_procedure_html: This procedure is closed. Your file has been submitted and can be investigated by the administration
-              other_html: "This procedure is closed. Your file has been submitted and can be processed by the administration. More information <a href=%{link} target=_blank rel=noopener noreferrer>here</a>"
+              other_html: This procedure is closed. Your file has been submitted and can be processed by the administration. More information %{link}
             termine:
-              internal_procedure_html: This procedure is closed and replaced by <a href="%{link}" target="_blank" rel="noopener noreferrer">this procedure</a>. Your file has been processed by the administration
-              other_html: This process is closed, you cannot submit a new file. More information <a href="%{link}" target="_blank" rel="noopener noreferrer">here</a>
+              internal_procedure_html: This procedure is closed and replaced by %{link}. Your file has been processed by the administration
+              other_html: This process is closed, you cannot submit a new file. More information %{link}
+            closing_details: Details on the closed procedure
+            here: here
+            procedure: procedure
+            this_procedure: this procedure
         transfers:
           sender_from_support: Technical support
           sender_demande_en_cours: "A transfer request is pending on file Nº %{id} to %{email}"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -505,14 +505,18 @@ fr:
           no_result_reset_filter: Réinitialiser les filtres
           procedure_closed:
             brouillon:
-              internal_procedure_html: Cette démarche est close, vous ne pouvez pas déposer ce dossier. Nous vous invitons à en déposer un nouveau sur la <a href="%{link}" target="_blank" rel="noopener noreferrer">démarche</a> qui la remplace
-              other_html: Cette démarche est close, vous ne pouvez pas déposer ce dossier. Plus d'informations <a href="%{link}" target="_blank" rel="noopener noreferrer">ici</a>
+              internal_procedure_html: Cette démarche est close, vous ne pouvez pas déposer ce dossier. Nous vous invitons à en déposer un nouveau sur la %{link} qui la remplace
+              other_html: Cette démarche est close, vous ne pouvez pas déposer ce dossier. Plus d’informations %{link}
             en_cours:
-              internal_procedure_html: Cette démarche est close. Votre dossier est bien déposé et peut être instruit par l'administration
-              other_html: "Cette démarche est close. Votre dossier est bien déposé et peut être instruit par l'administration. Plus d'informations <a href=%{link} target=_blank rel=noopener noreferrer>ici</a>"
+              internal_procedure_html: Cette démarche est close. Votre dossier est bien déposé et peut être instruit par l’administration
+              other_html: Cette démarche est close. Votre dossier est bien déposé et peut être instruit par l'administration. Vous ne pouvez pas déposer de nouveau dossier. Plus d’informations %{link}
             termine:
-              internal_procedure_html: Cette démarche est close et remplacée par <a href="%{link}" target="_blank" rel="noopener noreferrer">cette démarche</a>. Votre dossier a été traité par l'administration
-              other_html: Cette démarche est close, vous ne pourrez pas déposer de nouveau dossier à partir du lien de la démarche. Plus d'informations <a href="%{link}" target="_blank" rel="noopener noreferrer">ici</a>
+              internal_procedure_html: Cette démarche est close et remplacée par %{link}. Votre dossier a été traité par l'administration
+              other_html: Cette démarche est close, vous ne pourrez pas déposer de nouveau dossier à partir du lien de la démarche. Plus d’informations %{link}
+            closing_details: Détails sur la fermeture de la démarche
+            here: ici
+            procedure: démarche
+            this_procedure: cette démarche
           pending_correction_html: "Ce dossier attend vos corrections. Consultez les modifications à apporter dans la <a href=\"%{link}\">messagerie</a>."
           depose_at: Déposé le %{date}
           created_at: Créé le %{date}


### PR DESCRIPTION
J'en ai profité pour ajouter "Vous ne pouvez pas déposer de nouveau dossier" dans le cas de figure suivant : démarche fermée sans redirection interne - dossier en cours (correspond à une partie de #10194 )

Avant : 
<img width="1018" alt="Capture d’écran 2024-03-26 à 4 19 01 PM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/29131404/99616677-45c3-4e56-bbd3-b53a2ffc30fc">

Après : 

![image](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/29131404/35e17b21-4d07-4e41-9237-5cf1458f276a)
