### PR TITLE
[WIP] - Corrige la mauvaise utilisation des attributs `autocomplete` dans le formulaire "identité" d'une démarche

### DIFF
--- a/app/javascript/controllers/for_tiers_controller.ts
+++ b/app/javascript/controllers/for_tiers_controller.ts
@@ -10,7 +10,9 @@ export class ForTiersController extends ApplicationController {
     'email',
     'notificationMethod',
     'mandataireTitle',
+    'mandataireIdentity',
     'beneficiaireTitle',
+    'beneficiaireIdentity',
     'emailInput'
   ];
 
@@ -22,7 +24,9 @@ export class ForTiersController extends ApplicationController {
   declare notificationMethodTargets: NodeListOf<HTMLInputElement>;
   declare emailTarget: HTMLInputElement;
   declare mandataireTitleTarget: HTMLElement;
+  declare mandataireIdentityTarget: HTMLInputElement;
   declare beneficiaireTitleTarget: HTMLElement;
+  declare beneficiaireIdentityTarget: HTMLElement;
   declare emailInput: HTMLInputElement;
 
   connect() {
@@ -53,7 +57,9 @@ export class ForTiersController extends ApplicationController {
     this.mandataireFirstNameTarget.required = forTiersSelected;
     this.mandataireLastNameTarget.required = forTiersSelected;
     this.mandataireTitleTarget.classList.toggle('hidden', forTiersSelected);
+    this.mandataireIdentityTarget.classList.toggle('hidden', forTiersSelected);
     this.beneficiaireTitleTarget.classList.toggle('hidden', !forTiersSelected);
+    this.beneficiaireIdentityTarget.classList.toggle('hidden', !forTiersSelected);
     this.notificationMethodTargets.forEach((radio) => {
       radio.required = forTiersSelected;
     });

--- a/app/views/users/dossiers/identite.html.haml
+++ b/app/views/users/dossiers/identite.html.haml
@@ -39,10 +39,10 @@
           %h2.fr-h4= t('views.users.dossiers.identite.self_title')
 
         .fr-fieldset__element.fr-fieldset__element--short-text
-          = render Dsfr::InputComponent.new(form: f, attribute: :mandataire_first_name, opts: { "data-for-tiers-target" => "mandataireFirstName" })
+          = render Dsfr::InputComponent.new(form: f, attribute: :mandataire_first_name, opts: { "data-for-tiers-target" => "mandataireFirstName", autocomplete: 'given-name' })
 
         .fr-fieldset__element.fr-fieldset__element--short-text
-          = render Dsfr::InputComponent.new(form: f, attribute: :mandataire_last_name, opts: { "data-for-tiers-target" => "mandataireLastName" })
+          = render Dsfr::InputComponent.new(form: f, attribute: :mandataire_last_name, opts: { "data-for-tiers-target" => "mandataireLastName", autocomplete: 'family-name' })
 
     = f.fields_for :individual, include_id: false do |individual|
       .individual-infos
@@ -67,12 +67,18 @@
                 = individual.radio_button :gender, Individual::GENDER_MALE, required: true, id: "identite_champ_radio_#{Individual::GENDER_MALE}"
                 %label.fr-label{ for: "identite_champ_radio_#{Individual::GENDER_MALE}" }
                   = Individual.human_attribute_name('gender.male')
+          
+          .fr-fieldset.width-100.hidden{ "data-for-tiers-target" => "beneficiaireIdentity" }
+            .fr-fieldset__element.fr-fieldset__element--short-text
+              = render Dsfr::InputComponent.new(form: individual, attribute: :prenom)
+            .fr-fieldset__element.fr-fieldset__element--short-text
+              = render Dsfr::InputComponent.new(form: individual, attribute: :nom)  
 
-          .fr-fieldset__element.fr-fieldset__element--short-text
-            = render Dsfr::InputComponent.new(form: individual, attribute: :prenom, opts: { autocomplete: 'given-name' })
-
-          .fr-fieldset__element.fr-fieldset__element--short-text
-            = render Dsfr::InputComponent.new(form: individual, attribute: :nom, opts: { autocomplete: 'family-name' })
+          .fr-fieldset.width-100{ "data-for-tiers-target" => "mandataireIdentity" }
+            .fr-fieldset__element.fr-fieldset__element--short-text
+              = render Dsfr::InputComponent.new(form: individual, attribute: :prenom, opts: { autocomplete: 'given-name' })
+            .fr-fieldset__element.fr-fieldset__element--short-text
+              = render Dsfr::InputComponent.new(form: individual, attribute: :nom, opts: { autocomplete: 'family-name' })
 
         %fieldset.fr-fieldset{ "data-for-tiers-target" => "beneficiaireNotificationBlock" }
           %legend.fr-fieldset__legend--regular.fr-fieldset__legend

--- a/app/views/users/dossiers/identite.html.haml
+++ b/app/views/users/dossiers/identite.html.haml
@@ -53,20 +53,20 @@
           %legend.fr-fieldset__legend--regular.fr-fieldset__legend.hidden{ "data-for-tiers-target" => "beneficiaireTitle" }
             %h2.fr-h4= t('views.users.dossiers.identite.beneficiaire_title')
 
-
-          %legend.fr-fieldset__legend--regular.fr-fieldset__legend
-            = t('activerecord.attributes.individual.gender')
-            = render EditableChamp::AsteriskMandatoryComponent.new
-          .fr-fieldset__element
-            .fr-radio-group
-              = individual.radio_button :gender, Individual::GENDER_FEMALE, required: true, id: "identite_champ_radio_#{Individual::GENDER_FEMALE}"
-              %label.fr-label{ for: "identite_champ_radio_#{Individual::GENDER_FEMALE}" }
-                = Individual.human_attribute_name('gender.female')
-          .fr-fieldset__element
-            .fr-radio-group
-              = individual.radio_button :gender, Individual::GENDER_MALE, required: true, id: "identite_champ_radio_#{Individual::GENDER_MALE}"
-              %label.fr-label{ for: "identite_champ_radio_#{Individual::GENDER_MALE}" }
-                = Individual.human_attribute_name('gender.male')
+          %fieldset
+            %legend.fr-fieldset__legend--regular.fr-fieldset__legend
+              = t('activerecord.attributes.individual.gender')
+              = render EditableChamp::AsteriskMandatoryComponent.new
+            .fr-fieldset__element
+              .fr-radio-group
+                = individual.radio_button :gender, Individual::GENDER_FEMALE, required: true, id: "identite_champ_radio_#{Individual::GENDER_FEMALE}"
+                %label.fr-label{ for: "identite_champ_radio_#{Individual::GENDER_FEMALE}" }
+                  = Individual.human_attribute_name('gender.female')
+            .fr-fieldset__element
+              .fr-radio-group
+                = individual.radio_button :gender, Individual::GENDER_MALE, required: true, id: "identite_champ_radio_#{Individual::GENDER_MALE}"
+                %label.fr-label{ for: "identite_champ_radio_#{Individual::GENDER_MALE}" }
+                  = Individual.human_attribute_name('gender.male')
 
           .fr-fieldset__element.fr-fieldset__element--short-text
             = render Dsfr::InputComponent.new(form: individual, attribute: :prenom, opts: { autocomplete: 'given-name' })

--- a/app/views/users/dossiers/identite.html.haml
+++ b/app/views/users/dossiers/identite.html.haml
@@ -67,12 +67,12 @@
                 = individual.radio_button :gender, Individual::GENDER_MALE, required: true, id: "identite_champ_radio_#{Individual::GENDER_MALE}"
                 %label.fr-label{ for: "identite_champ_radio_#{Individual::GENDER_MALE}" }
                   = Individual.human_attribute_name('gender.male')
-          
+
           .fr-fieldset.width-100.hidden{ "data-for-tiers-target" => "beneficiaireIdentity" }
             .fr-fieldset__element.fr-fieldset__element--short-text
               = render Dsfr::InputComponent.new(form: individual, attribute: :prenom)
             .fr-fieldset__element.fr-fieldset__element--short-text
-              = render Dsfr::InputComponent.new(form: individual, attribute: :nom)  
+              = render Dsfr::InputComponent.new(form: individual, attribute: :nom)
 
           .fr-fieldset.width-100{ "data-for-tiers-target" => "mandataireIdentity" }
             .fr-fieldset__element.fr-fieldset__element--short-text
@@ -94,7 +94,7 @@
 
 
           .fr-fieldset__element.fr-fieldset__element--short-text.hidden{ "data-for-tiers-target" => "email" }
-            = render Dsfr::InputComponent.new(form: individual, attribute: :email)
+            = render Dsfr::InputComponent.new(form: individual, attribute: :email, input_type: :email_field)
 
 
         - if @dossier.procedure.ask_birthday?


### PR DESCRIPTION
# Ajoute les attributs `autocomplete` sur les champs relatifs à la personne qui remplit le formulaire uniquement
__Après__
- Présence d'attributs `autocomplete` sur les champs mandataire
- Absence d'attributs `autocomplete` sur les champs  bénéficiaire 
![Capture d’écran 2024-04-12 à 15 28 34](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/5b5f93cb-411d-455e-b9cf-2ff8091d52ca)
![Capture d’écran 2024-04-12 à 15 29 14](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/a09476a0-340a-475b-a1b2-1ebf8dcf7cc3)

__Avant__
- Absence d'attributs `autocomplete` sur les champs mandataire 
- Présence d'attributs `autocomplete` sur les champs bénéficiaire 
![Capture d’écran 2024-04-12 à 15 21 33](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/d5411741-b54b-4ac5-999a-6bfd38eb69f0)
![Capture d’écran 2024-04-12 à 15 20 47](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/669c3b3d-2fb1-4143-adde-dee13af57be9)

# Modifie la valeur de l'attribut `type`du champ "email"
__Après : `type="email"`__
![Capture d’écran 2024-04-12 à 15 16 27](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/0fac364a-cdb1-4fd2-aa98-ed208d621c22)

__Avant : `type="text"`__
![Capture d’écran 2024-04-12 à 15 17 00](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/8fae5795-da78-4762-b839-180cf6fae92d)

# Ajout d'un élément `fieldset` autour des boutons radio demandant la civilité
__Après__
![Capture d’écran 2024-04-12 à 15 31 08](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/005af70f-6c10-4d34-8dd8-c10f3130ce47)

__Avant__
![Capture d’écran 2024-04-12 à 15 32 00](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/438dc958-966c-4903-b4d2-c33aeb36a0d8)