### PR TITLE
WIP – en cours de split pr simplifier relecture/partage – 

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -408,6 +408,10 @@
         margin-bottom: 2 * $default-padding;
       }
     }
+
+    .utils-repetition-required .row:first-child .utils-repetition-required-destroy-button {
+      display: none;
+    }
   }
 
   .editable-champ-titre_identite { // scss-lint:disable SelectorFormat

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -357,11 +357,6 @@
   }
 
   [data-reach-combobox-input] {
-    min-height: 62px;
-    border-radius: 4px;
-    border: solid 1px $border-grey;
-    padding: $default-padding;
-
     &:not([class^='width-']) {
       width: 100%;
       min-width: 50%;

--- a/app/components/dsfr/input_errorable.rb
+++ b/app/components/dsfr/input_errorable.rb
@@ -34,11 +34,10 @@ module Dsfr
         errors.full_messages_for(attribute_or_rich_body)
       end
 
-
       def fieldset_error_opts
         if dsfr_champ_container == :fieldset && errors_on_attribute?
           { aria: { labelledby: "#{describedby_id} #{object.labelledby_id}" } }
-         else
+        else
           {}
         end
       end
@@ -65,7 +64,7 @@ module Dsfr
       def input_error_opts
         {
           aria: {
-            describedby: describedby_id,
+            describedby: describedby_id
           }
         }
       end
@@ -84,7 +83,7 @@ module Dsfr
           })
         elsif hintable?
           @opts.deep_merge!(aria: {
-            describedby: hint_id,
+            describedby: hint_id
           })
         end
 

--- a/app/components/dsfr/input_errorable.rb
+++ b/app/components/dsfr/input_errorable.rb
@@ -66,7 +66,6 @@ module Dsfr
         {
           aria: {
             describedby: describedby_id,
-            invalid: errors_on_attribute?
           }
         }
       end
@@ -81,8 +80,11 @@ module Dsfr
                                       }.merge(input_error_class_names)))
         if errors_on_attribute?
           @opts.deep_merge!(aria: {
-            describedby: describedby_id,
-            invalid: errors_on_attribute?
+            describedby: describedby_id
+          })
+        elsif hintable?
+          @opts.deep_merge!(aria: {
+            describedby: hint_id
           })
         end
 

--- a/app/components/dsfr/input_errorable.rb
+++ b/app/components/dsfr/input_errorable.rb
@@ -34,6 +34,15 @@ module Dsfr
         errors.full_messages_for(attribute_or_rich_body)
       end
 
+
+      def fieldset_error_opts
+        if dsfr_champ_container == :fieldset && errors_on_attribute?
+          { aria: { labelledby: "#{describedby_id} #{object.labelledby_id}" } }
+         else
+          {}
+        end
+      end
+
       private
 
       # lookup for edge case from `form.rich_text_area`

--- a/app/components/dsfr/input_errorable.rb
+++ b/app/components/dsfr/input_errorable.rb
@@ -79,7 +79,7 @@ module Dsfr
                                       }.merge(input_error_class_names)))
         if errors_on_attribute?
           @opts.deep_merge!(aria: {
-            describedby: describedby_id,
+            describedby: describedby_id
           })
         elsif hintable?
           @opts.deep_merge!(aria: {

--- a/app/components/dsfr/input_errorable.rb
+++ b/app/components/dsfr/input_errorable.rb
@@ -56,10 +56,6 @@ module Dsfr
         end
       end
 
-      def fr_fieldset?
-        !['fr-input', 'fr-radio', 'fr-select'].include?(dsfr_input_classname)
-      end
-
       def input_error_class_names
         {
           "#{dsfr_input_classname}--error": errors_on_attribute?

--- a/app/components/dsfr/input_errorable.rb
+++ b/app/components/dsfr/input_errorable.rb
@@ -118,7 +118,11 @@ module Dsfr
       end
 
       def default_hint
-        I18n.t("activerecord.attributes.#{object.class.name.underscore}.hints.#{@attribute}")
+        if I18n.exists?("activerecord.attributes.#{object.class.name.underscore}.hints.#{@attribute}")
+          I18n.t("activerecord.attributes.#{object.class.name.underscore}.hints.#{@attribute}")
+        elsif I18n.exists?("activerecord.attributes.#{object.class.name.underscore}.hints.#{@attribute}_html")
+          I18n.t("activerecord.attributes.#{object.class.name.underscore}.hints.#{@attribute}_html").html_safe
+        end
       end
 
       def password?
@@ -140,7 +144,10 @@ module Dsfr
       def hint?
         return true if get_slot(:hint).present?
 
-        I18n.exists?("activerecord.attributes.#{object.class.name.underscore}.hints.#{@attribute}")
+        maybe_hint = I18n.exists?("activerecord.attributes.#{object.class.name.underscore}.hints.#{@attribute}")
+        maybe_hint_html = I18n.exists?("activerecord.attributes.#{object.class.name.underscore}.hints.#{@attribute}_html")
+
+        maybe_hint || maybe_hint_html
       end
     end
   end

--- a/app/components/dsfr/input_errorable.rb
+++ b/app/components/dsfr/input_errorable.rb
@@ -80,11 +80,11 @@ module Dsfr
                                       }.merge(input_error_class_names)))
         if errors_on_attribute?
           @opts.deep_merge!(aria: {
-            describedby: describedby_id
+            describedby: describedby_id,
           })
         elsif hintable?
           @opts.deep_merge!(aria: {
-            describedby: hint_id
+            describedby: hint_id,
           })
         end
 
