### PR TITLE
Tech (kredis): configure la connection `shared` qui est celle par défaut

### DIFF
--- a/app/controllers/concerns/lockable_concern.rb
+++ b/app/controllers/concerns/lockable_concern.rb
@@ -3,7 +3,7 @@ module LockableConcern
 
   included do
     def lock_action(key)
-      lock = Kredis.flag(key, config: :volatile)
+      lock = Kredis.flag(key)
       head :locked and return if lock.marked?
 
       lock.mark(expires_in: 10.seconds)

--- a/config/initializers/kredis.rb
+++ b/config/initializers/kredis.rb
@@ -1,7 +1,7 @@
-redis_volatile_options = {
+redis_shared_options = {
   url: ENV['REDIS_CACHE_URL'], # will fallback to default redis url if empty, and won't fail if there is no redis server
   ssl: ENV['REDIS_CACHE_SSL'] == 'enabled'
 }
-redis_volatile_options[:ssl_params] = { verify_mode: OpenSSL::SSL::VERIFY_NONE } if ENV['REDIS_CACHE_SSL_VERIFY_NONE'] == 'enabled'
+redis_shared_options[:ssl_params] = { verify_mode: OpenSSL::SSL::VERIFY_NONE } if ENV['REDIS_CACHE_SSL_VERIFY_NONE'] == 'enabled'
 
-Kredis::Connections.connections[:volatile] = Redis.new(redis_volatile_options)
+Kredis::Connections.connections[:shared] = Redis.new(redis_shared_options)

--- a/spec/controllers/concerns/lockable_concern_spec.rb
+++ b/spec/controllers/concerns/lockable_concern_spec.rb
@@ -27,7 +27,7 @@ describe LockableConcern, type: :controller do
     context 'when there are concurrent requests' do
       it 'aborts the second request' do
         # Simulating the first request acquiring the lock
-        Kredis.flag(lock_key, config: :volatile).mark(expires_in: 3.seconds)
+        Kredis.flag(lock_key).mark(expires_in: 3.seconds)
 
         # Making the second request
         expect(subject).to have_http_status(:locked)
@@ -36,7 +36,7 @@ describe LockableConcern, type: :controller do
 
     context 'when the lock expires' do
       it 'allows another request after expiration' do
-        Kredis.flag(lock_key, config: :volatile).mark(expires_in: 0.001.seconds)
+        Kredis.flag(lock_key).mark(expires_in: 0.001.seconds)
         sleep 0.002
 
         expect(subject).to have_http_status(:ok)


### PR DESCRIPTION
Kredis utilise par défaut une connection `shared` qui correspond à la config de la gem redis par défaut (sur 127.0.0.1).

Or on n'avait configuré qu'une seule connection (`volatile`), donc à moins de faire pointer explicitement un attribut vers `volatile`, ça pointait vers `shared`, ce qui marchait en local (avec un redis local), mais pas en prod qui n'a pas de redis local.
Ceci corrige donc le debounce de l'indexation des dossiers.