### PR TITLE
WIP – tech(champs.validate_champ_value): only validates champs when required, ie: when a user save public champs or an instructeur save private champs

### DIFF
--- a/app/jobs/migrations/batch_update_pays_values_job.rb
+++ b/app/jobs/migrations/batch_update_pays_values_job.rb
@@ -74,8 +74,8 @@ class Migrations::BatchUpdatePaysValuesJob < ApplicationJob
   def perform(ids)
     ids.each do |id|
       pays_champ = Champs::PaysChamp.find(id)
-      next if pays_champ.valid?
 
+      next if pays_champ.valid?(pays_champ.public? ? :champs_public_value : :champs_private_value)
       code = APIGeoService.country_code(pays_champ.value)
       value = if code.present?
         APIGeoService.country_name(code)

--- a/app/models/champs/boolean_champ.rb
+++ b/app/models/champs/boolean_champ.rb
@@ -5,7 +5,10 @@ class Champs::BooleanChamp < Champ
   before_validation :set_value_to_nil, if: -> { value.blank? }
   before_validation :set_value_to_false, unless: -> { ([nil, TRUE_VALUE, FALSE_VALUE]).include?(value) }
 
-  validates :value, inclusion: [TRUE_VALUE, FALSE_VALUE], allow_nil: true, allow_blank: false
+  validates :value, inclusion: [TRUE_VALUE, FALSE_VALUE],
+                    allow_nil: true,
+                    allow_blank: false,
+                    if: :validate_champ_value?
 
   def true?
     value == TRUE_VALUE

--- a/app/models/champs/civilite_champ.rb
+++ b/app/models/champs/civilite_champ.rb
@@ -1,5 +1,8 @@
 class Champs::CiviliteChamp < Champ
-  validates :value, inclusion: ["M.", "Mme"], allow_nil: true, allow_blank: false
+  validates :value, inclusion: ["M.", "Mme"],
+                    allow_nil: true,
+                    allow_blank: false,
+                    if: -> { validate_champ_value? || validation_context == :prefill }
 
   def legend_label?
     true

--- a/app/models/champs/engagement_juridique_champ.rb
+++ b/app/models/champs/engagement_juridique_champ.rb
@@ -3,5 +3,5 @@ class Champs::EngagementJuridiqueChamp < Champ
   validates_with ExpressionReguliereValidator,
                  expression_reguliere: /([A-Z]|[0-9]|\-|\_|\+|\/)+/,
                  expression_reguliere_error_message: "Le numéro d'EJ ne peut contenir que des caractères alphanumérique et les caractères spéciaux suivant : “-“ ; “_“ ; “+“ ; “/“",
-                 if: -> { validation_context != :brouillon }
+                 if: :validate_champ_value?
 end

--- a/app/models/champs/integer_number_champ.rb
+++ b/app/models/champs/integer_number_champ.rb
@@ -7,7 +7,7 @@ class Champs::IntegerNumberChamp < Champ
       # i18n-tasks-use t('errors.messages.not_an_integer')
       "« #{object.libelle} » " + object.errors.generate_message(:value, :not_an_integer)
     }
-  }
+  }, if: -> { validate_champ_value? || validation_context == :prefill }
 
   def for_export
     processed_value

--- a/app/models/champs/phone_champ.rb
+++ b/app/models/champs/phone_champ.rb
@@ -25,7 +25,8 @@ class Champs::PhoneChamp < Champs::TextChamp
       possible: true,
       allow_blank: true,
       message: I18n.t(:not_a_phone, scope: 'activerecord.errors.messages')
-    }, unless: -> { Phonelib.valid_for_countries?(value, DEFAULT_COUNTRY_CODES) }
+    },
+    if: -> { (validate_champ_value? || validation_context == :prefill) && !Phonelib.valid_for_countries?(value, DEFAULT_COUNTRY_CODES) }
 
   def to_s
     return '' if value.blank?

--- a/spec/jobs/migrations/batch_update_pays_values_job_spec.rb
+++ b/spec/jobs/migrations/batch_update_pays_values_job_spec.rb
@@ -1,12 +1,8 @@
 describe Migrations::BatchUpdatePaysValuesJob, type: :job do
-  before do
-    pays_champ.save(validate: false)
-  end
-
   subject { described_class.perform_now([pays_champ.id]) }
 
   context "the value is correct" do
-    let(:pays_champ) { build(:champ_pays, value: 'France', external_id: 'FR') }
+    let(:pays_champ) { create(:champ_pays).tap { _1.update_columns(value: 'France', external_id: 'FR') } }
 
     it 'does not change it' do
       subject
@@ -16,7 +12,7 @@ describe Migrations::BatchUpdatePaysValuesJob, type: :job do
   end
 
   context "the value is incorrect" do
