### PR TITLE
ETQ usager je vois les infos de contact de mon groupe instructeur avant dépôt du dossier, une fois le(s) champ(s) de routage rempli(s) 

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -558,6 +558,10 @@ module Users
       @dossier.update_champs_attributes(champs_public_attributes_params, :public, updated_by: current_user.email)
       if @dossier.champs.any?(&:changed_for_autosave?)
         @dossier.last_champ_updated_at = Time.zone.now
+
+        if @dossier.champs_public.filter(&:changed_for_autosave?).any?(&:used_by_routing_rules?)
+          RoutingEngine.compute(@dossier)
+        end
       end
 
       # We save the dossier without validating fields, and if it is successful and the client

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -559,7 +559,7 @@ module Users
       if @dossier.champs.any?(&:changed_for_autosave?)
         @dossier.last_champ_updated_at = Time.zone.now
 
-        if @dossier.champs_public.filter(&:changed_for_autosave?).any?(&:used_by_routing_rules?)
+        if @dossier.champs_public.any? { _1.changed_for_autosave? && _1.used_by_routing_rules? }
           RoutingEngine.compute(@dossier)
         end
       end

--- a/app/views/shared/dossiers/_update_contact_information.html.haml
+++ b/app/views/shared/dossiers/_update_contact_information.html.haml
@@ -1,0 +1,30 @@
+#contact_information
+  - service = dossier&.service || procedure.service
+  - if service.present?
+    %h3.fr-footer__top-cat= I18n.t('users.procedure_footer.managed_by.header')
+    .fr-footer__top-link.fr-pb-2w
+      %span{ lang: :fr }= service.pretty_nom
+      %div{ lang: :fr }
+        = render SimpleFormatComponent.new(service.adresse, class_names_map: {paragraph: 'fr-footer__content-desc'})
+  %h3.fr-footer__top-cat= I18n.t('users.procedure_footer.contact.header')
+  %ul.fr-footer__top-list
+    - if dossier.present? && dossier.messagerie_available?
+      %li
+        = link_to I18n.t('users.procedure_footer.contact.in_app_mail.link'), messagerie_dossier_path(dossier), class: 'fr-footer__top-link'
+    - elsif service.present?
+      %li
+        %span.fr-footer__top-link
+          = I18n.t('users.procedure_footer.contact.email.link')
+        = link_to service.email, "mailto:#{service.email}", class: "fr-footer__top-link"
+
+    - if service.present?
+      - if service.telephone.present? || service.horaires.present?
+        %li
+          - horaires = "#{I18n.t('users.procedure_footer.contact.schedule.prefix')}#{formatted_horaires(service.horaires)}"
+          - if service.telephone.present?
+            = link_to service.telephone_url, class: 'fr-footer__top-link' do
+              %p
+                = I18n.t('users.procedure_footer.contact.phone.link', service_telephone: service.telephone)
+              - if service.horaires.present?
+                %p
+                  = horaires

--- a/app/views/users/_procedure_footer.html.haml
+++ b/app/views/users/_procedure_footer.html.haml
@@ -1,37 +1,9 @@
 %footer.fr-footer.footer-procedure#footer{ role: "contentinfo" }
-  - service = dossier&.service || procedure.service
   .fr-footer__top.fr-mb-0
     .fr-container
       .fr-grid-row.fr-grid-row--start.fr-grid-row--gutters
         .fr-col-12.fr-col-sm-4.fr-col-md-4
-          - if service.present?
-            %h3.fr-footer__top-cat= I18n.t('users.procedure_footer.managed_by.header')
-            .fr-footer__top-link.fr-pb-2w
-              %span{ lang: :fr }= service.pretty_nom
-              %div{ lang: :fr }
-                = render SimpleFormatComponent.new(service.adresse, class_names_map: {paragraph: 'fr-footer__content-desc'})
-          %h3.fr-footer__top-cat= I18n.t('users.procedure_footer.contact.header')
-          %ul.fr-footer__top-list
-            - if dossier.present? && dossier.messagerie_available?
-              %li
-                = link_to I18n.t('users.procedure_footer.contact.in_app_mail.link'), messagerie_dossier_path(dossier), class: 'fr-footer__top-link'
-            - elsif service.present?
-              %li
-                %span.fr-footer__top-link
-                  = I18n.t('users.procedure_footer.contact.email.link')
-                = link_to service.email, "mailto:#{service.email}", class: "fr-footer__top-link"
-
-            - if service.present?
-              - if service.telephone.present? || service.horaires.present?
-                %li
-                  - horaires = "#{I18n.t('users.procedure_footer.contact.schedule.prefix')}#{formatted_horaires(service.horaires)}"
-                  - if service.telephone.present?
-                    = link_to service.telephone_url, class: 'fr-footer__top-link' do
-                      %p
-                        = I18n.t('users.procedure_footer.contact.phone.link', service_telephone: service.telephone)
-                      - if service.horaires.present?
-                        %p
-                          = horaires
+          = render partial: 'shared/dossiers/update_contact_information', locals: { dossier: dossier, procedure: procedure }
 
         - politiques = politiques_conservation_de_donnees(procedure)
         - if politiques.present?

