### PR TITLE
Tech: config sidekiq indépendante de redis sentinels & fix cron

### DIFF
--- a/app/jobs/cron/cron_job.rb
+++ b/app/jobs/cron/cron_job.rb
@@ -4,14 +4,14 @@ class Cron::CronJob < ApplicationJob
 
   class << self
     def schedulable?
-      true && ENV['CRON_JOBS_DISABLED'].blank?
+      ENV['CRON_JOBS_DISABLED'].blank?
     end
 
     def schedule
       remove if cron_expression_changed?
 
       if !scheduled?
-        if queue_adapter == :sidekiq
+        if queue_adapter_name == "sidekiq"
           Sidekiq::Cron::Job.create(name: name, cron: cron_expression, class: name)
         else
           set(cron: cron_expression).perform_later
@@ -36,7 +36,7 @@ class Cron::CronJob < ApplicationJob
     end
 
     def enqueued_cron_job
-      if queue_adapter == :sidekiq
+      if queue_adapter_name == "sidekiq"
         sidekiq_cron_job
       else
         delayed_job

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,7 +51,7 @@ module TPS
     config.action_dispatch.ip_spoofing_check = false
 
     # Set the queue name for the mail delivery jobs to 'mailers'
-    config.action_mailer.deliver_later_queue_name = :mailers
+    config.action_mailer.deliver_later_queue_name = 'mailers'
 
     # Allow the error messages format to be customized
     config.active_model.i18n_customize_full_message = true

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,4 +1,8 @@
-if ENV.has_key?('REDIS_SIDEKIQ_SENTINELS')
+SIDEKIQ_ENABLED = ENV.key?('REDIS_SIDEKIQ_SENTINELS') || ENV.key?('REDIS_URL') || ENV['RAILS_QUEUE_ADAPTER'] == 'sidekiq'
+
+return if !SIDEKIQ_ENABLED
+
+sidekiq_redis = if ENV.key?('REDIS_SIDEKIQ_SENTINELS')
   name = ENV.fetch('REDIS_SIDEKIQ_MASTER')
   username = ENV.fetch('REDIS_SIDEKIQ_USERNAME')
   password = ENV.fetch('REDIS_SIDEKIQ_PASSWORD')
@@ -7,37 +11,30 @@ if ENV.has_key?('REDIS_SIDEKIQ_SENTINELS')
     .map { URI.parse(_1) }
     .map { { host: _1.host, port: _1.port, username:, password: } }
 
-  Sidekiq.configure_server do |config|
-    config.redis = {
-      name:,
-      sentinels:,
-      username:,
-      password:,
-      role: :master
-    }
+  {
+    name:,
+    sentinels:,
+    username:,
+    password:,
+    role: :master
+  }
+else
+  {} # default config from REDIS_URL
+end
 
-    if ENV['PROMETHEUS_EXPORTER_ENABLED'] == 'enabled'
-      Yabeda.configure!
-      Yabeda::Prometheus::Exporter.start_metrics_server!
-    end
+Sidekiq.configure_server do |config|
+  config.redis = sidekiq_redis
 
-    if ENV['SKIP_RELIABLE_FETCH'].blank?
-      Sidekiq::ReliableFetch.setup_reliable_fetch!(config)
-    end
-
-    config.capsule('api_entreprise') do |cap|
-      cap.concurrency = 1
-      cap.queues = ['api_entreprise']
-    end
+  if ENV['PROMETHEUS_EXPORTER_ENABLED'] == 'enabled'
+    Yabeda.configure!
+    Yabeda::Prometheus::Exporter.start_metrics_server!
   end
 
-  Sidekiq.configure_client do |config|
-    config.redis = {
-      name:,
-      sentinels:,
-      username:,
-      password:,
-      role: :master
-    }
+  if ENV['SKIP_RELIABLE_FETCH'].blank?
+    Sidekiq::ReliableFetch.setup_reliable_fetch!(config)
   end
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = sidekiq_redis
 end

--- a/config/initializers/transition_to_sidekiq.rb
+++ b/config/initializers/transition_to_sidekiq.rb
@@ -1,5 +1,3 @@
-SIDEKIQ_ENABLED = ENV.has_key?('REDIS_SIDEKIQ_SENTINELS') || ENV.has_key?('REDIS_URL')
-
 if Rails.env.production? && SIDEKIQ_ENABLED
   ActiveSupport.on_load(:after_initialize) do
     class ActiveStorage::PurgeJob < ActiveStorage::BaseJob


### PR DESCRIPTION
- Pas de changement en dev, on reste encore en delayed job par défaut pour 100% des jobs (sauf si on a explictement configuré RAILS_QUEUE_ADAPTER=sidekiq)
- J'en ai profité pour virer la capsule api_entreprise vu qu'elle est incompatible avec reliable fetch
- Fix pour les crons qui n'étaient pas correctement enqueue en tant que cron, mais juste enqueue  car `queue_adapter` sur une instance de job vaut l'instance de l'adapter, pas son nom. Ce qui provoquait d'être exécuté à chaque `jobs:schedule`