### PR TITLE
Tech: pour le prestataire de mail dolist, choisit le bon sender_id en fonction du domaine utilisé (migration gouv.fr)

### DIFF
--- a/app/lib/dolist/api.rb
+++ b/app/lib/dolist/api.rb
@@ -190,9 +190,11 @@ module Dolist
       format(base, account_id: account_id)
     end
 
-    def sender_id
-      Rails.cache.fetch("dolist_api_sender_id", expires_in: 1.hour) do
-        senders.dig("ItemList", 0, "Sender", "ID")
+    def sender_id(domain)
+      if domain == "demarches.gouv.fr"
+        Rails.application.secrets.dolist[:gouv_sender_id]
+      else
+        Rails.application.secrets.dolist[:default_sender_id]
       end
     end
 
@@ -267,7 +269,7 @@ module Dolist
         "Message": {
           "Name": mail['X-Dolist-Message-Name'].value,
           "Subject": mail.subject,
-          "SenderID": sender_id,
+          "SenderID": sender_id(mail.from_address.domain),
           "ForceHttp": false, # ForceHttp : force le tracking http non sécurisé (True/False).
           "Format": "html",
           "DisableOpenTracking": true, # DisableOpenTracking : désactivation du tracking d'ouverture (True/False).

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -137,6 +137,7 @@ MATOMO_IFRAME_URL="https://matomo.example.org/index.php?module=CoreAdminHome&act
 # DOLIST_ACCOUNT_ID=""
 # DOLIST_NO_REPLY_EMAIL=""
 # DOLIST_API_KEY=""
+# DOLIST_DEFAULT_SENDER_ID=""
 
 # SMTP Provider: SIB (Brevo)
 # SENDINBLUE_SMTP_ADDRESS=""

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -32,6 +32,8 @@ defaults: &defaults
     password: <%= ENV['DOLIST_PASSWORD'] %>
     account_id: <%= ENV['DOLIST_ACCOUNT_ID'] %>
     api_key: <%= ENV['DOLIST_API_KEY'] %>
+    default_sender_id: <%= ENV['DOLIST_DEFAULT_SENDER_ID'] || 1 %>
+    gouv_sender_id: <%= ENV['DOLIST_GOUV_SENDER_ID'] || 1 %>
   api_entreprise:
     key: <%= ENV['API_ENTREPRISE_KEY'] %>
   mailtrap:


### PR DESCRIPTION
hypothèses : 
- les sender_id ne change pas dans le temps, on ne va plus les actualiser toutes les heures.
- la valeur sender_id est de 1 pour la majorité des instances, si ce n'est pas le cas, ils peuvent changer la variable `DOLIST_DEFAULT_SENDER_ID`

RAF:
- [ ] on mep ce code
- [ ] on demande a dolist de rajouter un sender, entre temps le code utilise toujours le default sender_id (1)
- [ ] on rajoute l id du sender .gouv en variable d'env
- [ ] on fait la fête