### PR TITLE
correctif(lien.attestation): ETQ expert, je souhaite avoir accès à l'attestation même si je ne suis pas instructeur

### DIFF
--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -17,12 +17,6 @@ module Instructeurs
     after_action :mark_avis_as_read, only: [:avis, :create_avis]
     after_action :mark_annotations_privees_as_read, only: [:annotations_privees, :update_annotations]
 
-    def attestation
-      if dossier.attestation.pdf.attached?
-        redirect_to dossier.attestation.pdf.url, allow_other_host: true
-      end
-    end
-
     def extend_conservation
       dossier.extend_conservation(1.month)
       flash[:notice] = t('views.instructeurs.dossiers.archived_dossier')

--- a/app/views/shared/dossiers/_infos_generales.html.haml
+++ b/app/views/shared/dossiers/_infos_generales.html.haml
@@ -23,4 +23,4 @@
   - if dossier.attestation.present?
     = render Dossiers::RowShowComponent.new(label: "Attestation") do |c|
       - c.with_value do
-        = link_to('Voir l’attestation', attestation_instructeur_dossier_path(dossier.procedure, dossier), **external_link_attributes)
+        = render Dsfr::DownloadComponent.new(attachment: dossier.attestation.pdf, name: t(:download_attestation, scope: [:views, :shared, :dossiers, :form]))

--- a/app/views/shared/dossiers/_infos_generales.html.haml
+++ b/app/views/shared/dossiers/_infos_generales.html.haml
@@ -20,7 +20,7 @@
       - c.with_value do
         = simple_format dossier.motivation
 
-  - if dossier.attestation.present?
+  - if dossier.attestation.present? && dossier.attestation.pdf.attached?
     = render Dossiers::RowShowComponent.new(label: "Attestation") do |c|
       - c.with_value do
         = render Dsfr::DownloadComponent.new(attachment: dossier.attestation.pdf, name: t(:download_attestation, scope: [:views, :shared, :dossiers, :form]))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -346,6 +346,7 @@ en:
         form:
           submitted_at: "Submitted on %{datetime}"
           updated_at: "Updated on %{datetime}"
+          download_attestation: "Download attestation"
         edit:
           autosave: Your file is automatically saved after each modification. You can close the window at any time and pick up where you left off later.
         messages:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -348,6 +348,7 @@ fr:
         form:
           submitted_at: "Déposé le %{datetime}"
           updated_at: "Modifié le %{datetime}"
+          download_attestation: "Télécharger l‘attestation"
         edit:
           autosave: Votre dossier est enregistré automatiquement après chaque modification. Vous pouvez à tout moment fermer la fenêtre et reprendre plus tard là où vous en étiez.
         messages:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -475,7 +475,6 @@ Rails.application.routes.draw do
           member do
             resources :commentaires, only: [:destroy]
             post 'repousser-expiration' => 'dossiers#extend_conservation'
-            get 'attestation'
             get 'geo_data'
             get 'apercu_attestation'
             get 'bilans_bdf'

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -13,17 +13,6 @@ describe Instructeurs::DossiersController, type: :controller do
 
   before { sign_in(instructeur.user) }
 
-  describe '#attestation' do
-    context 'when a dossier has an attestation' do
-      let(:dossier) { create(:dossier, :accepte, attestation: create(:attestation, :with_pdf), procedure: procedure) }
-
-      it 'redirects to a service tmp_url' do
-        get :attestation, params: { procedure_id: procedure.id, dossier_id: dossier.id }
-        expect(response.location).to match '/rails/active_storage/disk/'
-      end
-    end
-  end
-
   describe '#send_to_instructeurs' do
     let(:mail) { double("mail") }
 

--- a/spec/views/instructeur/dossiers/show.html.haml_spec.rb
+++ b/spec/views/instructeur/dossiers/show.html.haml_spec.rb
@@ -35,8 +35,10 @@ describe 'instructeurs/dossiers/show', type: :view do
     let(:dossier) { create :dossier, :accepte, :with_attestation }
 
     it 'provides a link to the attestation' do
+      pdf = dossier.attestation.pdf
+      expect(dossier).to receive(:attestation).and_return(double(pdf: pdf)).at_least(2)
       expect(subject).to have_text('Attestation')
-      expect(subject).to have_link(href: attestation_instructeur_dossier_path(dossier.procedure, dossier))
+      expect(subject).to have_text("Télécharger l‘attestation")
     end
   end
 

