### PR TITLE
API v1: fix régression commentaire -> attachment url qui avait sauté

### DIFF
--- a/app/serializers/commentaire_serializer.rb
+++ b/app/serializers/commentaire_serializer.rb
@@ -2,9 +2,18 @@ class CommentaireSerializer < ActiveModel::Serializer
   attributes :email,
     :body,
     :created_at,
-    :piece_jointe_attachments
+    :piece_jointe_attachments,
+    :attachment
 
   def created_at
     object.created_at&.in_time_zone('UTC')
+  end
+
+  def attachment
+    piece_jointe = object.piece_jointe_attachments.first
+
+    if piece_jointe&.virus_scanner&.safe?
+      Rails.application.routes.url_helpers.url_for(piece_jointe)
+    end
   end
 end


### PR DESCRIPTION
HS https://secure.helpscout.net/conversation/2619126636/2076369/

Régression Introduite par les PJ multiples  dans la messagerie dans https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/9986/commits/bf622eb3ed3fadfdee7941dfe3353bad52bd6007 et [ici](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/9986/files#diff-d410324ce93f5aec073db617009dea18a2d6b719eeb3fcf856fd86b93323a8f7L70)

![Capture d’écran 2024-06-10 à 13 06 06](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/8c0eac4d-6238-4230-bd73-840186d9b216)
