### PR TITLE
ETQ instructeur: lorsque je demande des avis externes, ds suggere uniquement des utilisateurs s'étant connectée au moins 1 fois

### DIFF
--- a/app/controllers/experts/avis_controller.rb
+++ b/app/controllers/experts/avis_controller.rb
@@ -83,11 +83,7 @@ module Experts
 
     def avis_new
       @new_avis = Avis.new
-      if @dossier.procedure.experts_require_administrateur_invitation?
-        @experts_emails = @dossier.procedure.experts_procedures.where(revoked_at: nil).map { _1.expert.email }.sort
-      else
-        @experts_emails = @dossier.procedure.experts.map(&:email).sort
-      end
+      @experts_emails = Expert.autocomplete_mails(@dossier.procedure)
     end
 
     def create_avis

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -64,21 +64,13 @@ module Instructeurs
     def avis
       @avis_seen_at = current_instructeur.follows.find_by(dossier: dossier)&.avis_seen_at
       @avis = Avis.new
-      if @dossier.procedure.experts_require_administrateur_invitation?
-        @experts_emails = dossier.procedure.experts_procedures.where(revoked_at: nil).map(&:expert).map(&:email).sort
-      else
-        @experts_emails = @dossier.procedure.experts.map(&:email).sort
-      end
+      @experts_emails = Expert.autocomplete_mails(@dossier.procedure)
     end
 
     def avis_new
       @avis_seen_at = current_instructeur.follows.find_by(dossier: dossier)&.avis_seen_at
       @avis = Avis.new
-      if @dossier.procedure.experts_require_administrateur_invitation?
-        @experts_emails = dossier.procedure.experts_procedures.where(revoked_at: nil).map(&:expert).map(&:email).sort
-      else
-        @experts_emails = @dossier.procedure.experts.map(&:email).sort
-      end
+      @experts_emails = Expert.autocomplete_mails(@dossier.procedure)
     end
 
     def personnes_impliquees

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -33,6 +33,7 @@ class Expert < ApplicationRecord
     experts = Expert
       .joins(:experts_procedures, :user)
       .where(experts_procedures: { procedure: procedure })
+      .where.not(users: { confirmed_at: nil })
 
     if procedure.experts_require_administrateur_invitation?
       experts = experts

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -30,11 +30,18 @@ class Expert < ApplicationRecord
   end
 
   def self.autocomplete_mails(procedure)
+    experts = Expert
+      .joins(:experts_procedures, :user)
+      .where(experts_procedures: { procedure: procedure })
+
     if procedure.experts_require_administrateur_invitation?
-      procedure.experts_procedures.where(revoked_at: nil).map(&:expert).map(&:email).sort
-    else
-      procedure.experts.map(&:email).sort
+      experts = experts
+        .where(experts_procedures: { revoked_at: nil })
     end
+
+    experts
+      .pluck('users.email')
+      .sort
   end
 
   def merge(old_expert)

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -35,7 +35,7 @@ class Expert < ApplicationRecord
       .where(experts_procedures: { procedure: procedure })
 
     new_or_confirmed_experts = procedure_experts
-      .where.not(users: { confirmed_at: nil })
+      .where.not(users: { last_sign_in_at: nil })
       .or(procedure_experts.where(users: { created_at: 1.day.ago.. }))
 
     suggested_expert = if procedure.experts_require_administrateur_invitation?

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -29,6 +29,14 @@ class Expert < ApplicationRecord
     end
   end
 
+  def self.autocomplete_mails(procedure)
+    if procedure.experts_require_administrateur_invitation?
+      procedure.experts_procedures.where(revoked_at: nil).map(&:expert).map(&:email).sort
+    else
+      procedure.experts.map(&:email).sort
+    end
+  end
+
   def merge(old_expert)
     return if old_expert.nil?
 

--- a/spec/controllers/experts/avis_controller_spec.rb
+++ b/spec/controllers/experts/avis_controller_spec.rb
@@ -355,26 +355,12 @@ describe Experts::AvisController, type: :controller do
     end
 
     describe '#avis_new' do
-      let!(:revoked_expert) { create(:experts_procedure, revoked_at: 2.days.ago, procedure: procedure, expert: create(:expert)).expert }
       before do
+        allow(Expert).to receive(:autocomplete_mails).and_return([])
         get :avis_new, params: { procedure_id: procedure.id, id: avis_without_answer.id }
       end
-      context 'when procedure experts need administrateur invitation' do
-        let!(:procedure) { create(:procedure, experts_require_administrateur_invitation: true) }
 
-        it 'limit invited email list to not revoked experts' do
-          expect(assigns(:experts_emails)).to include(experts_procedure.expert.user.email)
-          expect(assigns(:experts_emails)).not_to include(revoked_expert.user.email)
-        end
-      end
-      context 'when procedure experts can be anyone' do
-        let!(:procedure) { create(:procedure, experts_require_administrateur_invitation: false) }
-
-        it 'prefill autocomplete with all experts in the procedure' do
-          expect(assigns(:experts_emails)).to include(experts_procedure.expert.user.email)
-          expect(assigns(:experts_emails)).to include(revoked_expert.user.email)
-        end
-      end
+      it { expect(Expert).to have_received(:autocomplete_mails).with(procedure) }
     end
 
     describe '#create_avis' do

