### PR TITLE
Tech: corrige le nom par defaut de la bulk_email_queue

### DIFF
--- a/app/jobs/priorized_mail_delivery_job.rb
+++ b/app/jobs/priorized_mail_delivery_job.rb
@@ -11,6 +11,6 @@ class PriorizedMailDeliveryJob < ActionMailer::MailDeliveryJob
   end
 
   def custom_queue
-    ENV.fetch('BULK_EMAIL_QUEUE') { Rails.application.config.action_mailer.deliver_later_queue_name }
+    ENV.fetch('BULK_EMAIL_QUEUE') { Rails.application.config.action_mailer.deliver_later_queue_name.to_s }
   end
 end


### PR DESCRIPTION
commentaire de @maatinito 

> n'utilisons pas la variable BULK_EMAIL_QUEUE. Et lorsque l'on passe la gestion des mails sous sidekiq, cela déclenche un erreur (incompréhensible). Pour corriger ca, app/jobs/priorized_mail_delivery.rb:12 ajouter le .to_s pour convertir le symbole retourné.