### PR TITLE
ETQ tech je peux re-router les dossiers d'une démarche si le routage a été configuré après publication - suite

### DIFF
--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -212,7 +212,7 @@ module Administrateurs
     def reaffecter_all_dossiers_to_defaut_groupe
       procedure.groupe_instructeurs_but_defaut.each do |gi|
         gi.dossiers.find_each do |dossier|
-          dossier.assign_to_groupe_instructeur(procedure.defaut_groupe_instructeur, DossierAssignment.modes.fetch(:manual), current_administrateur)
+          dossier.assign_to_groupe_instructeur(procedure.defaut_groupe_instructeur, DossierAssignment.modes.fetch(:auto), current_administrateur)
         end
       end
     end

--- a/lib/tasks/re_routing_dossiers.rake
+++ b/lib/tasks/re_routing_dossiers.rake
@@ -18,7 +18,7 @@ namespace :re_routing_dossiers do
     dossiers.each do |dossier|
       RoutingEngine.compute(dossier, assignment_mode:)
 
-      rake_puts "Dossier #{args[:dossier_id]} routed to groupe instructeur #{dossier.groupe_instructeur.label}"
+      rake_puts "Dossier #{dossier.id} routed to groupe instructeur #{dossier.groupe_instructeur.label}"
 
       progress.inc
     end

--- a/lib/tasks/re_routing_dossiers.rake
+++ b/lib/tasks/re_routing_dossiers.rake
@@ -24,4 +24,25 @@ namespace :re_routing_dossiers do
     end
     progress.finish
   end
+
+  desc <<~EOD
+    Given an procedure id in argument, reset value of forced_groupe_instructeur to false for all dossiers en_construction.
+    ex: rails re_routing_dossiers:reset_forced_groupe_instructeur\[85869\]
+  EOD
+  task :reset_forced_groupe_instructeur, [:procedure_id] => :environment do |_t, args|
+    procedure = Procedure.find_by(id: args[:procedure_id])
+
+    dossiers = procedure.dossiers.state_en_construction
+
+    progress = ProgressReport.new(dossiers.count)
+
+    dossiers.each do |dossier|
+      if dossier.update(forced_groupe_instructeur: false)
+        rake_puts "Dossier #{dossier.id} updated with forced_groupe_instructeur to false"
+
+        progress.inc
+      end
+    end
+    progress.finish
+  end
 end


### PR DESCRIPTION
La PR précédente #10293 ne suffisait pas.
Dans le cas où un admin configure le routage après que des dossiers ont déjà été déposés, les dossiers sont réaffectés à un nouveau groupe d'instructeurs (le nouveau groupe défaut). Dans ce cas, je passe le `assignment_mode` de `manual` à `auto` pour que les dossiers puissent être re-routés ensuite si besoin (soit côté tech via la rake task, soit côté usager si l'usager modifie le champ de routage de son dossier en construction)