### PR TITLE
Tech: deplace la migration des données fonctionnel vers le stockage ovh sur sa propre file

### DIFF
--- a/app/jobs/dossier_operation_log_move_to_cold_storage_batch_job.rb
+++ b/app/jobs/dossier_operation_log_move_to_cold_storage_batch_job.rb
@@ -1,5 +1,5 @@
 class DossierOperationLogMoveToColdStorageBatchJob < ApplicationJob
-  queue_as :low_priority
+  queue_as :low_priority_sub_second_batch
 
   def perform(ids)
     DossierOperationLog.where(id: ids)


### PR DESCRIPTION
Raisonnement :
- on a 7M de petit json à remonter sur la prod
- le point de contention se situe au niveau du réseau avec ~200 à 400ms l'appel
- le cluster sidekiq est peu chargé (vu de nez < 20%)
- on ne veut pas perturber les autres jobs

=> on fait une file dédiée `low_priority_sub_second_batch` , ou on enqueue des jobs rapide (en dessus de la seconde) et on met une très faible priorité.