### PR TITLE
ETQ opérateur, le form de contact devient asynchrone et l'antivirus passe sur les PJ

### DIFF
--- a/app/jobs/helpscout_create_conversation_job.rb
+++ b/app/jobs/helpscout_create_conversation_job.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class HelpscoutCreateConversationJob < ApplicationJob
+  queue_as :default
+
+  class FileNotScannedYetError < StandardError
+  end
+
+  retry_on FileNotScannedYetError, wait: :exponentially_longer, attempts: 10
+
+  def perform(blob_id: nil, **args)
+    if blob_id.present?
+      blob = ActiveStorage::Blob.find(blob_id)
+      raise FileNotScannedYetError if blob.virus_scanner.pending?
+
+      blob = nil unless blob.virus_scanner.safe?
+    end
+
+    Helpscout::FormAdapter.new(**args, blob:).send_form
+  end
+end

--- a/app/lib/helpscout/api.rb
+++ b/app/lib/helpscout/api.rb
@@ -22,7 +22,7 @@ class Helpscout::API
     })
   end
 
-  def create_conversation(email, subject, text, file)
+  def create_conversation(email, subject, text, blob)
     body = {
       subject: subject,
       customer: customer(email),
@@ -34,7 +34,7 @@ class Helpscout::API
           type: 'customer',
           customer: customer(email),
           text: text,
-          attachments: attachments(file)
+          attachments: attachments(blob)
         }
       ]
     }.compact
@@ -76,13 +76,13 @@ class Helpscout::API
 
   private
 
-  def attachments(file)
-    if file.present?
+  def attachments(blob)
+    if blob.present?
       [
         {
-          fileName: file.original_filename,
-          mimeType: file.content_type,
-          data: Base64.strict_encode64(file.read)
+          fileName: blob.filename,
+          mimeType: blob.content_type,
+          data: Base64.strict_encode64(blob.download)
         }
       ]
     else

--- a/app/lib/helpscout/form_adapter.rb
+++ b/app/lib/helpscout/form_adapter.rb
@@ -66,7 +66,7 @@ class Helpscout::FormAdapter
       params[:email],
       params[:subject],
       params[:text],
-      params[:file]
+      params[:blob]
     )
 
     if response.success?
@@ -74,6 +74,8 @@ class Helpscout::FormAdapter
         @api.add_phone_number(params[:email], params[:phone])
       end
       response.headers['Resource-ID']
+    else
+      raise StandardError, "Error while creating conversation: #{response.response_code} '#{response.body}'"
     end
   end
 end

--- a/config/initializers/transition_to_sidekiq.rb
+++ b/config/initializers/transition_to_sidekiq.rb
@@ -1,99 +1,32 @@
 if Rails.env.production? && SIDEKIQ_ENABLED
   ActiveSupport.on_load(:after_initialize) do
-    class ActiveStorage::PurgeJob < ActiveStorage::BaseJob
-      self.queue_adapter = :sidekiq
-    end
-
-    class ActiveStorage::AnalyzeJob < ActiveStorage::BaseJob
-      self.queue_adapter = :sidekiq
-    end
-
-    class VirusScannerJob
-      self.queue_adapter = :sidekiq
-    end
-
-    class DossierRebaseJob < ApplicationJob
-      self.queue_adapter = :sidekiq
-    end
-
-    class ProcedureExternalURLCheckJob < ApplicationJob
-      self.queue_adapter = :sidekiq
-    end
-
-    class MaintenanceTasks::TaskJob
-      self.queue_adapter = :sidekiq
-    end
-
-    class PriorizedMailDeliveryJob < ActionMailer::MailDeliveryJob
-      self.queue_adapter = :sidekiq
-    end
-
-    class ProcedureSVASVRProcessDossierJob < ApplicationJob
-      self.queue_adapter = :sidekiq
-    end
-
-    class WebHookJob < ApplicationJob
-      self.queue_adapter = :sidekiq
-    end
-
-    class DestroyRecordLaterJob < ApplicationJob
-      self.queue_adapter = :sidekiq
-    end
-
-    class ChampFetchExternalDataJob < ApplicationJob
-      self.queue_adapter = :sidekiq
-    end
-
-    class DossierIndexSearchTermsJob < ApplicationJob
-      self.queue_adapter = :sidekiq
-    end
-
-    class Migrations::BackfillStableIdJob
-      self.queue_adapter = :sidekiq
-    end
-
-    class Cron::CronJob < ApplicationJob
-      self.queue_adapter = :sidekiq
-    end
-
-    class APIEntreprise::Job < ApplicationJob
-      self.queue_adapter = :sidekiq
-    end
-
-    class DossierOperationLogMoveToColdStorageBatchJob < ApplicationJob
-      self.queue_adapter = :sidekiq
-    end
-
-    class BatchOperationEnqueueAllJob < ApplicationJob
-      self.queue_adapter = :sidekiq
-    end
-
-    class BatchOperationProcessOneJob < ApplicationJob
-      self.queue_adapter = :sidekiq
-    end
-
-    class TitreIdentiteWatermarkJob < ApplicationJob
-      self.queue_adapter = :sidekiq
-    end
-
-    class AdminUpdateDefaultZonesJob < ApplicationJob
-      self.queue_adapter = :sidekiq
-    end
-
-    class ProcessStalledDeclarativeDossierJob < ApplicationJob
-      self.queue_adapter = :sidekiq
-    end
-
-    class ResetExpiringDossiersJob < ApplicationJob
-      self.queue_adapter = :sidekiq
-    end
-
-    class SendClosingNotificationJob < ApplicationJob
-      self.queue_adapter = :sidekiq
-    end
-
-    class ImageProcessorJob < ApplicationJob
-      self.queue_adapter = :sidekiq
+    [
+      ActiveStorage::AnalyzeJob,
+      ActiveStorage::PurgeJob,
+      AdminUpdateDefaultZonesJob,
+      APIEntreprise::Job,
+      AdminUpdateDefaultZonesJob,
+      BatchOperationEnqueueAllJob,
+      BatchOperationProcessOneJob,
+      ChampFetchExternalDataJob,
+      Cron::CronJob,
+      DestroyRecordLaterJob,
+      DossierIndexSearchTermsJob,
+      DossierOperationLogMoveToColdStorageBatchJob,
+      DossierRebaseJob,
+      ImageProcessorJob,
+      MaintenanceTasks::TaskJob,
+      Migrations::BackfillStableIdJob,
+      PriorizedMailDeliveryJob,
+      ProcedureExternalURLCheckJob,
+      ProcedureSVASVRProcessDossierJob,
+      ProcessStalledDeclarativeDossierJob,
+      ResetExpiringDossiersJob,
+      SendClosingNotificationJob,
+      VirusScannerJob,
+      WebHookJob
+    ].each do |job_class|
+      job_class.queue_adapter = :sidekiq
     end
   end
 end

