### PR TITLE
Correctif ETQ admin je peux consulter la page "toutes les démarches" sans zone sélectionnée

### DIFF
--- a/app/models/procedure_detail.rb
+++ b/app/models/procedure_detail.rb
@@ -14,7 +14,7 @@ ProcedureDetail = Struct.new(:id, :libelle, :published_at, :aasm_state, :estimat
   end
 
   def parsed_latest_zone_labels
-    # Replace curly braces with square brackets to make it a valid JSON array
+    return [] if latest_zone_labels.nil? || latest_zone_labels.strip.empty?
     JSON.parse(latest_zone_labels.tr('{', '[').tr('}', ']'))
   rescue JSON::ParserError
     []

--- a/app/views/administrateurs/procedures/_detail.html.haml
+++ b/app/views/administrateurs/procedures/_detail.html.haml
@@ -31,7 +31,7 @@
 
 - if show_detail
   %tr.procedure{ id: "procedure_detail_#{procedure.id}" }
-    %td.fr-highlight--beige-gris-galet{ colspan: '8' }
+    %td.fr-highlight--green-emeraude{ colspan: '8' }
       .fr-container
         .fr-col-6
           - procedure.administrateurs.uniq.each do |admin|

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -95,9 +95,6 @@ describe Administrateurs::ProceduresController, type: :controller do
     let!(:draft_procedure)     { create(:procedure) }
     let!(:published_procedure) { create(:procedure_with_dossiers, :published, dossiers_count: 2) }
     let!(:closed_procedure)    { create(:procedure, :closed) }
-    let!(:procedure_detail_draft)     { ProcedureDetail.new(id: draft_procedure.id, latest_zone_labels: '{ "zone1", "zone2" }') }
-    let!(:procedure_detail_published) { ProcedureDetail.new(id: published_procedure.id, latest_zone_labels: '{ "zone3", "zone4" }') }
-    let!(:procedure_detail_closed)    { ProcedureDetail.new(id: closed_procedure.id, latest_zone_labels: '{ "zone5", "zone6" }') }
 
     subject { get :all }
 
@@ -122,19 +119,6 @@ describe Administrateurs::ProceduresController, type: :controller do
     it 'doesn’t display draft procedures' do
       subject
       expect(assigns(:procedures).any? { |p| p.id == draft_procedure.id }).to be_falsey
-    end
-
-    context 'with parsed latest zone labels' do
-      it 'parses the latest zone labels correctly' do
-        expect(procedure_detail_draft.parsed_latest_zone_labels).to eq(["zone1", "zone2"])
-        expect(procedure_detail_published.parsed_latest_zone_labels).to eq(["zone3", "zone4"])
-        expect(procedure_detail_closed.parsed_latest_zone_labels).to eq(["zone5", "zone6"])
-      end
-
-      it 'returns an empty array for invalid JSON' do
-        procedure_detail_draft.latest_zone_labels = '{ invalid json }'
-        expect(procedure_detail_draft.parsed_latest_zone_labels).to eq([])
-      end
     end
 
     context 'for default admin zones' do

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -1776,6 +1776,37 @@ describe Procedure do
     end
   end
 
+  describe "#parsed_latest_zone_labels" do
+    let!(:draft_procedure) { create(:procedure) }
+    let!(:published_procedure) { create(:procedure_with_dossiers, :published, dossiers_count: 2) }
+    let!(:closed_procedure) { create(:procedure, :closed) }
+    let!(:procedure_detail_draft) { ProcedureDetail.new(id: draft_procedure.id, latest_zone_labels: '{ "zone1", "zone2" }') }
+    let!(:procedure_detail_published) { ProcedureDetail.new(id: published_procedure.id, latest_zone_labels: '{ "zone3", "zone4" }') }
+    let!(:procedure_detail_closed) { ProcedureDetail.new(id: closed_procedure.id, latest_zone_labels: '{ "zone5", "zone6" }') }
+    context 'with parsed latest zone labels' do
+      it 'parses the latest zone labels correctly' do
+        expect(procedure_detail_draft.parsed_latest_zone_labels).to eq(["zone1", "zone2"])
+        expect(procedure_detail_published.parsed_latest_zone_labels).to eq(["zone3", "zone4"])
+        expect(procedure_detail_closed.parsed_latest_zone_labels).to eq(["zone5", "zone6"])
+      end
+
+      it 'returns an empty array for invalid JSON' do
+        procedure_detail_draft.latest_zone_labels = '{ invalid json }'
+        expect(procedure_detail_draft.parsed_latest_zone_labels).to eq([])
+      end
+
+      it 'returns an empty array when latest_zone_labels is nil' do
+        procedure_detail_draft.latest_zone_labels = nil
+        expect(procedure_detail_draft.parsed_latest_zone_labels).to eq([])
+      end
+
+      it 'returns an empty array when latest_zone_labels is empty' do
+        procedure_detail_draft.latest_zone_labels = ''
+        expect(procedure_detail_draft.parsed_latest_zone_labels).to eq([])
+      end
+    end
+  end
+
   private
 
   def create_dossier_with_pj_of_size(size, procedure)


### PR DESCRIPTION
@colinux fixe le bug sentry : https://demarches-simplifiees.sentry.io/issues/5432727344/?project=1429550&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=0

Aussi, pour la couleur de fond, il y a que 3 couleurs autorisées. J'ai mis le green emeraude qui passe mieux que l'autre, mais dis-moi. Au pire, on peut ne rien mettre aussi...