### PR TITLE
Tech: fais tourner sidekiq en dev

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,4 @@
 web: RAILS_QUEUE_ADAPTER=delayed_job bin/rails server -p 3000
 jobs: bin/rake jobs:work
+sidekiq: bundle exec sidekiq
 vite: bin/vite dev


### PR DESCRIPTION
Je pense pas qu'en dev on veuille conditionner sidekiq à la présence de `REDIS_URL` ou autre (surtout que sidekiq fallback sur des paramètres par défaut si nécessaire.)
