### PR TITLE
ETQ usager: je ne peux ajouter qu'une unique PJ pour les anciennes procédures qui l'exigent

### DIFF
--- a/app/components/attachment/edit_component.rb
+++ b/app/components/attachment/edit_component.rb
@@ -55,7 +55,7 @@ class Attachment::EditComponent < ApplicationComponent
   end
 
   def destroy_attachment_path
-    attachment_path(champ: @champ)
+    attachment_path(dossier_id: champ&.dossier_id, stable_id: champ&.stable_id, row_id: champ&.row_id)
   end
 
   def attachment_input_class

--- a/app/components/attachment/edit_component.rb
+++ b/app/components/attachment/edit_component.rb
@@ -9,7 +9,6 @@ class Attachment::EditComponent < ApplicationComponent
   alias as_multiple? as_multiple
 
   EXTENSIONS_ORDER = ['jpeg', 'png', 'pdf', 'zip'].freeze
-  DEFAULT_MAX_ATTACHMENTS = 10
 
   def initialize(champ: nil, auto_attach_url: nil, attached_file:, direct_upload: true, index: 0, as_multiple: false, view_as: :link, user_can_destroy: true, user_can_replace: false, attachments: [], max: nil, **kwargs)
     @champ = champ
@@ -25,7 +24,7 @@ class Attachment::EditComponent < ApplicationComponent
     @attachments = attachments.presence || (kwargs.key?(:attachment) ? [kwargs.delete(:attachment)] : [])
     @attachments << attached_file.attachment if attached_file.respond_to?(:attachment) && @attachments.empty?
     @attachments.compact!
-    @max = max || DEFAULT_MAX_ATTACHMENTS
+    @max = max
 
     # Utilisation du premier attachement comme référence pour la rétrocompatibilité
     @attachment = @attachments.first
@@ -56,7 +55,7 @@ class Attachment::EditComponent < ApplicationComponent
   end
 
   def destroy_attachment_path
-    attachment_path(champ_id: champ&.public_id, champ: @champ)
+    attachment_path(champ: @champ)
   end
 
   def attachment_input_class
@@ -79,7 +78,7 @@ class Attachment::EditComponent < ApplicationComponent
 
     options.merge!(has_content_type_validator? ? { accept: accept_content_type } : {})
     options[:multiple] = true if as_multiple?
-    options[:disabled] = true if @index >= @max
+    options[:disabled] = true if @max && @index >= @max
 
     options
   end

--- a/app/components/attachment/multiple_component.rb
+++ b/app/components/attachment/multiple_component.rb
@@ -30,10 +30,6 @@ class Attachment::MultipleComponent < ApplicationComponent
     @attachments.each_with_index(&block)
   end
 
-  def can_attach_next?
-    @attachments.count < @max
-  end
-
   def empty_component_id
     champ.present? ? "attachment-multiple-empty-#{champ.public_id}" : "attachment-multiple-empty-generic"
   end

--- a/app/components/attachment/multiple_component/multiple_component.html.haml
+++ b/app/components/attachment/multiple_component/multiple_component.html.haml
@@ -7,8 +7,8 @@
         %li{ id: dom_id(attachment) }
           = render Attachment::EditComponent.new(champ:, attached_file:, attachment:, index:, view_as:, user_can_destroy:, form_object_name:)
 
-  %div{ id: empty_component_id, class: class_names("hidden": !can_attach_next?), data: { turbo_force: :server } }
-    = render Attachment::EditComponent.new(champ:, as_multiple: champ.nil?, attached_file:, attachment: nil, index: attachments_count, user_can_destroy:, form_object_name:)
+  %div{ id: empty_component_id, data: { turbo_force: :server } }
+    = render Attachment::EditComponent.new(champ:, as_multiple: champ.nil?, attached_file:, attachment: nil, index: attachments_count, user_can_destroy:, form_object_name:, max: @max)
 
   // single poll and refresh message for all attachments
   = render Attachment::PendingPollComponent.new(attachments: attachments, poll_url:, context: poll_context)

