### PR TITLE
ETQ admin: je souhaite que le lien JDMA soit réinitialisé lors du clonage d'une procédure

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -559,6 +559,7 @@ class Procedure < ApplicationRecord
     procedure.closing_notification_brouillon = false
     procedure.closing_notification_en_cours = false
     procedure.template = false
+    procedure.monavis_embed = nil
 
     if !procedure.valid?
       procedure.errors.attribute_names.each do |attribute|


### PR DESCRIPTION
Léger fix qui remet à nil l'attribut "monavis_embed" d'une procédure clonée.

En effet, l'outil JDMA sous-jacent est propre à une procédure en particulier (point remonté par Philippe).

Ainsi, un admin qui clone une procédure, devra nécessairement lui réaffectée un nouveau lien "JDMA" s'il souhaite recueillir à nouveau des avis sur celle-ci.

