### PR TITLE
corrige quelques bugs de la feature export template (renommage dans le zip)

### DIFF
--- a/app/components/dossiers/export_dropdown_component/export_dropdown_component.html.haml
+++ b/app/components/dossiers/export_dropdown_component/export_dropdown_component.html.haml
@@ -15,12 +15,12 @@
       = link_to download_export_path(export_format: format), role: 'menuitem', data: { turbo_method: :post, turbo: true } do
         = t(".everything_#{format}_html")
 
-  - if export_templates.present?
-    - export_templates.each do |export_template|
+  - if @procedure.feature_enabled?(:export_template)
+    - if export_templates.present?
+      - export_templates.each do |export_template|
+        - menu.with_item do
+          = link_to download_export_path(export_template_id: export_template.id), role: 'menuitem', data: { turbo_method: :post, turbo: true } do
+            = "Exporter à partir du modèle #{export_template.name}"
       - menu.with_item do
-        = link_to download_export_path(export_template_id: export_template.id), role: 'menuitem', data: { turbo_method: :post, turbo: true } do
-          = "Exporter à partir du modèle #{export_template.name}"
-  - if feature_enabled?(:export_template)
-    - menu.with_item do
-      = link_to new_instructeur_export_template_path(procedure_id: params[:procedure_id]), role: 'menuitem' do
-        Ajouter un modèle d'export
+        = link_to new_instructeur_export_template_path(procedure_id: params[:procedure_id]), role: 'menuitem' do
+          Ajouter un modèle d'export

--- a/app/components/dossiers/export_link_component.rb
+++ b/app/components/dossiers/export_link_component.rb
@@ -11,9 +11,10 @@ class Dossiers::ExportLinkComponent < ApplicationComponent
     @export_url = export_url
   end
 
-  def download_export_path(export_format:, statut:, no_progress_notification: nil)
+  def download_export_path(export_format:, statut:, export_template_id: nil, no_progress_notification: nil)
     @export_url.call(@procedure,
       export_format: export_format,
+      export_template_id:,
       statut: statut,
       no_progress_notification: no_progress_notification)
   end

--- a/app/components/dossiers/export_link_component/export_link_component.html.haml
+++ b/app/components/dossiers/export_link_component/export_link_component.html.haml
@@ -7,6 +7,9 @@
             = export_title(export)
           %span.fr-text-mention--grey.fr-mb-1w
             = time_info(export)
+          - if export.export_template
+            %span.fr-tag.fr-tag--sm.fr-ml-1w
+              = export.export_template.name
         .fr-ml-auto
           = badge(export)
 

--- a/app/components/dossiers/export_link_component/export_link_component.html.haml
+++ b/app/components/dossiers/export_link_component/export_link_component.html.haml
@@ -14,4 +14,4 @@
         = export_button(export)
 
         - if export.failed?
-          = button_to refresh_button_options(export)[:title], download_export_path(export_format: export.format, statut: export.statut), refresh_button_options(export)
+          = button_to refresh_button_options(export)[:title], download_export_path(export_template_id: export.export_template&.id, export_format: export.format, statut: export.statut), refresh_button_options(export)

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -91,10 +91,6 @@ class Champ < ApplicationRecord
     parent_id.present?
   end
 
-  def stable_id_with_row
-    [row_id, stable_id].compact
-  end
-
   # used for the `required` html attribute
   # check visibility to avoid hidden required input
   # which prevent the form from being sent.

--- a/app/models/concerns/tags_substitution_concern.rb
+++ b/app/models/concerns/tags_substitution_concern.rb
@@ -307,7 +307,8 @@ module TagsSubstitutionConcern
 
   def format_date(date)
     if date.present?
-      date.strftime('%d/%m/%Y')
+      format = defined?(self.class::FORMAT_DATE) ? self.class::FORMAT_DATE : '%d/%m/%Y'
+      date.strftime(format)
     else
       ''
     end

--- a/app/models/export_template.rb
+++ b/app/models/export_template.rb
@@ -7,6 +7,7 @@ class ExportTemplate < ApplicationRecord
   validates_with ExportTemplateValidator
 
   DOSSIER_STATE = Dossier.states.fetch(:en_construction)
