### PR TITLE
ETQ Admin, Instructeur: fix traduction dans la page lien envoyé

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -312,7 +312,8 @@ class ApplicationController < ActionController::Base
       path == '/contact-admin' ||
       path.start_with?('/connexion-par-jeton') ||
       path.start_with?('/api/') ||
-      path.start_with?('/lien-envoye')
+      path.start_with?('/lien-envoye') ||
+      path.start_with?('/faq')
 
       false
     else

--- a/app/views/users/confirmations/new.html.haml
+++ b/app/views/users/confirmations/new.html.haml
@@ -17,7 +17,9 @@
         %p= t('views.confirmation.new.email_cta_html', email: resource.email)
         %p= t('views.confirmation.new.email_guidelines_html')
 
+    %p.fr-text--sm.fr-text-mention--grey.fr-mb-1w
+      = t('views.confirmation.new.email_missing')
+
     = form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { class: 'fr-mb-6w'}) do |f|
-      %legend.fr-hint-text.fr-mb-3w= t('views.confirmation.new.email_missing')
       = f.hidden_field :email
       = f.submit t('views.confirmation.new.resent'), class: 'fr-btn fr-btn--secondary'

--- a/app/views/users/sessions/link_sent.html.haml
+++ b/app/views/users/sessions/link_sent.html.haml
@@ -3,27 +3,26 @@
 - content_for :footer do
   = render partial: 'root/footer'
 
-.fr-container.fr-my-5w
-  .fr-grid-row
-    .fr-col-12.fr-col-offset-md-1.fr-col-md-7
-      %h1.fr-mt-6w Encore une petite étape !
+.fr-container
+  .fr-col-12.fr-col-md-6.fr-col-offset-md-3
+    %h1.fr-mt-6w.fr-h2.center
+      = t('views.confirmation.new.title')
 
-      %section
-        %p.fr-text--lead
-          Nous venons de vous envoyer un courriel sur votre boite email <strong>#{@email}</strong>.
-          Veuillez l’ouvrir et cliquer sur le lien de <strong>connexion sécurisée à #{Current.application_name}</strong>.
+    %p.center{ aria: { hidden: true } }= image_tag("user/confirmation-email.svg", alt: t('views.confirmation.new.image_alt'))
 
-        %p.fr-text--lead
-          Ce lien est <strong>valide une semaine</strong> et peut être réutilisé <strong>plusieurs fois</strong>.
+    = render Dsfr::AlertComponent.new(title: '', state: :info, heading_level: 'h2', extra_class_names: 'fr-mt-6w fr-mb-3w') do |c|
+      - c.with_body do
+        %p= t('views.users.sessions.link_sent.email_cta_html', email: @email)
+        %p= t('views.confirmation.new.email_guidelines_html')
 
-        %p.fr-text--sm.fr-text-mention--grey
-          Ce courriel peut mettre jusqu’à <strong>15 minutes</strong> pour arriver. Si vous n’avez pas reçu de courriel (n’hésitez pas à vérifier dans les indésirables), cliquez sur le bouton ci-dessous.
+    %p.fr-text--sm.fr-text-mention--grey.fr-mb-1w
+      = t('views.confirmation.new.email_missing')
 
-      = button_to instructeurs_reset_link_sent_path, class: 'fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-mail-line', method: 'POST' do
-        Renvoyer le courriel
+    = button_to instructeurs_reset_link_sent_path, class: 'fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-mail-line', method: 'POST' do
+      = t('views.confirmation.new.resent')
 
-      %section
-        %p.fr-mt-3w
-          Si vous voyez cette page trop souvent, #{link_to "consultez notre aide", t("links.common.faq.confirmer_compte_chaque_connexion_url")}
-        %p.fr-mt-3w
-          = t('views.users.shared.contact_us_if_any_trouble_html', href: contact_admin_url)
+    %p.fr-text--sm.fr-text-mention--grey.fr-mt-3w
+      = t('views.users.sessions.link_sent.consult_help_page_html', href: t("links.common.faq.confirmer_compte_chaque_connexion_url"))
+
+    %p.fr-text--sm.fr-text-mention--grey.fr-mt-3w.fr-mb-6w
+      = t('views.users.shared.contact_us_if_any_trouble_html', href: contact_admin_url)

--- a/app/views/users/sessions/link_sent.html.haml
+++ b/app/views/users/sessions/link_sent.html.haml
@@ -18,7 +18,7 @@
     %p.fr-text--sm.fr-text-mention--grey.fr-mb-1w
       = t('views.confirmation.new.email_missing')
 
-    = button_to instructeurs_reset_link_sent_path, class: 'fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-mail-line', method: 'POST' do
+    = button_to instructeurs_reset_link_sent_path, class: 'fr-btn fr-btn--secondary', method: 'POST' do
       = t('views.confirmation.new.resent')
 
     %p.fr-text--sm.fr-text-mention--grey.fr-mt-3w

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -554,6 +554,9 @@ en:
           connect_with_agent_connect: Visit our dedicated page
           subtitle: "Sign in with my account"
           for_tiers_alert: If you are completing a forme for someone else, you must use your own credentials.
+        link_sent:
+          consult_help_page_html: If you're seeing this page too often, <a target="_blank" rel="noopener noreferrer" href="%{href}">please consult our help page</a>.
+          email_cta_html: "We have to validate your email address <strong>%{email}</strong>."
       passwords:
         edit:
           subtitle: Change password

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -557,6 +557,9 @@ fr:
           connect_with_agent_connect: Accédez à notre page dédiée
           subtitle: "Se connecter avec son compte"
           for_tiers_alert: Si vous remplissez un dossier pour un tiers, vous devez utiliser vos propres identifiants.
+        link_sent:
+          consult_help_page_html: Si vous voyez cette page trop souvent, <a target="_blank" rel="noopener noreferrer" href="%{href}">consultez notre aide</a>.
+          email_cta_html: "Nous avons besoin de vérifier votre adresse électronique <strong>%{email}</strong>."
       passwords:
         edit:
           subtitle: Changement de mot de passe


### PR DESCRIPTION
Issue: https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/8821

Depuis l'ouverture de l'issue, la page "lien envoyé" ressemblait à ça (version EN):
![Capture d’écran 2024-06-12 à 10 21 51](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/72251526/062c3e87-f9a3-44f3-be00-ba791e92818d)

Dans la mise au propre de la traduction, j'en ai profité pour me rapprocher du design de la page "confirmation", étant celle-ci:
![Capture d’écran 2024-06-12 à 14 11 20](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/72251526/cb301be8-057b-4003-b420-51beabd297b5)

Voici donc la proposition pour la page "lien envoyé":
![Capture d’écran 2024-06-13 à 16 25 34](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/72251526/7095dbaf-499f-459a-9498-ec5fd84e2cf3)
![Capture d’écran 2024-06-13 à 16 26 12](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/72251526/d2a9ec54-b7ec-43d1-b1ec-6627fb04afb9)


J'ai fixé un bug par ailleurs sur le lien qui renvoie vers la FAQ, ça faisait tourner en rond l'utilisateur en raison que l'url était considérée comme sensible au sens de la méthode sensitive_path.
