### PR TITLE
Remplacement de l'attribut `aria-current="page"` par `aria-current="true"` lorsque le lien concerne un ensemble de pages

### DIFF
--- a/app/components/main_navigation/instructeur_expert_navigation_component.rb
+++ b/app/components/main_navigation/instructeur_expert_navigation_component.rb
@@ -10,7 +10,7 @@ class MainNavigation::InstructeurExpertNavigationComponent < ApplicationComponen
   end
 
   def aria_current_for(page)
-    { current: page == current_page ? :page : nil }
+    { current: page == current_page ? true : nil }
   end
 
   private

--- a/app/views/administrateurs/_main_navigation.html.haml
+++ b/app/views/administrateurs/_main_navigation.html.haml
@@ -1,6 +1,6 @@
 %nav#header-navigation.fr-nav{ role: 'navigation', 'aria-label': 'Menu principal administrateur' }
   %ul.fr-nav__list
-    %li.fr-nav__item= link_to 'Mes démarches', admin_procedures_path, class:'fr-nav__link', 'aria-current': current_page?(controller: 'administrateurs/procedures', action: :index) ? 'page' : nil
+    %li.fr-nav__item= link_to 'Mes démarches', admin_procedures_path, class:'fr-nav__link', 'aria-current': current_page?(controller: 'administrateurs/procedures', action: :index) ? 'true' : nil
     - if Rails.application.config.ds_zonage_enabled
       %li.fr-nav__item= link_to 'Toutes les démarches', all_admin_procedures_path(zone_ids: :admin_default), class:'fr-nav__link', 'aria-current': current_page?(all_admin_procedures_path) ? 'page' : nil
     - if current_administrateur.groupe_gestionnaire_id

--- a/app/views/users/_main_navigation.html.haml
+++ b/app/views/users/_main_navigation.html.haml
@@ -5,4 +5,4 @@
         = link_to t('back', scope: [:layouts, :header]), url_for(:back), title: t('back_title', scope: [:layouts, :header]), class: 'fr-nav__link', "aria-controls" => "modal-header__menu"
 
     %li.fr-nav__item
-      = link_to t('files', scope: [:layouts, :header]), dossiers_path, class: 'fr-nav__link', aria: { current: current_page?(dossiers_path) ? 'page' : nil, controls: "modal-header__menu" }
+      = link_to t('files', scope: [:layouts, :header]), dossiers_path, class: 'fr-nav__link', aria: { current: controller_name == 'dossiers' ? 'true' : nil, controls: "modal-header__menu" }

--- a/spec/components/main_navigation/instructeur_expert_navigation_component_spec.rb
+++ b/spec/components/main_navigation/instructeur_expert_navigation_component_spec.rb
@@ -24,7 +24,7 @@ describe MainNavigation::InstructeurExpertNavigationComponent, type: :component 
   describe 'when instructor is signed in' do
     it 'renders a link to instructeur procedures with current page class' do
       expect(subject).to have_link('Démarches', href: component.helpers.instructeur_procedures_path)
-      expect(subject).to have_selector('a[aria-current="page"]', text: 'Démarches')
+      expect(subject).to have_selector('a[aria-current="true"]', text: 'Démarches')
     end
 
     it 'does not have Avis' do
@@ -39,7 +39,7 @@ describe MainNavigation::InstructeurExpertNavigationComponent, type: :component 
 
       it 'render have Avis link' do
         expect(subject).to have_link('Avis', href: component.helpers.expert_all_avis_path)
-        expect(subject).not_to have_selector('a[aria-current="page"]', text: 'Avis')
+        expect(subject).not_to have_selector('a[aria-current="true"]', text: 'Avis')
       end
     end
 
@@ -65,7 +65,7 @@ describe MainNavigation::InstructeurExpertNavigationComponent, type: :component 
 
     it 'renders a link to expert all avis with current page class' do
       expect(subject).to have_link('Avis', href: component.helpers.expert_all_avis_path)
-      expect(subject).to have_selector('a[aria-current="page"]', text: 'Avis')
+      expect(subject).to have_selector('a[aria-current="true"]', text: 'Avis')
       expect(subject).not_to have_selector('span.badge')
     end
 
@@ -86,7 +86,7 @@ describe MainNavigation::InstructeurExpertNavigationComponent, type: :component 
 
       it 'render have Démarches link' do
         expect(subject).to have_link('Démarches', href: component.helpers.instructeur_procedures_path)
-        expect(subject).not_to have_selector('a[aria-current="page"]', text: 'Démarches')
+        expect(subject).not_to have_selector('a[aria-current="true"]', text: 'Démarches')
       end
     end
   end


### PR DESCRIPTION
# fix #8559 - Modification de la valeur de l'attribut `aria-current`
__Après__
![Capture d’écran 2024-04-08 à 10 49 08](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/43c03832-d5e3-47e9-b4cd-f4263f7ed0b2)
![Capture d’écran 2024-04-08 à 10 48 57](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/8d30fcbf-7211-4a7d-98cd-e3171f714da2)
__Avant__
![Capture d’écran 2024-04-08 à 11 13 26](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/97e68d5a-de6b-4025-bf4a-3077eb524336)

---

__Après__
![Capture d’écran 2024-04-08 à 10 47 27](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/0991a0a7-a05d-46cf-9da2-4d8635f54913)
![Capture d’écran 2024-04-08 à 10 47 20](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/d7d25d46-95c4-4b21-ac12-a76368a91e16)
__Avant__
![Capture d’écran 2024-04-08 à 11 13 44](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/e0206e8f-bf9f-40e6-8160-52283df966c6)

# fix #8135 - Ajout de l'attribut `aria-current="true"` sur la vue "Dossiers" des utilisateurs
__Après__
![Capture d’écran 2024-04-08 à 10 48 02](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/9e22287e-08f0-4065-b82d-838266e93f59)
![Capture d’écran 2024-04-08 à 10 47 51](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/41529ad2-bc22-4942-89e4-c9bc7b6c9324)

__Avant__
![Capture d’écran 2024-04-08 à 11 13 07](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/9c921d7a-abb7-4641-a2e2-e54a24dd6fb3)
