### PR TITLE
refactor(champ): remove stable_id delegate to type_de_champ

### DIFF
--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -50,7 +50,6 @@ class Champ < ApplicationRecord
     :siret?,
     :carte?,
     :datetime?,
-    :stable_id,
     :mandatory?,
     :prefillable?,
     :refresh_after_update?,

--- a/spec/models/champ_spec.rb
+++ b/spec/models/champ_spec.rb
@@ -496,41 +496,6 @@ describe Champ do
         expect(champ_text_row_1.dossier_id).to eq(champ.dossier_id)
       end
     end
-
-    context 'when updating using nested attributes' do
-      subject do
-        dossier.update!(champs_public_attributes: [
-          {
-            id: champ.id,
-            champs_attributes: [champ_text_attrs]
-          }
-        ])
-        champ.reload
-        dossier.reload
-      end
-
-      it 'associates nested champs to the parent dossier' do
-        subject
-
-        expect(dossier.champs_public.size).to eq(2)
-        expect(champ.rows.size).to eq(2)
-        second_row = champ.reload.rows.second
-        expect(second_row.size).to eq(1)
-        expect(second_row.first.dossier).to eq(dossier)
-
-        champ.champs << champ_integer
-        first_row = champ.reload.rows.first
-        expect(first_row.size).to eq(2)
-        expect(first_row.second).to eq(champ_integer)
-
-        champ.champs << champ_text
-        first_row = champ.reload.rows.first
-        expect(first_row.size).to eq(2)
-        expect(first_row.first).to eq(champ_text)
-
-        expect(champ.rows.size).to eq(2)
-      end
-    end
   end
 
   describe '#log_fetch_external_data_exception' do

--- a/spec/models/champs/carte_champ_spec.rb
+++ b/spec/models/champs/carte_champ_spec.rb
@@ -21,7 +21,7 @@ describe Champs::CarteChamp do
     let(:feature_collection) {
       {
         type: 'FeatureCollection',
-        id: champ.type_de_champ.stable_id,
+        id: champ.stable_id,
         bbox: champ.bounding_box,
         features: features
       }


### PR DESCRIPTION
- [x] Avant de merger cette PR, il faut attendre la fin de la tâche qui ajoute les `stable_id` à tous les champs