### PR TITLE
Correctif : etq instructeur, je peux voir une preview de pdf

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,7 @@ gem 'openid_connect'
 gem 'parsby'
 gem 'pg'
 gem 'phonelib'
+gem 'poppler', '~> 3.0', '>= 3.0.7'
 gem 'prawn-rails' # PDF Generation
 gem 'premailer-rails'
 gem 'puma' # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,13 @@ GEM
       racc
     browser (5.3.1)
     builder (3.2.4)
+    cairo (1.17.13)
+      native-package-installer (>= 1.0.3)
+      pkg-config (>= 1.2.2)
+      red-colors
+    cairo-gobject (3.5.1)
+      cairo (>= 1.16.2)
+      glib2 (= 3.5.1)
     capybara (3.40.0)
       addressable
       matrix
@@ -252,6 +259,7 @@ GEM
     faraday-net_http (3.1.0)
       net-http
     ffi (1.16.3)
+    fiddle (1.1.2)
     flipper (1.2.2)
       concurrent-ruby (< 2)
     flipper-active_record (1.2.2)
@@ -284,8 +292,16 @@ GEM
       raabro (~> 1.4)
     geo_coord (0.2.0)
     geocoder (1.8.2)
+    gio2 (3.5.1)
+      fiddle
+      gobject-introspection (= 3.5.1)
+    glib2 (3.5.1)
+      native-package-installer (>= 1.0.3)
+      pkg-config (>= 1.3.5)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    gobject-introspection (3.5.1)
+      glib2 (= 3.5.1)
     gon (6.4.0)
       actionpack (>= 3.0.20)
       i18n (>= 0.7)
@@ -444,6 +460,7 @@ GEM
     multi_json (1.15.0)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
+    native-package-installer (1.1.9)
     net-http (0.4.1)
       uri
     net-imap (0.4.11)
@@ -481,6 +498,10 @@ GEM
     pdf-core (0.9.0)
     pg (1.5.6)
     phonelib (0.8.8)
+    pkg-config (1.5.6)
+    poppler (3.5.1)
+      cairo-gobject (= 3.5.1)
+      gio2 (= 3.5.1)
     prawn (2.4.0)
       pdf-core (~> 0.9.0)
       ttfunk (~> 1.7)
@@ -582,6 +603,9 @@ GEM
       ffi (~> 1.0)
     rdoc (6.6.3.1)
       psych (>= 4.0.0)
+    red-colors (0.4.0)
+      json
+      matrix
     redcarpet (3.6.0)
     redis (5.2.0)
       redis-client (>= 0.22.0)
@@ -968,6 +992,7 @@ DEPENDENCIES
   parsby
   pg
   phonelib
+  poppler (~> 3.0, >= 3.0.7)
   prawn-rails
   premailer-rails
   puma

--- a/app/views/instructeurs/dossiers/pieces_jointes.html.haml
+++ b/app/views/instructeurs/dossiers/pieces_jointes.html.haml
@@ -8,20 +8,20 @@
       - champ.piece_justificative_file.with_all_variant_records.each do |attachment|
         .gallery-item
           - blob = attachment.blob
-          - if blob.content_type.in?(AUTHORIZED_PDF_TYPES)
+          - if blob.previewable?
             = link_to blob.url, id: blob.id, data: { iframe: true, src: blob.url }, class: 'gallery-link', type: blob.content_type, title: "#{champ.libelle} -- #{blob.filename}" do
               .thumbnail
-                = image_tag(attachment.representation(resize_to_limit: [400, 400]).processed.url, loading: :lazy)
+                = image_tag(attachment.preview(resize_to_limit: [400, 400]).processed.url, loading: :lazy)
                 .fr-btn.fr-btn--tertiary.fr-btn--icon-left.fr-icon-eye{ role: :button }
                   Visualiser
             .champ-libelle
               = champ.libelle.truncate(25)
             = render Attachment::ShowComponent.new(attachment: attachment, truncate: true)
 
