### PR TITLE
tech(a11y): Les champs répétables n'englobent pas leurs champs enfant dans un `fieldset` si il n'y a qu'un seul champ enfant. Idem pour les checkbox uniques

### DIFF
--- a/app/components/editable_champ/checkbox_component.rb
+++ b/app/components/editable_champ/checkbox_component.rb
@@ -1,9 +1,5 @@
 class EditableChamp::CheckboxComponent < EditableChamp::EditableChampBaseComponent
-  def dsfr_champ_container
-    :fieldset
-  end
-
   def dsfr_input_classname
-    'fr-radio'
+    'fr-checkbox'
   end
 end

--- a/app/components/editable_champ/checkbox_component/checkbox_component.html.haml
+++ b/app/components/editable_champ/checkbox_component/checkbox_component.html.haml
@@ -1,9 +1,8 @@
-.fr-fieldset__element
-  .fr-checkbox-group
-    = @form.check_box :value,
-      { required: @champ.required?, id: @champ.input_id, checked: @champ.true?, aria: { describedby: @champ.describedby_id }, class: class_names('required' => @champ.required?)},
-      'true',
-      'false'
-    %label.fr-label{ for: @champ.input_id, id: @champ.labelledby_id }
-      %span
-        = render EditableChamp::ChampLabelContentComponent.new form: @form, champ: @champ, seen_at: @seen_at
+.fr-checkbox-group
+  = @form.check_box :value,
+    { required: @champ.required?, id: @champ.input_id, checked: @champ.true?, aria: { describedby: @champ.describedby_id }, class: class_names('required' => @champ.required?)},
+    'true',
+    'false'
+  %label.fr-label{ for: @champ.input_id, id: @champ.labelledby_id }
+    %span
+      = render EditableChamp::ChampLabelContentComponent.new form: @form, champ: @champ, seen_at: @seen_at

--- a/app/components/editable_champ/section_component/section_component.html.haml
+++ b/app/components/editable_champ/section_component/section_component.html.haml
@@ -10,13 +10,12 @@
           = fields_for champ.input_name, champ do |form|
             = render EditableChamp::EditableChampComponent.new form:, champ:
 - else
-  .fr-fieldset__element.fr-my-0
-    - if header_section
-      .fr-fieldset__legend.fr-my-0{ class: "reset-#{tag_for_depth}" }
-        = render EditableChamp::HeaderSectionComponent.new(champ: header_section)
-    - splitted_tail.each do |section, champ|
-      - if section.present?
-        = render section
-      - else
-        = fields_for champ.input_name, champ do |form|
-          = render EditableChamp::EditableChampComponent.new form:, champ:
+  - if header_section
+    .fr-fieldset__legend.fr-my-0{ class: "reset-#{tag_for_depth}" }
+      = render EditableChamp::HeaderSectionComponent.new(champ: header_section)
+  - splitted_tail.each do |section, champ|
+    - if section.present?
+      = render section
+    - else
+      = fields_for champ.input_name, champ do |form|
+        = render EditableChamp::EditableChampComponent.new form:, champ:

--- a/app/components/editable_champ/section_component/section_component.html.haml
+++ b/app/components/editable_champ/section_component/section_component.html.haml
@@ -10,9 +10,9 @@
           = fields_for champ.input_name, champ do |form|
             = render EditableChamp::EditableChampComponent.new form:, champ:
 - else
-  %fieldset.fr-fieldset.fr-my-0
+  .fr-fieldset__element.fr-my-0
     - if header_section
-      %legend.fr-fieldset__legend.fr-my-0{ class: "reset-#{tag_for_depth}" }
+      .fr-fieldset__legend.fr-my-0{ class: "reset-#{tag_for_depth}" }
         = render EditableChamp::HeaderSectionComponent.new(champ: header_section)
     - splitted_tail.each do |section, champ|
       - if section.present?

--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -21,7 +21,7 @@
 
           = render Procedure::NoticeComponent.new(procedure: dossier.procedure)
 
