### PR TITLE
ETQ usager, je veux que tous les champs aient un style DSFR

### DIFF
--- a/app/components/editable_champ/address_component.rb
+++ b/app/components/editable_champ/address_component.rb
@@ -1,2 +1,5 @@
 class EditableChamp::AddressComponent < EditableChamp::EditableChampBaseComponent
+  def dsfr_input_classname
+    'fr-select'
+  end
 end

--- a/app/components/editable_champ/annuaire_education_component.rb
+++ b/app/components/editable_champ/annuaire_education_component.rb
@@ -2,4 +2,11 @@ class EditableChamp::AnnuaireEducationComponent < EditableChamp::ComboSearchComp
   def dsfr_input_classname
     'fr-input'
   end
+
+  def react_input_opts
+    opts = input_opts(id: @champ.input_id, required: @champ.required?, aria: { describedby: @champ.describedby_id })
+    opts[:className] = "#{opts.delete(:class)} fr-mt-1w"
+
+    opts
+  end
 end

--- a/app/components/editable_champ/annuaire_education_component/annuaire_education_component.html.haml
+++ b/app/components/editable_champ/annuaire_education_component/annuaire_education_component.html.haml
@@ -3,7 +3,5 @@
 = @form.hidden_field :value
 = @form.hidden_field :external_id
 = react_component("ComboAnnuaireEducationSearch",
-  required: @champ.required?,
-  id: @champ.input_id,
-  describedby: @champ.describedby_id,
+  **react_input_opts,
   **react_combo_props)

--- a/app/components/editable_champ/communes_component.rb
+++ b/app/components/editable_champ/communes_component.rb
@@ -1,3 +1,7 @@
 class EditableChamp::CommunesComponent < EditableChamp::EditableChampBaseComponent
   include ApplicationHelper
+
+  def dsfr_input_classname
+    'fr-select'
+  end
 end

--- a/app/components/editable_champ/rnf_component.rb
+++ b/app/components/editable_champ/rnf_component.rb
@@ -1,2 +1,5 @@
 class EditableChamp::RNFComponent < EditableChamp::EditableChampBaseComponent
+  def dsfr_input_classname
+    'fr-input'
+  end
 end

--- a/app/components/editable_champ/rnf_component/rnf_component.html.haml
+++ b/app/components/editable_champ/rnf_component/rnf_component.html.haml
@@ -1,4 +1,4 @@
-= @form.text_field :external_id, required: @champ.required?, class: "width-33-desktop fr-input small-margin", id: @champ.input_id
+= @form.text_field :external_id, input_opts(id: @champ.input_id, required: @champ.required?, class: "width-33-desktop fr-input small-margin", aria: { describedby: @champ.describedby_id })
 
 .rnf-info{ id: dom_id(@champ, :rnf_info) }
   - if @champ.fetch_external_data_error?


### PR DESCRIPTION
- [x] commune (passe le style en erreur au dsfr)

**avant**
<img width="1071" alt="Capture d’écran 2024-04-11 à 9 07 35 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/d2b2a0ab-3ef1-4a26-b228-51ff21269244">

**apres**
<img width="983" alt="Capture d’écran 2024-04-11 à 9 10 57 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/ef9aeeed-4e5b-498d-b065-17dad17ea902">

____

- [x] annuaire education, utilise le style dsfr 

**avant**
<img width="988" alt="Capture d’écran 2024-04-12 à 7 58 02 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/5a6daabc-0e4f-4d0d-a442-604d520bf674">

**apres**
<img width="956" alt="Capture d’écran 2024-04-12 à 7 57 50 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/2a6fdcdd-8ddf-468e-bce5-49206a011528">

____ 

- [x] address (passe le style en erreur au dsfr)

**avant**
<img width="1085" alt="Capture d’écran 2024-04-11 à 9 07 38 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/520e1099-289c-44e2-bf92-6c79dd11bce0">

**apres**
<img width="994" alt="Capture d’écran 2024-04-11 à 9 11 51 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/efb723e2-ddbc-4501-86a1-d84cf886a8c0">

____
- [x] rnf (passe le style en erreur au dsfr)

**avant**
<img width="410" alt="Capture d’écran 2024-04-11 à 9 07 24 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/211fe8c7-052f-4b8f-8291-85538aa921ef">

**apres**
<img width="358" alt="Capture d’écran 2024-04-11 à 9 10 39 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/e026a226-f601-4849-8cfb-415c6359e14d">
