### PR TITLE
ETQ Mainteneur, les emails non vérifiés ne sont pas envoyés

### DIFF
--- a/app/controllers/instructeurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/instructeurs/groupe_instructeurs_controller.rb
@@ -65,7 +65,7 @@ module Instructeurs
         administrateurs: [procedure.administrateurs.first]
       )
 
-      user.invite! if user.valid?
+      user.invite_instructeur! if user.valid?
       user.instructeur
     end
 

--- a/app/controllers/manager/instructeurs_controller.rb
+++ b/app/controllers/manager/instructeurs_controller.rb
@@ -2,7 +2,7 @@ module Manager
   class InstructeursController < Manager::ApplicationController
     def reinvite
       instructeur = Instructeur.find(params[:id])
-      instructeur.user.invite!
+      instructeur.user.invite_instructeur!
       flash[:notice] = "Instructeur réinvité."
       redirect_to manager_instructeur_path(instructeur)
     end

--- a/app/lib/balancer_delivery_method.rb
+++ b/app/lib/balancer_delivery_method.rb
@@ -14,6 +14,7 @@
 #
 # Be sure to restart your server when you modify this file.
 class BalancerDeliveryMethod
+  BYPASS_UNVERIFIED_MAIL_PROTECTION = 'BYPASS_UNVERIFIED_MAIL_PROTECTION'.freeze
   FORCE_DELIVERY_METHOD_HEADER = 'X-deliver-with'
   # Allows configuring the random number generator used for selecting a delivery method,
   # mostly for testing purposes.
@@ -24,6 +25,8 @@ class BalancerDeliveryMethod
   end
 
   def deliver!(mail)
+    return if prevent_delivery?(mail)
+
     balanced_delivery_method = delivery_method(mail)
     ApplicationMailer.wrap_delivery_behavior(mail, balanced_delivery_method)
 
@@ -39,6 +42,18 @@ class BalancerDeliveryMethod
   end
 
   private
+
+  def prevent_delivery?(mail)
+    return false if mail[BYPASS_UNVERIFIED_MAIL_PROTECTION].present?
+
+    user = User.find_by(email: mail.to.first)
+    return user.unverified_email? if user.present?
+
+    individual = Individual.find_by(email: mail.to.first)
+    return individual.unverified_email? if individual.present?
+
+    true
+  end
 
   def force_delivery_method?(mail)
     @delivery_methods.keys.map(&:to_s).include?(mail[FORCE_DELIVERY_METHOD_HEADER]&.value)

--- a/app/mailers/administrateur_mailer.rb
+++ b/app/mailers/administrateur_mailer.rb
@@ -8,6 +8,8 @@ class AdministrateurMailer < ApplicationMailer
     @expiration_date = @user.reset_password_sent_at + Devise.reset_password_within
     @subject = "N'oubliez pas d’activer votre compte administrateur"
 
+    bypass_unverified_mail_protection!
+
     mail(to: user.email,
       subject: @subject,
       reply_to: CONTACT_EMAIL)

--- a/app/mailers/administration_mailer.rb
+++ b/app/mailers/administration_mailer.rb
@@ -8,6 +8,8 @@ class AdministrationMailer < ApplicationMailer
     @author_name = "Équipe de #{APPLICATION_NAME}"
     subject = "Activez votre compte administrateur"
 
+    bypass_unverified_mail_protection!
+
     mail(to: user.email,
       subject: subject,
       reply_to: CONTACT_EMAIL)
@@ -15,6 +17,8 @@ class AdministrationMailer < ApplicationMailer
 
   def refuse_admin(admin_email)
     subject = "Votre demande de compte a été refusée"