+  FORMAT_DATE = "%Y-%m-%d"
 
   def set_default_values
     content["default_dossier_directory"] = tiptap_json("dossier-")

--- a/app/models/export_template.rb
+++ b/app/models/export_template.rb
@@ -48,7 +48,7 @@ class ExportTemplate < ApplicationRecord
   def attachment_and_path(dossier, attachment, index: 0, row_index: nil, champ: nil)
     [
       attachment,
-      path(dossier, attachment, index, row_index, champ)
+      path(dossier, attachment, index:, row_index:, champ:)
     ]
   end
 
@@ -116,7 +116,7 @@ class ExportTemplate < ApplicationRecord
     "#{render_attributes_for(content["pdf_name"], dossier)}.pdf"
   end
 
-  def path(dossier, attachment, index, row_index, champ)
+  def path(dossier, attachment, index: 0, row_index: nil, champ: nil)
     if attachment.name == 'pdf_export_for_instructeur'
       return export_path(dossier)
     end

--- a/app/models/export_template.rb
+++ b/app/models/export_template.rb
@@ -128,7 +128,7 @@ class ExportTemplate < ApplicationRecord
       'messagerie'
     when 'Avis'
       'avis'
-    when 'Attestation'
+    when 'Attestation', 'Etablissement'
       'pieces_justificatives'
     else
       # for attachment

--- a/app/models/export_template.rb
+++ b/app/models/export_template.rb
@@ -128,6 +128,8 @@ class ExportTemplate < ApplicationRecord
       'messagerie'
     when 'Avis'
       'avis'
+    when 'Attestation'
+      'pieces_justificatives'
     else
       # for attachment
       return attachment_path(dossier, attachment, index, row_index, champ)

--- a/app/services/pieces_justificatives_service.rb
+++ b/app/services/pieces_justificatives_service.rb
@@ -169,7 +169,12 @@ class PiecesJustificativesService
       .filter { |a| safe_attachment(a) }
       .map do |a|
         dossier_id = commentaire_id_dossier_id[a.record_id]
-        ActiveStorage::DownloadableFile.pj_and_path(dossier_id, a)
+        if @export_template
+          dossier = dossiers.find { _1.id == dossier_id }
+          @export_template.attachment_and_path(dossier, a)
+        else
+          ActiveStorage::DownloadableFile.pj_and_path(dossier_id, a)
+        end
       end
   end
 

--- a/app/services/pieces_justificatives_service.rb
+++ b/app/services/pieces_justificatives_service.rb
@@ -206,7 +206,12 @@ class PiecesJustificativesService
       .filter { |a| safe_attachment(a) }
       .map do |a|
         dossier_id = a.record_id
-        ActiveStorage::DownloadableFile.pj_and_path(dossier_id, a)
+        if @export_template
+          dossier = dossiers.find { _1.id == dossier_id }
+          @export_template.attachment_and_path(dossier, a)
+        else
+          ActiveStorage::DownloadableFile.pj_and_path(dossier_id, a)
+        end
       end
   end
 

--- a/app/services/pieces_justificatives_service.rb
+++ b/app/services/pieces_justificatives_service.rb
@@ -195,7 +195,12 @@ class PiecesJustificativesService
       .where(record_type: "Etablissement", record_id: etablissement_id_dossier_id.keys)
       .map do |a|
         dossier_id = etablissement_id_dossier_id[a.record_id]
-        ActiveStorage::DownloadableFile.pj_and_path(dossier_id, a)
+        if @export_template
+          dossier = dossiers.find { _1.id == dossier_id }
+          @export_template.attachment_and_path(dossier, a)
+        else
+          ActiveStorage::DownloadableFile.pj_and_path(dossier_id, a)
+        end
       end
   end
 

--- a/app/services/pieces_justificatives_service.rb
+++ b/app/services/pieces_justificatives_service.rb
@@ -246,7 +246,12 @@ class PiecesJustificativesService
       .filter { |a| safe_attachment(a) }
       .map do |a|
         dossier_id = avis_ids_dossier_id[a.record_id]
