### PR TITLE
Tech: active le code coverage avec simplecov & codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,11 @@ jobs:
         run: |
           bun run test
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
   unit_tests:
     name: Unit tests
     runs-on: ubuntu-latest
@@ -100,6 +105,11 @@ jobs:
           name: rspec-results-${{ github.job }}-${{ strategy.job-index }}
           path: tmp/rspec_${{ github.job }}_${{ strategy.job-index }}.junit.xml
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
   system_tests:
     name: System tests
     runs-on: ubuntu-latest
@@ -143,6 +153,11 @@ jobs:
         with:
           name: rspec-results-${{ github.job }}-${{ strategy.job-index }}
           path: tmp/rspec_${{ github.job }}_${{ strategy.job-index }}.junit.xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   save_test_reports:
     name: Save test reports

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ yarn-debug.log*
 /public/assets
 /spec/support/spec_config.local.rb
 /config/initializers/config.local.rb
+/coverage
 
 # Local Netlify folder
 .netlify

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+SimpleCov.start "rails" do
+  enable_coverage :branch
+
+  command_name "RSpec process #{Process.pid}"
+
+  formatter SimpleCov::Formatter::MultiFormatter.new([
+    SimpleCov::Formatter::SimpleFormatter,
+    SimpleCov::Formatter::HTMLFormatter
+  ])
+
+  add_filter "/channels/" # not used
+  groups.delete("Channels")
+
+  add_group "Components", "app/components"
+  add_group "API", ["app/graphql", "app/serializers"]
+  add_group "Manager", ["app/dashboards", "app/fields"]
+  add_group "Models", ["app/models", "app/validators"]
+  add_group "Policies", "app/policies"
+  add_group "Services", "app/services"
+  add_group "Tasks", ["app/tasks", "lib/tasks"]
+end

--- a/.simplecov
+++ b/.simplecov
@@ -5,10 +5,15 @@ SimpleCov.start "rails" do
 
   command_name "RSpec process #{Process.pid}"
 
-  formatter SimpleCov::Formatter::MultiFormatter.new([
-    SimpleCov::Formatter::SimpleFormatter,
-    SimpleCov::Formatter::HTMLFormatter
-  ])
+  if ENV["CI"] # codecov compatibility
+    require 'simplecov-cobertura'
+    formatter SimpleCov::Formatter::CoberturaFormatter
+  else
+    formatter SimpleCov::Formatter::MultiFormatter.new([
+      SimpleCov::Formatter::SimpleFormatter,
+      SimpleCov::Formatter::HTMLFormatter
+    ])
+  end
 
   add_filter "/channels/" # not used
   groups.delete("Channels")

--- a/Gemfile
+++ b/Gemfile
@@ -125,6 +125,8 @@ group :test do
   gem 'selenium-devtools'
   gem 'selenium-webdriver'
   gem 'shoulda-matchers', require: false
+  gem 'simplecov', require: false
+  gem 'simplecov-cobertura', require: false
   gem 'timecop'
   gem 'vcr'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,6 +223,7 @@ GEM
     diff-lcs (1.5.1)
     discard (1.3.0)
       activerecord (>= 4.2, < 8)
+    docile (1.4.0)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
@@ -728,6 +729,15 @@ GEM
     simple_xlsx_reader (1.0.4)
       nokogiri
       rubyzip
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-cobertura (2.1.0)
+      rexml
+      simplecov (~> 0.19)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     simpleidn (0.2.1)
       unf (~> 0.1.4)
     sinatra (3.2.0)
@@ -991,6 +1001,8 @@ DEPENDENCIES
   sidekiq
   sidekiq-cron
   simple_xlsx_reader
+  simplecov
+  simplecov-cobertura
   skylight
   spreadsheet_architect
   spring

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,10 @@
 # users commonly want.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+#
+#
+require 'simplecov' # see config in .simplecov file
+
 require 'rspec/retry'
 
 SECURE_PASSWORD = 'my-s3cure-p4ssword'


### PR DESCRIPTION
- en local on peut parcourir coverage/index.html régénéré après chaque run. Pratique pour vérifier que notre nouveau code est bien couvert par les tests
- le CI envoie l'ensemble des résultats mergés sur codecov 
- un résumé viendra en commentaire à chaque PR