--- a/config/initializers/transition_to_sidekiq.rb
+++ b/config/initializers/transition_to_sidekiq.rb
@@ -14,6 +14,7 @@ if Rails.env.production? && SIDEKIQ_ENABLED
       DossierIndexSearchTermsJob,
       DossierOperationLogMoveToColdStorageBatchJob,
       DossierRebaseJob,
+      HelpscoutCreateConversationJob,
       ImageProcessorJob,
       MaintenanceTasks::TaskJob,
       Migrations::BackfillStableIdJob,

--- a/spec/jobs/helpscout_create_conversation_job_spec.rb
+++ b/spec/jobs/helpscout_create_conversation_job_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe HelpscoutCreateConversationJob, type: :job do
+  let(:args) { { email: 'sender@email.com' } }
+
+  describe '#perform' do
+    context 'when blob_id is not present' do
+      it 'sends the form without a file' do
+        form_adapter = double('Helpscout::FormAdapter')
+        allow(Helpscout::FormAdapter).to receive(:new).with(hash_including(args.merge(blob: nil))).and_return(form_adapter)
+        expect(form_adapter).to receive(:send_form)
+
+        described_class.perform_now(**args)
+      end
+    end
+
+    context 'when blob_id is present' do
+      let(:blob) {
+        ActiveStorage::Blob.create_and_upload!(io: StringIO.new("toto"), filename: "toto.png")
+      }
+
+      before do
+        allow(blob).to receive(:virus_scanner).and_return(double('VirusScanner', pending?: pending, safe?: safe))
+      end
+
+      context 'when the file has not been scanned yet' do
+        let(:pending) { true }
+        let(:safe) { false }
+
+        it 'reenqueue job' do
+          expect {
+            described_class.perform_now(blob_id: blob.id, **args)
+          }.to have_enqueued_job(described_class).with(blob_id: blob.id, **args)
+        end
+      end
+
+      context 'when the file is safe' do
+        let(:pending) { false }
+        let(:safe) { true }
+
+        it 'downloads the file and sends the form' do
+          form_adapter = double('Helpscout::FormAdapter')
+          allow(Helpscout::FormAdapter).to receive(:new).with(hash_including(args.merge(blob:))).and_return(form_adapter)
+          allow(form_adapter).to receive(:send_form)
+
+          described_class.perform_now(blob_id: blob.id, **args)
+        end
+      end
+
+      context 'when the file is not safe' do
+        let(:pending) { false }
+        let(:safe) { false }
+
+        it 'downloads the file and sends the form' do
+          form_adapter = double('Helpscout::FormAdapter')
+          allow(Helpscout::FormAdapter).to receive(:new).with(hash_including(args.merge(blob: nil))).and_return(form_adapter)
+          allow(form_adapter).to receive(:send_form)
+
+          described_class.perform_now(blob_id: blob.id, **args)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/helpscout/form_adapter_spec.rb
+++ b/spec/lib/helpscout/form_adapter_spec.rb
@@ -5,7 +5,7 @@ describe Helpscout::FormAdapter do
     context 'create_conversation' do
       before do
         allow(api).to receive(:create_conversation)
-          .and_return(double(success?: false))
+          .and_return(double(success?: true, headers: {}))
         described_class.new(params, api).send_form
       end
 


### PR DESCRIPTION
En bonus : 
- plus de visibilité sur les erreurs de creation de conversation qui étaient invisibles jusque là
- transition des jobs vers sidekiq ne (ré)ouvre pas les classes, ce qui permet d'éviter une typo sur une classe qui n'existe plus comme `TitreIdentiteWatermarkJob `;)