### PR TITLE
[UX] Améliorer les filtres d'un dossier sur le tableau de bord d'un usager

### DIFF
--- a/app/assets/stylesheets/dsfr.scss
+++ b/app/assets/stylesheets/dsfr.scss
@@ -37,6 +37,7 @@ trix-editor.fr-input {
 
     .fr-menu__list {
       width: 100%;
+      max-height: 300px;
     }
   }
 

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -656,7 +656,6 @@ textarea::placeholder {
 .fr-menu__list {
   padding: $default-spacer;
   overflow-y: auto;
-  max-height: 300px;
 
   .fr-menu__item {
     list-style-type: none;

--- a/app/components/dossiers/user_filter_component/user_filter_component.en.yml
+++ b/app/components/dossiers/user_filter_component/user_filter_component.en.yml
@@ -1,11 +1,11 @@
 en:
   legend:
     state: States
-    created_at: Creation date since
-    depose_at: Submission date since
+    created_at: Created since
+    depose_at: Submitted since
   button:
     apply_filters: Apply filters
-    reset_filters: Reset filters
+    cancel_filters: Cancel
     select_filters: Select a filter
   tag:
     active_filters:

--- a/app/components/dossiers/user_filter_component/user_filter_component.fr.yml
+++ b/app/components/dossiers/user_filter_component/user_filter_component.fr.yml
@@ -1,11 +1,11 @@
 fr:
   legend:
     state: Statut
-    created_at: Date de création depuis le
-    depose_at: Date de dépôt depuis le
+    created_at: Créé depuis le
+    depose_at: Déposé depuis le
   button:
     apply_filters: Appliquer les filtres
-    reset_filters: Réinitialiser les filtres
+    cancel_filters: Annuler
     select_filters: Sélectionner un filtre
   tag:
     active_filters:

--- a/app/components/dossiers/user_filter_component/user_filter_component.html.haml
+++ b/app/components/dossiers/user_filter_component/user_filter_component.html.haml
@@ -25,7 +25,7 @@
 
               .fr-my-2w
                 = f.submit t('.button.apply_filters'), class: 'fr-btn fr-btn--sm'
-                = link_to t('.button.reset_filters'), dossiers_path(statut: @statut), class: 'fr-btn fr-btn--sm fr-btn--tertiary-no-outline'
+                = link_to t('.button.cancel_filters'), dossiers_path(statut: @statut), class: 'fr-btn fr-btn--sm fr-btn--tertiary-no-outline'
 
   - if @filter.filter_params.present?
     .fr-col-12.text-right

--- a/spec/system/users/list_dossiers_spec.rb
+++ b/spec/system/users/list_dossiers_spec.rb
@@ -104,7 +104,7 @@ describe 'user access to the list of their dossiers', js: true do
       expect(page).to have_select 'Statut', selected: 'Refusé', options: ['Sélectionner un statut', 'Accepté', 'Refusé', 'Classé sans suite']
 
       click_on('Sélectionner un filtre')
-      click_on('Réinitialiser les filtres')
+      click_on('Annuler')
       expect(page).to have_text('2 sur 2 dossiers')
       expect(page).to have_select 'Statut', selected: 'Sélectionner un statut', options: ['Sélectionner un statut', 'Accepté', 'Refusé', 'Classé sans suite']
     end


### PR DESCRIPTION
closes #10192 

- Renommage des labels de date
- renommage du bouton "annuler" (au lieu de "réinitialiser les filtres")
- affichage de la dropdown en entier sans couper avant les boutons d'actions
<img width="329" alt="Capture d’écran 2024-04-08 à 10 20 53" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/0aa56598-6c5e-48f9-a9dd-abed86668f84">