-    let(:pays_champ) { build(:champ_pays, value: 'Incorrect') }
+    let(:pays_champ) { create(:champ_pays).tap { _1.update_columns(value: 'Incorrect') } }
 
     it 'updates value to nil' do
       subject
@@ -26,7 +22,7 @@ describe Migrations::BatchUpdatePaysValuesJob, type: :job do
   end
 
   context "the value is easily cleanable" do
-    let(:pays_champ) { build(:champ_pays, value: 'Vietnam') }
+    let(:pays_champ) { create(:champ_pays).tap { _1.update_columns(value: 'Vietnam') } }
 
     it 'cleans the value' do
       subject
@@ -36,7 +32,7 @@ describe Migrations::BatchUpdatePaysValuesJob, type: :job do
   end
 
   context "the value is hard to clean" do
-    let(:pays_champ) { build(:champ_pays, value: 'CHRISTMAS (ILE)') }
+    let(:pays_champ) { create(:champ_pays).tap { _1.update_columns(value: 'CHRISTMAS (ILE)') } }
 
     it 'cleans the value' do
       subject

--- a/spec/models/champs/integer_number_champ_spec.rb
+++ b/spec/models/champs/integer_number_champ_spec.rb
@@ -1,37 +1,42 @@
 describe Champs::IntegerNumberChamp do
-  subject { build(:champ_integer_number, value: value).tap(&:valid?) }
+  let(:champ) { build(:champ_integer_number, value:) }
+  subject { champ.validate(:champs_public_value) }
 
   describe '#valid?' do
     context 'when the value is integer number' do
       let(:value) { 2 }
 
-      it { is_expected.to be_valid }
+      it { is_expected.to be_truthy }
     end
 
     context 'when the value is decimal number' do
       let(:value) { 2.6 }
 
-      it { is_expected.to_not be_valid }
-      it { expect(subject.errors[:value]).to eq(["« #{subject.libelle} » doit être un nombre entier (sans chiffres après la virgule)"]) }
+      it 'is not valid and contains errors' do
+        is_expected.to be_falsey
+        expect(champ.errors[:value]).to eq(["« #{champ.libelle} » doit être un nombre entier (sans chiffres après la virgule)"])
+      end
     end
 
     context 'when the value is not a number' do
       let(:value) { 'toto' }
 
-      it { is_expected.to_not be_valid }
-      it { expect(subject.errors[:value]).to eq(["« #{subject.libelle} » doit être un nombre entier (sans chiffres après la virgule)"]) }
+      it 'is not valid and contains errors' do
+        is_expected.to be_falsey
+        expect(champ.errors[:value]).to eq(["« #{champ.libelle} » doit être un nombre entier (sans chiffres après la virgule)"])
+      end
     end
 
     context 'when the value is blank' do
       let(:value) { '' }
 
-      it { is_expected.to be_valid }
+      it { is_expected.to be_truthy }
     end
 
     context 'when the value is nil' do
       let(:value) { nil }
 
-      it { is_expected.to be_valid }
+      it { is_expected.to be_truthy }
     end
   end
 end

--- a/spec/models/champs/phone_champ_spec.rb
+++ b/spec/models/champs/phone_champ_spec.rb
@@ -1,44 +1,45 @@
 describe Champs::PhoneChamp do
-  let(:phone_champ) { build(:champ_phone) }
+  let(:champ) { build(:champ_phone) }
+  # subject { champ }
 
-  describe '#valid?' do
+  describe '#validate' do
     it do
