### PR TITLE
Tech: n'indexe plus les dossiers en autosave

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -304,7 +304,6 @@ module Users
       @dossier = dossier_with_champs(pj_template: false)
       @can_passer_en_construction_was = @dossier.can_passer_en_construction?
       update_dossier_and_compute_errors
-      @dossier.index_search_terms_later if @dossier.errors.empty?
       @can_passer_en_construction_is = @dossier.can_passer_en_construction?
       respond_to do |format|
         format.turbo_stream do


### PR DESCRIPTION
En attendant sidekiq-grouping pour réduire drastiquement le nb de jobs, n'indexe plus en autosave  pour éviter les engorgements de jobs et pénaliser la délivrance des emails (entre autres)