-        ActiveStorage::DownloadableFile.pj_and_path(dossier_id, a)
+        if @export_template
+          dossier = dossiers.find { _1.id == dossier_id }
+          @export_template.attachment_and_path(dossier, a)
+        else
+          ActiveStorage::DownloadableFile.pj_and_path(dossier_id, a)
+        end
       end
   end
 

--- a/app/services/pieces_justificatives_service.rb
+++ b/app/services/pieces_justificatives_service.rb
@@ -227,7 +227,12 @@ class PiecesJustificativesService
       .where(record_type: "Attestation", record_id: attestation_id_dossier_id.keys)
       .map do |a|
         dossier_id = attestation_id_dossier_id[a.record_id]
-        ActiveStorage::DownloadableFile.pj_and_path(dossier_id, a)
+        if @export_template
+          dossier = dossiers.find { _1.id == dossier_id }
+          @export_template.attachment_and_path(dossier, a)
+        else
+          ActiveStorage::DownloadableFile.pj_and_path(dossier_id, a)
+        end
       end
   end
 

--- a/app/views/instructeurs/procedures/exports.html.haml
+++ b/app/views/instructeurs/procedures/exports.html.haml
@@ -23,7 +23,7 @@
   - else
     = t('.no_export_html', expiration_time: Export::MAX_DUREE_CONSERVATION_EXPORT.in_hours.to_i )
 
-  - if feature_enabled?(:export_template)
+  - if @procedure.feature_enabled?(:export_template)
     %h2.fr-mb-1w.fr-mt-8w
       Liste des modèles d'export
     %p.fr-hint-text

--- a/spec/factories/export_template.rb
+++ b/spec/factories/export_template.rb
@@ -64,5 +64,25 @@ FactoryBot.define do
         export_template.save
       end
     end
+
+    trait :with_date_depot_for_export_pdf do
+      to_create do |export_template, _|
+        export_template.set_default_values
+        export_template.content["pdf_name"]["content"] = [
+          {
+            "type" => "paragraph",
+            "content" =>
+            [
+              { "text" => "export_", "type" => "text" },
+              { "type" => "mention", "attrs" => { "id" => "dossier_number", "label" => "numéro du dossier" } },
+              { "text" => "-", "type" => "text" },
+              { "type" => "mention", "attrs" => { "id" => "dossier_depose_at", "label" => "date de dépôt" } },
+              { "text" => " ", "type" => "text" }
+            ]
+          }
+        ]
+        export_template.save
+      end
+    end
   end
 end

--- a/spec/factories/export_template.rb
+++ b/spec/factories/export_template.rb
@@ -11,24 +11,36 @@ FactoryBot.define do
       { "type" => "paragraph", "content" => [{ "text" => "export_", "type" => "text" }, { "type" => "mention", "attrs" => { "id" => "dossier_id", "label" => "id dossier" } }, { "text" => " .pdf", "type" => "text" }] }
     ]
    },
- "default_dossier_directory" =>
- {
-   "type" => "doc",
-  "content" =>
- [
-   {
-     "type" => "paragraph",
-      "content" =>
-    [
-      { "text" => "dossier_", "type" => "text" },
-      { "type" => "mention", "attrs" => { "id" => "dossier_number", "label" => "numéro du dossier" } },
-      { "text" => " ", "type" => "text" }
-    ]
+   "default_dossier_directory" => {
+     "type" => "doc",
+     "content" =>
+     [
+       {
+         "type" => "paragraph",
+         "content" =>
+         [
+           { "text" => "dossier_", "type" => "text" },
+           { "type" => "mention", "attrs" => { "id" => "dossier_number", "label" => "numéro du dossier" } },
+           { "text" => " ", "type" => "text" }
+         ]
+       }
+     ]
    }
- ]
- }
   }
 }
     kind { "zip" }
+
+    to_create do |export_template, _context|
+      export_template.set_default_values
+      export_template.save
+    end
+
+    trait :with_custom_content do
+      to_create do |export_template, context|
+        export_template.set_default_values
+        export_template.content = context.content
+        export_template.save
+      end
+    end
   end
 end

