### PR TITLE
ETQ instructeur, j'ai une colonne vide s'il n'y a pas les checkbox des actions multiples

### DIFF
--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -8,7 +8,8 @@ span.notifications {
   background-color: $orange;
 }
 
-.fr-tabs__list span.notifications {
+.fr-tabs__list span.notifications,
+span.notifications.absolute-right {
   z-index: 2;
   top: 5px;
   right: 8px;

--- a/app/views/experts/avis/procedure.html.haml
+++ b/app/views/experts/avis/procedure.html.haml
@@ -40,8 +40,7 @@
           %tr
             %td.number-col
               = link_to(expert_avis_path(avis.procedure, avis), class: 'cell-link') do
-                = dsfr_icon('fr-icon-file-text-line')
-                #{avis.dossier.id}
+                = avis.dossier.id
             %td= link_to(avis.dossier.user_email_for(:display), expert_avis_path(avis.procedure, avis), class: 'cell-link')
             %td= link_to(avis.procedure.libelle, expert_avis_path(avis.procedure, avis), class: 'cell-link')
     = paginate @avis, views_prefix: 'shared'

--- a/app/views/instructeurs/procedures/deleted_dossiers.html.haml
+++ b/app/views/instructeurs/procedures/deleted_dossiers.html.haml
@@ -38,15 +38,12 @@
       %table.table.dossiers-table.hoverable
         %thead
           %tr
-            %th.notification-col
             %th.number-col N° dossier
             %th Raison de suppression
             %th Date de suppression
         %tbody
           - @deleted_dossiers.each do |deleted_dossier|
             %tr
-              %td.text-center
-                = dsfr_icon('fr-icon-file-text-line')
               %td.number-col
                 = deleted_dossier.dossier_id
               %td

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -136,12 +136,14 @@
                         = check_box_tag :"batch_operation[dossier_ids][]", p.dossier_id, false, data: { batch_operation_target: "input", action: "batch-operation#onCheckOne", operations: batch_operation_component.operations_for_dossier(p).join(',') }, form: dom_id(BatchOperation.new), id: dom_id(BatchOperation.new, "checkbox_#{p.dossier_id}"), aria: { label: t('views.instructeurs.dossiers.batch_operation.enabled', dossier_id: p.dossier_id) }
 
                   %td.number-col
-                    - if @not_archived_notifications_dossier_ids.include?(p.dossier_id)
-                      %span.notifications{ 'aria-label': 'notifications' }
                     - if p.hidden_by_administration_at.present?
                       %span.cell-link= p.dossier_id
                     - else
-                      %a.cell-link{ href: path }= p.dossier_id
+                      %a.cell-link.relative{ href: path }
+                        = p.dossier_id
+                        - if @not_archived_notifications_dossier_ids.include?(p.dossier_id)
+                          %span.notifications.absolute-right{ 'aria-label': 'notifications' }
+
 
                   - p.columns.each do |column|
                     %td

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -97,11 +97,6 @@
                 - if batch_operation_component.render?
                   %th.text-center
                     %input{ type: "checkbox", disabled: @disable_checkbox_all, checked: @disable_checkbox_all, data: { action: "batch-operation#onCheckAll" }, id: dom_id(BatchOperation.new, :checkbox_all), aria: { label: t('views.instructeurs.dossiers.select_all') } }
-                - else
-                  - if @statut.in? %w(suivis traites tous)
-                    = render partial: "header_field", locals: { field: { "label" => "●", "table" => "notifications", "column" => "notifications" }, classname: "notification-col text-center" }
-                  - else
-                    %th.notification-col
 
                 - @procedure_presentation.displayed_fields_for_headers.each do |field|
                   = render partial: "header_field", locals: { field: field, classname: field['classname'] }
@@ -133,26 +128,16 @@
               - @projected_dossiers.each do |p|
                 - path = instructeur_dossier_path(@procedure, p.dossier_id)
                 %tr{ class: [p.hidden_by_user_at.present? && "file-hidden-by-user"] }
-                  %td.text-center
-                    - if batch_operation_component.render?
+                  - if batch_operation_component.render?
+                    %td.text-center
                       - if p.batch_operation_id.present?
                         = check_box_tag :"batch_operation[dossier_ids][]", p.dossier_id, true, disabled: true, id: dom_id(BatchOperation.new, "checkbox_#{p.dossier_id}"), aria: { label: t('views.instructeurs.dossiers.batch_operation.disabled', dossier_id: p.dossier_id) }
                       - else
                         = check_box_tag :"batch_operation[dossier_ids][]", p.dossier_id, false, data: { batch_operation_target: "input", action: "batch-operation#onCheckOne", operations: batch_operation_component.operations_for_dossier(p).join(',') }, form: dom_id(BatchOperation.new), id: dom_id(BatchOperation.new, "checkbox_#{p.dossier_id}"), aria: { label: t('views.instructeurs.dossiers.batch_operation.enabled', dossier_id: p.dossier_id) }
 
-                      - if @not_archived_notifications_dossier_ids.include?(p.dossier_id)
-                        %span.notifications{ 'aria-label': 'notifications' }
-                    - else
-                      - if p.hidden_by_administration_at.present?
-                        %span.cell-link
-                          = dsfr_icon('fr-icon-file-text-line')
-                      - else
-                        %a.cell-link{ href: path }
-                          = dsfr_icon('fr-icon-file-text-line')
-                          - if @not_archived_notifications_dossier_ids.include?(p.dossier_id)
-                            %span.notifications{ 'aria-label': 'notifications' }
-
                   %td.number-col
+                    - if @not_archived_notifications_dossier_ids.include?(p.dossier_id)
+                      %span.notifications{ 'aria-label': 'notifications' }
                     - if p.hidden_by_administration_at.present?
                       %span.cell-link= p.dossier_id
                     - else

--- a/app/views/recherche/_hidden_dossier.html.haml
+++ b/app/views/recherche/_hidden_dossier.html.haml
@@ -1,7 +1,3 @@
-%td.text-center
-  %p.cell-link
-    = dsfr_icon('fr-icon-file-text-line')
-
 %td.number-col
   %p.cell-link= p.dossier_id
 

--- a/app/views/recherche/index.html.haml
+++ b/app/views/recherche/index.html.haml
@@ -19,7 +19,6 @@
       %table.table.dossiers-table.hoverable
         %thead
           %tr
-            %th.notification-col
             %th.number-col Nº dossier
             %th Démarche
             %th Demandeur
@@ -36,12 +35,11 @@
 
           %tr{ class: [p.hidden_by_administration_at.present? && "file-hidden-by-user"] }
             - if instructeur_and_expert_dossier
-              %td.text-center.cell-link
-                = dsfr_icon('fr-icon-file-text-line')
-                - if @notifications_dossier_ids.include?(p.dossier_id)
-                  %span.notifications{ 'aria-label': 'notifications' }
               %td.number-col
-                .cell-link= p.dossier_id
+                .cell-link.relative
+                  = p.dossier_id
+                  - if @notifications_dossier_ids.include?(p.dossier_id)
+                    %span.notifications.absolute-right{ 'aria-label': 'notifications' }
               %td
                 .cell-link= procedure_libelle
               %td
@@ -53,15 +51,11 @@
               = render partial: "recherche/hidden_dossier", locals: {p: p, procedure_libelle: procedure_libelle, user_email: user_email}
 
             - else
-
-              %td.text-center
-                %a.cell-link{ href: path }
-                  = dsfr_icon('fr-icon-file-text-line')
-                  - if @notifications_dossier_ids.include?(p.dossier_id)
-                    %span.notifications{ 'aria-label': 'notifications' }
-
               %td.number-col
-                %a.cell-link{ href: path }= p.dossier_id
+                %a.cell-link.relative{ href: path }
+                  = p.dossier_id
+                  - if @notifications_dossier_ids.include?(p.dossier_id)
+                    %span.notifications.absolute-right{ 'aria-label': 'notifications' }
 
               %td
                 %a.cell-link{ href: path }= procedure_libelle


### PR DESCRIPTION
closes #10226 

ETQ instructeur, j'ai une colonne vide s'il n'y a pas les checkbox des actions multiples et les notifications passent sur le numero de dossier.

**APRES**
<img width="797" alt="Capture d’écran 2024-04-04 à 17 19 06" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/d86a3f75-9635-4a9f-8c9c-ae6424fca1b2">
<img width="751" alt="Capture d’écran 2024-04-04 à 17 19 15" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/8d5fa5a8-dd8b-4356-9464-3274d6a9e0e6">

**AVANT**
<img width="842" alt="Capture d’écran 2024-04-04 à 17 22 30" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/ca8745f1-dd3b-41e8-8514-709c9f5fd049">
<img width="818" alt="Capture d’écran 2024-04-04 à 17 22 38" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/100851d4-4754-46e4-b528-121433bf297d">

