### PR TITLE
Correctif ETQ usager : bouton "Afficher toutes les erreurs" s'affiche en français

### DIFF
--- a/app/components/expandable_error_list/expandable_error_list.html.haml
+++ b/app/components/expandable_error_list/expandable_error_list.html.haml
@@ -6,7 +6,7 @@
         = error_descriptor.error_message
 
   - if tail.size > 0
-    %button.fr-mt-0.fr-btn.fr-btn--sm.fr-btn--tertiary-no-outline{ type: "button", "aria-controls": 'tail-errors', "aria-expanded": "false", class: "" }= t('see_more')
+    %button.fr-mt-0.fr-btn.fr-btn--sm.fr-btn--tertiary-no-outline{ type: "button", "aria-controls": 'tail-errors', "aria-expanded": "false", class: "" }= t('.see_more')
     %ul#tail-errors.fr-collapse.fr-mt-0
       - tail.each do |error_descriptor|
         %li


### PR DESCRIPTION
**AVANT**

![Capture d’écran 2024-06-14 à 10 36 22](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/e7039a6b-381b-4589-b21e-2c77c212ea79)

**APRES**
![Capture d’écran 2024-06-14 à 10 36 10](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/03668d24-f8b2-4c0b-89da-ab8432030a94)
