### PR TITLE
ETQ developpeur, je souhaite pouvoir utiliser le playground même si je ne suis pas administrateur

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -1,14 +1,11 @@
 class GraphqlController < ApplicationController
-  before_action :authenticate_administrateur!
-
   def playground
-    procedure = current_administrateur.procedures&.last
-
-    gon.default_query = API::V2::StoredQuery.get('ds-query-v2')
+    procedure = current_administrateur&.procedures&.last
     gon.default_variables = {
-      "demarcheNumber": procedure&.id,
+      "demarcheNumber": procedure&.id || 42,
       "includeDossiers": true
     }.compact.to_json
+    gon.default_query = API::V2::StoredQuery.get('ds-query-v2')
 
     render :playground, layout: false
   end

--- a/app/javascript/entrypoints/playground.ts
+++ b/app/javascript/entrypoints/playground.ts
@@ -24,8 +24,7 @@ function GraphiQLWithExplorer() {
     plugins: [explorer],
     query: query,
     variables: defaultVariables,
-    onEditQuery: setQuery,
-    isHeadersEditorEnabled: false
+    onEditQuery: setQuery
   });
 }
 


### PR DESCRIPTION
# Problème

Suite à un echange avec des devs qui n'avaient pas de compte admin sur la plateforme (leurs mandataire leur donne un token), l'usage du playground leurs était impossible. Ça aide pas a prendre en main les APIs

# Solution
On active l'option pour permettre a un dev de renseigner les headers dans le playground

<img width="810" alt="Capture d’écran 2024-04-23 à 9 54 30 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/2f171c2d-e19c-4919-923e-f26ffe7229df">