-    = render EditableChamp::SectionComponent.new(dossier: dossier_for_editing, types_de_champ: dossier_for_editing.revision.types_de_champ_public)
+    %fieldset.fr-fieldset= render EditableChamp::SectionComponent.new(dossier: dossier_for_editing, types_de_champ: dossier_for_editing.revision.types_de_champ_public)
 
     = render Dossiers::PendingCorrectionCheckboxComponent.new(dossier: dossier)
 

--- a/app/views/shared/dossiers/_edit_annotations.html.haml
+++ b/app/views/shared/dossiers/_edit_annotations.html.haml
@@ -3,7 +3,7 @@
     %section.counter-start-header-section
       = render NestedForms::FormOwnerComponent.new
       = form_for dossier, url: annotations_instructeur_dossier_path(dossier.procedure, dossier), html: { class: 'form', multipart: true } do |f|
-        = render EditableChamp::SectionComponent.new(dossier:, types_de_champ: dossier.revision.types_de_champ_private)
+        %fieldset.fr-fieldset= render EditableChamp::SectionComponent.new(dossier:, types_de_champ: dossier.revision.types_de_champ_private)
 
       = render Dossiers::EditFooterComponent.new(dossier: dossier, annotation: true)
   - else

--- a/spec/components/editable_champ/section_component_spec.rb
+++ b/spec/components/editable_champ/section_component_spec.rb
@@ -10,8 +10,8 @@ describe EditableChamp::SectionComponent, type: :component do
   context 'list of champs without an header_section' do
     let(:types_de_champ_public) { [{ type: :text }, { type: :textarea }] }
 
-    it 'render in a fieldset' do
-      expect(page).to have_selector("fieldset", count: 1)
+    it 'does not renders within a fieldset' do
+      expect(page).to have_selector("fieldset", count: 0)
     end
 
     it 'renders champs' do
@@ -37,14 +37,16 @@ describe EditableChamp::SectionComponent, type: :component do
   context 'list of champs without section and an header_section having champs' do
     let(:types_de_champ_public) { [{ type: :text }, { type: :header_section, level: 1 }, { type: :text }] }
 
-    it 'renders fieldset' do
-      expect(page).to have_selector("fieldset", count: 2)
-      expect(page).to have_selector("legend h2")
+    it 'renders nested champs (after an header section) within a fieldset' do
+      expect(page).to have_selector("fieldset", count: 1)
+      expect(page).to have_selector("fieldset legend h2")
+      expect(page).to have_selector("input[type=text]", count: 2)
+      expect(page).to have_selector("fieldset input[type=text]", count: 1)
     end
 
-    it 'renders all champs, each in its fieldset' do
+    it 'renders nested within its fieldset' do
       expect(page).to have_selector("input[type=text]", count: 2)
-      expect(page).to have_selector("fieldset > .fr-fieldset__element input[type=text]", count: 2)
+      expect(page).to have_selector("fieldset > .fr-fieldset__element input[type=text]", count: 1)
     end
   end
 


### PR DESCRIPTION
cf: https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/

# regle
rg2a 8.9 – Dans chaque page web, les balises ne doivent pas être utilisées uniquement à des fins de présentation. Cette règle est-elle respectée ? 

____

- [x] champ repetable : 
**avant**
<img width="1270" alt="Capture d’écran 2024-04-12 à 9 50 52 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/b0bc340a-acd0-4e20-bf28-97776001a761">
_(on a deux fieldset la)_ , un pr la repetition dans sa globalité, un par répétition (lui est de trop)
 
**apres**: on utilise un `div`
<img width="1271" alt="Capture d’écran 2024-04-12 à 9 52 50 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/4e0e105a-48d9-46b8-a1d3-ffb0c159d8ce">

____ 

- [x] checkbox (sort le checkbox uniq d'un `fieldset`)

**avant**
<img width="1273" alt="Capture d’écran 2024-04-12 à 10 50 48 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/f435c268-e21b-4235-a23f-3be93553c757">


**apres**
<img width="1599" alt="Capture d’écran 2024-04-12 à 10 49 57 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/555956ff-b2ff-410f-a88f-766c06dd37ea">
