### PR TITLE
Correctif (galerie) : catche les erreurs de type ActionViewTemplate

### DIFF
--- a/app/helpers/gallery_helper.rb
+++ b/app/helpers/gallery_helper.rb
@@ -9,19 +9,19 @@ module GalleryHelper
 
   def preview_url_for(attachment)
     attachment.preview(resize_to_limit: [400, 400]).processed.url
-  rescue ActiveStorage::Error
+  rescue StandardError
     'pdf-placeholder.png'
   end
 
   def variant_url_for(attachment)
     attachment.variant(resize_to_limit: [400, 400]).processed.url
-  rescue ActiveStorage::Error
+  rescue StandardError
     'apercu-indisponible.png'
   end
 
   def blob_url(attachment)
     attachment.blob.content_type.in?(RARE_IMAGE_TYPES) ? attachment.variant(resize_to_limit: [2000, 2000]).processed.url : attachment.blob.url
-  rescue ActiveStorage::Error
+  rescue StandardError
     attachment.blob.url
   end
 end


### PR DESCRIPTION
Permet de gérer les erreurs avec les types de fichier autorisés mais pas encore gérés par ImageMagick (ex : .webp)