### PR TITLE
Bouton copier/coller: améliore support quand le clipboard n'est pas disponible

### DIFF
--- a/app/javascript/controllers/clipboard_controller.ts
+++ b/app/javascript/controllers/clipboard_controller.ts
@@ -17,7 +17,11 @@ export class ClipboardController extends Controller {
   connect(): void {
     // some extensions or browsers block clipboard
     if (!navigator.clipboard) {
-      this.element.classList.add('hidden');
+      if (this.hasToHideTarget) {
+        this.toHideTarget.classList.add('hidden');
+      } else {
+        this.element.classList.add('hidden');
+      }
     }
   }
 


### PR DESCRIPTION
Sur la page d'affichage des tokens API, on utilise du texte ET des buttons d'actions avec targets spécifiques. Le texte (`this.element`) était caché, alors qu'on veut garder le texte mais cacher les boutons.