--- a/spec/models/expert_spec.rb
+++ b/spec/models/expert_spec.rb
@@ -102,17 +102,19 @@ RSpec.describe Expert, type: :model do
     let(:expert) { create(:expert) }
     let(:revoked_expert) { create(:expert) }
     let(:unconfirmed_expert) { create(:expert) }
+    let(:new_unconfirmed_expert) { create(:expert) }
 
     before do
-      procedure.experts << expert << revoked_expert << unconfirmed_expert
+      procedure.experts << expert << revoked_expert << unconfirmed_expert << new_unconfirmed_expert
       ExpertsProcedure.find_by(expert: revoked_expert, procedure: procedure)
         .update!(revoked_at: 1.day.ago)
-      unconfirmed_expert.user.update!(confirmed_at: nil)
+      unconfirmed_expert.user.update!(confirmed_at: nil, created_at: 2.days.ago)
+      new_unconfirmed_expert.user.update!(confirmed_at: nil)
     end
 
     context 'when procedure experts need administrateur invitation' do
       it 'returns only confirmed not revoked experts' do
-        expect(subject).to eq([expert.user.email])
+        expect(subject).to eq([expert.user.email, new_unconfirmed_expert.user.email])
       end
     end
 
@@ -120,7 +122,7 @@ RSpec.describe Expert, type: :model do
       let(:procedure) { create(:procedure, experts_require_administrateur_invitation: false) }
 
       it 'prefill autocomplete with all confirmed experts in the procedure' do
-        expect(subject).to eq([expert.user.email, revoked_expert.user.email])
+        expect(subject).to eq([expert.user.email, revoked_expert.user.email, new_unconfirmed_expert.user.email])
       end
     end
   end

--- a/spec/models/expert_spec.rb
+++ b/spec/models/expert_spec.rb
@@ -101,16 +101,17 @@ RSpec.describe Expert, type: :model do
     let(:procedure) { create(:procedure, experts_require_administrateur_invitation: true) }
     let(:expert) { create(:expert) }
     let(:revoked_expert) { create(:expert) }
+    let(:unconfirmed_expert) { create(:expert) }
 
     before do
-      procedure.experts << expert << revoked_expert
+      procedure.experts << expert << revoked_expert << unconfirmed_expert
       ExpertsProcedure.find_by(expert: revoked_expert, procedure: procedure)
         .update!(revoked_at: 1.day.ago)
+      unconfirmed_expert.user.update!(confirmed_at: nil)
     end
 
     context 'when procedure experts need administrateur invitation' do
-
-      it 'returns only not revoked experts' do
+      it 'returns only confirmed not revoked experts' do
         expect(subject).to eq([expert.user.email])
       end
     end
@@ -118,7 +119,7 @@ RSpec.describe Expert, type: :model do
     context 'when procedure experts can be anyone' do
       let(:procedure) { create(:procedure, experts_require_administrateur_invitation: false) }
 
-      it 'prefill autocomplete with all experts in the procedure' do
+      it 'prefill autocomplete with all confirmed experts in the procedure' do
         expect(subject).to eq([expert.user.email, revoked_expert.user.email])
       end
     end

--- a/spec/models/expert_spec.rb
+++ b/spec/models/expert_spec.rb
@@ -101,20 +101,20 @@ RSpec.describe Expert, type: :model do
     let(:procedure) { create(:procedure, experts_require_administrateur_invitation: true) }
     let(:expert) { create(:expert) }
     let(:revoked_expert) { create(:expert) }
-    let(:unconfirmed_expert) { create(:expert) }
-    let(:new_unconfirmed_expert) { create(:expert) }
+    let(:unsigned_expert) { create(:expert) }
+    let(:new_unsigned_expert) { create(:expert) }
 
     before do
-      procedure.experts << expert << revoked_expert << unconfirmed_expert << new_unconfirmed_expert
+      procedure.experts << expert << revoked_expert << unsigned_expert << new_unsigned_expert
       ExpertsProcedure.find_by(expert: revoked_expert, procedure: procedure)
         .update!(revoked_at: 1.day.ago)
-      unconfirmed_expert.user.update!(confirmed_at: nil, created_at: 2.days.ago)
-      new_unconfirmed_expert.user.update!(confirmed_at: nil)
+      unsigned_expert.user.update!(last_sign_in_at: nil, created_at: 2.days.ago)
+      new_unsigned_expert.user.update!(last_sign_in_at: nil)
     end
 
     context 'when procedure experts need administrateur invitation' do
       it 'returns only confirmed not revoked experts' do
-        expect(subject).to eq([expert.user.email, new_unconfirmed_expert.user.email])
+        expect(subject).to eq([expert.user.email, new_unsigned_expert.user.email].sort)
       end
     end
 
@@ -122,7 +122,7 @@ RSpec.describe Expert, type: :model do
       let(:procedure) { create(:procedure, experts_require_administrateur_invitation: false) }
 
       it 'prefill autocomplete with all confirmed experts in the procedure' do
-        expect(subject).to eq([expert.user.email, revoked_expert.user.email, new_unconfirmed_expert.user.email])
+        expect(subject).to eq([expert.user.email, revoked_expert.user.email, new_unsigned_expert.user.email].sort)
       end
     end
   end


### PR DESCRIPTION
Ou des utilisateurs récents de moins d'un jour.

Cette feature est développée pour éviter que le système ne suggère des emails comportant des typo.