### PR TITLE
chore(browser): be more agressive about browser deprecation

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -96,15 +96,6 @@ class RootController < ApplicationController
   def suivi
   end
 
-  def dismiss_outdated_browser
-    dismiss_outdated_browser_banner
-
-    respond_to do |format|
-      format.html { redirect_back(fallback_location: root_path) }
-      format.turbo_stream
-    end
-  end
-
   def save_locale
     set_locale(params[:locale])
     redirect_back(fallback_location: root_path)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -122,23 +122,8 @@ module ApplicationHelper
     end
   end
 
-  def dismiss_outdated_browser_banner
-    cookies[:dismissed_outdated_browser_banner] = {
-      value: 'true',
-      expires: 1.week.from_now
-    }
-  end
-
-  def has_dismissed_outdated_browser_banner?
-    cookies[:dismissed_outdated_browser_banner] == 'true'
-  end
-
-  def supported_browser?
-    BrowserSupport.supported?(browser)
-  end
-
   def show_outdated_browser_banner?
-    !supported_browser? && !has_dismissed_outdated_browser_banner?
+    !BrowserSupport.supported?(browser)
   end
 
   def vite_legacy?

--- a/app/views/layouts/_outdated_browser_banner.html.haml
+++ b/app/views/layouts/_outdated_browser_banner.html.haml
@@ -1,21 +1,10 @@
 - if show_outdated_browser_banner?
-  #outdated-browser-banner.site-banner
-    .container
-      .site-banner-icon ⚠️
-      - if browser.ie?(11)
-        .site-banner-text
-          Internet Explorer 11 est un navigateur trop ancien. Nous cesserons de gérer son fonctionnement à partir du
-          %strong
-            31 janvier 2021.
-          %br
-          Merci de changer pour un navigateur plus récent avant cette date ; il peut être nécessaire de prendre contact avec un responsable informatique.
-      - else
-        .site-banner-text
-          %strong
-            #{browser.name} #{browser.version} est trop ancien pour utiliser #{Current.application_name}.
-          %br
-          Certaines parties du site ne fonctionneront pas correctement.
-      .site-banner-actions
-        = button_to 'Ignorer', dismiss_outdated_browser_path, method: :post, form: { data: { turbo: true } }, class: 'button btn', title: 'Ne plus afficher cet avertissement pendant une semaine'
-        %a.btn.button.primary{ href: "https://browser-update.org/fr/update.html", target: "_blank", rel: "noopener" }
-          Mettre à jour mon navigateur
+  = render Dsfr::AlertComponent.new(state: :warning, title: "Navigateur trop ancien", heading_level: :h2) do |c|
+    - c.with_body do
+      Votre navigateur internet, #{browser.name} #{browser.version}, est malheureusement trop ancien. Il ne sera plus compatible avec #{APPLICATION_NAME} à partir du 
+      %strong
+        1 juin 2024.
+      %br
+      Veuillez installer un navigateur plus récent en suivant le lien suivant :
+      %br
+      = link_to "Mettre à jour mon navigateur", "https://betagouv.github.io/navigateur-trop-ancien/", class: "fr-btn fr-btn--secondary fr-mt-2w", target: "_blank", rel: "noopener"

--- a/app/views/root/dismiss_outdated_browser.turbo_stream.haml
+++ b/app/views/root/dismiss_outdated_browser.turbo_stream.haml
@@ -1,1 +1,0 @@
-= turbo_stream.remove('outdated-browser-banner')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -216,7 +216,6 @@ Rails.application.routes.draw do
 
   get "patron" => "root#patron" if Rails.env.development? || Rails.env.test?
   get "suivi" => "root#suivi"
-  post "dismiss_outdated_browser" => "root#dismiss_outdated_browser"
   post "save_locale" => "root#save_locale"
 
   get "contact", to: "support#index"

--- a/spec/system/outdated_browser_spec.rb
+++ b/spec/system/outdated_browser_spec.rb
@@ -7,43 +7,8 @@ describe 'Outdated browsers support:' do
 
     scenario 'a banner is displayed' do
       visit new_user_session_path
-      expect(page).to have_content('Internet Explorer 10 est trop ancien')
-    end
-
-    scenario 'the banner can be dismissed' do
-      visit new_user_session_path
-      expect(page).to have_content('Internet Explorer 10 est trop ancien')
-
-      # The banner is hidden immediately
-      within '#outdated-browser-banner' do
-        click_on 'Ignorer'
-      end
-      expect(page).not_to have_content('Internet Explorer 10 est trop ancien')
-      expect(page).to have_current_path(new_user_session_path)
-
-      # The banner is hidden after a refresh
-      page.refresh
-      expect(page).not_to have_content('Internet Explorer 10 est trop ancien')
-    end
-  end
-
-  context 'when the user browser is about to be outdated' do
-    before(:each) do
-      ie_11_user_agent = 'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko'
-      Capybara.page.driver.header('user-agent', ie_11_user_agent)
-    end
-
-    scenario 'IE11 gets a dedicated depreciation banner for update before jan 31st 2021' do
-      visit new_user_session_path
-      expect(page).to have_content('31 janvier 2021')
-      expect(page).to have_content('Internet Explorer 11 est un navigateur trop ancien')
-
-      within '#outdated-browser-banner' do
-        click_on 'Ignorer'
-      end
-
-      page.refresh
-      expect(page).not_to have_content('Internet Explorer 11 est un navigateur trop ancien')
+      expect(page).to have_content('1 juin 2024')
+      expect(page).to have_content('Votre navigateur internet, Internet Explorer 10, est malheureusement trop ancien')
     end
   end
 end


### PR DESCRIPTION
J'annonce la fin du support des navigateurs trop anciens au 1er juin. Ce sont des navigateurs qui ont au moins 7 ans. Ils ne sont pratiquement plus utilisé du côté des dépositaires de dossiers. Il reste quelques dizaines d'instructeurs.

J'en profite aussi pour utiliser une page de mise à jour de navigateur au DSFR et sans publicités 😱

![CleanShot 2024-04-02 at 21 35 23@2x](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/12428/1c987168-42fa-4905-ad9c-09795e8c68f2)