--- a/spec/views/instructeur/dossiers/show.html.haml_spec.rb
+++ b/spec/views/instructeur/dossiers/show.html.haml_spec.rb
@@ -23,37 +23,6 @@ describe 'instructeurs/dossiers/show', type: :view do
     expect(subject).to have_text('en construction')
   end
 
-  context 'with a motivation' do
-    let(:dossier) { create :dossier, :accepte, :with_motivation }
-
-    it 'displays the motivation text' do
-      expect(subject).to have_content(dossier.motivation)
-    end
-  end
-
-  context 'with an attestation' do
-    let(:dossier) { create :dossier, :accepte, :with_attestation }
-
-    it 'provides a link to the attestation' do
-      pdf = dossier.attestation.pdf
-      expect(dossier).to receive(:attestation).and_return(double(pdf: pdf)).at_least(2)
-      expect(subject).to have_text('Attestation')
-      expect(subject).to have_text("Télécharger l‘attestation")
-    end
-  end
-
-  context 'with a justificatif' do
-    let(:dossier) do
-      dossier = create(:dossier, :accepte, :with_justificatif)
-      dossier.justificatif_motivation.blob.update(virus_scan_result: ActiveStorage::VirusScanner::SAFE)
-      dossier
-    end
-
-    it 'allows to download the justificatif' do
-      expect(subject).to have_css("a[href*='/rails/active_storage/blobs/']", text: dossier.justificatif_motivation.attachment.filename.to_s)
-    end
-  end
-
   context 'en_construction' do
     let(:dossier) { create(:dossier, :en_construction) }
     it 'displays the correct actions' do

--- a/spec/views/shared/dossiers/_infos_generales.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_infos_generales.html.haml_spec.rb
@@ -1,0 +1,58 @@
+describe 'shared/dossiers/_infos_generales', type: :view do
+  let(:dossier) { create(:dossier, :en_construction) }
+  subject { render }
+  before do
+    sign_in(current_role.user)
+    allow(view).to receive(:current_instructeur).and_return(current_role)
+    allow(view).to receive(:dossier).and_return(dossier)
+  end
+
+  context 'when expert' do
+    let(:current_role) { create(:expert) }
+
+    context 'with an attestation' do
+      let(:dossier) { create :dossier, :accepte, :with_attestation }
+
+      it 'provides a link to the attestation' do
+        pdf = dossier.attestation.pdf
+        expect(dossier).to receive(:attestation).and_return(double(pdf: pdf)).at_least(2)
+        expect(subject).to have_text('Attestation')
+        expect(subject).to have_text("Télécharger l‘attestation")
+      end
+    end
+  end
+
+  context 'when instructeur' do
+    let(:current_role) { create(:instructeur) }
+    context 'with a motivation' do
+      let(:dossier) { create :dossier, :accepte, :with_motivation }
+
+      it 'displays the motivation text' do
+        expect(subject).to have_content(dossier.motivation)
+      end
+    end
+
+    context 'with an attestation' do
+      let(:dossier) { create :dossier, :accepte, :with_attestation }
+
+      it 'provides a link to the attestation' do
+        pdf = dossier.attestation.pdf
+        expect(dossier).to receive(:attestation).and_return(double(pdf: pdf)).at_least(2)
+        expect(subject).to have_text('Attestation')
+        expect(subject).to have_text("Télécharger l‘attestation")
+      end
+    end
+
+    context 'with a justificatif' do
+      let(:dossier) do
+        dossier = create(:dossier, :accepte, :with_justificatif)
+        dossier.justificatif_motivation.blob.update(virus_scan_result: ActiveStorage::VirusScanner::SAFE)
+        dossier
+      end
+
+      it 'allows to download the justificatif' do
+        expect(subject).to have_css("a[href*='/rails/active_storage/blobs/']", text: dossier.justificatif_motivation.attachment.filename.to_s)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Le lien vers l'attestation pour les expert pointait sur l'URL de l'attestation pour les instructeurs.
J'en ai profité pour supprimer cette route car a la difference, côté usager nous avons bien une route pour DL la PJ, mais c'est pour être utilisé dans les mails.
J'en ai aussi profité pour passer le lien au DSFR et le traduire

crisp: https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_593509ac-3d66-4b53-8dc1-c2bc000a90b2/
mattermost: https://mattermost.incubateur.net/betagouv/pl/7t46ir51xpyhxxhxxypgn3uobr