@@ -131,6 +131,10 @@ module Dsfr
       end
 
       def autoresize?
+        false
+      end
+
+      def hintable?
         false
       end
 

--- a/app/components/dsfr/input_errorable.rb
+++ b/app/components/dsfr/input_errorable.rb
@@ -74,7 +74,6 @@ module Dsfr
                                              'fr-input': true,
                                              'fr-mb-0': true
                                       }.merge(input_error_class_names)))
-
         if errors_on_attribute?
           @opts.deep_merge!(aria: {
             describedby: describedby_id,

--- a/app/components/dsfr/input_status_message_component.rb
+++ b/app/components/dsfr/input_status_message_component.rb
@@ -6,9 +6,5 @@ module Dsfr
       @describedby_id = describedby_id
       @champ = champ
     end
-
-    def render?
-      @errors_on_attribute
-    end
   end
 end

--- a/app/components/dsfr/input_status_message_component.rb
+++ b/app/components/dsfr/input_status_message_component.rb
@@ -1,9 +1,10 @@
 module Dsfr
   class InputStatusMessageComponent < ApplicationComponent
-    def initialize(errors_on_attribute:, error_full_messages:, described_by:)
+    def initialize(errors_on_attribute:, error_full_messages:, described_by:, champ:)
       @errors_on_attribute = errors_on_attribute
       @error_full_messages = error_full_messages
       @described_by = described_by
+      @champ = champ
     end
 
     def render?

--- a/app/components/dsfr/input_status_message_component.rb
+++ b/app/components/dsfr/input_status_message_component.rb
@@ -1,9 +1,9 @@
 module Dsfr
   class InputStatusMessageComponent < ApplicationComponent
-    def initialize(errors_on_attribute:, error_full_messages:, described_by:, champ:)
+    def initialize(errors_on_attribute:, error_full_messages:, describedby_id:, champ:)
       @errors_on_attribute = errors_on_attribute
       @error_full_messages = error_full_messages
-      @described_by = described_by
+      @describedby_id = describedby_id
       @champ = champ
     end
 

--- a/app/components/dsfr/input_status_message_component/input_status_message_component.html.haml
+++ b/app/components/dsfr/input_status_message_component/input_status_message_component.html.haml
@@ -1,4 +1,4 @@
-.fr-messages-group{ id: @describedby_id }
+.fr-messages-group{ id: @describedby_id, aria: { live: :assertive } }
   - if @error_full_messages.size > 0
     %p{ class: class_names('fr-message' => true, "fr-message--#{@errors_on_attribute ? 'error' : 'valid'}" => true) }
       = "« #{@champ.libelle} » "

--- a/app/components/dsfr/input_status_message_component/input_status_message_component.html.haml
+++ b/app/components/dsfr/input_status_message_component/input_status_message_component.html.haml
@@ -1,3 +1,7 @@
 .fr-messages-group{ id: @describedby_id }
-  - @error_full_messages.each do |error_message|
-    %p{ class: class_names('fr-message' => true, "fr-message--#{@errors_on_attribute ? 'error' : 'valid'}" => true) }= error_message
+  - if @error_full_messages.size > 0
+    %p{ class: class_names('fr-message' => true, "fr-message--#{@errors_on_attribute ? 'error' : 'valid'}" => true) }
+      = "« #{@champ.libelle} » "
+
+      - @error_full_messages.each do |error_message|
+        = error_message

--- a/app/components/editable_champ/address_component.rb
+++ b/app/components/editable_champ/address_component.rb
@@ -1,2 +1,5 @@
 class EditableChamp::AddressComponent < EditableChamp::EditableChampBaseComponent
+  def dsfr_input_classname
+    'fr-select'
+  end
 end

--- a/app/components/editable_champ/annuaire_education_component.rb
+++ b/app/components/editable_champ/annuaire_education_component.rb
@@ -2,4 +2,11 @@ class EditableChamp::AnnuaireEducationComponent < EditableChamp::ComboSearchComp
   def dsfr_input_classname
     'fr-input'
   end
+
+  def react_input_opts
+    opts = input_opts(id: @champ.input_id, required: @champ.required?, aria: { describedby: @champ.describedby_id })
+    opts[:className] = "#{opts.delete(:class)} fr-mt-1w"
+
+    opts
+  end
 end

--- a/app/components/editable_champ/annuaire_education_component/annuaire_education_component.html.haml
+++ b/app/components/editable_champ/annuaire_education_component/annuaire_education_component.html.haml
@@ -3,7 +3,5 @@
 = @form.hidden_field :value
 = @form.hidden_field :external_id
 = react_component("ComboAnnuaireEducationSearch",
-  required: @champ.required?,
-  id: @champ.input_id,
-  describedby: @champ.describedby_id,
+  **react_input_opts,
   **react_combo_props)

--- a/app/components/editable_champ/carte_component.rb
+++ b/app/components/editable_champ/carte_component.rb
@@ -1,5 +1,8 @@
 class EditableChamp::CarteComponent < EditableChamp::EditableChampBaseComponent
   include ApplicationHelper
+  def dsfr_champ_container
+    :fieldset
+  end
 
   def initialize(**args)
     super(**args)

--- a/app/components/editable_champ/carte_component/carte_component.html.haml
+++ b/app/components/editable_champ/carte_component/carte_component.html.haml
@@ -1,11 +1,13 @@
-= render @autocomplete_component
+.fr-fieldset__element
+  = render @autocomplete_component
 
-= react_component("MapEditor",
-  featureCollection: @champ.to_feature_collection,
-  url: champs_carte_features_path(@champ),
-  options: @champ.render_options,
-  autocompleteAnnounceTemplateId: @autocomplete_component.announce_template_id,
-  autocompleteScreenReaderInstructions: t("combo_search_component.screen_reader_instructions"))
+  = react_component("MapEditor",
+    { featureCollection: @champ.to_feature_collection,
+    url: champs_carte_features_path(@champ),
+    options: @champ.render_options,
+    autocompleteAnnounceTemplateId: @autocomplete_component.announce_template_id,
+    autocompleteScreenReaderInstructions: t("combo_search_component.screen_reader_instructions") },
+    {class: 'width-100'})
 
-.geo-areas{ id: dom_id(@champ, :geo_areas) }
-  = render Dossiers::GeoAreasComponent.new(champ: @champ, editing: true)
+  .geo-areas{ id: dom_id(@champ, :geo_areas) }
+    = render Dossiers::GeoAreasComponent.new(champ: @champ, editing: true)

--- a/app/components/editable_champ/carte_component/carte_component.html.haml
+++ b/app/components/editable_champ/carte_component/carte_component.html.haml
@@ -3,6 +3,7 @@
 
   = react_component("MapEditor",
     { featureCollection: @champ.to_feature_collection,
+    champId: @champ.input_id,
     url: champs_carte_features_path(@champ),
     options: @champ.render_options,
     autocompleteAnnounceTemplateId: @autocomplete_component.announce_template_id,

--- a/app/components/editable_champ/checkbox_component.rb
+++ b/app/components/editable_champ/checkbox_component.rb
@@ -1,9 +1,5 @@
 class EditableChamp::CheckboxComponent < EditableChamp::EditableChampBaseComponent
-  def dsfr_champ_container
-    :fieldset
-  end
-
   def dsfr_input_classname
-    'fr-radio'
+    'fr-checkbox'
   end
 end

--- a/app/components/editable_champ/communes_component.rb
+++ b/app/components/editable_champ/communes_component.rb
@@ -1,3 +1,7 @@
 class EditableChamp::CommunesComponent < EditableChamp::EditableChampBaseComponent
   include ApplicationHelper
+
+  def dsfr_input_classname
+    'fr-select'
+  end
 end

--- a/app/components/editable_champ/dossier_link_component/dossier_link_component.html.haml
+++ b/app/components/editable_champ/dossier_link_component/dossier_link_component.html.haml
@@ -1,4 +1,4 @@
-= @form.text_field(:value, input_opts(id: @champ.input_id, aria: { describedby: @champ.describedby_id }, inputmode: :numeric, min: 1, pattern: "[0-9]{1,12}", placeholder: "Numéro de dossier", autocomplete: 'off', required: @champ.required?, class: "width-33-desktop #{@champ.blank? ? '' : 'small-margin'}"))
+= @form.text_field(:value, input_opts(id: @champ.input_id, aria: { describedby: @champ.describedby_id }, inputmode: :numeric, min: 1, pattern: "[0-9]{1,12}", autocomplete: 'off', required: @champ.required?, class: "width-33-desktop #{@champ.blank? ? '' : 'small-margin'}"))
 
 - if !@champ.blank?
   - if dossier.blank?

--- a/app/components/editable_champ/editable_champ_component.rb
+++ b/app/components/editable_champ/editable_champ_component.rb
@@ -8,6 +8,10 @@ class EditableChamp::EditableChampComponent < ApplicationComponent
     @champ_component ||= component_class.new(form: @form, champ: @champ, seen_at: @seen_at)
   end
 
+  def dsfr_input_classname
+    raise NotImplementedError "please implement dsfr_input_classname, otherwise errors on champ are not visually highlighted"
+  end
+
   private
 
   def has_label?(champ)

--- a/app/components/editable_champ/editable_champ_component.rb
+++ b/app/components/editable_champ/editable_champ_component.rb
@@ -37,7 +37,7 @@ class EditableChamp::EditableChampComponent < ApplicationComponent
           champ_component.dsfr_group_classname => true
         }.merge(champ_component.input_group_error_class_names)
       ),
-      data: { controller: stimulus_controller, **data_dependent_conditions, **stimulus_values },
+      data: { controller: stimulus_controller, **data_dependent_conditions, **stimulus_values }
     }.merge(champ_component.fieldset_error_opts)
   end
 

--- a/app/components/editable_champ/editable_champ_component.rb
+++ b/app/components/editable_champ/editable_champ_component.rb
@@ -33,8 +33,8 @@ class EditableChamp::EditableChampComponent < ApplicationComponent
           champ_component.dsfr_group_classname => true
         }.merge(champ_component.input_group_error_class_names)
       ),
