### PR TITLE
Tech: pas d'erreur si un usager essaie d'ajouter une ligne d'un champ répétition sans enfant

### DIFF
--- a/app/controllers/champs/repetition_controller.rb
+++ b/app/controllers/champs/repetition_controller.rb
@@ -6,7 +6,7 @@ class Champs::RepetitionController < ApplicationController
     row = @champ.add_row(@champ.dossier.revision)
     @first_champ_id = row.map(&:focusable_input_id).compact.first
     @row_id = row.first&.row_id
-    @row_number = @champ.row_ids.find_index(@row_id) + 1
+    @row_number = @row_id.nil? ? 0 : @champ.row_ids.find_index(@row_id) + 1
   end
 
   def remove


### PR DESCRIPTION
Cf procedure#31063 stable_id#1078289 qui est une répétition sans enfant (vieille démarche publiée avant la validation qui oblige à avoir au moins un enfant)
Au moins ça remonte plus dans sentry
https://demarches-simplifiees.sentry.io/issues/5079584709/