-          - elsif blob.content_type.in?(AUTHORIZED_IMAGE_TYPES)
+          - elsif blob.variable?
             = link_to image_url(blob.url), title: "#{champ.libelle} -- #{blob.filename}", data: { src: blob.url }, class: 'gallery-link' do
               .thumbnail
-                = image_tag(attachment.representation(resize_to_limit: [400, 400]).processed.url, loading: :lazy)
+                = image_tag(attachment.variant(resize_to_limit: [400, 400]).processed.url, loading: :lazy)
                 .fr-btn.fr-btn--tertiary.fr-btn--icon-left.fr-icon-eye{ role: :button }
                   Visualiser
             .champ-libelle

--- a/app/views/shared/champs/piece_justificative/_show.html.haml
+++ b/app/views/shared/champs/piece_justificative/_show.html.haml
@@ -8,17 +8,17 @@
       - champ.piece_justificative_file.attachments.with_all_variant_records.each do |attachment|
         .gallery-item
           - blob = attachment.blob
-          - if blob.content_type.in?(AUTHORIZED_PDF_TYPES)
+          - if blob.previewable?
             = link_to blob.url, id: blob.id, data: { iframe: true, src: blob.url }, class: 'gallery-link', type: blob.content_type, title: "#{champ.libelle} -- #{blob.filename}" do
               .thumbnail
-                = image_tag(attachment.representation(resize_to_limit: [400, 400]).processed.url, loading: :lazy)
+                = image_tag(attachment.preview(resize_to_limit: [400, 400]).processed.url, loading: :lazy)
                 .fr-btn.fr-btn--tertiary.fr-btn--icon-left.fr-icon-eye{ role: :button }
                   = 'Visualiser'
 
-          - elsif blob.content_type.in?(AUTHORIZED_IMAGE_TYPES)
+          - elsif blob.variable?
             = link_to image_url(blob.url), title: "#{champ.libelle} -- #{blob.filename}", data: { src: blob.url }, class: 'gallery-link' do
               .thumbnail
-                = image_tag(attachment.representation(resize_to_limit: [400, 400]).processed.url, loading: :lazy)
+                = image_tag(attachment.variant(resize_to_limit: [400, 400]).processed.url, loading: :lazy)
                 .fr-btn.fr-btn--tertiary.fr-btn--icon-left.fr-icon-eye{ role: :button }
                   = 'Visualiser'
           - else


### PR DESCRIPTION
La preview de pdf fonctionne en local mais pas en dev, où on a cette erreur : 
![C2F9A9DB-6FE0-4DAA-B62D-4E672872A891](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/29131404/e795547b-5757-4d00-b743-d89b3c07f8ce)

- j'ai regardé le code soure de `previewable?` : https://github.com/rails/rails/blob/56bcc0abd3c9a6b09469e9428f6eea0dd77c2294/activestorage/app/models/active_storage/blob/representable.rb
- qui renvoie vers `ActiveStorage.previewers`, soit `[ActiveStorage::Previewer::PopplerPDFPreviewer, ActiveStorage::Previewer::MuPDFPreviewer, ActiveStorage::Previewer::VideoPreviewer]`
- je suis aller voir dans le code des previewer Poppler et mupdf.
- c'est le meme fonctionnement dans les deux. Dans celle de Poppler (https://github.com/rails/rails/blob/56bcc0abd3c9a6b09469e9428f6eea0dd77c2294/activestorage/lib/active_storage/previewer/poppler_pdf_previewer.rb), il y a une methode `def pdftoppm_exists?` dont le contenu (`system(pdftoppm_path, "-v", out: File::NULL, err: File::NULL)`) renvoie nil en dev mais true en local.
Je pense que c'est la clé du prb. On a l'outil pdftoppm installé sur nos pc de dev mais pas sur les serveurs de dev/prod.

Dans le 2e commit de cette [PR](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/10438) j'ajoute la gem poppler, mais pas sûr que ce soit la bonne approche.
Peut-être qu'on peut plutôt faire une merge request sur le repo Ansible pour installer pdftoppm sur les serveurs de dev/prod ?
