### PR TITLE
Amélioration du wording de la pagination des éléments affichés sur une seule page

### DIFF
--- a/app/views/administrateurs/procedures/index.html.haml
+++ b/app/views/administrateurs/procedures/index.html.haml
@@ -6,7 +6,7 @@
     %nav.fr-tabs{ role: 'navigation', 'aria-label': t('views.users.dossiers.secondary_menu') }
       %ul.fr-tabs__list{ role: 'tablist' }
         = tab_item(t('pluralize.published', count: @procedures_publiees_count), admin_procedures_path(statut: 'publiees'), active: @statut == 'publiees', badge: number_with_html_delimiter(@procedures_publiees_count))
-        = tab_item('En test', admin_procedures_path(statut: 'brouillons'), active: @statut == 'brouillons', badge: number_with_html_delimiter(@procedures_draft_count))
+        = tab_item('en test', admin_procedures_path(statut: 'brouillons'), active: @statut == 'brouillons', badge: number_with_html_delimiter(@procedures_draft_count))
         = tab_item(t('pluralize.closed', count: @procedures_closed_count), admin_procedures_path(statut: 'archivees'), active: @statut == 'archivees', badge: number_with_html_delimiter(@procedures_closed_count))
         = tab_item(t('pluralize.deleted', count: @procedures_deleted_count), admin_procedures_path(statut: 'supprimees'), active: @statut === 'supprimees', badge: number_with_html_delimiter(@procedures_deleted_count))
 

--- a/config/locales/kaminari.en.yml
+++ b/config/locales/kaminari.en.yml
@@ -9,8 +9,8 @@ en:
         display_entries: "%{first} - %{last} <span class='fr-text--sm'>in %{total} %{entry_name}</span>"
       one_page:
         display_entries:
-          one: "<b>%{count}</b> %{entry_name}"
-          other: "%{count} <span class='fr-text--sm'>in %{count} %{entry_name}</span>"
+          one: "%{count} %{entry_name}"
+          other: "%{count} %{entry_name}"
   views:
     pagination:
       first: "&laquo; First"

--- a/config/locales/kaminari.fr.yml
+++ b/config/locales/kaminari.fr.yml
@@ -9,8 +9,8 @@ fr:
         display_entries: "%{first} - %{last} <span class='fr-text--sm'>sur %{total} %{entry_name}</span>"
       one_page:
         display_entries:
-          one: "<b>%{count}</b> %{entry_name}"
-          other: "%{count} <span class='fr-text--sm'>sur %{count} %{entry_name}</span>"
+          one: "%{count} %{entry_name}"
+          other: "%{count} %{entry_name}"
   views:
     pagination:
       first: "&laquo; Premier"

--- a/spec/system/users/list_dossiers_spec.rb
+++ b/spec/system/users/list_dossiers_spec.rb
@@ -75,7 +75,7 @@ describe 'user access to the list of their dossiers', js: true do
     scenario 'user filters state on tab "en-cours"' do
       expect(page).to have_text('7 en cours')
       expect(page).to have_text('3 traités')
-      expect(page).to have_text('7 sur 7 dossiers')
+      expect(page).to have_text('7 dossiers')
 
       click_on('Sélectionner un filtre')
       expect(page).to have_select 'Statut', selected: 'Sélectionner un statut', options: ['Sélectionner un statut', 'Brouillon', 'En construction', 'En instruction', 'À corriger']
@@ -97,7 +97,7 @@ describe 'user access to the list of their dossiers', js: true do
       visit dossiers_path(statut: 'traites')
       expect(page).to have_text('7 en cours')
       expect(page).to have_text('3 traités')
-      expect(page).to have_text('3 sur 3 dossiers')
+      expect(page).to have_text('3 dossiers')
 
       click_on('Sélectionner un filtre')
       expect(page).to have_select 'Statut', selected: 'Sélectionner un statut', options: ['Sélectionner un statut', 'Accepté', 'Refusé', 'Classé sans suite']
@@ -119,18 +119,18 @@ describe 'user access to the list of their dossiers', js: true do
 
       click_on('Sélectionner un filtre')
       click_on('Annuler')
-      expect(page).to have_text('3 sur 3 dossiers')
+      expect(page).to have_text('3 dossiers')
       expect(page).to have_select 'Statut', selected: 'Sélectionner un statut', options: ['Sélectionner un statut', 'Accepté', 'Refusé', 'Classé sans suite']
     end
 
     scenario 'user filters by created_at' do
       dossier_en_construction.update!(created_at: Date.yesterday)
 
-      expect(page).to have_text('7 sur 7 dossiers')
+      expect(page).to have_text('7 dossiers')
       click_on('Sélectionner un filtre')
       fill_in 'from_created_at_date', with: Date.today
       click_on('Appliquer les filtres')
-      expect(page).to have_text('6 sur 6 dossiers')
+      expect(page).to have_text('6 dossiers')
     end
 
     scenario 'user uses multiple filters' do
@@ -138,11 +138,11 @@ describe 'user access to the list of their dossiers', js: true do
 
       expect(page).to have_select 'Statut', selected: 'Sélectionner un statut', options: ['Sélectionner un statut', 'Brouillon', 'En construction', 'En instruction', 'À corriger']
 
-      expect(page).to have_text('7 sur 7 dossiers')
+      expect(page).to have_text('7 dossiers')
       click_on('Sélectionner un filtre')
       fill_in 'from_created_at_date', with: Date.today
       click_on('Appliquer les filtres')
-      expect(page).to have_text('6 sur 6 dossiers')
+      expect(page).to have_text('6 dossiers')
       expect(page).to have_text('1 filtre actif')
 
       click_on('Sélectionner un filtre')
@@ -154,10 +154,10 @@ describe 'user access to the list of their dossiers', js: true do
       click_on('Sélectionner un filtre')
       fill_in 'from_depose_at_date', with: Date.today
       click_on('Appliquer les filtres')
-      expect(page).to have_text('2 sur 2 dossiers')
+      expect(page).to have_text('2 dossiers')
       expect(page).to have_text('3 filtres actifs')
       click_on('3 filtres actifs')
-      expect(page).to have_text('7 sur 7 dossiers')
+      expect(page).to have_text('7 dossiers')
       expect(page).not_to have_text('5 filtres actifs')
     end
   end
@@ -275,7 +275,7 @@ describe 'user access to the list of their dossiers', js: true do
           expect(current_path).to eq(dossiers_path)
           expect(page).to have_link(dossier_en_construction.procedure.libelle)
           expect(page).to have_link(dossier_with_champs.procedure.libelle)
-          expect(page).to have_text("2 sur 2 dossiers")
+          expect(page).to have_text("2 dossiers")
         end
 
         it "can be filtered by procedure and display the result - one item" do


### PR DESCRIPTION
Fix #10391

_Après_
![Capture d’écran 2024-05-03 à 10 16 41](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/0395237f-365f-40a3-b655-f10586baea50)

_Avant_
![Capture d’écran 2024-05-03 à 10 29 25](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/f3fbcf7a-1846-4792-b728-53f80150ede8)

Fix typo

_Après_
![Capture d’écran 2024-05-03 à 10 32 11](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/1596d3e3-a54b-4b79-b14d-28b943fb70c4)

_Avant_
![Capture d’écran 2024-05-03 à 10 30 56](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/9e4ca349-87c8-4633-b693-1da4bf9681fd)