### PR TITLE
Tech: ajoute une maintenance task pour recalculer les checksums de pj erronées

### DIFF
--- a/app/tasks/maintenance/recompute_blob_checksum_task.rb
+++ b/app/tasks/maintenance/recompute_blob_checksum_task.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class RecomputeBlobChecksumTask < MaintenanceTasks::Task
+    attribute :blob_ids, :string
+    validates :blob_ids, presence: true
+
+    def collection
+      ids = blob_ids.split(',').map(&:strip).map(&:to_i)
+      ActiveStorage::Blob.where(id: ids)
+    end
+
+    def process(blob)
+      blob.upload(StringIO.new(blob.download), identify: false)
+      blob.save!
+    end
+
+    def count
+      # Optionally, define the number of rows that will be iterated over
+      # This is used to track the task's progress
+    end
+  end
+end


### PR DESCRIPTION
Les filigranes ont, avant le fix de colin de février 2024, corrompus les hash des fichiers.

Régulièrement, des dossiers en brouillon sont déposés avec ce problème. On retrouve les fichiers corrompu dans l'onglet retry de sidekiq.

Cette tache recalcule les hashes.