### PR TITLE
Tech (css): maintient les labels de toggle sur une seule ligne

### DIFF
--- a/app/assets/stylesheets/dsfr.scss
+++ b/app/assets/stylesheets/dsfr.scss
@@ -179,3 +179,10 @@ button.fr-tag-bug {
   border: initial;
   display: block; // Pour cette valeur spécifique, on récupère celle de .fr-label
 }
+
+// Fix toggles having labels on 2 lines
+// From upstream https://github.com/GouvernementFR/dsfr/pull/928
+// Remove it when PR is merged (v1.12 ?)
+.fr-toggle label[data-fr-unchecked-label][data-fr-checked-label]::before {
+  word-wrap: normal;
+}

--- a/app/components/release_note/form_component/form_component.html.haml
+++ b/app/components/release_note/form_component/form_component.html.haml
@@ -6,7 +6,7 @@
 
     .fr-fieldset__element
       .fr-toggle
-        = f.check_box :published, class: "fr-toggle-input", id: dom_id(release_note, :published)
+        = f.check_box :published, class: "fr-toggle__input", id: dom_id(release_note, :published)
         %label.fr-toggle__label{ for: dom_id(release_note, :published), data: { fr_checked_label: "Publié", fr_unchecked_label: "Brouillon" } }
           Publier
 

--- a/app/views/administrateurs/attestation_template_v2s/edit.html.haml
+++ b/app/views/administrateurs/attestation_template_v2s/edit.html.haml
@@ -38,8 +38,8 @@
             %h2.fr-h4 En-tête
 
           .fr-fieldset__element
-            .fr-toggle
-              = f.check_box :official_layout, class: "fr-toggle-input", id: dom_id(@attestation_template, :official_layout), data: { "attestation-target": "layoutToggle"}
+            .fr-toggle.fr-toggle--label-left
+              = f.check_box :official_layout, class: "fr-toggle__input", id: dom_id(@attestation_template, :official_layout), data: { "attestation-target": "layoutToggle"}
               %label.fr-toggle__label{ for: dom_id(@attestation_template, :official_layout), data: { fr_checked_label: "Activé", fr_unchecked_label: "Désactivé" } }
                 Je souhaite générer une attestation à la charte de l’état (logo avec Marianne)
 


### PR DESCRIPTION
- Patch récupéré de https://github.com/GouvernementFR/dsfr/pull/928
- passe le label à gauche pour l'attestation v2