### PR TITLE
ETQ usager : pas d'`aria-invalid`

### DIFF
--- a/app/components/dsfr/input_errorable.rb
+++ b/app/components/dsfr/input_errorable.rb
@@ -60,8 +60,7 @@ module Dsfr
       def input_error_opts
         {
           aria: {
-            describedby: describedby_id,
-            invalid: errors_on_attribute?
+            describedby: describedby_id
           }
         }
       end
@@ -77,8 +76,7 @@ module Dsfr
 
         if errors_on_attribute?
           @opts.deep_merge!(aria: {
-            describedby: describedby_id,
-            invalid: errors_on_attribute?
+            describedby: describedby_id
           })
         end
 


### PR DESCRIPTION
__Critère RGAA : 11.10 - Dans chaque formulaire, le contrôle de saisie est-il utilisé de manière pertinente (hors cas particuliers) ?__

Un message d'erreur visible permettant d’identifier nommément le champ concerné permet de valider le test 11.10.3.