### PR TITLE
Tech (jobs): (re)enqueue crons dans sidekiq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'chunky_png'
 gem 'clamav-client', require: 'clamav/client'
 gem 'daemons'
 gem 'deep_cloneable' # Enable deep clone of active record models
-gem 'delayed_cron_job' # Cron jobs
+gem 'delayed_cron_job', require: false # Cron jobs
 gem 'delayed_job_active_record'
 gem 'delayed_job_web'
 gem 'devise', git: 'https://github.com/heartcombo/devise.git', ref: "edffc79bf05d7f1c58ba50ffeda645e2e4ae0cb1" # Gestion des comptes utilisateurs, drop ref on next release: 4.9.4

--- a/app/jobs/cron/cron_job.rb
+++ b/app/jobs/cron/cron_job.rb
@@ -11,7 +11,7 @@ class Cron::CronJob < ApplicationJob
       remove if cron_expression_changed?
 
       if !scheduled?
-        if SIDEKIQ_ENABLED
+        if queue_adapter == :sidekiq
           Sidekiq::Cron::Job.create(name: name, cron: cron_expression, class: name)
         else
           set(cron: cron_expression).perform_later
@@ -36,7 +36,7 @@ class Cron::CronJob < ApplicationJob
     end
 
     def enqueued_cron_job
-      if SIDEKIQ_ENABLED
+      if queue_adapter == :sidekiq
         sidekiq_cron_job
       else
         delayed_job

--- a/config/initializers/transition_to_sidekiq.rb
+++ b/config/initializers/transition_to_sidekiq.rb
@@ -53,5 +53,9 @@ if Rails.env.production? && SIDEKIQ_ENABLED
     class Migrations::BackfillStableIdJob
       self.queue_adapter = :sidekiq
     end
+
+    class Cron::CronJob < ApplicationJob
+      self.queue_adapter = :sidekiq
+    end
   end
 end


### PR DESCRIPTION
En sous jacent sidekiq-cron (et delayed job cron) utilisent `perform_later` pour enqueue et reenqueue les jobs, qui se base sur le queue_adapter. 

En bonus on load plus `delayed_cron_job` par défaut, c'est de toute façon autoloadé lorsque le cron est cablé sur delayed job