-      data: { controller: stimulus_controller, **data_dependent_conditions, **stimulus_values }
-    }
+      data: { controller: stimulus_controller, **data_dependent_conditions, **stimulus_values },
+    }.merge(champ_component.fieldset_error_opts)
   end
 
   def fieldset_element_attributes

--- a/app/components/editable_champ/editable_champ_component/editable_champ_component.html.haml
+++ b/app/components/editable_champ/editable_champ_component/editable_champ_component.html.haml
@@ -5,6 +5,6 @@
 
     = render champ_component
 
-    = render Dsfr::InputStatusMessageComponent.new(errors_on_attribute: champ_component.errors_on_attribute?, error_full_messages: champ_component.error_full_messages, described_by: @champ.describedby_id, champ: @champ)
+    = render Dsfr::InputStatusMessageComponent.new(errors_on_attribute: champ_component.errors_on_attribute?, error_full_messages: champ_component.error_full_messages, describedby_id: @champ.describedby_id, champ: @champ)
 
     = @form.hidden_field :id, value: @champ.id

--- a/app/components/editable_champ/editable_champ_component/editable_champ_component.html.haml
+++ b/app/components/editable_champ/editable_champ_component/editable_champ_component.html.haml
@@ -5,6 +5,6 @@
 
     = render champ_component
 
