### PR TITLE
Yabeda sidekiq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,6 +100,8 @@ gem 'ulid-ruby', require: 'ulid'
 gem 'view_component'
 gem 'vite_rails'
 gem 'warden'
+gem 'yabeda-prometheus'
+gem 'yabeda-sidekiq'
 gem 'zipline'
 gem 'zxcvbn-ruby', require: 'zxcvbn'
 

--- a/Gemfile
+++ b/Gemfile
@@ -100,6 +100,7 @@ gem 'ulid-ruby', require: 'ulid'
 gem 'view_component'
 gem 'vite_rails'
 gem 'warden'
+gem 'webrick', require: false
 gem 'yabeda-prometheus'
 gem 'yabeda-sidekiq'
 gem 'zipline'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,8 @@ GEM
     ancestry (4.3.3)
       activerecord (>= 5.2.6)
     anchored (1.1.0)
+    anyway_config (2.6.3)
+      ruby-next-core (~> 1.0)
     ast (2.4.2)
     attr_required (1.0.2)
     axe-core-api (4.8.2)
@@ -226,6 +228,7 @@ GEM
     dry-core (1.0.1)
       concurrent-ruby (~> 1.0)
       zeitwerk (~> 2.6)
+    dry-initializer (3.1.1)
     dry-monads (1.6.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.0, < 2)
@@ -493,6 +496,7 @@ GEM
       actionmailer (>= 3)
       net-smtp
       premailer (~> 1.7, >= 1.7.9)
+    prometheus-client (4.2.2)
     promise.rb (0.7.4)
     psych (5.1.2)
       stringio
@@ -651,6 +655,7 @@ GEM
       rubocop-factory_bot (~> 2.22)
     ruby-graphviz (1.2.5)
       rexml
+    ruby-next-core (1.0.2)
     ruby-pg-extras (5.3.1)
       pg
       terminal-table
@@ -821,6 +826,18 @@ GEM
       nokogiri (~> 1.11)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yabeda (0.12.0)
+      anyway_config (>= 1.0, < 3)
+      concurrent-ruby
+      dry-initializer
+    yabeda-prometheus (0.9.1)
+      prometheus-client (>= 3.0, < 5.0)
+      rack
+      yabeda (~> 0.10)
+    yabeda-sidekiq (0.12.0)
+      anyway_config (>= 1.3, < 3)
+      sidekiq
+      yabeda (~> 0.6)
     zeitwerk (2.6.13)
     zip_tricks (5.6.0)
     zipline (1.5.0)
@@ -969,6 +986,8 @@ DEPENDENCIES
   warden
   web-console
   webmock
+  yabeda-prometheus
+  yabeda-sidekiq
   zipline
   zxcvbn-ruby
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -813,6 +813,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    webrick (1.8.1)
     websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -986,6 +987,7 @@ DEPENDENCIES
   warden
   web-console
   webmock
+  webrick
   yabeda-prometheus
   yabeda-sidekiq
   zipline

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -246,6 +246,12 @@ REDIS_SIDEKIQ_MASTER='master_name'
 REDIS_SIDEKIQ_PASSWORD='sentinel_and_redis_password'
 REDIS_SIDEKIQ_USERNAME='sentinel_and_redis_username'
 
+# configuration for prometheus metrics web server
+# launched with sidekiq
+PROMETHEUS_EXPORTER_BIND="0.0.0.0"
+PROMETHEUS_EXPORTER_PORT="9394"
+PROMETHEUS_EXPORTER_ENABLED="disabled"
+
 # Setup log level, info if nil
 # can be debug, info, warn, error, fatal, and unknown
 DS_LOG_LEVEL='info'

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -16,6 +16,11 @@ if ENV.has_key?('REDIS_SIDEKIQ_SENTINELS')
       role: :master
     }
 
+    if ENV['PROMETHEUS_EXPORTER_ENABLED'] == 'enabled'
+      Yabeda.configure!
+      Yabeda::Prometheus::Exporter.start_metrics_server!
+    end
+
     if ENV['SKIP_RELIABLE_FETCH'].blank?
       Sidekiq::ReliableFetch.setup_reliable_fetch!(config)
     end


### PR DESCRIPTION
la configuration par défaut : 

PROMETHEUS_EXPORTER_BIND="0.0.0.0"
PROMETHEUS_EXPORTER_PORT="9394"
PROMETHEUS_EXPORTER_ENABLED="disabled"

modifiable par var d'env.

Se lance uniquement sur le process sidekiq, metriques disponibles sur  `/metrics`