### PR TITLE
ETQ Usager, je souhaite que mon screen reader verbalise les erreurs sur les champs unique contenu dans un `fieldset`

### DIFF
--- a/app/components/dsfr/input_errorable.rb
+++ b/app/components/dsfr/input_errorable.rb
@@ -34,6 +34,14 @@ module Dsfr
         errors.full_messages_for(attribute_or_rich_body)
       end
 
+      def fieldset_error_opts
+        if dsfr_champ_container == :fieldset && errors_on_attribute?
+          { aria: { labelledby: "#{describedby_id} #{object.labelledby_id}" } }
+        else
+          {}
+        end
+      end
+
       private
 
       # lookup for edge case from `form.rich_text_area`
@@ -73,7 +81,6 @@ module Dsfr
                                              'fr-input': true,
                                              'fr-mb-0': true
                                       }.merge(input_error_class_names)))
-
         if errors_on_attribute?
           @opts.deep_merge!(aria: {
             describedby: describedby_id

--- a/app/components/dsfr/input_status_message_component.rb
+++ b/app/components/dsfr/input_status_message_component.rb
@@ -1,14 +1,10 @@
 module Dsfr
   class InputStatusMessageComponent < ApplicationComponent
-    def initialize(errors_on_attribute:, error_full_messages:, described_by:, champ:)
+    def initialize(errors_on_attribute:, error_full_messages:, describedby_id:, champ:)
       @errors_on_attribute = errors_on_attribute
       @error_full_messages = error_full_messages
-      @described_by = described_by
+      @describedby_id = describedby_id
       @champ = champ
-    end
-
-    def render?
-      @errors_on_attribute
     end
   end
 end

--- a/app/components/dsfr/input_status_message_component/input_status_message_component.html.haml
+++ b/app/components/dsfr/input_status_message_component/input_status_message_component.html.haml
@@ -1,4 +1,4 @@
-.fr-messages-group{ id: @describedby_id }
+.fr-messages-group{ id: @describedby_id, aria: { live: :assertive } }
   - if @error_full_messages.size > 0
     %p{ class: class_names('fr-message' => true, "fr-message--#{@errors_on_attribute ? 'error' : 'valid'}" => true) }
       = "« #{@champ.libelle} » "

--- a/app/components/editable_champ/editable_champ_component.rb
+++ b/app/components/editable_champ/editable_champ_component.rb
@@ -34,7 +34,7 @@ class EditableChamp::EditableChampComponent < ApplicationComponent
         }.merge(champ_component.input_group_error_class_names)
       ),
       data: { controller: stimulus_controller, **data_dependent_conditions, **stimulus_values }
-    }
+    }.deep_merge(champ_component.fieldset_error_opts)
   end
 
   def fieldset_element_attributes

--- a/app/components/editable_champ/editable_champ_component/editable_champ_component.html.haml
+++ b/app/components/editable_champ/editable_champ_component/editable_champ_component.html.haml
@@ -5,6 +5,6 @@
 
     = render champ_component
 
-    = render Dsfr::InputStatusMessageComponent.new(errors_on_attribute: champ_component.errors_on_attribute?, error_full_messages: champ_component.error_full_messages, described_by: @champ.describedby_id, champ: @champ)
+    = render Dsfr::InputStatusMessageComponent.new(errors_on_attribute: champ_component.errors_on_attribute?, error_full_messages: champ_component.error_full_messages, describedby_id: @champ.describedby_id, champ: @champ)
 
     = @form.hidden_field :id, value: @champ.id

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -188,7 +188,7 @@ class Champ < ApplicationRecord
   end
 
   def describedby_id
-    "#{html_id}-description" if description.present?
+    "#{html_id}-describedby_id"
   end
 
   def log_fetch_external_data_exception(exception)


### PR DESCRIPTION
contexte: les champ : radio / checkbox multiple... sont wrappés dans un fieldset. 
ces fieldset contiennent plusieurs inputs (ex, plusieurs radio/checkbox).

pour declarer que le fieldset est en erreur, localiser l'erreur. on passe par `aria-labelledby` pointant d'une part la légende (qui est le libelle du groupe de champ), d'autre part `aria-labelledby` pointe aussi sur l'erreur quand il y en une. 🎉 

<img width="1269" alt="Capture d’écran 2024-04-12 à 11 46 10 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/a2d6a621-c6a7-4d9e-82e1-2d017a324492">