+
+    bypass_unverified_mail_protection!
 
     mail(to: admin_email,
       subject: subject,

--- a/app/mailers/concerns/balanced_delivery_concern.rb
+++ b/app/mailers/concerns/balanced_delivery_concern.rb
@@ -8,6 +8,10 @@ module BalancedDeliveryConcern
       self.class.critical_email?(action_name)
     end
 
+    def bypass_unverified_mail_protection!
+      headers[BalancerDeliveryMethod::BYPASS_UNVERIFIED_MAIL_PROTECTION] = true
+    end
+
     private
 
     def forced_delivery_provider?

--- a/app/mailers/devise_user_mailer.rb
+++ b/app/mailers/devise_user_mailer.rb
@@ -34,6 +34,8 @@ class DeviseUserMailer < Devise::Mailer
     @procedure = opts[:procedure_after_confirmation] || nil
     @prefill_token = opts[:prefill_token]
 
+    bypass_unverified_mail_protection!
+
     I18n.with_locale(record.locale) do
       super
     end

--- a/app/mailers/devise_user_mailer.rb
+++ b/app/mailers/devise_user_mailer.rb
@@ -41,6 +41,12 @@ class DeviseUserMailer < Devise::Mailer
     end
   end
 
+  def reset_password_instructions(record, token, opts = {})
+    bypass_unverified_mail_protection!
+
+    super
+  end
+
   def self.critical_email?(action_name)
     true
   end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -41,6 +41,8 @@ class UserMailer < ApplicationMailer
 
     configure_defaults_for_user(user)
 
+    bypass_unverified_mail_protection!
+
     mail(to: user.email,
       subject: subject,
       reply_to: Current.contact_email)
@@ -53,6 +55,8 @@ class UserMailer < ApplicationMailer
     subject = "Activez votre compte gestionnaire"
 
     configure_defaults_for_user(user)
+
+    bypass_unverified_mail_protection!
 
     mail(to: user.email,
       subject: subject,

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -58,7 +58,7 @@ class GroupeInstructeur < ApplicationRecord
     if not_found_emails.present?
       instructeurs_to_add += not_found_emails.map do |email|
         user = User.create_or_promote_to_instructeur(email, SecureRandom.hex, administrateurs: procedure.administrateurs)
-        user.invite!
+        user.invite_instructeur!
         user.instructeur
       end
     end

--- a/app/models/individual.rb
+++ b/app/models/individual.rb
@@ -29,4 +29,6 @@ class Individual < ApplicationRecord
       gender: fc_information.gender == 'female' ? GENDER_FEMALE : GENDER_MALE
     )
   end
+
+  def unverified_email? = !email_verified_at?
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,7 +79,7 @@ class User < ApplicationRecord
     owns?(dossier) || invite?(dossier)
   end
 
-  def invite!
+  def invite_instructeur!
     UserMailer.invite_instructeur(self, set_reset_password_token).deliver_later
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -267,6 +267,8 @@ class User < ApplicationRecord
     super && blocked_at.nil?
   end
 
+  def unverified_email? = !email_verified_at?
+
   private
 
   def does_not_merge_on_self

--- a/spec/lib/balancer_delivery_method_spec.rb
+++ b/spec/lib/balancer_delivery_method_spec.rb
@@ -1,20 +1,23 @@
 RSpec.describe BalancerDeliveryMethod do
   class ExampleMailer < ApplicationMailer
+    include BalancedDeliveryConcern
+
     def greet(name, bypass_unverified_mail_protection: true)
       mail(to: name, from: "smtp_from", body: "Hello #{name}")
 
-      if bypass_unverified_mail_protection
-        headers['BYPASS_UNVERIFIED_MAIL_PROTECTION'] = true
-      end
+      bypass_unverified_mail_protection! if bypass_unverified_mail_protection
     end
   end
 
   class ImportantEmail < ApplicationMailer
+    include BalancedDeliveryConcern
+
     before_action :set_x_deliver_with
 
     def greet(name)
       mail(to: name, from: "smtp_from", body: "Hello #{name}")
-      headers['BYPASS_UNVERIFIED_MAIL_PROTECTION'] = true
+
+      bypass_unverified_mail_protection!
     end
 
     private

--- a/spec/mailers/administrateur_mailer_spec.rb
+++ b/spec/mailers/administrateur_mailer_spec.rb
@@ -23,7 +23,10 @@ RSpec.describe AdministrateurMailer, type: :mailer do
     subject { described_class.activate_before_expiration(user, token) }
 
     context 'without SafeMailer configured' do
-      it { expect(subject[BalancerDeliveryMethod::FORCE_DELIVERY_METHOD_HEADER]&.value).to eq(nil) }
+      it do
+        expect(subject[BalancerDeliveryMethod::FORCE_DELIVERY_METHOD_HEADER]&.value).to eq(nil)
+        expect(subject['BYPASS_UNVERIFIED_MAIL_PROTECTION']).to be_present
+      end
     end
 
     context 'with SafeMailer configured' do

--- a/spec/mailers/administration_mailer_spec.rb
+++ b/spec/mailers/administration_mailer_spec.rb
@@ -9,8 +9,11 @@ RSpec.describe AdministrationMailer, type: :mailer do
     it { expect(subject.subject).not_to be_empty }
 
     describe "when the user has not been activated" do
-      it { expect(subject.body).to include(admin_activate_path(token: token)) }
-      it { expect(subject.body).not_to include(edit_user_password_url(admin_user, reset_password_token: token)) }
+      it do
+        expect(subject.body).to include(admin_activate_path(token: token))
+        expect(subject.body).not_to include(edit_user_password_url(admin_user, reset_password_token: token))
+        expect(subject['BYPASS_UNVERIFIED_MAIL_PROTECTION']).to be_present
+      end
     end
 
     describe "when the user is already active" do
@@ -25,6 +28,9 @@ RSpec.describe AdministrationMailer, type: :mailer do
 
     subject { described_class.refuse_admin(mail) }
 
-    it { expect(subject.subject).not_to be_empty }
+    it do
+      expect(subject.subject).not_to be_empty
+      expect(subject['BYPASS_UNVERIFIED_MAIL_PROTECTION']).to be_present
+    end
   end
 end

--- a/spec/mailers/devise_user_mailer_spec.rb
+++ b/spec/mailers/devise_user_mailer_spec.rb
@@ -5,7 +5,10 @@ RSpec.describe DeviseUserMailer, type: :mailer do
     subject { described_class.confirmation_instructions(user, token, opts = {}) }
 
     context 'without SafeMailer configured' do
-      it { expect(subject[BalancerDeliveryMethod::FORCE_DELIVERY_METHOD_HEADER]&.value).to eq(nil) }
+      it do
+        expect(subject[BalancerDeliveryMethod::FORCE_DELIVERY_METHOD_HEADER]&.value).to eq(nil)
+        expect(subject[BalancerDeliveryMethod::BYPASS_UNVERIFIED_MAIL_PROTECTION]).to be_present
+      end
     end
 
     context 'with SafeMailer configured' do

--- a/spec/mailers/devise_user_mailer_spec.rb
+++ b/spec/mailers/devise_user_mailer_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe DeviseUserMailer, type: :mailer do
         it "respect preferred domain" do
           expect(header_value("From", subject.message)).to include(CONTACT_EMAIL)
           expect(subject.message.to_s).to include("#{ENV.fetch("APP_HOST_LEGACY")}/users/password")
+          expect(subject[BalancerDeliveryMethod::BYPASS_UNVERIFIED_MAIL_PROTECTION]).to be_present
         end
       end
 

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -168,4 +168,17 @@ RSpec.describe UserMailer, type: :mailer do
       end
     end
   end
+
+  describe '.invite_instructeur' do
+    subject { described_class.invite_instructeur(user, "reset_token") }
+
+    it { expect(subject['BYPASS_UNVERIFIED_MAIL_PROTECTION']).to be_present }
+  end
+
+  describe '.invite_gestionnaire' do
+    let(:groupe_gestionnaire) { create(:groupe_gestionnaire) }
+    subject { described_class.invite_gestionnaire(user, "reset_token", groupe_gestionnaire) }
+
+    it { expect(subject['BYPASS_UNVERIFIED_MAIL_PROTECTION']).to be_present }
+  end
 end


### PR DESCRIPTION
closes #10450 

On risque d'avoir un une charge non négligeable sur la base vu qu'on va requeter à chaque envoie.
on pourrait faire un `User.where(email:).pick(:email_verified_at)` mais le gain ne doit pas être fou.
La bonne solution doit probablement être l'utilisation d'un cache.