### PR TITLE
Tech: replace le job de migration des logs fontionnelles sur une queue standard

### DIFF
--- a/app/jobs/dossier_operation_log_move_to_cold_storage_batch_job.rb
+++ b/app/jobs/dossier_operation_log_move_to_cold_storage_batch_job.rb
@@ -1,5 +1,5 @@
 class DossierOperationLogMoveToColdStorageBatchJob < ApplicationJob
-  queue_as :low_priority_sub_second_batch
+  queue_as :low_priority
 
   def perform(ids)
     DossierOperationLog.where(id: ids)


### PR DESCRIPTION
on reprend le cron standard qui enqueue 1000 migration par job.
Du coup, ca prend plus de temps et on ne peut plus rester sur la queue `low_priority_sub_second_batch`