### PR TITLE
Tech: l’affichage du bandeau .gouv.fr sticky à l'user

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,7 +13,7 @@ module ApplicationHelper
   end
 
   def switch_domain_enabled?(request)
-    request.params.key?(:switch_domain) || Flipper.enabled?(:switch_domain)
+    request.params.key?(:switch_domain) || Flipper.enabled?(:switch_domain, Current.user)
   end
 
   def html_lang


### PR DESCRIPTION
- permet d'activer à un certain % d'utilisateurs connectés, stable au fil des pages pour ce même user
- en revanche les non connectés ne le verront pas encore: (sinon le bandeau s'afficherait ou non aléatoirement suivant les pages tant qu'on est pas à 100%)