### PR TITLE
[ETQ admin] Je veux comprendre pourquoi je ne peux pas personnaliser mes mails si l'accusé de lecture est activé

### DIFF
--- a/app/assets/stylesheets/procedure_admin.scss
+++ b/app/assets/stylesheets/procedure_admin.scss
@@ -25,7 +25,6 @@
 
 .container {
   a {
-    cursor: pointer;
     overflow-wrap: break-word;
   }
 }

--- a/app/components/procedure/email_template_card_component.rb
+++ b/app/components/procedure/email_template_card_component.rb
@@ -32,4 +32,12 @@ class Procedure::EmailTemplateCardComponent < ApplicationComponent
   def edit_path
     edit_admin_procedure_mail_template_path(@email_template.procedure, @email_template.class.const_get(:SLUG))
   end
+
+  def final_decision_templates
+    [Mails::WithoutContinuationMail.const_get(:SLUG), Mails::RefusedMail.const_get(:SLUG), Mails::ClosedMail.const_get(:SLUG)]
+  end
+
+  def not_editable?
+    @email_template.procedure.accuse_lecture? && final_decision_templates.include?(@email_template.class.const_get(:SLUG))
+  end
 end

--- a/app/components/procedure/email_template_card_component/email_template_card_component.html.haml
+++ b/app/components/procedure/email_template_card_component/email_template_card_component.html.haml
@@ -1,3 +1,7 @@
 = render Dsfr::CardVerticalComponent.new(title: title, desc: desc, error: error, tags: [tag]) do |c|
   - c.with_footer_button do
-    = link_to 'Modifier', edit_path, class: 'fr-btn'
+    - if not_editable?
+      %a{ role: "link", "aria-disabled" => "true", class: 'fr-link fr-icon-arrow-right-line fr-link--icon-right' }
+        Modifier
+    - else
+      = link_to 'Modifier', edit_path, class: 'fr-link fr-icon-arrow-right-line fr-link--icon-right'

--- a/app/views/administrateurs/mail_templates/index.html.haml
+++ b/app/views/administrateurs/mail_templates/index.html.haml
@@ -3,8 +3,25 @@
                     ["#{@procedure.libelle.truncate_words(10)}", admin_procedure_path(@procedure)],
                     ["Configuration des emails"]] }
 
-.container
-  .fr-grid-row.fr-grid-row--gutters.fr-py-5w
+.fr-container
+  .fr-grid-row.fr-grid-row--gutters
+    .fr-col-12
+      %h1 Configuration des emails
+      - if @procedure.accuse_lecture?
+        = render Dsfr::AlertComponent.new(state: :info, size: :sm) do |c|
+          - c.with_body do
+            %p
+              L'accusé de lecture est activé sur cette démarche. Dans ce contexte, les emails « d’acceptation », « de rejet » et de « classement sans suite », ne sont pas modifiables afin de s'assurer que la décision finale reste masquée pour l'usager.
+
     - @mail_templates.each do |mail_template|
       .fr-col-md-6.fr-col-12
         = render Procedure::EmailTemplateCardComponent.new(email_template: mail_template)
+
+
+.padded-fixed-footer
+  .fixed-footer
+    .fr-container
+      .fr-grid-row
+        .fr-col-12.fr-pb-2w
+          = link_to admin_procedure_path(id: @procedure), class: 'fr-link fr-icon-arrow-left-line fr-link--icon-left fr-mb-2w' do
+            Revenir à la démarche

--- a/app/views/administrateurs/procedures/accuse_lecture.html.haml
+++ b/app/views/administrateurs/procedures/accuse_lecture.html.haml
@@ -29,7 +29,7 @@
 
             = render Dsfr::ToggleComponent.new(form: f,
               target: :accuse_lecture,
-              title: "Accusé de lecture de la démarche",
+              title: "Accusé de lecture de la décision par l’usager",
               hint: "L’accusé de lecture est à activer uniquement pour les démarches avec voies de recours car il complexifie l’accès à la décision finale pour les usagers",
               opt: {"checked" => @procedure.accuse_lecture})
 


### PR DESCRIPTION
Suite à la MEP de l'accusé de lecture, j'avais eu 2 retours de wording et d'incomprehension sur pourquoi l'email n'etait pas modifié lorsqu'il y avait customisation du coté de l'admin.

Dans cette PR, on désactive les liens pour personnaliser les mails de décision finale, si l'accusé de reception est activé.

J'en ai profité pour passer du style "bouton" au style "lien" pour les liens "modifier" qui amènent sur une autre page et ajouter un footer pour faciliter la navigation.

**APRES**
<img width="1258" alt="Capture d’écran 2024-05-14 à 10 41 04" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/48e08793-6229-410a-8811-160961ffdfaa">

**AVANT**
<img width="1154" alt="Capture d’écran 2024-05-14 à 10 42 23" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/6756627/609f47cc-b92b-47a9-a21e-35db6363d257">