--- a/app/components/editable_champ/champ_label_component/champ_label_component.html.haml
+++ b/app/components/editable_champ/champ_label_component/champ_label_component.html.haml
@@ -1,13 +1,8 @@
 = # we do this trick because some html elements should use 'label' and some should be plain paragraphs
 
 - if @champ.html_label?
-  - if @champ.piece_justificative? && !@champ.procedure.piece_justificative_multiple
-    -# champ piece_justificative : remove the asociation with the input
-    = @form.label @champ.main_value_name, id: @champ.labelledby_id, class: 'fr-label' do
-      - render EditableChamp::ChampLabelContentComponent.new form: @form, champ: @champ, seen_at: @seen_at
-  - else
-    = @form.label @champ.main_value_name, id: @champ.labelledby_id, for: @champ.input_id, class: 'fr-label' do
-      - render EditableChamp::ChampLabelContentComponent.new form: @form, champ: @champ, seen_at: @seen_at
+  = @form.label @champ.main_value_name, id: @champ.labelledby_id, for: @champ.input_id, class: 'fr-label' do
+    - render EditableChamp::ChampLabelContentComponent.new form: @form, champ: @champ, seen_at: @seen_at
 - elsif @champ.legend_label?
   %legend.fr-fieldset__legend.fr-text--regular{ id: @champ.labelledby_id }= render EditableChamp::ChampLabelContentComponent.new form: @form, champ: @champ, seen_at: @seen_at
 - elsif @champ.single_checkbox?

--- a/app/components/editable_champ/champ_label_component/champ_label_component.html.haml
+++ b/app/components/editable_champ/champ_label_component/champ_label_component.html.haml
@@ -1,8 +1,13 @@
 = # we do this trick because some html elements should use 'label' and some should be plain paragraphs
 
 - if @champ.html_label?
-  = @form.label @champ.main_value_name, id: @champ.labelledby_id, for: @champ.input_id, class: 'fr-label' do
-    - render EditableChamp::ChampLabelContentComponent.new form: @form, champ: @champ, seen_at: @seen_at
+  - if @champ.piece_justificative?
+    -# champ piece_justificative : remove the asociation with the input
+    = @form.label @champ.main_value_name, id: @champ.labelledby_id, class: 'fr-label' do
+      - render EditableChamp::ChampLabelContentComponent.new form: @form, champ: @champ, seen_at: @seen_at
+  - else
+    = @form.label @champ.main_value_name, id: @champ.labelledby_id, for: @champ.input_id, class: 'fr-label' do
+      - render EditableChamp::ChampLabelContentComponent.new form: @form, champ: @champ, seen_at: @seen_at
 - elsif @champ.legend_label?
   %legend.fr-fieldset__legend.fr-text--regular{ id: @champ.labelledby_id }= render EditableChamp::ChampLabelContentComponent.new form: @form, champ: @champ, seen_at: @seen_at
 - elsif @champ.single_checkbox?

--- a/app/components/editable_champ/champ_label_component/champ_label_component.html.haml
+++ b/app/components/editable_champ/champ_label_component/champ_label_component.html.haml
@@ -1,7 +1,7 @@
 = # we do this trick because some html elements should use 'label' and some should be plain paragraphs
 
 - if @champ.html_label?
-  - if @champ.piece_justificative?
+  - if @champ.piece_justificative? && !@champ.procedure.piece_justificative_multiple
     -# champ piece_justificative : remove the asociation with the input
     = @form.label @champ.main_value_name, id: @champ.labelledby_id, class: 'fr-label' do
       - render EditableChamp::ChampLabelContentComponent.new form: @form, champ: @champ, seen_at: @seen_at

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -21,7 +21,6 @@ class AttachmentsController < ApplicationController
     @attachment.purge_later
     flash.notice = 'La pièce jointe a bien été supprimée.'
 
