### PR TITLE
Correctif : restreint le type d'images à pré-traiter et à afficher dans la galerie

### DIFF
--- a/app/views/instructeurs/dossiers/pieces_jointes.html.haml
+++ b/app/views/instructeurs/dossiers/pieces_jointes.html.haml
@@ -18,7 +18,7 @@
               = champ.libelle.truncate(25)
             = render Attachment::ShowComponent.new(attachment: attachment, truncate: true)
 
-          - elsif blob.content_type.in?(AUTHORIZED_IMAGE_TYPES)
+          - elsif blob.content_type.in?(AUTHORIZED_GALLERY_IMAGE_TYPES)
             = link_to image_url(blob.url), title: "#{champ.libelle} -- #{blob.filename}", data: { src: blob.url }, class: 'gallery-link' do
               .thumbnail
                 = image_tag(attachment.variant(resize_to_limit: [400, 400]).processed.url, loading: :lazy)

--- a/app/views/instructeurs/dossiers/pieces_jointes.html.haml
+++ b/app/views/instructeurs/dossiers/pieces_jointes.html.haml
@@ -21,7 +21,10 @@
           - elsif blob.content_type.in?(AUTHORIZED_GALLERY_IMAGE_TYPES)
             = link_to image_url(blob.url), title: "#{champ.libelle} -- #{blob.filename}", data: { src: blob.url }, class: 'gallery-link' do
               .thumbnail
-                = image_tag(attachment.variant(resize_to_limit: [400, 400]).processed.url, loading: :lazy)
+                - if blob.content_type.in?(IMAGEMAGICK_COMPATIBLE_IMAGE_TYPES)
+                  = image_tag(attachment.variant(resize_to_limit: [400, 400]).processed.url, loading: :lazy)
+                - else
+                  = image_tag('apercu-indisponible.png')
                 .fr-btn.fr-btn--tertiary.fr-btn--icon-left.fr-icon-eye{ role: :button }
                   Visualiser
             .champ-libelle

--- a/app/views/shared/champs/piece_justificative/_show.html.haml
+++ b/app/views/shared/champs/piece_justificative/_show.html.haml
@@ -15,7 +15,7 @@
                 .fr-btn.fr-btn--tertiary.fr-btn--icon-left.fr-icon-eye{ role: :button }
                   = 'Visualiser'
 
-          - elsif blob.content_type.in?(AUTHORIZED_IMAGE_TYPES)
+          - elsif blob.content_type.in?(AUTHORIZED_GALLERY_IMAGE_TYPES)
             = link_to image_url(blob.url), title: "#{champ.libelle} -- #{blob.filename}", data: { src: blob.url }, class: 'gallery-link' do
               .thumbnail
                 = image_tag(attachment.variant(resize_to_limit: [400, 400]).processed.url, loading: :lazy)

--- a/app/views/shared/champs/piece_justificative/_show.html.haml
+++ b/app/views/shared/champs/piece_justificative/_show.html.haml
@@ -18,7 +18,10 @@
           - elsif blob.content_type.in?(AUTHORIZED_GALLERY_IMAGE_TYPES)
             = link_to image_url(blob.url), title: "#{champ.libelle} -- #{blob.filename}", data: { src: blob.url }, class: 'gallery-link' do
               .thumbnail
-                = image_tag(attachment.variant(resize_to_limit: [400, 400]).processed.url, loading: :lazy)
+                - if blob.content_type.in?(IMAGEMAGICK_COMPATIBLE_IMAGE_TYPES)
+                  = image_tag(attachment.variant(resize_to_limit: [400, 400]).processed.url, loading: :lazy)
+                - else
+                  = image_tag('apercu-indisponible.png')
                 .fr-btn.fr-btn--tertiary.fr-btn--icon-left.fr-icon-eye{ role: :button }
                   = 'Visualiser'
           - else

--- a/config/initializers/authorized_content_types.rb
+++ b/config/initializers/authorized_content_types.rb
@@ -24,6 +24,11 @@ AUTHORIZED_GALLERY_IMAGE_TYPES = [
   'image/vnd.dwg' # multimedia x 137 auto desk
 ]
 
+IMAGEMAGICK_COMPATIBLE_IMAGE_TYPES = [
+  'image/jpeg', # multimedia x 1467465
+  'image/png', # multimedia x 126662
+]
+
 AUTHORIZED_CONTENT_TYPES = AUTHORIZED_IMAGE_TYPES + AUTHORIZED_PDF_TYPES + [
   # multimedia
   'video/mp4', # multimedia x 2075

--- a/config/initializers/authorized_content_types.rb
+++ b/config/initializers/authorized_content_types.rb
@@ -15,6 +15,15 @@ AUTHORIZED_IMAGE_TYPES = [
   'image/vnd.dwg' # multimedia x 137 auto desk
 ]
 
+AUTHORIZED_GALLERY_IMAGE_TYPES = [
+  'image/jpeg', # multimedia x 1467465
+  'image/png', # multimedia x 126662
+  'image/bmp', # multimedia x 3656
+  'image/webp', # multimedia x 529
+  'image/gif', # multimedia x 463
+  'image/vnd.dwg' # multimedia x 137 auto desk
+]
+
 AUTHORIZED_CONTENT_TYPES = AUTHORIZED_IMAGE_TYPES + AUTHORIZED_PDF_TYPES + [
   # multimedia
   'video/mp4', # multimedia x 2075


### PR DESCRIPTION
- On n'affiche pas les tiff dans la galerie car la lib ne permet pas leur affichage
- En attendant des évolutions côté ops, on n'affiche des aperçus que pour les images de type jpg et png