### PR TITLE
Tech: block l'envoi de mails à des adresses douteuses

### DIFF
--- a/lib/tasks/deployment/20240530090353_block_dubious_email.rake
+++ b/lib/tasks/deployment/20240530090353_block_dubious_email.rake
@@ -1,0 +1,27 @@
+namespace :after_party do
+  desc 'Deployment task: block_dubious_email'
+  task block_dubious_email: :environment do
+    User
+      .where.associated(:instructeur)
+      .where(created_at: ..3.months.ago)
+      .where(last_sign_in_at: nil)
+      .update_all(email_verified_at: nil)
+
+    User
+      .where.associated(:expert)
+      .where(created_at: ..3.months.ago)
+      .where(last_sign_in_at: nil)
+      .update_all(email_verified_at: nil)
+
+    # rubocop:disable DS/Unscoped
+    User
+      .unscoped
+      .where.missing(:instructeur, :expert)
+      .where(confirmed_at: nil)
+      .update_all(email_verified_at: nil)
+    # rubocop:enable DS/Unscoped
+
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/lib/tasks/deployment/20240530090353_block_dubious_email_spec.rb
+++ b/spec/lib/tasks/deployment/20240530090353_block_dubious_email_spec.rb
@@ -1,0 +1,57 @@
+describe '20240530090353_block_dubious_email' do
+  let(:rake_task) { Rake::Task['after_party:block_dubious_email'] }
+  let(:now) { Time.current }
+  let(:confirmed_user) { create(:user, email_verified_at: now, created_at: 1.year.ago) }
+  let(:unconfirmed_user) { create(:user, email_verified_at: now, created_at: 1.year.ago, confirmed_at: nil) }
+
+  let(:never_seen_instructeur) do
+    instructeur = create(:instructeur)
+    instructeur.user.update!(email_verified_at: now, created_at: 1.year.ago)
+    instructeur.user
+  end
+  let(:seen_instructeur) do
+    instructeur = create(:instructeur)
+    instructeur.user.update!(
+      email_verified_at: now,
+      created_at: 1.year.ago,
+      last_sign_in_at: now
+    )
+    instructeur.user
+  end
+
+  let(:young_never_seen_instructeur) do
+    instructeur = create(:instructeur)
+    instructeur.user.update!(
+      email_verified_at: now,
+      created_at: 2.months.ago,
+      confirmed_at: nil
+    )
+    instructeur.user
+  end
+
+  subject(:run_task) { rake_task.invoke }
+
+  after { rake_task.reenable }
+
+  it 'block_dubious_email' do
+    people = [
+      confirmed_user,
+      unconfirmed_user,
+      never_seen_instructeur,
+      young_never_seen_instructeur,
+      seen_instructeur
+    ]
+
+    expect(people.map(&:email_verified_at)).to all(be_present)
+
+    run_task
+    people.each(&:reload)
+
+    expect(confirmed_user.email_verified_at).to be_present
+    expect(seen_instructeur.email_verified_at).to be_present
+    expect(young_never_seen_instructeur.email_verified_at).to be_present
+
+    expect(never_seen_instructeur.email_verified_at).to be_nil
+    expect(unconfirmed_user.email_verified_at).to be_nil
+  end
+end


### PR DESCRIPTION
closes #10445 

- on bloque tous les instructeurs / admins / experts créé il y a plus de 3 mois ne s'étant jamais connecté