-      expect(champ_with_value(nil)).to be_valid
-      expect(champ_with_value("0123456789 0123456789")).to_not be_valid
-      expect(champ_with_value("01.23.45.67.89 01.23.45.67.89")).to_not be_valid
-      expect(champ_with_value("3646")).to be_valid
-      expect(champ_with_value("0123456789")).to be_valid
-      expect(champ_with_value("01.23.45.67.89")).to be_valid
-      expect(champ_with_value("0123 45.67.89")).to be_valid
-      expect(champ_with_value("0033 123-456-789")).to be_valid
-      expect(champ_with_value("0033 123-456-789")).to be_valid
-      expect(champ_with_value("0033(0)123456789")).to be_valid
-      expect(champ_with_value("+33-1.23.45.67.89")).to be_valid
-      expect(champ_with_value("+33 - 123 456 789")).to be_valid
-      expect(champ_with_value("+33(0) 123 456 789")).to be_valid
-      expect(champ_with_value("+33 (0)123 45 67 89")).to be_valid
-      expect(champ_with_value("+33 (0)1 2345-6789")).to be_valid
-      expect(champ_with_value("+33(0) - 123456789")).to be_valid
-      expect(champ_with_value("+1(0) - 123456789")).to be_valid
-      expect(champ_with_value("+49 2109 87654321")).to be_valid
-      expect(champ_with_value("012345678")).to be_valid
+      expect(champ_with_value(nil).validate(:champs_public_value)).to be_truthy
+      expect(champ_with_value("0123456789 0123456789").validate(:champs_public_value)).to_not be_truthy
+      expect(champ_with_value("01.23.45.67.89 01.23.45.67.89").validate(:champs_public_value)).to_not be_truthy
+      expect(champ_with_value("3646").validate(:champs_public_value)).to be_truthy
+      expect(champ_with_value("0123456789").validate(:champs_public_value)).to be_truthy
+      expect(champ_with_value("01.23.45.67.89").validate(:champs_public_value)).to be_truthy
+      expect(champ_with_value("0123 45.67.89").validate(:champs_public_value)).to be_truthy
+      expect(champ_with_value("0033 123-456-789").validate(:champs_public_value)).to be_truthy
+      expect(champ_with_value("0033 123-456-789").validate(:champs_public_value)).to be_truthy
+      expect(champ_with_value("0033(0)123456789").validate(:champs_public_value)).to be_truthy
+      expect(champ_with_value("+33-1.23.45.67.89").validate(:champs_public_value)).to be_truthy
+      expect(champ_with_value("+33 - 123 456 789").validate(:champs_public_value)).to be_truthy
+      expect(champ_with_value("+33(0) 123 456 789").validate(:champs_public_value)).to be_truthy
+      expect(champ_with_value("+33 (0)123 45 67 89").validate(:champs_public_value)).to be_truthy
+      expect(champ_with_value("+33 (0)1 2345-6789").validate(:champs_public_value)).to be_truthy
+      expect(champ_with_value("+33(0) - 123456789").validate(:champs_public_value)).to be_truthy
+      expect(champ_with_value("+1(0) - 123456789").validate(:champs_public_value)).to be_truthy
+      expect(champ_with_value("+49 2109 87654321").validate(:champs_public_value)).to be_truthy
+      expect(champ_with_value("012345678").validate(:champs_public_value)).to be_truthy
       # DROM numbers should be valid
-      expect(champ_with_value("06 96 04 78 07")).to be_valid
-      expect(champ_with_value("05 94 22 31 31")).to be_valid
-      expect(champ_with_value("+594 5 94 22 31 31")).to be_valid
+      expect(champ_with_value("06 96 04 78 07").validate(:champs_public_value)).to be_truthy
+      expect(champ_with_value("05 94 22 31 31").validate(:champs_public_value)).to be_truthy
+      expect(champ_with_value("+594 5 94 22 31 31").validate(:champs_public_value)).to be_truthy
       # polynesian numbers should not return errors in any way
       ## landline numbers start with 40 or 45
-      expect(champ_with_value("45187272")).to be_valid
-      expect(champ_with_value("40 473 500")).to be_valid
-      expect(champ_with_value("40473500")).to be_valid
-      expect(champ_with_value("45473500")).to be_valid
+      expect(champ_with_value("45187272").validate(:champs_public_value)).to be_truthy
+      expect(champ_with_value("40 473 500").validate(:champs_public_value)).to be_truthy
+      expect(champ_with_value("40473500").validate(:champs_public_value)).to be_truthy
+      expect(champ_with_value("45473500").validate(:champs_public_value)).to be_truthy
       ## +689 is the international indicator
-      expect(champ_with_value("+689 45473500")).to be_valid
-      expect(champ_with_value("0145473500")).to be_valid
+      expect(champ_with_value("+689 45473500").validate(:champs_public_value)).to be_truthy
+      expect(champ_with_value("0145473500").validate(:champs_public_value)).to be_truthy
       ## polynesian mobile numbers start with 87, 88, 89
-      expect(champ_with_value("87473500")).to be_valid
-      expect(champ_with_value("88473500")).to be_valid
-      expect(champ_with_value("89473500")).to be_valid
+      expect(champ_with_value("87473500").validate(:champs_public_value)).to be_truthy
+      expect(champ_with_value("88473500").validate(:champs_public_value)).to be_truthy
+      expect(champ_with_value("89473500").validate(:champs_public_value)).to be_truthy
     end
   end
 
@@ -61,6 +62,6 @@ describe Champs::PhoneChamp do
   end
 
   def champ_with_value(number)
-    phone_champ.tap { |c| c.value = number }
+    champ.tap { |c| c.value = number }
   end
 end


### PR DESCRIPTION
suite a ce bug: https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/10242, j'ai testé un fix. je deporte sur la PR original