--- a/spec/factories/export_template.rb
+++ b/spec/factories/export_template.rb
@@ -42,5 +42,27 @@ FactoryBot.define do
         export_template.save
       end
     end
+
+    trait :with_custom_ddd_prefix do
+      transient do
+        ddd_prefix { 'dossier_' }
+      end
+
+      to_create do |export_template, context|
+        export_template.set_default_values
+        export_template.content["default_dossier_directory"]["content"] = [
+          {
+            "type" => "paragraph",
+            "content" =>
+            [
+              { "text" => context.ddd_prefix, "type" => "text" },
+              { "type" => "mention", "attrs" => { "id" => "dossier_number", "label" => "numéro du dossier" } },
+              { "text" => " ", "type" => "text" }
+            ]
+          }
+        ]
+        export_template.save
+      end
+    end
   end
 end

--- a/spec/models/export_template_spec.rb
+++ b/spec/models/export_template_spec.rb
@@ -1,6 +1,6 @@
 describe ExportTemplate do
   let(:groupe_instructeur) { create(:groupe_instructeur, procedure:) }
-  let(:export_template) { create(:export_template, groupe_instructeur:, content:) }
+  let(:export_template) { create(:export_template, :with_custom_content, groupe_instructeur:, content:) }
   let(:procedure) { create(:procedure_with_dossiers, types_de_champ_public:, for_individual:) }
   let(:dossier) { procedure.dossiers.first }
   let(:for_individual) { false }

--- a/spec/models/export_template_spec.rb
+++ b/spec/models/export_template_spec.rb
@@ -69,6 +69,22 @@ describe ExportTemplate do
     end
   end
 