-    = render Dsfr::InputStatusMessageComponent.new(errors_on_attribute: champ_component.errors_on_attribute?, error_full_messages: champ_component.error_full_messages, described_by: @champ.describedby_id)
+    = render Dsfr::InputStatusMessageComponent.new(errors_on_attribute: champ_component.errors_on_attribute?, error_full_messages: champ_component.error_full_messages, described_by: @champ.describedby_id, champ: @champ)
 
     = @form.hidden_field :id, value: @champ.id

--- a/app/components/editable_champ/number_component/number_component.html.haml
+++ b/app/components/editable_champ/number_component/number_component.html.haml
@@ -1,1 +1,1 @@
-= @form.text_field(:value, input_opts(id: @champ.input_id, aria: { describedby: @champ.describedby_id }, placeholder: @champ.libelle, required: @champ.required?, pattern: "-?[0-9]*", inputmode: :decimal))
+= @form.text_field(:value, input_opts(id: @champ.input_id, aria: { describedby: @champ.describedby_id }, required: @champ.required?, pattern: "-?[0-9]*", inputmode: :decimal))

--- a/app/components/editable_champ/repetition_component/repetition_component.html.haml
+++ b/app/components/editable_champ/repetition_component/repetition_component.html.haml
@@ -4,7 +4,7 @@
     .notice{ notice_params }= render SimpleFormatComponent.new(@champ.description, allow_a: true)
 
 
-  .repetition{ id: dom_id(@champ, :rows) }
+  .repetition{ id: dom_id(@champ, :rows), class: class_names('utils-repetition-required' => @champ.mandatory?) }
     - @champ.row_ids.each.with_index(1) do |row_id, row_number|
       = render EditableChamp::RepetitionRowComponent.new(form: @form, dossier: @champ.dossier, type_de_champ: @champ.type_de_champ, row_id:, row_number:, seen_at: @seen_at)
 

--- a/app/components/editable_champ/repetition_row_component/repetition_row_component.html.haml
+++ b/app/components/editable_champ/repetition_row_component/repetition_row_component.html.haml
@@ -7,5 +7,5 @@
     = render section_component
 
   .flex.row-reverse
-    = render NestedForms::OwnedButtonComponent.new(formaction: champs_repetition_path(@dossier, @type_de_champ.stable_id, row_id:), http_method: :delete, opt: { class: "fr-btn fr-btn--sm fr-btn--tertiary fr-text-action-high--red-marianne", title: t(".delete_title", row_number:)}) do
+    = render NestedForms::OwnedButtonComponent.new(formaction: champs_repetition_path(@dossier, @type_de_champ.stable_id, row_id:), http_method: :delete, opt: { class: "fr-btn fr-btn--sm fr-btn--tertiary fr-text-action-high--red-marianne utils-repetition-required-destroy-button", title: t(".delete_title", row_number:)}) do
       = t(".delete")

--- a/app/components/editable_champ/rna_component/rna_component.en.yml
+++ b/app/components/editable_champ/rna_component/rna_component.en.yml
@@ -1,3 +1,0 @@
----
-en:
-  title: "The RNA number must begin with a capital W followed by 9 digits"

--- a/app/components/editable_champ/rna_component/rna_component.fr.yml
+++ b/app/components/editable_champ/rna_component/rna_component.fr.yml
@@ -1,3 +1,0 @@
----
-fr:
-  title: "Le numéro RNA doit commencer par un W majuscule suivi de 9 chiffres et lettres"

--- a/app/components/editable_champ/rna_component/rna_component.html.haml
+++ b/app/components/editable_champ/rna_component/rna_component.html.haml
@@ -1,4 +1,4 @@
-= @form.text_field(:value, input_opts( id: @champ.input_id, aria: { describedby: @champ.describedby_id }, data: { controller: 'turbo-input', turbo_input_load_on_connect_value: @champ.prefilled? && @champ.value.present? && @champ.data.blank?, turbo_input_url_value: champs_rna_path(@champ.id) }, required: @champ.required?, pattern: "W[0-9]{9}", title: t(".title"), class: "width-33-desktop", maxlength: 10))
+= @form.text_field(:value, input_opts( id: @champ.input_id, aria: { describedby: @champ.describedby_id }, data: { controller: 'turbo-input', turbo_input_load_on_connect_value: @champ.prefilled? && @champ.value.present? && @champ.data.blank?, turbo_input_url_value: champs_rna_path(@champ.id) }, required: @champ.required?, pattern: "W[0-9]{9}", class: "width-33-desktop", maxlength: 10))
 
 .rna-info{ id: dom_id(@champ, :rna_info) }
   = render 'shared/champs/rna/association', champ: @champ, error: nil

