### PR TITLE
Usager: fix champ adresse dans un TOM sans code postal dans la BAN (ex. Nouvelle-Calédonie à Nouméa)

### DIFF
--- a/app/models/champs/address_champ.rb
+++ b/app/models/champs/address_champ.rb
@@ -97,9 +97,13 @@ class Champs::AddressChamp < Champs::TextChamp
   end
 
   def commune_name
-    if full_address?
-      "#{APIGeoService.commune_name(code_departement, address['city_code'])} (#{address['postal_code']})"
-    end
+    return if !full_address?
+
+    commune = APIGeoService.commune_name(code_departement, address['city_code'])
+
+    return commune if address['postal_code'].blank?
+
+    "#{commune} (#{address['postal_code']})"
   end
 
   def commune

--- a/app/services/api_geo_service.rb
+++ b/app/services/api_geo_service.rb
@@ -115,7 +115,7 @@ class APIGeoService
         label: properties.fetch('label'),
         type: properties.fetch('type'),
         street_address: properties.fetch('name'),
-        postal_code: properties.fetch('postcode'),
+        postal_code: properties.fetch('postcode') { '' }, # API graphql / serializer requires non-null data
         street_number: properties['housenumber'],
         street_name: properties['street'],
         geometry: feature['geometry']

--- a/spec/models/champs/address_champ_spec.rb
+++ b/spec/models/champs/address_champ_spec.rb
@@ -53,4 +53,24 @@ describe Champs::AddressChamp do
     it { expect(champ.full_address?).to be_truthy }
     it { expect(champ.commune).to eq({ name: 'Les Trois Lacs', code: '27676', postal_code: '27700' }) }
   end
+
+  context "with empty code postal" do
+    let(:value) { '15 rue Baudelaire Nouméa' }
+    let(:data) do
+      {
+        "type" => "housenumber",
+        "label" => "15 Rue BAUDELAIRE Nouméa",
+        "city_code" => "98818",
+        "city_name" => "Nouméa",
+        "postal_code" => "",
+        "department_code" => "988",
+        "department_name" => "Nouvelle-Calédonie"
+      }
+    end
+
+    it do
+      expect(champ.commune).to eq({ name: 'Nouméa', code: '98818', postal_code: '' })
+      expect(champ.commune_name).to eq("Nouméa")
+    end
+  end
 end

--- a/spec/services/api_geo_service_spec.rb
+++ b/spec/services/api_geo_service_spec.rb
@@ -106,6 +106,15 @@ describe APIGeoService do
 
       it { expect(subject[:city_name]).to eq('Paris') }
     end
+
+    context 'without postcode (nouméa…)' do
+      let(:feature) do
+        features.first.tap { _1["properties"].delete("postcode") }
+      end
+
+      it { expect(subject[:postal_code]).to eq('') }
+      it { expect(subject[:city_name]).to eq('Paris') }
+    end
   end
 
   describe 'safely_normalize_city_name' do


### PR DESCRIPTION
https://demarches-simplifiees.sentry.io/issues/4997710373

On fallback sur string vide car notre API s'attend à un type non-nullable