+  describe '#assign_pj_names' do
+    let(:pj_params) do
+      {
+        "tiptap_pj_1" => {
+          "type" => "doc", "content" => [{ "type" => "paragraph", "content" => [{ "type" => "text", "text" => "avis-commission-" }, { "type" => "mention", "attrs" => { "id" => "dossier_number", "label" => "numéro du dossier" } }] }]
+        }.to_json
+      }
+    end
+    it 'values content from pj params' do
+      export_template.assign_pj_names(pj_params)
+      expect(export_template.content["pjs"]).to eq [
+        { :path => { "content" => [{ "content" => [{ "text" => "avis-commission-", "type" => "text" }, { "attrs" => { "id" => "dossier_number", "label" => "numéro du dossier" }, "type" => "mention" }], "type" => "paragraph" }], "type" => "doc" }, :stable_id => "1" }
+      ]
+    end
+  end
+
   describe '#tiptap_default_dossier_directory' do
     it 'returns tiptap_default_dossier_directory from content' do
       expect(export_template.tiptap_default_dossier_directory).to eq({
@@ -297,20 +313,36 @@ describe ExportTemplate do
     end
   end
 
-  describe 'specific_tags' do
-    context 'for entreprise procedure' do
-      let(:for_individual) { false }
+  context 'for entreprise procedure' do
+    let(:for_individual) { false }
+    describe 'specific_tags' do
       it do
         tags = export_template.specific_tags
         expect(tags.map { _1[:id] }).to eq ["entreprise_siren", "entreprise_numero_tva_intracommunautaire", "entreprise_siret_siege_social", "entreprise_raison_sociale", "entreprise_adresse", "dossier_depose_at", "dossier_procedure_libelle", "dossier_service_name", "dossier_number", "dossier_groupe_instructeur"]
       end
     end
 
-    context 'for individual procedure' do
-      let(:for_individual) { true }
+    describe 'tags_for_pj' do
+      it do
+        tags = export_template.tags_for_pj
+        expect(tags.map { _1[:id] }).to eq ["entreprise_siren", "entreprise_numero_tva_intracommunautaire", "entreprise_siret_siege_social", "entreprise_raison_sociale", "entreprise_adresse", "dossier_depose_at", "dossier_procedure_libelle", "dossier_service_name", "dossier_number", "dossier_groupe_instructeur", "original-filename"]
+      end
+    end
+  end
+
+  context 'for individual procedure' do
+    let(:for_individual) { true }
+    describe 'specific_tags' do
       it do
         tags = export_template.specific_tags
         expect(tags.map { _1[:id] }).to eq ["individual_gender", "individual_last_name", "individual_first_name", "dossier_depose_at", "dossier_procedure_libelle", "dossier_service_name", "dossier_number", "dossier_groupe_instructeur"]
+      end
+    end
+
+    describe 'tags_for_pj' do
+      it do
+        tags = export_template.tags_for_pj
+        expect(tags.map { _1[:id] }).to eq ["individual_gender", "individual_last_name", "individual_first_name", "dossier_depose_at", "dossier_procedure_libelle", "dossier_service_name", "dossier_number", "dossier_groupe_instructeur", "original-filename"]
       end
     end
   end

--- a/spec/models/export_template_spec.rb
+++ b/spec/models/export_template_spec.rb
@@ -190,6 +190,14 @@ describe ExportTemplate do
     it 'convert pdf_name' do
       expect(export_template.tiptap_convert(procedure.dossiers.first, "pdf_name")).to eq "mon_export_#{dossier.id}"
     end
+
+    context 'for date' do
+      let(:export_template) { create(:export_template, :with_date_depot_for_export_pdf, groupe_instructeur:) }
+      let(:dossier) { create(:dossier, :en_construction, procedure:, depose_at: Date.parse("2024/03/30")) }
+      it 'convert date with dash' do
+        expect(export_template.tiptap_convert(dossier, "pdf_name")).to eq "export_#{dossier.id}-2024-03-30"
+      end
+    end
   end
 
   describe '#tiptap_convert_pj' do

--- a/spec/services/pieces_justificatives_service_spec.rb
+++ b/spec/services/pieces_justificatives_service_spec.rb
@@ -236,6 +236,17 @@ describe PiecesJustificativesService do
         end
 
         it { expect(subject).to match_array([attestation_sociale.attachment, attestation_fiscale.attachment]) }
+
+        it 'uses default name for dossier directory' do
+          expect(PiecesJustificativesService.new(user_profile:, export_template: nil).liste_documents(dossiers).map(&:second)[0].starts_with?("dossier-#{dossier.id}/pieces_justificatives")).to be true
+        end
+
+        context 'with export_template' do
+          let(:export_template) { create(:export_template, :with_custom_ddd_prefix, ddd_prefix: "DOSSIER-", groupe_instructeur: procedure.defaut_groupe_instructeur) }
+          it 'uses specific name for dossier directory' do
+            expect(PiecesJustificativesService.new(user_profile:, export_template:).liste_documents(dossiers).map(&:second)[0].starts_with?("DOSSIER-#{dossier.id}/pieces_justificatives")).to be true
+          end
+        end
       end
     end
 

--- a/spec/services/pieces_justificatives_service_spec.rb
+++ b/spec/services/pieces_justificatives_service_spec.rb
@@ -209,6 +209,16 @@ describe PiecesJustificativesService do
         let!(:witness) { create(:dossier, :with_attestation) }
 
         it { expect(subject).to match_array(dossier.attestation.pdf.attachment) }
+        it 'uses default name for dossier directory' do
+          expect(PiecesJustificativesService.new(user_profile:, export_template: nil).liste_documents(dossiers).map(&:second)[0].starts_with?("dossier-#{dossier.id}/pieces_justificatives")).to be true
+        end
+
+        context 'with export_template' do
+          let(:export_template) { create(:export_template, :with_custom_ddd_prefix, ddd_prefix: "DOSSIER-", groupe_instructeur: procedure.defaut_groupe_instructeur) }
+          it 'uses specific name for dossier directory' do
+            expect(PiecesJustificativesService.new(user_profile:, export_template:).liste_documents(dossiers).map(&:second)[0].starts_with?("DOSSIER-#{dossier.id}/pieces_justificatives")).to be true
+          end
+        end
       end
 
       context 'with an etablissement' do

--- a/spec/services/pieces_justificatives_service_spec.rb
+++ b/spec/services/pieces_justificatives_service_spec.rb
@@ -110,7 +110,7 @@ describe PiecesJustificativesService do
         it { expect(subject).to match_array(pj_champ.call(dossier).piece_justificative_file.attachments) }
 
         context 'with export_template' do
-          let(:export_template) { create(:export_template, groupe_instructeur: procedure.defaut_groupe_instructeur).tap(&:set_default_values) }
+          let(:export_template) { create(:export_template, groupe_instructeur: procedure.defaut_groupe_instructeur) }
           it { expect(subject).to match_array(pj_champ.call(dossier).piece_justificative_file.attachments) }
         end
       end

--- a/spec/services/pieces_justificatives_service_spec.rb
+++ b/spec/services/pieces_justificatives_service_spec.rb
@@ -387,6 +387,13 @@ describe PiecesJustificativesService do
           it "return confidentiel avis.piece_justificative_file" do
             expect(subject.size).to eq(2)
           end
+
+          context 'with export_template' do
+            let(:export_template) { create(:export_template, :with_custom_ddd_prefix, ddd_prefix: "DOSSIER-", groupe_instructeur: procedure.defaut_groupe_instructeur) }
+            it 'uses specific name for dossier directory' do
+              expect(PiecesJustificativesService.new(user_profile:, export_template:).liste_documents(dossiers).map(&:second)[0].starts_with?("DOSSIER-#{dossier.id}/avis")).to be true
+            end
+          end
         end
 
         context 'given an expert' do

--- a/spec/services/pieces_justificatives_service_spec.rb
+++ b/spec/services/pieces_justificatives_service_spec.rb
@@ -323,14 +323,14 @@ describe PiecesJustificativesService do
 
         context 'given an administrateur' do
           let(:user_profile) { build(:administrateur) }
-          it "doesn't return confidentiel avis.piece_justificative_file" do
+          it "return confidentiel avis.piece_justificative_file" do
             expect(subject.size).to eq(2)
           end
         end
 
         context 'given an instructeur' do
           let(:user_profile) { create(:instructeur) }
-          it "doesn't return confidentiel avis.piece_justificative_file" do
+          it "return confidentiel avis.piece_justificative_file" do
             expect(subject.size).to eq(2)
           end
         end
@@ -346,7 +346,7 @@ describe PiecesJustificativesService do
           let(:experts_procedure) { create(:experts_procedure, expert: user_profile, procedure:) }
           let(:avis) { create(:avis, experts_procedure:, dossier: dossier, confidentiel: true) }
           let(:user_profile) { create(:expert) }
-          it "doesn't return confidentiel avis.piece_justificative_file" do
+          it "return confidentiel avis.piece_justificative_file" do
             expect(subject.size).to eq(2)
           end
         end
@@ -370,21 +370,21 @@ describe PiecesJustificativesService do
 
         context 'given an administrateur' do
           let(:user_profile) { build(:administrateur) }
-          it "doesn't return confidentiel avis.piece_justificative_file" do
+          it "return confidentiel avis.piece_justificative_file" do
             expect(subject.size).to eq(2)
           end
         end
 
         context 'given an instructeur' do
           let(:user_profile) { create(:instructeur) }
-          it "doesn't return confidentiel avis.piece_justificative_file" do
+          it "return confidentiel avis.piece_justificative_file" do
             expect(subject.size).to eq(2)
           end
         end
 
         context 'given an expert' do
           let(:user_profile) { create(:expert) }
-          it "doesn't return confidentiel avis.piece_justificative_file" do
+          it "return confidentiel avis.piece_justificative_file" do
             expect(subject.size).to eq(2)
           end
         end

--- a/spec/services/pieces_justificatives_service_spec.rb
+++ b/spec/services/pieces_justificatives_service_spec.rb
@@ -164,6 +164,13 @@ describe PiecesJustificativesService do
         end
 
         it { expect(subject).to match_array(dossier.commentaires.first.piece_jointe.attachments) }
+
+        context 'with export_template' do
+          let(:export_template) { create(:export_template, :with_custom_ddd_prefix, ddd_prefix: "DOSSIER-", groupe_instructeur: procedure.defaut_groupe_instructeur) }
+          it 'uses specific name for dossier directory' do
+            expect(PiecesJustificativesService.new(user_profile:, export_template:).liste_documents(dossiers).map(&:second)[0].starts_with?("DOSSIER-#{dossier.id}/messagerie")).to be true
+          end
+        end
       end
 
       context 'with a pj not safe on a commentaire' do

--- a/spec/services/pieces_justificatives_service_spec.rb
+++ b/spec/services/pieces_justificatives_service_spec.rb
@@ -187,6 +187,13 @@ describe PiecesJustificativesService do
         let!(:witness) { create(:dossier, :with_justificatif) }
 
         it { expect(subject).to match_array(dossier.justificatif_motivation.attachment) }
+
+        context 'with export_template' do
+          let(:export_template) { create(:export_template, :with_custom_ddd_prefix, ddd_prefix: "DOSSIER-", groupe_instructeur: procedure.defaut_groupe_instructeur) }
+          it 'uses specific name for dossier directory' do
+            expect(PiecesJustificativesService.new(user_profile:, export_template:).liste_documents(dossiers).map(&:second)[0].starts_with?("DOSSIER-#{dossier.id}/dossier")).to be true
+          end
+        end
       end
 
       context 'with a motivation not safe' do

--- a/spec/services/procedure_export_service_spec.rb
+++ b/spec/services/procedure_export_service_spec.rb
@@ -529,7 +529,7 @@ describe ProcedureExportService do
       context 'with export_template' do
         let!(:dossier) { create(:dossier, :accepte, :with_populated_champs, :with_individual, procedure: procedure) }
         let(:dossier_exports) { PiecesJustificativesService.new(user_profile: instructeur, export_template:).generate_dossiers_export(Dossier.where(id: dossier)) }
-        let(:export_template) { create(:export_template, groupe_instructeur: procedure.defaut_groupe_instructeur).tap(&:set_default_values) }
+        let(:export_template) { create(:export_template, groupe_instructeur: procedure.defaut_groupe_instructeur) }
         before do
           allow_any_instance_of(ActiveStorage::Attachment).to receive(:url).and_return("https://opengraph.githubassets.com/d0e7862b24d8026a3c03516d865b28151eb3859029c6c6c2e86605891fbdcd7a/socketry/async-io")
         end

--- a/spec/services/procedure_export_service_zip_spec.rb
+++ b/spec/services/procedure_export_service_zip_spec.rb
@@ -2,7 +2,7 @@ describe ProcedureExportService do
   let(:instructeur) { create(:instructeur) }
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative, libelle: 'pj' }, { type: :repetition, children: [{ type: :piece_justificative, libelle: 'repet_pj' }] }]) }
   let(:dossiers) { create_list(:dossier, 10, procedure: procedure) }
-  let(:export_template) { create(:export_template, groupe_instructeur: procedure.defaut_groupe_instructeur).tap(&:set_default_values) }
+  let(:export_template) { create(:export_template, groupe_instructeur: procedure.defaut_groupe_instructeur) }
   let(:service) { ProcedureExportService.new(procedure, procedure.dossiers, instructeur, export_template) }
 
   def pj_champ(d) = d.champs_public.find_by(type: 'Champs::PieceJustificativeChamp')


### PR DESCRIPTION
Cette PR : 

- permet d'utiliser le feature flag `export_template` au niveau d'une procédure
- affiche le nom du modèle d'export dans la liste des exports (voir screenshot plus bas)
- corrige la regénération d'export après erreur, lorsque l'export est généré à partir d'un modèle d'export
- corrige dans le zip généré le nom du répertoire de chaque dossier pour les pj des commentaires, avis,  attestations et motivations
- ajoute quelques tests à la feature export template 
- supprime du code mort

![2024-05-29-164145_933x106_scrot](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/1111966/0d70e8ed-5981-48d9-86b3-39d5655f0190)