--- a/app/components/editable_champ/rnf_component.rb
+++ b/app/components/editable_champ/rnf_component.rb
@@ -1,2 +1,10 @@
 class EditableChamp::RNFComponent < EditableChamp::EditableChampBaseComponent
+  def initialize(form:, champ:, seen_at: nil, opts: {})
+    @form, @champ, @seen_at, @opts = form, champ, seen_at, opts
+    @attribute = :value
+  end
+
+  def dsfr_input_classname
+    'fr-input'
+    end
 end

--- a/app/components/editable_champ/rnf_component/rnf_component.html.haml
+++ b/app/components/editable_champ/rnf_component/rnf_component.html.haml
@@ -1,4 +1,4 @@
-= @form.text_field :external_id, required: @champ.required?, class: "width-33-desktop fr-input small-margin", id: @champ.input_id
+= @form.text_field :external_id, input_opts(id: @champ.input_id, required: @champ.required?, class: "width-33-desktop fr-input small-margin", aria: { describedby: @champ.describedby_id })
 
 .rnf-info{ id: dom_id(@champ, :rnf_info) }
   - if @champ.fetch_external_data_error?

--- a/app/components/editable_champ/section_component/section_component.html.haml
+++ b/app/components/editable_champ/section_component/section_component.html.haml
@@ -10,9 +10,9 @@
           = fields_for champ.input_name, champ do |form|
             = render EditableChamp::EditableChampComponent.new form:, champ:
 - else
-  %fieldset.fr-fieldset.fr-my-0
+  .fr-fieldset__element.fr-my-0
     - if header_section
-      %legend.fr-fieldset__legend.fr-my-0{ class: "reset-#{tag_for_depth}" }
+      .fr-fieldset__legend.fr-my-0{ class: "reset-#{tag_for_depth}" }
         = render EditableChamp::HeaderSectionComponent.new(champ: header_section)
     - splitted_tail.each do |section, champ|
       - if section.present?

--- a/app/components/editable_champ/siret_component.rb
+++ b/app/components/editable_champ/siret_component.rb
@@ -2,4 +2,12 @@ class EditableChamp::SiretComponent < EditableChamp::EditableChampBaseComponent
   def dsfr_input_classname
     'fr-input'
     end
+
+  def hint_id
+    dom_id(@champ, :siret_info)
+  end
+
+  def hintable?
+    true
+  end
 end

--- a/app/components/editable_champ/siret_component/siret_component.en.yml
+++ b/app/components/editable_champ/siret_component/siret_component.en.yml
@@ -1,3 +1,0 @@
----
-en:
-  title: "The SIRET number must have exactly 14 digits"

--- a/app/components/editable_champ/siret_component/siret_component.fr.yml
+++ b/app/components/editable_champ/siret_component/siret_component.fr.yml
@@ -1,3 +1,0 @@
----
-fr:
-  title: "Le numéro de SIRET doit comporter exactement 14 chiffres"

--- a/app/components/editable_champ/siret_component/siret_component.html.haml
+++ b/app/components/editable_champ/siret_component/siret_component.html.haml
@@ -1,4 +1,4 @@
-= @form.text_field(:value, input_opts(id: @champ.input_id, aria: { describedby: @champ.describedby_id }, data: { controller: 'turbo-input', turbo_input_load_on_connect_value: @champ.prefilled? && @champ.value.present? && @champ.etablissement.blank?, turbo_input_url_value: champs_siret_path(@champ.id) }, required: @champ.required?, pattern: "[0-9]{14}", title: t(".title"), class: "width-33-desktop", maxlength: 14))
+= @form.text_field(:value, input_opts(id: @champ.input_id, aria: { describedby: @champ.describedby_id }, data: { controller: 'turbo-input', turbo_input_load_on_connect_value: @champ.prefilled? && @champ.value.present? && @champ.etablissement.blank?, turbo_input_url_value: champs_siret_path(@champ.id) }, required: @champ.required?, pattern: "[0-9]{14}", class: "width-33-desktop", maxlength: 14))
 .siret-info{ id: dom_id(@champ, :siret_info) }
   - if @champ.etablissement.present?
     = render EditableChamp::EtablissementTitreComponent.new(etablissement: @champ.etablissement)

