### PR TITLE
[fix] Probleme de titre de la tuile template de mail accusé de reception

### DIFF
--- a/config/locales/models/mail/initiated_mail/fr.yml
+++ b/config/locales/models/mail/initiated_mail/fr.yml
@@ -4,4 +4,4 @@ fr:
       mail:
         initiated_mail:
           default_subject: Votre dossier nº %{dossier_number} a bien été déposé (%{procedure_libelle})
-          proof_of_receipt: Accusé de lecture
+          proof_of_receipt: Accusé de réception


### PR DESCRIPTION
En faisant un renommage global "d'accusé de reception" vers "accusé de lecture" lors de ma derniere PR j'ai renommé une trad pas accident.