### PR TITLE
Tech: déplace APIEntreprise vers sidekiq

### DIFF
--- a/app/lib/api_entreprise/api.rb
+++ b/app/lib/api_entreprise/api.rb
@@ -126,7 +126,7 @@ class APIEntreprise::API
     elsif response.code == 400
       raise Error::BadFormatRequest.new(response)
     elsif response.code == 502
-      raise	Error::BadGateway.new(response)
+      raise Error::BadGateway.new(response)
     elsif response.code == 503
       raise Error::ServiceUnavailable.new(response)
     elsif response.timed_out?

--- a/app/lib/api_entreprise/api/error.rb
+++ b/app/lib/api_entreprise/api/error.rb
@@ -6,7 +6,7 @@ class APIEntreprise::API::Error < ::StandardError
     msg = <<~TEXT
       url: #{uri.host}#{uri.path}
       HTTP error code: #{response.code}
-      body: #{CGI.escape(response.body)}
+      body: #{response.body}
       curl message: #{response.return_message}
       total time: #{response.total_time}
       connect time: #{response.connect_time}

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -24,6 +24,11 @@ if ENV.has_key?('REDIS_SIDEKIQ_SENTINELS')
     if ENV['SKIP_RELIABLE_FETCH'].blank?
       Sidekiq::ReliableFetch.setup_reliable_fetch!(config)
     end
+
+    config.capsule('api_entreprise') do |cap|
+      cap.concurrency = 1
+      cap.queues = ['api_entreprise']
+    end
   end
 
   Sidekiq.configure_client do |config|

--- a/config/initializers/transition_to_sidekiq.rb
+++ b/config/initializers/transition_to_sidekiq.rb
@@ -58,7 +58,7 @@ if Rails.env.production? && SIDEKIQ_ENABLED
       self.queue_adapter = :sidekiq
     end
 
-    class APIEntreprise::EntrepriseJob < APIEntreprise::Job
+    class APIEntreprise::Job < ApplicationJob
       self.queue_adapter = :sidekiq
     end
   end

--- a/config/initializers/transition_to_sidekiq.rb
+++ b/config/initializers/transition_to_sidekiq.rb
@@ -57,5 +57,9 @@ if Rails.env.production? && SIDEKIQ_ENABLED
     class Cron::CronJob < ApplicationJob
       self.queue_adapter = :sidekiq
     end
+
+    class APIEntreprise::EntrepriseJob < APIEntreprise::Job
+      self.queue_adapter = :sidekiq
+    end
   end
 end


### PR DESCRIPTION
- utilise une `capsule` pour limiter le nombre de thread à 1

RAF:
- [ ] déclarer la file `api_entreprise`
- [ ] mettre la var d'env `API_ENTREPRISE_DELAY` à 1 pour avoir un rate limit max à 60 appels/min
- [ ] attendre qu'il n'y ait plus de job sur delayed_job avant de lancer les sidekiq

~~Attention, du fait d'avoir des jobs sur sidekiq et sur delayed_job, on peut doubler le rate limit à 120~~
On passe tout sur sidekiq pour simplifier

. La doc indique 2 limites : 1000 appels/min au global , et 250 appels/min pour du json ou 50 appels/min pour des documents.
On a 2 appels qui concernent des documents: attestation_fiscale et vigilance.

-> du coup, en bougeant que entreprise job, on risque seulement de dépasser le quota global.