--- a/app/views/users/dossiers/update.turbo_stream.haml
+++ b/app/views/users/dossiers/update.turbo_stream.haml
@@ -5,3 +5,5 @@
     = turbo_stream.append('contenu', render(Dossiers::InvalidIneligibiliteRulesComponent.new(dossier: @dossier)))
   - else @ineligibilite_rules_is_computable
     = turbo_stream.remove(dom_id(@dossier, :ineligibilite_rules_broken))
+
+= turbo_stream.update "contact_information", partial: 'shared/dossiers/update_contact_information', locals: { dossier: @dossier, procedure: @procedure }

--- a/app/views/users/dossiers/update.turbo_stream.haml
+++ b/app/views/users/dossiers/update.turbo_stream.haml
@@ -5,5 +5,5 @@
     = turbo_stream.append('contenu', render(Dossiers::InvalidIneligibiliteRulesComponent.new(dossier: @dossier)))
   - else @ineligibilite_rules_is_computable
     = turbo_stream.remove(dom_id(@dossier, :ineligibilite_rules_broken))
-
-= turbo_stream.update "contact_information", partial: 'shared/dossiers/update_contact_information', locals: { dossier: @dossier, procedure: @procedure }
+- if @dossier.champs.any? {  _1.used_by_routing_rules? && params[:dossier][:champs_public_attributes].key?(_1.stable_id.to_s) }
+  = turbo_stream.update "contact_information", partial: 'shared/dossiers/update_contact_information', locals: { dossier: @dossier, procedure: @procedure }

--- a/spec/system/routing/rules_full_scenario_spec.rb
+++ b/spec/system/routing/rules_full_scenario_spec.rb
@@ -125,6 +125,9 @@ describe 'The routing with rules', js: true do
     expect(page).to have_text('Le groupe d’instructeurs « artistique » a été créé. ')
     expect(procedure.groupe_instructeurs.count).to eq(4)
 
+    # add contact_information to all groupes instructeur
+    procedure.groupe_instructeurs.each { |gi| gi.update!(contact_information: create(:contact_information)) }
+
     # publish
     publish_procedure(procedure)
     log_out
@@ -267,8 +270,17 @@ describe 'The routing with rules', js: true do
     # the old system should not be present
     expect(page).not_to have_selector("#dossier_groupe_instructeur_id")
 
+    dossier = user.dossiers.first
+
+    expect(dossier.groupe_instructeur_id).to be_nil
+    expect(page).to have_text(procedure.service.nom)
+
     choose(groupe)
     wait_for_autosave
+
+    expect(dossier.reload.groupe_instructeur_id).not_to be_nil
+    expect(page).to have_text(dossier.service.nom)
+    expect(page).not_to have_text(procedure.service.nom)
 
     click_on 'Déposer le dossier'
     expect(page).to have_text('Merci')

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -674,7 +674,8 @@ describe 'The user' do
 
   def champ_for(libelle)
     champs = user_dossier.reload.champs_public
-    champs.find { |c| c.libelle == libelle }
+    champ = champs.find { |c| c.libelle == libelle }
+    champ.reload
   end
 
   def fill_individual


### PR DESCRIPTION
closes #10028

- Pour un dossier en brouillon, le routage est lancé suite à l'autosave d'un champ utilisé pour le routage. En même temps l'info de contact est mise à jour dans le footer
- On lance aussi le routage au dépôt du dossier (important si par exemple le champ de routage n'est pas obligatoire et pas rempli par l'usager)
- Lorsqu'un dossier en construction est modifié, le routage ne se fait pas en autosave mais que lorqu'il est re-déposé 

Démo du routage et mise à jour du foter en autosave : 

[Démo du routage et mise à jour du foter en autosave](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/29131404/19bf49fa-2cf1-48bb-8962-059d4fa049e9)

