### PR TITLE
Correctif: redirige la page fermeture vers la page commencer si la démarche n'est pas fermée

### DIFF
--- a/app/controllers/users/commencer_controller.rb
+++ b/app/controllers/users/commencer_controller.rb
@@ -83,6 +83,8 @@ module Users
 
       return procedure_not_found if @procedure.blank?
 
+      redirect_to commencer_path(params[:path]) and return if !@procedure.close?
+
       render 'closing_details', layout: 'closing_details'
     end
 


### PR DESCRIPTION
il y a encore qq erreurs liées à la fermeture des démarches sur Sentry : https://demarches-simplifiees.sentry.io/issues/5061650724/

cela peut arriver si l'usager tente de se reconnecter à la page fermeture alors que la démarche a été réouverte entre temps par exemple