### PR TITLE
Correctif(galerie): réduit la taille des images miniatures dans les pages /demande et /pieces_jointes

### DIFF
--- a/app/models/champs/piece_justificative_champ.rb
+++ b/app/models/champs/piece_justificative_champ.rb
@@ -1,6 +1,11 @@
 class Champs::PieceJustificativeChamp < Champ
   FILE_MAX_SIZE = 200.megabytes
 
+  has_many_attached :piece_justificative_file do |attachable|
+    attachable.variant :small, resize: '300x300'
+    attachable.variant :medium, resize: '400x400'
+  end
+
   # TODO: if: -> { validate_champ_value? || validation_context == :prefill }
   validates :piece_justificative_file,
     size: { less_than: FILE_MAX_SIZE },

--- a/app/models/champs/titre_identite_champ.rb
+++ b/app/models/champs/titre_identite_champ.rb
@@ -1,6 +1,12 @@
 class Champs::TitreIdentiteChamp < Champ
   FILE_MAX_SIZE = 20.megabytes
   ACCEPTED_FORMATS = ['image/png', 'image/jpeg']
+
+  has_many_attached :piece_justificative_file do |attachable|
+    attachable.variant :small, resize: '300x300'
+    attachable.variant :medium, resize: '400x400'
+  end
+
   # TODO: if: -> { validate_champ_value? || validation_context == :prefill }
   validates :piece_justificative_file, content_type: ACCEPTED_FORMATS, size: { less_than: FILE_MAX_SIZE }
 

--- a/app/views/instructeurs/dossiers/pieces_jointes.html.haml
+++ b/app/views/instructeurs/dossiers/pieces_jointes.html.haml
@@ -25,7 +25,7 @@
             - elsif blob.content_type.in?(AUTHORIZED_IMAGE_TYPES)
               = link_to image_url(blob.url), title: "#{champ.libelle} -- #{blob.filename}", data: { src: blob.url }, class: 'gallery-link' do
                 .thumbnail
-                  = image_tag(blob.url, loading: :lazy)
+                  = image_tag(attachment.variant(:medium), loading: :lazy)
                   .fr-btn.fr-btn--tertiary.fr-btn--icon-left.fr-icon-eye{ role: :button }
                     Visualiser
               .champ-libelle

--- a/app/views/shared/champs/piece_justificative/_show.html.haml
+++ b/app/views/shared/champs/piece_justificative/_show.html.haml
@@ -19,6 +19,6 @@
         - elsif blob.content_type.in?(AUTHORIZED_IMAGE_TYPES)
           = link_to image_url(blob.url), title: "#{champ.libelle} -- #{blob.filename}", data: { src: blob.url }, class: 'gallery-link' do
             .thumbnail
-              = image_tag(blob.url, loading: :lazy)
+              = image_tag(attachment.variant(:small), loading: :lazy)
               .fr-btn.fr-btn--tertiary.fr-btn--icon-left.fr-icon-eye{ role: :button }
                 = 'Visualiser'


### PR DESCRIPTION
Les blocs carrés des miniatures font 150/150 dans la page /demande et 200/200 dans la page /pieces_jointes.
J'ai retaillé les images qu'on met à l'intérieur en un peu plus grand pour éviter que la vignette soit floue (en 200x200 et 400x400).
En effet, le mode d'affichage de l'image dans le carré repose sur le css `object-fit: cover;` pour remplir le carré