-    @champ_id = params[:champ_id]
     @champ = Champ.find(params[:champ]) if params[:champ]
 
     respond_to do |format|

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -21,11 +21,18 @@ class AttachmentsController < ApplicationController
     @attachment.purge_later
     flash.notice = 'La pièce jointe a bien été supprimée.'
 
-    @champ = Champ.find(params[:champ]) if params[:champ]
+    @champ = find_champ if params[:dossier_id]
 
     respond_to do |format|
       format.turbo_stream
       format.html { redirect_back(fallback_location: root_url) }
     end
+  end
+
+  private
+
+  def find_champ
+    dossier = policy_scope(Dossier).includes(:champs).find(params[:dossier_id])
+    dossier.champs.find_by(stable_id: params[:stable_id], row_id: params[:row_id])
   end
 end

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -22,6 +22,7 @@ class AttachmentsController < ApplicationController
     flash.notice = 'La pièce jointe a bien été supprimée.'
 
     @champ_id = params[:champ_id]
+    @champ = Champ.find(params[:champ]) if params[:champ]
 
     respond_to do |format|
       format.turbo_stream

--- a/app/views/attachments/destroy.turbo_stream.haml
+++ b/app/views/attachments/destroy.turbo_stream.haml
@@ -5,3 +5,9 @@
   = turbo_stream.focus_all "#attachment-multiple-empty-#{@champ_id} input"
 
 = turbo_stream.show_all ".attachment-input-#{@attachment.id}"
+
+- if @champ
+  = fields_for @champ.input_name, @champ do |form|
+    = turbo_stream.replace @champ.input_group_id do
+      = render EditableChamp::EditableChampComponent.new champ: @champ, form: form
+  = turbo_stream.focus_all "#attachment-multiple-empty-#{@champ_id} input"

--- a/app/views/attachments/destroy.turbo_stream.haml
+++ b/app/views/attachments/destroy.turbo_stream.haml
@@ -1,13 +1,9 @@
 = turbo_stream.remove dom_id(@attachment, :persisted_row)
 
-- if @champ_id
-  = turbo_stream.show "attachment-multiple-empty-#{@champ_id}"
-  = turbo_stream.focus_all "#attachment-multiple-empty-#{@champ_id} input"
-
 = turbo_stream.show_all ".attachment-input-#{@attachment.id}"
 
 - if @champ
   = fields_for @champ.input_name, @champ do |form|
     = turbo_stream.replace @champ.input_group_id do
       = render EditableChamp::EditableChampComponent.new champ: @champ, form: form
-  = turbo_stream.focus_all "#attachment-multiple-empty-#{@champ_id} input"
+  = turbo_stream.focus_all "#attachment-multiple-empty-#{@champ.public_id} input"

--- a/spec/components/attachment/multiple_component_spec.rb
+++ b/spec/components/attachment/multiple_component_spec.rb
@@ -75,8 +75,8 @@ RSpec.describe Attachment::MultipleComponent, type: :component do
   context 'max attachments' do
     let(:kwargs) { { max: 1 } }
 
-    it 'does not render visible input file where max attachments has been reached' do
-      expect(subject).to have_selector('.hidden input[type=file]')
+    it 'renders a disabled input file where max attachments has been reached' do
+      expect(subject).to have_selector('input[type=file][disabled]')
     end
   end
 


### PR DESCRIPTION
En réponse à l'issue https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/10186

Ceci concerne donc que les anciennes démarches où l'admin pouvait indiquer si une ou plusieurs PJ étaient autorisées.

Le pb venait de l'association entre le for dans la balise du label et l'id de l'input associé, qui rendait donc cliquable le label, permettant ainsi à l'usager de sélectionner une nouvelle PJ.

La modification proposée introduit une exception pour le type de champ PJ et lorsque les PJ multiples ne sont pas autorisées, avec pour conséquence de ne plus forcer la valeur de l'attribut for.