### PR TITLE
ETQ admin: form des infos de démarche plus lisible

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -2,6 +2,11 @@
 @import "colors";
 @import "placeholders";
 
+.fr-input-group,
+.fr-select-group {
+  margin-bottom: 1rem;
+}
+
 .form {
   input.unstyled {
     padding: 0 !important;
@@ -18,11 +23,6 @@
   .placeholder {
     color: $dark-grey;
     font-style: italic;
-  }
-
-  .fr-input-group,
-  .fr-select-group {
-    margin-bottom: 1rem;
   }
 
   .section-2 {

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -2,11 +2,6 @@
 @import "colors";
 @import "placeholders";
 
-.fr-input-group,
-.fr-select-group {
-  margin-bottom: 1rem;
-}
-
 .form {
   input.unstyled {
     padding: 0 !important;
@@ -23,6 +18,11 @@
   .placeholder {
     color: $dark-grey;
     font-style: italic;
+  }
+
+  .fr-input-group,
+  .fr-select-group {
+    margin-bottom: 1rem;
   }
 
   .section-2 {

--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -383,7 +383,7 @@ module Administrateurs
 
     def close
       @published_procedures = current_administrateur.procedures.publiees.to_h { |p| ["#{p.libelle} (#{p.id})", p.id] }
-      @closing_reason_options = Procedure.closing_reasons.values.map { |reason| [I18n.t("activerecord.attributes.procedure.closing_reasons.#{reason}"), reason] }
+      @closing_reason_options = Procedure.closing_reasons.values.map { |reason| [I18n.t("activerecord.attributes.procedure.closing_reasons.#{reason}", app_name: Current.application_name), reason] }
     end
 
     def confirmation

--- a/app/views/administrateurs/procedures/_informations.html.haml
+++ b/app/views/administrateurs/procedures/_informations.html.haml
@@ -171,7 +171,7 @@
           .fr-radio-group
             = f.radio_button :declarative_with_state, ''
             = f.label :declarative_with_state, value: '', class: "fr-label" do
-              En construction (l'usager peut modifier son dossier jusqu'à sa mise en instruction)
+              La démarche n’est pas déclarative (l’usager peut modifier son dossier jusqu'à sa mise en instruction)
 
 
         .fr-fieldset__element

--- a/app/views/administrateurs/procedures/_informations.html.haml
+++ b/app/views/administrateurs/procedures/_informations.html.haml
@@ -15,18 +15,15 @@
 = f.label :logo, 'Ajouter un logo de la démarche (facultatif)', class: 'fr-label'
 = render Attachment::EditComponent.new(attached_file: @procedure.logo, view_as: :link)
 
-= render Dsfr::CalloutComponent.new(title: "Conservation des données") do |c|
-  - c.with_body do
-    %p
-      = t(:notice, scope: [:administrateurs, :duree_conservation_dossiers_dans_ds])
-    - if f.object.duree_conservation_dossiers_dans_ds.to_i < Expired::DEFAULT_DOSSIER_RENTENTION_IN_MONTH
-      %p
-        = t(:new_duration_constraint, scope: [:administrateurs, :duree_conservation_dossiers_dans_ds], new_duration_in_month: f.object.max_duree_conservation_dossiers_dans_ds)
-
 .fr-input-group
   = f.label :duree_conservation_dossiers_dans_ds, class: 'fr-label' do
     = Procedure.human_attribute_name(:duree_conservation_dossiers_dans_ds, app_name: Current.application_name)
     = render EditableChamp::AsteriskMandatoryComponent.new
+
+    %span.fr-hint-text
+      = t(:notice, scope: [:administrateurs, :duree_conservation_dossiers_dans_ds])
+      - if f.object.duree_conservation_dossiers_dans_ds.to_i < Expired::DEFAULT_DOSSIER_RENTENTION_IN_MONTH
+        = t(:new_duration_constraint, scope: [:administrateurs, :duree_conservation_dossiers_dans_ds], new_duration_in_month: f.object.max_duree_conservation_dossiers_dans_ds)
 
   = f.number_field :duree_conservation_dossiers_dans_ds, { class: 'fr-input', placeholder: '6', required: true, max: f.object.max_duree_conservation_dossiers_dans_ds }
 
@@ -51,11 +48,8 @@
 = f.label :deliberation, 'Importer le texte', class: 'fr-label'
 = render Attachment::EditComponent.new(attached_file: @procedure.deliberation, view_as: :download)
 
-= render Dsfr::CalloutComponent.new(title: "RGPD") do |c|
-  - c.with_body do
-    %p Pour certaines démarches, veuillez indiquer soit le mail de contact de votre délégué à la protection des données, soit un lien web pointant vers les informations
-
-= render Dsfr::InputComponent.new(form: f, attribute: :lien_dpo, input_type: :text_field, opts: {}, required: false)
+= render Dsfr::InputComponent.new(form: f, attribute: :lien_dpo, input_type: :text_field, opts: {}, required: false) do |c|
+  - c.with_hint_content("Pour certaines démarches, veuillez indiquer soit le mail de contact de votre délégué à la protection des données, soit un lien web pointant vers les informations")
 
 - if Rails.application.config.ds_opendata_enabled
   = render Dsfr::CalloutComponent.new(title: t(:opendata_header, scope: [:administrateurs, :informations])) do |c|
@@ -70,13 +64,11 @@
       %span.toggle-switch-label.on Oui
       %span.toggle-switch-label.off Non
 
-= render Dsfr::CalloutComponent.new(title: "Notice explicative de la démarche") do |c|
-  - c.with_body do
-    %p Une notice explicative est un document destiné à guider l’usager dans sa démarche. C’est un document que vous avez élaboré et qui peut prendre la forme d’un fichier doc, d’un pdf ou encore de diapositives. Le bouton pour télécharger cette notice apparaît en haut du formulaire pour l’usager.
-
 .fr-mb-3w
-  = f.label :notice, 'Notice', class: 'fr-label'
+  = f.label :notice, 'Notice explicative de la démarche', class: 'fr-label'
   %p.fr-hint-text
+    Une notice explicative est un document destiné à guider l’usager dans sa démarche. C’est un document que vous avez élaboré et qui peut prendre la forme d’un fichier doc, d’un pdf ou encore de diapositives. Le bouton pour télécharger cette notice apparaît en haut du formulaire pour l’usager.
+    %br
     Formats acceptés : .doc, .odt, .pdf, .ppt, .pptx
   = render Attachment::EditComponent.new(attached_file: @procedure.notice, view_as: :download)
 
@@ -122,43 +114,44 @@
 %details.procedure-form__options-details
   %summary.procedure-form__options-summary
     %h3.fr-h6 Options avancées
+  %fieldset
+    .fr-fieldset__element
+      - if feature_enabled?(:administrateur_web_hook)
+        = f.label :web_hook_url, class: 'fr-label' do
+          Lien de rappel HTTP (webhook)
+        %p.fr-hint-text
+          %strong Les webhooks sont maintenant dépréciés
+          Nous vous recommandons d'utiliser l'API GraphQL en faisant du polling,
+          = link_to "voici un exemple d'implementation ", WEBHOOK_ALTERNATIVE_DOC_URL, rel: "noopener", target: "_blank", title: "Voir une implémentation alternative à l'ancien système de webhook"
+        = f.text_field :web_hook_url, class: 'fr-input', placeholder: 'https://callback.exemple.fr/'
 
-  - if feature_enabled?(:administrateur_web_hook)
-    = f.label :web_hook_url, class: 'fr-label' do
-      Lien de rappel HTTP (webhook)
-    %p.fr-hint-text
-      %strong Les webhooks sont maintenant dépréciés
-      Nous vous recommandons d'utiliser l'API GraphQL en faisant du polling,
-      = link_to "voici un exemple d'implementation ", WEBHOOK_ALTERNATIVE_DOC_URL, rel: "noopener", target: "_blank", title: "Voir une implémentation alternative à l'ancien système de webhook"
-    = f.text_field :web_hook_url, class: 'fr-input', placeholder: 'https://callback.exemple.fr/'
+    .fr-fieldset__element
+      = f.label :auto_archive_on, class: 'fr-label fr-mb-2w' do
+        Date limite de dépôt des dossiers (facultatif)
+        %span.fr-hint-text
+          Si une date est définie, aucun dossier ne pourra plus être déposé ou modifié après cette limite.
+          Les dossiers en construction passeront en instruction et la démarche sera clôturée.
+      %p.notice
+        Le
+        - value = @procedure.auto_archive_on ? @procedure.auto_archive_on - 1.day : nil
+        = f.date_field :auto_archive_on, id: 'auto_archive_on', class: 'fr-input', value: value
+        #{procedure_auto_archive_time(@procedure)}.
 
-  = render Dsfr::CalloutComponent.new(title: "Date limite de dépôt des dossiers") do |c|
-    - c.with_body do
-      %p
-        Si une date est définie, aucun dossier ne pourra plus être déposé ou modifié après cette limite.
-        Les dossiers en construction passeront en instruction et la démarche sera clôturée.
+    .fr-fieldset__element
+      = f.label :declarative_with_state, class: 'fr-label' do
+        Démarche déclarative (facultatif)
+        %span.fr-hint-text
+          Par défaut, un dossier déposé peut être complété ou corrigé par le demandeur jusqu'à sa mise en instruction.<br>
+          Dans une démarche déclarative, une fois déposé, un dossier ne peut plus être modifié.
+          Mentionnez l’état d’avancement pour qu’il passe immédiatement « en instruction » pour être traité ou qu’il soit immédiatement « accepté ».
 
-  = f.label :auto_archive_on, 'Mentionnez une date (facultatif)', class: 'fr-label fr-mb-2w'
-  %p.notice
-    Le
-    - value = @procedure.auto_archive_on ? @procedure.auto_archive_on - 1.day : nil
-    = f.date_field :auto_archive_on, id: 'auto_archive_on', class: 'fr-input', value: value
-    #{procedure_auto_archive_time(@procedure)}.
+      = f.select :declarative_with_state, Procedure.declarative_attributes_for_select, { include_blank: 'Non' }, class: 'fr-select'
 
-  = render Dsfr::CalloutComponent.new(title: "Démarche déclarative") do |c|
-    - c.with_body do
-      %p
-        Par défaut, un dossier déposé peut être complété ou corrigé par le demandeur jusqu'à sa mise en instruction.<br>
-        Dans une démarche déclarative, une fois déposé, un dossier ne peut plus être modifié.
-        Soit il passe immédiatement « en instruction » pour être traité soit il est immédiatement « accepté ».
-
-  = f.label :declarative_with_state, 'Mentionnez l’état d’avancement (facultatif)', class: 'fr-label fr-mb-2w'
-  = f.select :declarative_with_state, Procedure.declarative_attributes_for_select, { include_blank: 'Non' }, class: 'fr-select'
-
-  - if !@procedure.piece_justificative_multiple?
-    .fr-checkbox-group
-      = f.check_box :piece_justificative_multiple
-      = f.label :piece_justificative_multiple, class: 'fr-label' do
-        Champ “Pièce justificative” avec multiples fichiers
-    %p.fr-hint-text
-      Autorise les usagers à envoyer plusieurs fichiers pour les champs de type “Pièce justificative”. L'activation de cette option est irréversible et peut nécessiter des modifications si vous utilisez des systèmes automatisés pour traiter les dossiers.
+    - if !@procedure.piece_justificative_multiple?
+      .fr-fieldset__element
+        .fr-checkbox-group.fr-mt-3w
+          = f.check_box :piece_justificative_multiple
+          = f.label :piece_justificative_multiple, class: 'fr-label' do
+            Champ “Pièce justificative” avec multiples fichiers
+        %p.fr-hint-text
+          Autorise les usagers à envoyer plusieurs fichiers pour les champs de type “Pièce justificative”. L'activation de cette option est irréversible et peut nécessiter des modifications si vous utilisez des systèmes automatisés pour traiter les dossiers.

--- a/app/views/administrateurs/procedures/_informations.html.haml
+++ b/app/views/administrateurs/procedures/_informations.html.haml
@@ -25,7 +25,7 @@
 
 .fr-input-group
   = f.label :duree_conservation_dossiers_dans_ds, class: 'fr-label' do
-    Sur #{Current.application_name}
+    = Procedure.human_attribute_name(:duree_conservation_dossiers_dans_ds, app_name: Current.application_name)
     = render EditableChamp::AsteriskMandatoryComponent.new
 
   = f.number_field :duree_conservation_dossiers_dans_ds, { class: 'fr-input', placeholder: '6', required: true, max: f.object.max_duree_conservation_dossiers_dans_ds }

--- a/app/views/administrateurs/procedures/_informations.html.haml
+++ b/app/views/administrateurs/procedures/_informations.html.haml
@@ -18,7 +18,7 @@
 
 .fr-input-group
   = f.label :duree_conservation_dossiers_dans_ds, class: 'fr-label' do
-    = Procedure.human_attribute_name(:duree_conservation_dossiers_dans_ds, app_name: Current.application_name)
+    = Procedure.human_attribute_name(:duree_conservation_dossiers_dans_ds)
     = render EditableChamp::AsteriskMandatoryComponent.new
 
     %span.fr-hint-text

--- a/app/views/administrateurs/procedures/_informations.html.haml
+++ b/app/views/administrateurs/procedures/_informations.html.haml
@@ -94,19 +94,29 @@
       À qui s’adresse ma démarche ?
       %span.fr-hint-text Si votre démarche s’adresse indifféremment à une personne morale ou un particulier, choisissez l'option « Particuliers ». Vous pourrez ajouter un champ SIRET directement dans le formulaire.
     .fr-fieldset__element
-      .fr-radio-group
+      .fr-radio-group.fr-radio-rich
         = f.radio_button :for_individual, true
         = f.label :for_individual, value: true, class: "fr-label" do
           Ma démarche s’adresse à un particulier
           %span.fr-hint-text En choisissant cette option, l’usager devra renseigner son nom et prénom avant d’accéder au formulaire
+        .fr-radio-rich__img
+          %svg.fr-artwork{ aria_hidden: "true", viewBox: "0 0 80 80", width: "80px", height: "80px" }
+            %use.fr-artwork-decorative{ href: image_path("pictograms/digital/avatar.svg#artwork-decorative") }
+            %use.fr-artwork-minor{ href: image_path("pictograms/digital/avatar.svg#artwork-minor") }
+            %use.fr-artwork-major{ href: image_path("pictograms/digital/avatar.svg#artwork-major") }
 
     .fr-fieldset__element
-      .fr-radio-group
+      .fr-radio-group.fr-radio-rich
         = f.radio_button :for_individual, false
         = f.label :for_individual, value: false, class: 'fr-label' do
           Ma démarche s’adresse à une personne morale
           %span.fr-hint-text
             En choisissant cette option, l’usager devra renseigner son n° SIRET.<br>Grâce à l’API Entreprise, les informations sur la personne morale (raison sociale, adresse du siège, etc.) seront automatiquement renseignées.
+        .fr-radio-rich__img
+          %svg.fr-artwork{ aria_hidden: "true", viewBox: "0 0 80 80", width: "80px", height: "80px" }
+            %use.fr-artwork-decorative{ href: image_path("pictograms/buildings/school.svg#artwork-decorative") }
+            %use.fr-artwork-minor{ href: image_path("pictograms/buildings/school.svg#artwork-minor") }
+            %use.fr-artwork-major{ href: image_path("pictograms/buildings/school.svg#artwork-major") }
 
 %fieldset.fr-fieldset
   .fr-fieldset__element

--- a/app/views/administrateurs/procedures/_informations.html.haml
+++ b/app/views/administrateurs/procedures/_informations.html.haml
@@ -12,8 +12,9 @@
 
 = render Dsfr::InputComponent.new(form: f, attribute: :description_pj, input_type: :text_area, opts: {placeholder: t('activerecord.attributes.procedure.description_pj_placeholder')}, required: false)
 
-= f.label :logo, 'Ajouter un logo de la démarche (facultatif)', class: 'fr-label'
-= render Attachment::EditComponent.new(attached_file: @procedure.logo, view_as: :link)
+.fr-input-group
+  = f.label :logo, 'Ajouter un logo de la démarche', class: 'fr-label'
+  = render Attachment::EditComponent.new(attached_file: @procedure.logo, view_as: :link)
 
 .fr-input-group
   = f.label :duree_conservation_dossiers_dans_ds, class: 'fr-label' do
@@ -42,11 +43,11 @@
       = link_to("En savoir plus avec cette vidéo de 5 minutes", CADRE_JURIDIQUE_URL, target: "_blank", rel: "noopener")
     %p Vous pouvez saisir un lien web vers ce texte, ou l’importer depuis un fichier.
 
-
 = render Dsfr::InputComponent.new(form: f, attribute: :cadre_juridique, input_type: :text_field, opts: {})
 
-= f.label :deliberation, 'Importer le texte', class: 'fr-label'
-= render Attachment::EditComponent.new(attached_file: @procedure.deliberation, view_as: :download)
+.fr-input-group
+  = f.label :deliberation, 'Cadre juridique - texte à importer', class: 'fr-label'
+  = render Attachment::EditComponent.new(attached_file: @procedure.deliberation, view_as: :download)
 
 = render Dsfr::InputComponent.new(form: f, attribute: :lien_dpo, input_type: :text_field, opts: {}, required: false) do |c|
   - c.with_hint_content("Pour certaines démarches, veuillez indiquer soit le mail de contact de votre délégué à la protection des données, soit un lien web pointant vers les informations")
@@ -64,17 +65,20 @@
       %span.toggle-switch-label.on Oui
       %span.toggle-switch-label.off Non
 
-.fr-mb-3w
+.fr-input-group
   = f.label :notice, 'Notice explicative de la démarche', class: 'fr-label'
   %p.fr-hint-text
-    Une notice explicative est un document destiné à guider l’usager dans sa démarche. C’est un document que vous avez élaboré et qui peut prendre la forme d’un fichier doc, d’un pdf ou encore de diapositives. Le bouton pour télécharger cette notice apparaît en haut du formulaire pour l’usager.
+    Une notice explicative est un document que vous avez élaboré, destiné à guider l’usager dans sa démarche. Le bouton pour télécharger cette notice apparaît en haut du formulaire pour l’usager.
     %br
+
     Formats acceptés : .doc, .odt, .pdf, .ppt, .pptx
   = render Attachment::EditComponent.new(attached_file: @procedure.notice, view_as: :download)
 
 - if !@procedure.locked?
   %fieldset.fr-fieldset{ "aria-labelledby": "for-individual-legend" }
-    %legend#for-individual-legend.fr-fieldset__legend.fr-fieldset__legend--regular À qui s’adresse ma démarche ?
+    %legend#for-individual-legend.fr-fieldset__legend.fr-fieldset__legend--regular
+      À qui s’adresse ma démarche ?
+      %span.fr-hint-text Si votre démarche s’adresse indifféremment à une personne morale ou un particulier, choisissez l'option « Particuliers ». Vous pourrez ajouter un champ SIRET directement dans le formulaire.
     .fr-fieldset__element
       .fr-radio-group
         = f.radio_button :for_individual, true
@@ -90,14 +94,7 @@
           %span.fr-hint-text
             En choisissant cette option, l’usager devra renseigner son n° SIRET.<br>Grâce à l’API Entreprise, les informations sur la personne morale (raison sociale, adresse du siège, etc.) seront automatiquement renseignées.
 
-    .fr-fieldset__element
-      .fr-highlight
-        %p.fr-text--sm
-          Si votre démarche s’adresse indifféremment à une personne morale ou un particulier, choisissez l'option « Particuliers ».
-          Vous pourrez ajouter un champ SIRET directement dans le formulaire.
-
-
-= f.label :tags, 'Associez les tags à la démarche (facultatif)', class: 'fr-label'
+= f.label :tags, 'Associez les tags à la démarche', class: 'fr-label'
 %p.fr-hint-text Les tags sont des mots ou des expressions que vous attribuez aux démarches pour décrire leur contenu et pour les retrouver. Les tags sont partagés avec la communauté, ce qui vous permet de voir les tags attribués aux démarches créées par les autres administrateurs.
 = hidden_field_tag  'procedure[tags]', JSON.generate(@procedure.tags)
 = react_component("ComboMultiple",
@@ -114,44 +111,62 @@
 %details.procedure-form__options-details
   %summary.procedure-form__options-summary
     %h3.fr-h6 Options avancées
-  %fieldset
-    .fr-fieldset__element
-      - if feature_enabled?(:administrateur_web_hook)
-        = f.label :web_hook_url, class: 'fr-label' do
-          Lien de rappel HTTP (webhook)
-        %p.fr-hint-text
-          %strong Les webhooks sont maintenant dépréciés
-          Nous vous recommandons d'utiliser l'API GraphQL en faisant du polling,
-          = link_to "voici un exemple d'implementation ", WEBHOOK_ALTERNATIVE_DOC_URL, rel: "noopener", target: "_blank", title: "Voir une implémentation alternative à l'ancien système de webhook"
-        = f.text_field :web_hook_url, class: 'fr-input', placeholder: 'https://callback.exemple.fr/'
+  .card
+    %fieldset.fr-fieldset
+      .fr-fieldset__element
+        - if feature_enabled?(:administrateur_web_hook)
+          = f.label :web_hook_url, class: 'fr-label' do
+            Lien de rappel HTTP (webhook)
+          %p.fr-hint-text
+            %strong Les webhooks sont maintenant dépréciés
+            Nous vous recommandons d'utiliser l'API GraphQL en faisant du polling,
+            = link_to "voici un exemple d'implementation ", WEBHOOK_ALTERNATIVE_DOC_URL, rel: "noopener", target: "_blank", title: "Voir une implémentation alternative à l'ancien système de webhook"
+          = f.text_field :web_hook_url, class: 'fr-input', placeholder: 'https://callback.exemple.fr/'
 
-    .fr-fieldset__element
-      = f.label :auto_archive_on, class: 'fr-label fr-mb-2w' do
-        Date limite de dépôt des dossiers (facultatif)
-        %span.fr-hint-text
-          Si une date est définie, aucun dossier ne pourra plus être déposé ou modifié après cette limite.
-          Les dossiers en construction passeront en instruction et la démarche sera clôturée.
-      %p.notice
-        Le
-        - value = @procedure.auto_archive_on ? @procedure.auto_archive_on - 1.day : nil
-        = f.date_field :auto_archive_on, id: 'auto_archive_on', class: 'fr-input', value: value
-        #{procedure_auto_archive_time(@procedure)}.
+      .fr-fieldset__element
+        = f.label :auto_archive_on, class: 'fr-label fr-mb-2w' do
+          Date limite de dépôt des dossiers
+          %span.fr-hint-text
+            Si une date est définie, aucun dossier ne pourra plus être déposé ou modifié après cette limite.
+            Les dossiers en construction passeront en instruction et la démarche sera clôturée.
+        %span.flex.align-center
+          - value = @procedure.auto_archive_on ? @procedure.auto_archive_on - 1.day : nil
+          = f.date_field :auto_archive_on, id: 'auto_archive_on', class: 'fr-input', value: value
+          %span.fr-ml-1w.fr-text-mention--grey
+            #{procedure_auto_archive_time(@procedure)}.
 
-    .fr-fieldset__element
-      = f.label :declarative_with_state, class: 'fr-label' do
-        Démarche déclarative (facultatif)
+    %fieldset.fr-fieldset{ "aria-labelledby": "declarative_with_state-legend" }
+      %legend#declarative_with_state-legend.fr-fieldset__legend.fr-fieldset__legend--regular
+        Démarche déclarative
         %span.fr-hint-text
           Par défaut, un dossier déposé peut être complété ou corrigé par le demandeur jusqu'à sa mise en instruction.<br>
-          Dans une démarche déclarative, une fois déposé, un dossier ne peut plus être modifié.
-          Mentionnez l’état d’avancement pour qu’il passe immédiatement « en instruction » pour être traité ou qu’il soit immédiatement « accepté ».
-
-      = f.select :declarative_with_state, Procedure.declarative_attributes_for_select, { include_blank: 'Non' }, class: 'fr-select'
-
-    - if !@procedure.piece_justificative_multiple?
+          Dans une démarche déclarative, une fois déposé, un dossier ne peut plus être modifié. Soit il passe immédiatement « en instruction » pour être traité, soit il est immédiatement « accepté ».
       .fr-fieldset__element
-        .fr-checkbox-group.fr-mt-3w
-          = f.check_box :piece_justificative_multiple
-          = f.label :piece_justificative_multiple, class: 'fr-label' do
-            Champ “Pièce justificative” avec multiples fichiers
-        %p.fr-hint-text
-          Autorise les usagers à envoyer plusieurs fichiers pour les champs de type “Pièce justificative”. L'activation de cette option est irréversible et peut nécessiter des modifications si vous utilisez des systèmes automatisés pour traiter les dossiers.
+        .fr-radio-group
+          = f.radio_button :declarative_with_state, ''
+          = f.label :declarative_with_state, value: '', class: "fr-label" do
+            En construction (l'usager peut modifier son dossier jusqu'à sa mise en instruction)
+
+
+      .fr-fieldset__element
+        .fr-radio-group
+          = f.radio_button :declarative_with_state, Procedure.declarative_with_states.fetch(:en_instruction)
+          = f.label :declarative_with_state, value: Procedure.declarative_with_states.fetch(:en_instruction), class: 'fr-label' do
+            Passage automatique en instruction (l'usager ne peut plus modifier son dossier)
+
+
+      .fr-fieldset__element
+        .fr-radio-group
+          = f.radio_button :declarative_with_state, Procedure.declarative_with_states.fetch(:accepte)
+          = f.label :declarative_with_state, value: Procedure.declarative_with_states.fetch(:accepte), class: 'fr-label' do
+            Passage automatique au statut « accepté » (l'usager ne peut plus modifier son dossier)
+
+
+      - if !@procedure.piece_justificative_multiple?
+        .fr-fieldset__element
+          .fr-checkbox-group.fr-mt-3w
+            = f.check_box :piece_justificative_multiple
+            = f.label :piece_justificative_multiple, class: 'fr-label' do
+              Champ “Pièce justificative” avec multiples fichiers
+          %p.fr-hint-text
+            Autorise les usagers à envoyer plusieurs fichiers pour les champs de type “Pièce justificative”. L'activation de cette option est irréversible et peut nécessiter des modifications si vous utilisez des systèmes automatisés pour traiter les dossiers.

--- a/app/views/administrateurs/procedures/_informations.html.haml
+++ b/app/views/administrateurs/procedures/_informations.html.haml
@@ -88,37 +88,37 @@
         Formats acceptés : .doc, .odt, .pdf, .ppt, .pptx
       = render Attachment::EditComponent.new(attached_file: @procedure.notice, view_as: :download)
 
-- if !@procedure.locked?
-  %fieldset.fr-fieldset{ "aria-labelledby": "for-individual-legend" }
-    %legend#for-individual-legend.fr-fieldset__legend.fr-fieldset__legend--regular
-      À qui s’adresse ma démarche ?
-      %span.fr-hint-text Si votre démarche s’adresse indifféremment à une personne morale ou un particulier, choisissez l'option « Particuliers ». Vous pourrez ajouter un champ SIRET directement dans le formulaire.
+  - if !@procedure.locked?
     .fr-fieldset__element
-      .fr-radio-group.fr-radio-rich
-        = f.radio_button :for_individual, true
-        = f.label :for_individual, value: true, class: "fr-label" do
-          Ma démarche s’adresse à un particulier
-          %span.fr-hint-text En choisissant cette option, l’usager devra renseigner son nom et prénom avant d’accéder au formulaire
-        .fr-radio-rich__img
-          %svg.fr-artwork{ aria_hidden: "true", viewBox: "0 0 80 80", width: "80px", height: "80px" }
-            %use.fr-artwork-decorative{ href: image_path("pictograms/digital/avatar.svg#artwork-decorative") }
-            %use.fr-artwork-minor{ href: image_path("pictograms/digital/avatar.svg#artwork-minor") }
-            %use.fr-artwork-major{ href: image_path("pictograms/digital/avatar.svg#artwork-major") }
+      %fieldset.fr-fieldset{ "aria-labelledby": "for-individual-legend" }
+        %legend#for-individual-legend.fr-fieldset__legend.fr-fieldset__legend--regular
+          À qui s’adresse ma démarche ?
+          %span.fr-hint-text Si votre démarche s’adresse indifféremment à une personne morale ou un particulier, choisissez l'option « Particuliers ». Vous pourrez ajouter un champ SIRET directement dans le formulaire.
+        .fr-fieldset__element
+          .fr-radio-group.fr-radio-rich
+            = f.radio_button :for_individual, true
+            = f.label :for_individual, value: true, class: "fr-label" do
+              Ma démarche s’adresse à un particulier
+              %span.fr-hint-text En choisissant cette option, l’usager devra renseigner son nom et prénom avant d’accéder au formulaire
+            .fr-radio-rich__img
+              %svg.fr-artwork{ aria_hidden: "true", viewBox: "0 0 80 80", width: "80px", height: "80px" }
+                %use.fr-artwork-decorative{ href: image_path("pictograms/digital/avatar.svg#artwork-decorative") }
+                %use.fr-artwork-minor{ href: image_path("pictograms/digital/avatar.svg#artwork-minor") }
+                %use.fr-artwork-major{ href: image_path("pictograms/digital/avatar.svg#artwork-major") }
 
-    .fr-fieldset__element
-      .fr-radio-group.fr-radio-rich
-        = f.radio_button :for_individual, false
-        = f.label :for_individual, value: false, class: 'fr-label' do
-          Ma démarche s’adresse à une personne morale
-          %span.fr-hint-text
-            En choisissant cette option, l’usager devra renseigner son n° SIRET.<br>Grâce à l’API Entreprise, les informations sur la personne morale (raison sociale, adresse du siège, etc.) seront automatiquement renseignées.
-        .fr-radio-rich__img
-          %svg.fr-artwork{ aria_hidden: "true", viewBox: "0 0 80 80", width: "80px", height: "80px" }
-            %use.fr-artwork-decorative{ href: image_path("pictograms/buildings/school.svg#artwork-decorative") }
-            %use.fr-artwork-minor{ href: image_path("pictograms/buildings/school.svg#artwork-minor") }
-            %use.fr-artwork-major{ href: image_path("pictograms/buildings/school.svg#artwork-major") }
+        .fr-fieldset__element
+          .fr-radio-group.fr-radio-rich
+            = f.radio_button :for_individual, false
+            = f.label :for_individual, value: false, class: 'fr-label' do
+              Ma démarche s’adresse à une personne morale
+              %span.fr-hint-text
+                En choisissant cette option, l’usager devra renseigner son n° SIRET.<br>Grâce à l’API Entreprise, les informations sur la personne morale (raison sociale, adresse du siège, etc.) seront automatiquement renseignées.
+            .fr-radio-rich__img
+              %svg.fr-artwork{ aria_hidden: "true", viewBox: "0 0 80 80", width: "80px", height: "80px" }
+                %use.fr-artwork-decorative{ href: image_path("pictograms/buildings/school.svg#artwork-decorative") }
+                %use.fr-artwork-minor{ href: image_path("pictograms/buildings/school.svg#artwork-minor") }
+                %use.fr-artwork-major{ href: image_path("pictograms/buildings/school.svg#artwork-major") }
 
-%fieldset.fr-fieldset
   .fr-fieldset__element
     = f.label :tags, 'Associez les tags à la démarche', class: 'fr-label'
     %p.fr-hint-text Les tags sont des mots ou des expressions que vous attribuez aux démarches pour décrire leur contenu et pour les retrouver. Les tags sont partagés avec la communauté, ce qui vous permet de voir les tags attribués aux démarches créées par les autres administrateurs.
@@ -164,7 +164,7 @@
       %fieldset.fr-fieldset{ "aria-labelledby": "declarative_with_state-legend" }
         %legend#declarative_with_state-legend.fr-fieldset__legend.fr-fieldset__legend--regular
           Démarche déclarative
-          %span.fr-hint-text
+          %span.fr-hint-text.fr-mt-0
             Par défaut, un dossier déposé peut être complété ou corrigé par le demandeur jusqu'à sa mise en instruction.<br>
             Dans une démarche déclarative, une fois déposé, un dossier ne peut plus être modifié. Soit il passe immédiatement « en instruction » pour être traité, soit il est immédiatement « accepté ».
         .fr-fieldset__element

--- a/app/views/administrateurs/procedures/_informations.html.haml
+++ b/app/views/administrateurs/procedures/_informations.html.haml
@@ -4,75 +4,89 @@
       %p
         Certains éléments de la description ne sont plus modifiables.
 
-= render Dsfr::InputComponent.new(form: f, attribute: :libelle, input_type: :text_field, opts: {})
+%fieldset.fr-fieldset
+  .fr-fieldset__element
+    = render Dsfr::InputComponent.new(form: f, attribute: :libelle, input_type: :text_field, opts: {})
+  .fr-fieldset__element
+    = render Dsfr::InputComponent.new(form: f, attribute: :description, input_type: :text_area, opts: {})
+  .fr-fieldset__element
+    = render Dsfr::InputComponent.new(form: f, attribute: :description_target_audience, input_type: :text_area, opts: {}, required: false)
+  .fr-fieldset__element
+    = render Dsfr::InputComponent.new(form: f, attribute: :description_pj, input_type: :text_area, opts: {placeholder: t('activerecord.attributes.procedure.description_pj_placeholder')}, required: false)
 
-= render Dsfr::InputComponent.new(form: f, attribute: :description, input_type: :text_area, opts: {})
+  .fr-fieldset__element
+    .fr-input-group
+      = f.label :logo, 'Ajouter un logo de la démarche', class: 'fr-label'
+      = render Attachment::EditComponent.new(attached_file: @procedure.logo, view_as: :link)
+  .fr-fieldset__element
+    .fr-input-group
+      = f.label :duree_conservation_dossiers_dans_ds, class: 'fr-label' do
+        = Procedure.human_attribute_name(:duree_conservation_dossiers_dans_ds)
+        = render EditableChamp::AsteriskMandatoryComponent.new
 
-= render Dsfr::InputComponent.new(form: f, attribute: :description_target_audience, input_type: :text_area, opts: {}, required: false)
+        %span.fr-hint-text
+          = t(:notice, scope: [:administrateurs, :duree_conservation_dossiers_dans_ds])
+          - if f.object.duree_conservation_dossiers_dans_ds.to_i < Expired::DEFAULT_DOSSIER_RENTENTION_IN_MONTH
+            = t(:new_duration_constraint, scope: [:administrateurs, :duree_conservation_dossiers_dans_ds], new_duration_in_month: f.object.max_duree_conservation_dossiers_dans_ds)
 
-= render Dsfr::InputComponent.new(form: f, attribute: :description_pj, input_type: :text_area, opts: {placeholder: t('activerecord.attributes.procedure.description_pj_placeholder')}, required: false)
+      = f.number_field :duree_conservation_dossiers_dans_ds, { class: 'fr-input', placeholder: '6', required: true, max: f.object.max_duree_conservation_dossiers_dans_ds }
 
-.fr-input-group
-  = f.label :logo, 'Ajouter un logo de la démarche', class: 'fr-label'
-  = render Attachment::EditComponent.new(attached_file: @procedure.logo, view_as: :link)
+  - if @procedure.persisted?
+    .fr-fieldset__element
+      = render Dsfr::InputComponent.new(form: f, attribute: :lien_site_web, input_type: :text_field, opts: {}, required: false)
 
-.fr-input-group
-  = f.label :duree_conservation_dossiers_dans_ds, class: 'fr-label' do
-    = Procedure.human_attribute_name(:duree_conservation_dossiers_dans_ds)
-    = render EditableChamp::AsteriskMandatoryComponent.new
+%fieldset.fr-fieldset
+  %legend.fr-fieldset__legend Cadre juridique
+  .fr-fieldset__element
+    = render Dsfr::CalloutComponent.new(title: nil) do |c|
+      - c.with_body do
+        %p
+          Le cadre juridique justifie le droit de collecter les données demandées dans votre démarche auprès des usagers. Par exemple :
+          %br
+          • Texte de loi (loi, décret, circulaire, arrêté…)
+          %br
+          • Texte juridique (statuts, délibération, décision du conseil d’administration…)
+          %br
+          = link_to("En savoir plus avec cette vidéo de 5 minutes", CADRE_JURIDIQUE_URL, target: "_blank", rel: "noopener")
+        %p Vous pouvez saisir un lien web vers ce texte, ou l’importer depuis un fichier.
 
-    %span.fr-hint-text
-      = t(:notice, scope: [:administrateurs, :duree_conservation_dossiers_dans_ds])
-      - if f.object.duree_conservation_dossiers_dans_ds.to_i < Expired::DEFAULT_DOSSIER_RENTENTION_IN_MONTH
-        = t(:new_duration_constraint, scope: [:administrateurs, :duree_conservation_dossiers_dans_ds], new_duration_in_month: f.object.max_duree_conservation_dossiers_dans_ds)
+  .fr-fieldset__element
+    = render Dsfr::InputComponent.new(form: f, attribute: :cadre_juridique, input_type: :text_field, opts: {})
 
-  = f.number_field :duree_conservation_dossiers_dans_ds, { class: 'fr-input', placeholder: '6', required: true, max: f.object.max_duree_conservation_dossiers_dans_ds }
+  .fr-fieldset__element
+    .fr-input-group
+      = f.label :deliberation, 'Cadre juridique - texte à importer', class: 'fr-label'
+      = render Attachment::EditComponent.new(attached_file: @procedure.deliberation, view_as: :download)
 
-- if @procedure.persisted?
-  = render Dsfr::InputComponent.new(form: f, attribute: :lien_site_web, input_type: :text_field, opts: {}, required: false)
+%fieldset.fr-fieldset
+  .fr-fieldset__element
+    = render Dsfr::InputComponent.new(form: f, attribute: :lien_dpo, input_type: :text_field, opts: {}, required: false) do |c|
+      - c.with_hint_content("Pour certaines démarches, veuillez indiquer soit le mail de contact de votre délégué à la protection des données, soit un lien web pointant vers les informations")
 
-= render Dsfr::CalloutComponent.new(title: "Cadre juridique") do |c|
-  - c.with_body do
-    %p
-      Le cadre juridique justifie le droit de collecter les données demandées dans votre démarche auprès des usagers. Par exemple :
-      %br
-      • Texte de loi (loi, décret, circulaire, arrêté…)
-      %br
-      • Texte juridique (statuts, délibération, décision du conseil d’administration…)
-      %br
-      = link_to("En savoir plus avec cette vidéo de 5 minutes", CADRE_JURIDIQUE_URL, target: "_blank", rel: "noopener")
-    %p Vous pouvez saisir un lien web vers ce texte, ou l’importer depuis un fichier.
+  - if Rails.application.config.ds_opendata_enabled
+    .fr-fieldset__element
+      = render Dsfr::CalloutComponent.new(title: t(:opendata_header, scope: [:administrateurs, :informations])) do |c|
+        - c.with_body do
+          %p= t(:opendata_notice_html, scope: [:administrateurs, :informations])
 
-= render Dsfr::InputComponent.new(form: f, attribute: :cadre_juridique, input_type: :text_field, opts: {})
+    .fr-fieldset__element
+      .fr-input-group
+        = f.label :opendata, t(:opendata, scope: [:administrateurs, :informations]), class: 'fr-label'
+        %label.toggle-switch
+          = f.check_box :opendata, class: 'toggle-switch-checkbox'
+          %span.toggle-switch-control.round
+          %span.toggle-switch-label.on Oui
+          %span.toggle-switch-label.off Non
 
-.fr-input-group
-  = f.label :deliberation, 'Cadre juridique - texte à importer', class: 'fr-label'
-  = render Attachment::EditComponent.new(attached_file: @procedure.deliberation, view_as: :download)
+  .fr-fieldset__element
+    .fr-input-group
+      = f.label :notice, 'Notice explicative de la démarche', class: 'fr-label'
+      %p.fr-hint-text
+        Une notice explicative est un document que vous avez élaboré, destiné à guider l’usager dans sa démarche. Le bouton pour télécharger cette notice apparaît en haut du formulaire pour l’usager.
+        %br
 
-= render Dsfr::InputComponent.new(form: f, attribute: :lien_dpo, input_type: :text_field, opts: {}, required: false) do |c|
-  - c.with_hint_content("Pour certaines démarches, veuillez indiquer soit le mail de contact de votre délégué à la protection des données, soit un lien web pointant vers les informations")
-
-- if Rails.application.config.ds_opendata_enabled
-  = render Dsfr::CalloutComponent.new(title: t(:opendata_header, scope: [:administrateurs, :informations])) do |c|
-    - c.with_body do
-      %p= t(:opendata_notice_html, scope: [:administrateurs, :informations])
-
-  .fr-input-group
-    = f.label :opendata, t(:opendata, scope: [:administrateurs, :informations]), class: 'fr-label'
-    %label.toggle-switch
-      = f.check_box :opendata, class: 'toggle-switch-checkbox'
-      %span.toggle-switch-control.round
-      %span.toggle-switch-label.on Oui
-      %span.toggle-switch-label.off Non
-
-.fr-input-group
-  = f.label :notice, 'Notice explicative de la démarche', class: 'fr-label'
-  %p.fr-hint-text
-    Une notice explicative est un document que vous avez élaboré, destiné à guider l’usager dans sa démarche. Le bouton pour télécharger cette notice apparaît en haut du formulaire pour l’usager.
-    %br
-
-    Formats acceptés : .doc, .odt, .pdf, .ppt, .pptx
-  = render Attachment::EditComponent.new(attached_file: @procedure.notice, view_as: :download)
+        Formats acceptés : .doc, .odt, .pdf, .ppt, .pptx
+      = render Attachment::EditComponent.new(attached_file: @procedure.notice, view_as: :download)
 
 - if !@procedure.locked?
   %fieldset.fr-fieldset{ "aria-labelledby": "for-individual-legend" }
@@ -94,79 +108,81 @@
           %span.fr-hint-text
             En choisissant cette option, l’usager devra renseigner son n° SIRET.<br>Grâce à l’API Entreprise, les informations sur la personne morale (raison sociale, adresse du siège, etc.) seront automatiquement renseignées.
 
-= f.label :tags, 'Associez les tags à la démarche', class: 'fr-label'
-%p.fr-hint-text Les tags sont des mots ou des expressions que vous attribuez aux démarches pour décrire leur contenu et pour les retrouver. Les tags sont partagés avec la communauté, ce qui vous permet de voir les tags attribués aux démarches créées par les autres administrateurs.
-= hidden_field_tag  'procedure[tags]', JSON.generate(@procedure.tags)
-= react_component("ComboMultiple",
-  id: "procedure_tags_combo",
-  options: Procedure.tags,
-  selected: @procedure.tags,
-  disabled: [],
-  label: 'Tags',
-  group: '.procedure_tags_combo',
-  name: 'tags',
-  describedby: 'procedure-tags',
-  acceptNewValues: true)
+%fieldset.fr-fieldset
+  .fr-fieldset__element
+    = f.label :tags, 'Associez les tags à la démarche', class: 'fr-label'
+    %p.fr-hint-text Les tags sont des mots ou des expressions que vous attribuez aux démarches pour décrire leur contenu et pour les retrouver. Les tags sont partagés avec la communauté, ce qui vous permet de voir les tags attribués aux démarches créées par les autres administrateurs.
+    = hidden_field_tag  'procedure[tags]', JSON.generate(@procedure.tags)
+    = react_component("ComboMultiple",
+      id: "procedure_tags_combo",
+      options: Procedure.tags,
+      selected: @procedure.tags,
+      disabled: [],
+      label: 'Tags',
+      group: '.procedure_tags_combo',
+      name: 'tags',
+      describedby: 'procedure-tags',
+      acceptNewValues: true)
 
-%details.procedure-form__options-details
-  %summary.procedure-form__options-summary
-    %h3.fr-h6 Options avancées
-  .card
-    %fieldset.fr-fieldset
-      .fr-fieldset__element
-        - if feature_enabled?(:administrateur_web_hook)
-          = f.label :web_hook_url, class: 'fr-label' do
-            Lien de rappel HTTP (webhook)
-          %p.fr-hint-text
-            %strong Les webhooks sont maintenant dépréciés
-            Nous vous recommandons d'utiliser l'API GraphQL en faisant du polling,
-            = link_to "voici un exemple d'implementation ", WEBHOOK_ALTERNATIVE_DOC_URL, rel: "noopener", target: "_blank", title: "Voir une implémentation alternative à l'ancien système de webhook"
-          = f.text_field :web_hook_url, class: 'fr-input', placeholder: 'https://callback.exemple.fr/'
-
-      .fr-fieldset__element
-        = f.label :auto_archive_on, class: 'fr-label fr-mb-2w' do
-          Date limite de dépôt des dossiers
-          %span.fr-hint-text
-            Si une date est définie, aucun dossier ne pourra plus être déposé ou modifié après cette limite.
-            Les dossiers en construction passeront en instruction et la démarche sera clôturée.
-        %span.flex.align-center
-          - value = @procedure.auto_archive_on ? @procedure.auto_archive_on - 1.day : nil
-          = f.date_field :auto_archive_on, id: 'auto_archive_on', class: 'fr-input', value: value
-          %span.fr-ml-1w.fr-text-mention--grey
-            #{procedure_auto_archive_time(@procedure)}.
-
-    %fieldset.fr-fieldset{ "aria-labelledby": "declarative_with_state-legend" }
-      %legend#declarative_with_state-legend.fr-fieldset__legend.fr-fieldset__legend--regular
-        Démarche déclarative
-        %span.fr-hint-text
-          Par défaut, un dossier déposé peut être complété ou corrigé par le demandeur jusqu'à sa mise en instruction.<br>
-          Dans une démarche déclarative, une fois déposé, un dossier ne peut plus être modifié. Soit il passe immédiatement « en instruction » pour être traité, soit il est immédiatement « accepté ».
-      .fr-fieldset__element
-        .fr-radio-group
-          = f.radio_button :declarative_with_state, ''
-          = f.label :declarative_with_state, value: '', class: "fr-label" do
-            En construction (l'usager peut modifier son dossier jusqu'à sa mise en instruction)
-
-
-      .fr-fieldset__element
-        .fr-radio-group
-          = f.radio_button :declarative_with_state, Procedure.declarative_with_states.fetch(:en_instruction)
-          = f.label :declarative_with_state, value: Procedure.declarative_with_states.fetch(:en_instruction), class: 'fr-label' do
-            Passage automatique en instruction (l'usager ne peut plus modifier son dossier)
-
-
-      .fr-fieldset__element
-        .fr-radio-group
-          = f.radio_button :declarative_with_state, Procedure.declarative_with_states.fetch(:accepte)
-          = f.label :declarative_with_state, value: Procedure.declarative_with_states.fetch(:accepte), class: 'fr-label' do
-            Passage automatique au statut « accepté » (l'usager ne peut plus modifier son dossier)
-
-
-      - if !@procedure.piece_justificative_multiple?
+  %details.procedure-form__options-details
+    %summary.procedure-form__options-summary
+      %h3.fr-h6 Options avancées
+    .card
+      %fieldset.fr-fieldset
         .fr-fieldset__element
-          .fr-checkbox-group.fr-mt-3w
-            = f.check_box :piece_justificative_multiple
-            = f.label :piece_justificative_multiple, class: 'fr-label' do
-              Champ “Pièce justificative” avec multiples fichiers
-          %p.fr-hint-text
-            Autorise les usagers à envoyer plusieurs fichiers pour les champs de type “Pièce justificative”. L'activation de cette option est irréversible et peut nécessiter des modifications si vous utilisez des systèmes automatisés pour traiter les dossiers.
+          - if feature_enabled?(:administrateur_web_hook)
+            = f.label :web_hook_url, class: 'fr-label' do
+              Lien de rappel HTTP (webhook)
+            %p.fr-hint-text
+              %strong Les webhooks sont maintenant dépréciés
+              Nous vous recommandons d'utiliser l'API GraphQL en faisant du polling,
+              = link_to "voici un exemple d'implementation ", WEBHOOK_ALTERNATIVE_DOC_URL, rel: "noopener", target: "_blank", title: "Voir une implémentation alternative à l'ancien système de webhook"
+            = f.text_field :web_hook_url, class: 'fr-input', placeholder: 'https://callback.exemple.fr/'
+
+        .fr-fieldset__element
+          = f.label :auto_archive_on, class: 'fr-label fr-mb-2w' do
+            Date limite de dépôt des dossiers
+            %span.fr-hint-text
+              Si une date est définie, aucun dossier ne pourra plus être déposé ou modifié après cette limite.
+              Les dossiers en construction passeront en instruction et la démarche sera clôturée.
+          %span.flex.align-center
+            - value = @procedure.auto_archive_on ? @procedure.auto_archive_on - 1.day : nil
+            = f.date_field :auto_archive_on, id: 'auto_archive_on', class: 'fr-input', value: value
+            %span.fr-ml-1w.fr-text-mention--grey
+              #{procedure_auto_archive_time(@procedure)}.
+
+      %fieldset.fr-fieldset{ "aria-labelledby": "declarative_with_state-legend" }
+        %legend#declarative_with_state-legend.fr-fieldset__legend.fr-fieldset__legend--regular
+          Démarche déclarative
+          %span.fr-hint-text
+            Par défaut, un dossier déposé peut être complété ou corrigé par le demandeur jusqu'à sa mise en instruction.<br>
+            Dans une démarche déclarative, une fois déposé, un dossier ne peut plus être modifié. Soit il passe immédiatement « en instruction » pour être traité, soit il est immédiatement « accepté ».
+        .fr-fieldset__element
+          .fr-radio-group
+            = f.radio_button :declarative_with_state, ''
+            = f.label :declarative_with_state, value: '', class: "fr-label" do
+              En construction (l'usager peut modifier son dossier jusqu'à sa mise en instruction)
+
+
+        .fr-fieldset__element
+          .fr-radio-group
+            = f.radio_button :declarative_with_state, Procedure.declarative_with_states.fetch(:en_instruction)
+            = f.label :declarative_with_state, value: Procedure.declarative_with_states.fetch(:en_instruction), class: 'fr-label' do
+              Passage automatique en instruction (l'usager ne peut plus modifier son dossier)
+
+
+        .fr-fieldset__element
+          .fr-radio-group
+            = f.radio_button :declarative_with_state, Procedure.declarative_with_states.fetch(:accepte)
+            = f.label :declarative_with_state, value: Procedure.declarative_with_states.fetch(:accepte), class: 'fr-label' do
+              Passage automatique au statut « accepté » (l'usager ne peut plus modifier son dossier)
+
+
+        - if !@procedure.piece_justificative_multiple?
+          .fr-fieldset__element
+            .fr-checkbox-group.fr-mt-3w
+              = f.check_box :piece_justificative_multiple
+              = f.label :piece_justificative_multiple, class: 'fr-label' do
+                Champ “Pièce justificative” avec multiples fichiers
+            %p.fr-hint-text
+              Autorise les usagers à envoyer plusieurs fichiers pour les champs de type “Pièce justificative”. L'activation de cette option est irréversible et peut nécessiter des modifications si vous utilisez des systèmes automatisés pour traiter les dossiers.

--- a/config/locales/models/procedure/en.yml
+++ b/config/locales/models/procedure/en.yml
@@ -35,7 +35,7 @@ en:
         procedure_path_placeholder: procedure-name
         cadre_juridique: Link to the legal text
         lien_dpo: Link or email to contact the data protection officer (DPO)
-        duree_conservation_dossiers_dans_ds: Duration files will be kept on %{app_name}
+        duree_conservation_dossiers_dans_ds: Duration files will be kept
         max_duree_conservation_dossiers_dans_ds: Max duration allowed to keep files
         aasm_state:
           brouillon: Draft

--- a/config/locales/models/procedure/en.yml
+++ b/config/locales/models/procedure/en.yml
@@ -30,12 +30,12 @@ en:
         closing_reason: Closing reason
         closing_reasons:
           other: Other
-          internal_procedure: I replace my procedure with another in Démarches Simplifiées
+          internal_procedure: I replace my procedure with another in %{app_name}
         procedure_path: Procedure link to disseminate to users
         procedure_path_placeholder: procedure-name
         cadre_juridique: Link to the legal text
         lien_dpo: Link or email to contact the data protection officer (DPO)
-        duree_conservation_dossiers_dans_ds: Duration files will be kept
+        duree_conservation_dossiers_dans_ds: Duration files will be kept on %{app_name}
         max_duree_conservation_dossiers_dans_ds: Max duration allowed to keep files
         aasm_state:
           brouillon: Draft

--- a/config/locales/models/procedure/fr.yml
+++ b/config/locales/models/procedure/fr.yml
@@ -18,7 +18,7 @@ fr:
           closing_details_placeholder: "Cette démarche a été remplacée par la page…\n\nLe guide de la nouvelle démarche est disponible ici\n\nPour toute information complémentaire, contactez…\n\nCordialement,"
         path: Lien public
         organisation: Organisme
-        duree_conservation_dossiers_dans_ds: Durée de conservation des dossiers sur demarches-simplifiees.fr (choisi par un usager)
+        duree_conservation_dossiers_dans_ds: Durée de conservation des dossiers sur %{app_name}
         max_duree_conservation_dossiers_dans_ds: Durée maximale de conservation des dossiers (autorisée par un super admin de DS)
         id: Id
         libelle: Titre de la démarche
@@ -34,7 +34,7 @@ fr:
         closing_reason: Raison de la clôture
         closing_reasons:
           other: Autre
-          internal_procedure: Je remplace ma démarche par une autre dans Démarches simplifiées
+          internal_procedure: Je remplace ma démarche par une autre dans %{app_name}
         procedure_path: Lien de la démarche à diffuser aux usagers
         procedure_path_placeholder: nom-de-la-demarche
         cadre_juridique: Lien vers le texte

--- a/config/locales/models/procedure/fr.yml
+++ b/config/locales/models/procedure/fr.yml
@@ -18,8 +18,8 @@ fr:
           closing_details_placeholder: "Cette démarche a été remplacée par la page…\n\nLe guide de la nouvelle démarche est disponible ici\n\nPour toute information complémentaire, contactez…\n\nCordialement,"
         path: Lien public
         organisation: Organisme
-        duree_conservation_dossiers_dans_ds: Durée de conservation des dossiers sur %{app_name}
-        max_duree_conservation_dossiers_dans_ds: Durée maximale de conservation des dossiers (autorisée par un super admin de DS)
+        duree_conservation_dossiers_dans_ds: Durée de conservation des dossiers
+        max_duree_conservation_dossiers_dans_ds: Durée maximale de conservation des dossiers (autorisée par un super admin)
         id: Id
         libelle: Titre de la démarche
         description: Quel est l’objet de la démarche ?

--- a/config/locales/models/procedure/fr.yml
+++ b/config/locales/models/procedure/fr.yml
@@ -37,7 +37,7 @@ fr:
           internal_procedure: Je remplace ma démarche par une autre dans %{app_name}
         procedure_path: Lien de la démarche à diffuser aux usagers
         procedure_path_placeholder: nom-de-la-demarche
-        cadre_juridique: Lien vers le texte
+        cadre_juridique: Cadre juridique - lien web vers le texte
         lien_dpo: Lien ou email pour contacter le Délégué à la Protection des Données (DPO)
         published_at: 'Date de publication'
         aasm_state: 'Statut'

--- a/spec/system/administrateurs/procedure_closing_spec.rb
+++ b/spec/system/administrateurs/procedure_closing_spec.rb
@@ -34,7 +34,7 @@ describe 'Closing a procedure', js: true do
 
       expect(page).to have_text('Clore la démarche')
 
-      select('Je remplace ma démarche par une autre dans Démarches simplifiées')
+      select('Je remplace ma démarche par une autre dans demarches-simplifiees.fr')
 
       select("#{other_procedure.libelle} (#{other_procedure.id})")
 


### PR DESCRIPTION
- ça a commence avec 2 référénces à "demarches-simplifiees.fr" hardcodées dans les traductions
- et puis ça finit en homogénisation du form des infos de la démarche fait avec @lisa-durand 
- en lien avec un ticket de la revue UX closes #10210 

![demarches-gouv-fr](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/7f008d8e-0510-46f5-b667-cb5427c6e37e)

