### PR TITLE
Tech: fix memory leak pendant le téléchargement des PJ des exports

### DIFF
--- a/app/lib/download_manager/parallel_download_queue.rb
+++ b/app/lib/download_manager/parallel_download_queue.rb
@@ -14,7 +14,7 @@ module DownloadManager
     def download_all
       hydra = Typhoeus::Hydra.new(max_concurrency: DOWNLOAD_MAX_PARALLEL)
 
-      attachments.map do |attachment, path|
+      attachments.each do |attachment, path|
         begin
           download_one(attachment: attachment,
                        path_in_download_dir: path,
@@ -23,7 +23,10 @@ module DownloadManager
           on_error.call(attachment, path, e)
         end
       end
+
       hydra.run
+
+      GC.start
     end
 
     # can't be used with typhoeus, otherwise block is closed before the request is run by hydra


### PR DESCRIPTION
Benchmarks pour des exports d'un zip d'1go de PJ pour 3 dossiers, dont 1 de 700mo

Un `.map` au lieu d'un `.each` qui trainait, et la parallélisation avec hydra/ethon qui mettait chaque pj en mémoire et prévenait d'un passage efficace du GC. Donc on le force au bon moment pour éviter que l'empreinte augmente trop vite.

Avant : le volume total des pj pouvait être mis en mémoire pendant l'export (+1go par export dans mon exemple)
Après: de +10 à +30%

Exemples:

**AVANT**
```txt
[ActiveJob] [ExportJob] [5c3b4165-0832-48b2-9950-aac02781a1fd] Mémoire utilisée après le téléchargement de l'attachment package.json: 786768 Ko
[ActiveJob] [ExportJob] [5c3b4165-0832-48b2-9950-aac02781a1fd] Mémoire utilisée après le téléchargement de l'attachment package.json: 788288 Ko
[ActiveJob] [ExportJob] [5c3b4165-0832-48b2-9950-aac02781a1fd] Mémoire utilisée après le téléchargement de l'attachment icon-android-adaptative.png: 788288 Ko
[ActiveJob] [ExportJob] [5c3b4165-0832-48b2-9950-aac02781a1fd] Mémoire utilisée après le téléchargement de l'attachment 05c999f9-e73c-4136-9be4-ac99bcf3d084.png: 788288 Ko
[ActiveJob] [ExportJob] [5c3b4165-0832-48b2-9950-aac02781a1fd] Mémoire utilisée après le téléchargement de l'attachment CuteMonsters.zip: 788304 Ko
[ActiveJob] [ExportJob] [5c3b4165-0832-48b2-9950-aac02781a1fd] Mémoire utilisée après le téléchargement de l'attachment NOTICE PISCINE ELECTROLYSEUR Pool Technologie Minisalt 50.pdf: 788304 Ko
[ActiveJob] [ExportJob] [5c3b4165-0832-48b2-9950-aac02781a1fd] Mémoire utilisée après le téléchargement de l'attachment hap.2023-10-13.sql.gz: 788304 Ko
[ActiveJob] [ExportJob] [5c3b4165-0832-48b2-9950-aac02781a1fd] Mémoire utilisée après le téléchargement de l'attachment bsh_06_2022_vf.pdf: 788304 Ko
[ActiveJob] [ExportJob] [5c3b4165-0832-48b2-9950-aac02781a1fd] Mémoire utilisée après le téléchargement 1476096 Ko
[ActiveJob] [ExportJob] [5c3b4165-0832-48b2-9950-aac02781a1fd] Mémoire utilisée après le téléchargement 1476096 Ko
[ActiveJob] [ExportJob] [5c3b4165-0832-48b2-9950-aac02781a1fd] Mémoire utilisée après génération du zip  1476096 Ko
```

**APRES**
```
[ActiveJob] [ExportJob] [1bde4454-8176-4f75-bbfa-e88e39b3c89c] Mémoire utilisée après le téléchargement de l'attachment package.json: 574448 Ko
[ActiveJob] [ExportJob] [1bde4454-8176-4f75-bbfa-e88e39b3c89c] Mémoire utilisée après le téléchargement de l'attachment package.json: 574512 Ko
[ActiveJob] [ExportJob] [1bde4454-8176-4f75-bbfa-e88e39b3c89c] Mémoire utilisée après le téléchargement de l'attachment icon-android-adaptative.png: 574512 Ko
[ActiveJob] [ExportJob] [1bde4454-8176-4f75-bbfa-e88e39b3c89c] Mémoire utilisée après le téléchargement de l'attachment 05c999f9-e73c-4136-9be4-ac99bcf3d084.png: 574592 Ko
[ActiveJob] [ExportJob] [1bde4454-8176-4f75-bbfa-e88e39b3c89c] Mémoire utilisée après le téléchargement de l'attachment CuteMonsters.zip: 574592 Ko
[ActiveJob] [ExportJob] [1bde4454-8176-4f75-bbfa-e88e39b3c89c] Mémoire utilisée après le téléchargement de l'attachment NOTICE PISCINE ELECTROLYSEUR Pool Technologie Minisalt 50.pdf: 574592 Ko
[ActiveJob] [ExportJob] [1bde4454-8176-4f75-bbfa-e88e39b3c89c] Mémoire utilisée après le téléchargement de l'attachment hap.2023-10-13.sql.gz: 574592 Ko
[ActiveJob] [ExportJob] [1bde4454-8176-4f75-bbfa-e88e39b3c89c] Mémoire utilisée après le téléchargement de l'attachment bsh_06_2022_vf.pdf: 574592 Ko
[ActiveJob] [ExportJob] [1bde4454-8176-4f75-bbfa-e88e39b3c89c] Mémoire utilisée après le téléchargement 632752 Ko
[ActiveJob] [ExportJob] [1bde4454-8176-4f75-bbfa-e88e39b3c89c] Mémoire utilisée après le téléchargement 632752 Ko
[ActiveJob] [ExportJob] [1bde4454-8176-4f75-bbfa-e88e39b3c89c] Mémoire utilisée après génération du zip  632752 Ko
```