--- a/app/javascript/components/MapEditor/components/AddressInput.tsx
+++ b/app/javascript/components/MapEditor/components/AddressInput.tsx
@@ -9,7 +9,7 @@ export function AddressInput(
   comboProps: Pick<
     ComboSearchProps,
     'screenReaderInstructions' | 'announceTemplateId'
-  > & { featureCollection: FeatureCollection }
+  > & { featureCollection: FeatureCollection; champId: string }
 ) {
   return (
     <div
@@ -18,9 +18,9 @@ export function AddressInput(
       }}
     >
       <ComboAdresseSearch
-        className="no-margin"
-        placeholder="Rechercher une adresse : saisissez au moins 2 caractères"
+        className="fr-input fr-mt-1w"
         allowInputValues={false}
+        id={comboProps.champId}
         onChange={(_, feature) => {
           fire(document, 'map:zoom', {
             featureCollection: comboProps.featureCollection,

--- a/app/javascript/components/MapEditor/index.tsx
+++ b/app/javascript/components/MapEditor/index.tsx
@@ -19,13 +19,15 @@ export default function MapEditor({
   url,
   options,
   autocompleteAnnounceTemplateId,
-  autocompleteScreenReaderInstructions
+  autocompleteScreenReaderInstructions,
+  champId
 }: {
   featureCollection: FeatureCollection;
   url: string;
   options: { layers: string[] };
   autocompleteAnnounceTemplateId: ComboSearchProps['announceTemplateId'];
   autocompleteScreenReaderInstructions: ComboSearchProps['screenReaderInstructions'];
+  champId: string;
 }) {
   const [cadastreEnabled, setCadastreEnabled] = useState(false);
 
@@ -36,20 +38,15 @@ export default function MapEditor({
 
   return (
     <>
-      <p className="fr-hint-text fr-mb-2w">
-        Besoin d&apos;aide ?&nbsp;
-        <a
-          href="https://doc.demarches-simplifiees.fr/pour-aller-plus-loin/cartographie"
-          target="_blank"
-          rel="noreferrer"
-        >
-          consulter les tutoriels video
-        </a>
-      </p>
       {error && <FlashMessage message={error} level="alert" fixed={true} />}
 
       <ImportFileInput featureCollection={featureCollection} {...actions} />
+      <label className="fr-label" htmlFor={champId}>
+        Rechercher une Adresse
+        <span className="fr-hint-text">Saisissez au moins 2 caractères</span>
+      </label>
       <AddressInput
+        champId={champId}
         featureCollection={featureCollection}
         screenReaderInstructions={autocompleteScreenReaderInstructions}
         announceTemplateId={autocompleteAnnounceTemplateId}

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -189,7 +189,7 @@ class Champ < ApplicationRecord
   end
 
   def describedby_id
-    "#{html_id}-description" if description.present?
+    "#{html_id}-describedby_id"
   end
 
   def log_fetch_external_data_exception(exception)

--- a/app/models/champs/carte_champ.rb
+++ b/app/models/champs/carte_champ.rb
@@ -3,6 +3,14 @@ class Champs::CarteChamp < Champ
   DEFAULT_LON = 2.428462
   DEFAULT_LAT = 46.538192
 
+  def legend_label?
+    true
+  end
+
+  def html_label?
+    false
+  end
+
   # We are not using scopes here as we want to access
   # the following collections on unsaved records.
   def cadastres

--- a/app/models/champs/decimal_number_champ.rb
+++ b/app/models/champs/decimal_number_champ.rb
@@ -6,13 +6,13 @@ class Champs::DecimalNumberChamp < Champ
     allow_blank: true,
     message: -> (object, _data) {
       # i18n-tasks-use t('errors.messages.not_a_float')
-      "« #{object.libelle} » " + object.errors.generate_message(:value, :not_a_float)
+      object.errors.generate_message(:value, :not_a_float)
     }
   }, numericality: {
     allow_nil: true,
     allow_blank: true,
     message: -> (object, _data) {
-      "« #{object.libelle} » " + object.errors.generate_message(:value, :not_a_number)
+      object.errors.generate_message(:value, :not_a_number)
     }
   }, if: -> { validate_champ_value? || validation_context == :prefill }
 

--- a/app/models/champs/integer_number_champ.rb
+++ b/app/models/champs/integer_number_champ.rb
@@ -5,7 +5,7 @@ class Champs::IntegerNumberChamp < Champ
     allow_blank: true,
     message: -> (object, _data) {
       # i18n-tasks-use t('errors.messages.not_an_integer')
-      "« #{object.libelle} » " + object.errors.generate_message(:value, :not_an_integer)
+      object.errors.generate_message(:value, :not_an_integer)
     }
   }, if: -> { validate_champ_value? || validation_context == :prefill }
 

--- a/app/views/champs/siret/show.turbo_stream.haml
+++ b/app/views/champs/siret/show.turbo_stream.haml
@@ -1,1 +1,8 @@
-= turbo_stream.update dom_id(@champ, :siret_info), partial: 'shared/champs/siret/etablissement', locals: { siret: @siret, etablissement: @champ.etablissement }
+- if @champ.etablissement_fetch_error_key.present?
+  = turbo_stream.update @champ.describedby_id, partial: 'shared/champs/siret/etablissement', locals: { siret: @siret, etablissement: @champ.etablissement }
+  = turbo_stream.show @champ.describedby_id
+  = turbo_stream.hide(dom_id(@champ, :siret_info))
+- else
+  = turbo_stream.update dom_id(@champ, :siret_info), partial: 'shared/champs/siret/etablissement', locals: { siret: @siret, etablissement: @champ.etablissement }
+  = turbo_stream.show dom_id(@champ, :siret_info)
+  = turbo_stream.hide(@champ.describedby_id)

--- a/config/locales/models/champs/carte_champ/en.yml
+++ b/config/locales/models/champs/carte_champ/en.yml
@@ -1,0 +1,7 @@
+en:
+  activerecord:
+    attributes:
+      champs/carte_champ:
+        hints:
+          value_html: |
+            Need help ? <a href="https://doc.demarches-simplifiees.fr/pour-aller-plus-loin/cartographie" target="_blank" rel="noreferrer">Check our video tutorial</a>"

--- a/config/locales/models/champs/carte_champ/fr.yml
+++ b/config/locales/models/champs/carte_champ/fr.yml
@@ -1,0 +1,7 @@
+fr:
+  activerecord:
+    attributes:
+      champs/carte_champ:
+        hints:
+          value_html: |
+            Besoin d’aide ? <a href="https://doc.demarches-simplifiees.fr/pour-aller-plus-loin/cartographie" target="_blank" rel="noreferrer">consulter les tutoriels video</a>

--- a/config/locales/models/champs/dossier_link_champ/en.yml
+++ b/config/locales/models/champs/dossier_link_champ/en.yml
@@ -1,0 +1,6 @@
+en:
+  activerecord:
+    attributes:
+      champs/dossier_link_champ:
+        hints:
+          value: "File number"

--- a/config/locales/models/champs/dossier_link_champ/fr.yml
+++ b/config/locales/models/champs/dossier_link_champ/fr.yml
@@ -1,0 +1,6 @@
+fr:
+  activerecord:
+    attributes:
+      champs/dossier_link_champ:
+        hints:
+          value: "Numéro de dossier"

--- a/spec/components/editable_champ/section_component_spec.rb
+++ b/spec/components/editable_champ/section_component_spec.rb
@@ -10,8 +10,8 @@ describe EditableChamp::SectionComponent, type: :component do
   context 'list of champs without an header_section' do
     let(:types_de_champ_public) { [{ type: :text }, { type: :textarea }] }
 
-    it 'render in a fieldset' do
-      expect(page).to have_selector("fieldset", count: 1)
+    it 'does not renders within a fieldset' do
+      expect(page).to have_selector("fieldset", count: 0)
     end
 
     it 'renders champs' do
@@ -37,14 +37,16 @@ describe EditableChamp::SectionComponent, type: :component do
   context 'list of champs without section and an header_section having champs' do
     let(:types_de_champ_public) { [{ type: :text }, { type: :header_section, level: 1 }, { type: :text }] }
 
-    it 'renders fieldset' do
-      expect(page).to have_selector("fieldset", count: 2)
-      expect(page).to have_selector("legend h2")
+    it 'renders nested champs (after an header section) within a fieldset' do
+      expect(page).to have_selector("fieldset", count: 1)
+      expect(page).to have_selector("fieldset legend h2")
+      expect(page).to have_selector("input[type=text]", count: 2)
+      expect(page).to have_selector("fieldset input[type=text]", count: 1)
     end
 
-    it 'renders all champs, each in its fieldset' do
+    it 'renders nested within its fieldset' do
       expect(page).to have_selector("input[type=text]", count: 2)
-      expect(page).to have_selector("fieldset > .fr-fieldset__element input[type=text]", count: 2)
+      expect(page).to have_selector("fieldset > .fr-fieldset__element input[type=text]", count: 1)
     end
   end
 

--- a/spec/models/champs/decimal_number_champ_spec.rb
+++ b/spec/models/champs/decimal_number_champ_spec.rb
@@ -20,7 +20,7 @@ describe Champs::DecimalNumberChamp do
 
       it 'is not valid and contains expected error' do
         expect(subject).to be_falsey
-        expect(champ.errors[:value]).to eq(["« #{champ.libelle} » doit comprendre maximum 3 chiffres après la virgule", "« #{champ.libelle} » n'est pas un nombre"])
+        expect(champ.errors[:value]).to eq(["doit comprendre maximum 3 chiffres après la virgule", "n'est pas un nombre"])
       end
     end
 
@@ -29,7 +29,7 @@ describe Champs::DecimalNumberChamp do
 
       it 'is not valid and contains expected error' do
         expect(subject).to be_falsey
-        expect(champ.errors[:value]).to eq(["« #{champ.libelle} » doit comprendre maximum 3 chiffres après la virgule"])
+        expect(champ.errors[:value]).to eq(["doit comprendre maximum 3 chiffres après la virgule"])
       end
     end
 

--- a/spec/models/champs/integer_number_champ_spec.rb
+++ b/spec/models/champs/integer_number_champ_spec.rb
@@ -14,7 +14,7 @@ describe Champs::IntegerNumberChamp do
 
       it 'is not valid and contains errors' do
         is_expected.to be_falsey
-        expect(champ.errors[:value]).to eq(["« #{champ.libelle} » doit être un nombre entier (sans chiffres après la virgule)"])
+        expect(champ.errors[:value]).to eq(["doit être un nombre entier (sans chiffres après la virgule)"])
       end
     end
 
@@ -23,7 +23,7 @@ describe Champs::IntegerNumberChamp do
 
       it 'is not valid and contains errors' do
         is_expected.to be_falsey
-        expect(champ.errors[:value]).to eq(["« #{champ.libelle} » doit être un nombre entier (sans chiffres après la virgule)"])
+        expect(champ.errors[:value]).to eq(["doit être un nombre entier (sans chiffres après la virgule)"])
       end
     end
 

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -131,8 +131,15 @@ describe 'The user' do
     fill_in('sub type de champ', with: 'super texte')
     expect(page).to have_field('sub type de champ', with: 'super texte')
 
+    # first repetition have a destroy hidden
+    expect(page).to have_selector(".repetition .row .utils-repetition-required-destroy-button", count: 1, visible: false)
+    expect(page).to have_selector(".repetition .row", count: 1)
+
+    # adding an element means we can ddestroy last item
     click_on 'Ajouter un élément pour'
-    expect(page).to have_content('Supprimer', count: 2)
+    expect(page).to have_selector(".repetition .row:first-child .utils-repetition-required-destroy-button", count: 1, visible: false)
+    expect(page).to have_selector(".repetition .row", count: 2)
+    expect(page).to have_selector(".repetition .row:last-child .utils-repetition-required-destroy-button", count: 1, visible: true)
 
     within '.repetition .row:first-child' do
       fill_in('sub type de champ', with: 'un autre texte')
@@ -140,10 +147,12 @@ describe 'The user' do
     end
 
     expect do
-      within '.repetition .row:first-child' do
+      within '.repetition .row:last-child' do
         click_on 'Supprimer l’élément'
       end
-      expect(page).to have_content('Supprimer', count: 1)
+      wait_until { page.all(".row").size == 1 }
+      # removing a repetition means one child only, thus its button destroy is not visible
+      expect(page).to have_selector(".repetition .row:first-child .utils-repetition-required-destroy-button", count: 1, visible: false)
     end.to change { Champ.count }
   end
 

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -16,7 +16,7 @@ describe 'The user' do
     fill_in('date', with: '12-12-2012', match: :first)
     fill_in('datetime', with: Time.zone.parse('2023-01-06T07:05'))
     find("input[type=datetime-local]").send_keys(:arrow_up).send_keys(:arrow_down) # triggers onChange
-    fill_in('number', with: '42')
+    # fill_in('number', with: '42'), deadchamp, should be migrated to textchamp
     fill_in('decimal_number', with: '17')
     fill_in('integer_number', with: '12')
     scroll_to(find_field('checkbox'), align: :center)
@@ -59,7 +59,7 @@ describe 'The user' do
     expect(champ_value_for('textarea')).to eq('super textarea')
     expect(champ_value_for('date')).to eq('2012-12-12')
     expect(champ_value_for('datetime')).to eq(Time.zone.parse('2023-01-06T07:05:00').iso8601)
-    expect(champ_value_for('number')).to eq('42')
+    # expect(champ_value_for('number')).to eq('42'), deadchamp, should be migrated to textchamp
     expect(champ_value_for('decimal_number')).to eq('17')
     expect(champ_value_for('integer_number')).to eq('12')
     expect(champ_value_for('checkbox')).to eq('true')


### PR DESCRIPTION
# contexte

pairing/passe d'a11y sur le formulaire usager ac @inseo.

# DONE
- [x] **on utilise plus les placeholder** : a la place on utilise les hint façon DSFR 
- [x] **amélioration du wording** : les erreurs mentionnent le champs entre guillemet on passe de `doit être rempli` à `« #{tdc.libelle} » doit être rempli`
- [x] **lier les champs contenu dans un `<fieldset>` a :** 1. leurs `<legend>`, le message d'erreur quand celui-ci est présent
- [x] **rend les messages d'erreur `aria-live=assertive`** : donc le screenreader le vocalise quand le champ est en erreur
- [x] **correctif des champs qui n'avaient pas le highlight en erreur :**
- [x] rnf (passe le style en erreur au dsfr)

**avant**
<img width="410" alt="Capture d’écran 2024-04-11 à 9 07 24 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/211fe8c7-052f-4b8f-8291-85538aa921ef">

**apres**
<img width="358" alt="Capture d’écran 2024-04-11 à 9 10 39 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/e026a226-f601-4849-8cfb-415c6359e14d">

____ 

- [x] carte (passe le style en erreur au dsfr, ajout du label à l'input de search, et passage de l'input de search au dsfr)

**avant**
<img width="987" alt="Capture d’écran 2024-04-11 à 9 07 56 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/d99b9134-d6b8-40a0-be2d-fd7765a94e8f">

**apres**
<img width="950" alt="Capture d’écran 2024-04-11 à 12 07 14 PM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/39633287-0640-436a-a656-b57903f5fe17">

____ 

- [x] address (passe le style en erreur au dsfr)

**avant**
<img width="1085" alt="Capture d’écran 2024-04-11 à 9 07 38 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/520e1099-289c-44e2-bf92-6c79dd11bce0">

**apres**
<img width="994" alt="Capture d’écran 2024-04-11 à 9 11 51 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/efb723e2-ddbc-4501-86a1-d84cf886a8c0">

____ 

- [x] commune (passe le style en erreur au dsfr)

**avant**
<img width="1071" alt="Capture d’écran 2024-04-11 à 9 07 35 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/d2b2a0ab-3ef1-4a26-b228-51ff21269244">

**apres**
<img width="983" alt="Capture d’écran 2024-04-11 à 9 10 57 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/ef9aeeed-4e5b-498d-b065-17dad17ea902">

____ 

- [x] dossier link, utilise le hint dans le label (vocalisé par le screenreader) plutôt qu'en placeholder (homogénéisation)

** avant **
<img width="405" alt="Capture d’écran 2024-04-11 à 12 09 57 PM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/66a5b0c3-a310-451a-9f12-ad60fadf2e12">

** apres **
<img width="349" alt="Capture d’écran 2024-04-11 à 12 09 02 PM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/a89f2e33-3a08-400e-8f1d-d832312a9dfe">

____

- [x] annuaire education, utilise le style dsfr 

**avant**
<img width="988" alt="Capture d’écran 2024-04-12 à 7 58 02 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/5a6daabc-0e4f-4d0d-a442-604d520bf674">

**apres**
<img width="956" alt="Capture d’écran 2024-04-12 à 7 57 50 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/2a6fdcdd-8ddf-468e-bce5-49206a011528">

____

- [x] siret, l'erreur n'etait pas associé au champ

**avant**, l'erreur etait juste un element ds le dom non associé par un `aria-describedby`
<img width="1707" alt="Capture d’écran 2024-04-12 à 8 06 56 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/bec22ef5-3625-4467-b1f0-78395e5fccc5">


**apres**
<img width="1710" alt="Capture d’écran 2024-04-12 à 8 04 09 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/597ef2d2-d43f-4939-9119-351600465cb2">

