### PR TITLE
Tech (CI): agressive timeout because system tests sometimes hang forever

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
   unit_tests:
     name: Unit tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       RUBY_YJIT_ENABLE: "1"
     services:
@@ -113,6 +114,7 @@ jobs:
   system_tests:
     name: System tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       RUBY_YJIT_ENABLE: "1"
     services:


### PR DESCRIPTION
On a régulièrement les jobs des tests system qui hang à cause des I/O (log writing failed), et qui monopolisent des runners pour rien pendant des heures. En général, les jobs mettent ~6 minutes, avec un peu de marge je passe à 20min le timeout.