### PR TITLE
Mise à jour de la décalaration d'accessibilité

### DIFF
--- a/app/views/static_pages/accessibility_statement.html.haml
+++ b/app/views/static_pages/accessibility_statement.html.haml
@@ -9,20 +9,20 @@
       .fr-col-xl-8
         %h1.fr-mb-4w
           = t('views.accessibility_statement.title')
-        %p.fr-mb-2w= t('views.accessibility_statement.line_one')
-        %p.fr-mb-2w= t('views.accessibility_statement.line_two', app_name: Current.application_name, host: URI(Current.application_base_url).host)
+        %p.fr-mb-2w= t('views.accessibility_statement.line_one_html')
+        %p.fr-mb-2w= t('views.accessibility_statement.line_two_html', app_name: Current.application_name, host: URI(Current.application_base_url).host)
 
         %div
           %h2
             = t('views.accessibility_statement.compliance.title')
-          %p.fr-mb-2w= t('views.accessibility_statement.compliance.line_one_html')
-
+          %p.fr-mb-2w= t('views.accessibility_statement.compliance.content_html')
           %h3
             = t('views.accessibility_statement.results.title')
-          %p.fr-mb-2w= t('views.accessibility_statement.results.line_one')
-          %p.fr-mb-2w= t('views.accessibility_statement.results.line_three')
+          %p.fr-mb-2w= t('views.accessibility_statement.results.content')
           %p.fr-mb-2w
+            = t('views.accessibility_statement.results.programme.intro')
             = link_to t("views.accessibility_statement.results.programme.label"), t("views.accessibility_statement.results.programme.url"), title: t("views.accessibility_statement.results.programme.title"), target: "_blank", rel: "noopener noreferrer"
+            = "."
 
         %div
           %h2
@@ -31,6 +31,9 @@
             = t('views.accessibility_statement.no_accessible.subtitle_one')
           .fr-mb-2w
             = t('views.accessibility_statement.no_accessible.examples_html')
+          %h3
+            = t('views.accessibility_statement.no_accessible.subtitle_two')
+          = t('views.accessibility_statement.no_accessible.content_html')
 
         %div
           %h2
@@ -45,6 +48,10 @@
               = "HTML 5"
             %li
               = "CSS 3"
+            %li
+              = "SVG"
+            %li
+              = "ARIA"
             %li
               = "Javascript"
             %li
@@ -94,18 +101,6 @@
             %li
               = t("views.accessibility_statement.preparation.page_six")
             %li
-              = link_to t("views.accessibility_statement.preparation.page_seven.label"), t("views.accessibility_statement.preparation.page_seven.url"),
-                title: t("views.accessibility_statement.preparation.page_seven.title")
-            %li
-              = link_to t("views.accessibility_statement.preparation.page_eight.label"), t("views.accessibility_statement.preparation.page_eight.url"),
-                title: t("views.accessibility_statement.preparation.page_eight.title")
-            %li
-              = t("views.accessibility_statement.preparation.page_nine")
-            %li
-              = t("views.accessibility_statement.preparation.page_ten")
-            %li
-              = t("views.accessibility_statement.preparation.page_eleven")
-            %li
               = t("views.accessibility_statement.preparation.page_twelve")
             %li
               = t("views.accessibility_statement.preparation.page_thirteen")
@@ -131,11 +126,18 @@
           %h2
             = t('views.accessibility_statement.remedies.title')
           %p.fr-mb-2w= t('views.accessibility_statement.remedies.line_one')
-          %p.fr-mb-2w= t('views.accessibility_statement.remedies.line_two')
-          %ul.fr-mb-2w
+          %h3
+            = t('views.accessibility_statement.remedies.arcom_title')
+          %p.fr-mb-2w= t('views.accessibility_statement.remedies.arcom_content_html')
+          %h3
+            = t('views.accessibility_statement.remedies.ddd_title')
+          %p.fr-mb-2w= t('views.accessibility_statement.remedies.ddd_intro')
+          %ul
             %li
               = link_to t("views.accessibility_statement.remedies.remedies_one.label"), t("views.accessibility_statement.remedies.remedies_one.url"), title: t("views.accessibility_statement.remedies.remedies_one.title"), target: "_blank", rel: "noopener noreferrer"
+              %br
+              = t('views.accessibility_statement.remedies.remedies_one.info')
             %li
               = link_to t("views.accessibility_statement.remedies.remedies_two.label"), t("views.accessibility_statement.remedies.remedies_two.url"), title: t("views.accessibility_statement.remedies.remedies_two.title"), target: "_blank", rel: "noopener noreferrer"
             %li
-              = t('views.accessibility_statement.remedies.remedies_three')
+              = t('views.accessibility_statement.remedies.remedies_three_html')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -115,32 +115,44 @@ en:
         line_five: "Head office : 2 rue Kellermann - 59100 Roubaix - France."
     accessibility_statement:
       title: "Accessibility statement"
-      line_one: "DINUM is committed to making its service accessible in accordance with Article 47 of Law No. 2005-102 of 11 February 2005."
-      line_two: "This accessibility statement applies to %{app_name} (%{host})."
+      line_one_html: "DINUM is committed to making its service accessible in accordance with <a href=\"https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000037388867\" hreflang=\"fr\">Article 47 of Law No. 2005-102 of 11 February 2005</a>."
+      line_two_html: "This accessibility statement applies to <a href=\"%{host}\">%{app_name}</a> website."
       compliance:
         title: "Compliance status"
-        line_one_html: "The website Démarches simplifiées is <strong>partially compliant</strong> with the General Accessibility Guidelines (RGAA) version 4."
+        content_html: "The website Démarches simplifiées is <strong>partially compliant</strong> with <a href=\"https://accessibilite.numerique.gouv.fr/\">the General Accessibility Guidelines (RGAA)</a> version 4.1.2 as a result of the non-compliances listed below."
       results:
         title: "Test results"
-        line_one: "As of 13 June 2023, the average compliance rate of the site is 80%."
-        line_three: "Users can follow the measures taken by the service to improve the accessibility of the site at the following address:"
+        content: "The internal audit performed in June 2023 revealed an overall compliance rate of 81.36% on the sample of pages analyzed."
         programme:
-          label: "Follow the DS accessibility continuous improvement programme"
+          intro: "Users can follow the measures taken by the service to improve the accessibility of the site via "
+          label: "the DS accessibility continuous improvement programme"
           url: "https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues?q=accessibilit%C3%A9+"
-          title: "Follow the DS accessibility continuous improvement programme - new tab"
+          title: "the DS accessibility continuous improvement programme - new tab"
       no_accessible:
         title: "Non-accessible content"
         subtitle_one: "Non-compliances"
-        examples_html: "Exemples :
+        examples_html: "List of non-compliant criteria:
           <ul>
-            <li>The documentation pages are not fully accessible and are managed by a third party tool.</li>
-            <li>The same applies to the FAQ pages.</li>
-          </ul>
-          <p>We are taking this into account for the future development of the site's pages.</p>
-          "
+            <li>1.3 - A few alternative text descriptions of images conveying information are irrelevant.</li>
+            <li>3.1 - A few informations are conveyed solely through colour.</li>
+            <li>6.1 - Some links are not explicit.</li>
+            <li>7.1 - Some scripts are not compatible with assistive technologies.</li>
+            <li>7.5 - Some status messages are not correctly presented to assistive technologies.</li>
+            <li>8.9 - Some semantic elements are used for presentational effect.</li>
+            <li>9.3 - A few lists are not properly structured.</li>
+            <li>10.14 - A few additional contents appearing solely through CSS cannot be made visible by keyboard and any pointing device.</li>
+            <li>11.5 - A few related form fields are not regrouped.</li>
+            <li>11.11 - Input assistance does not provide suggestions to help correct errors.</li>
+            <li>13.3 - Some/Certain/A few downloadable documents do not have an accessible version.</li>
+          </ul>"
+        subtitle_two: "Additional notes"
+        content_html: "<p class=\"fr-mb-2w\">The documentation pages are managed by a third-party tool. They are not fully accessible.</p>
+          <p class=\"fr-mb-2w\">FAQ management was delegated to a third-party tool. It was reintegrated into the platform in May 2024 and has not yet been audited.</p>"
+
+          
       preparation:
         title: "Preparation of this accessibility declaration"
-        intro: "This declaration was drawn up on 27 April 2022. It was updated on 1 April 2023."
+        intro: "This declaration was drawn up on 27 April 2022. It was updated on 14 June 2024."
         subtitle_one: "Technologies used to create the site"
         techno_ruby:
           label: "Ruby on Rails"
@@ -172,17 +184,6 @@ en:
         page_five:
           label: "Authentification"
         page_six: "Home page - User search results"
-        page_seven:
-          label: "FAQ"
-          url: "/faq"
-          title: "FAQ - new tab"
-        page_eight:
-          label: "FAQ - User (submission of a file)"
-          url: "/faq#accordion-usager-0"
-          title: "FAQ - User (submission of a file)"
-        page_nine: "Documentation - Presentation"
-        page_ten: "Documentation - Start-up"
-        page_eleven: "Documentation - General"
         page_twelve: "File creation - Identity"
         page_thirteen: "File creation - Draft"
         page_fourteen: "Dossier - Summary"
@@ -196,17 +197,24 @@ en:
           adress_html: "By post : DINUM , 20 avenue de Ségur 75007 Paris"
       remedies:
         title: "Remedies"
-        line_one: "If you notice a lack of accessibility that prevents you from accessing a content or functionality of the site, and you report it to us and do not manage to obtain a rapid response from us, you are entitled to send your complaints or a request for referral to the Rights Defender."
-        line_two: "Several means are available to you:"
+        line_one: "If you notice a lack of accessibility that prevents you from accessing a content or functionality of the site, and you report it to us and do not manage to obtain a rapid response from us, you are entitled to contact Arcom or send your complaints to the Human Rights Defender."
+        arcom_title: "Contact Arcom"
+        arcom_content_html: "To report one or more violations of digital accessibility regulations, please use the <a href=\"https://www.arcom.fr/contact\">contact form available on the Arcom website</a>."
+        ddd_title: "Reach Out to the Human Rights Defender"
+        ddd_intro: "There are a number of ways you can exercise your rights with regard to accessibility issues you may have encountered:"
         remedies_one:
           label: "A contact form"
           url: "https://www.defenseurdesdroits.fr/nous-contacter"
           title: "A contact form - new tab"
+          info: "Select “I am a victim of discrimination,” followed by “Private goods and services,” and then “Disability.”"
         remedies_two:
           label: "Contact the delegate of the Human Rights Defender in your region"
           url: "https://www.defenseurdesdroits.fr/fr/saisir/delegues"
           title: "Contact the delegate of the Human Rights Defender in your region - new tab"
-        remedies_three: "Send a letter by post (free of charge, do not put a stamp) Défenseur des droits Libre réponse 71120 75342 Paris CEDEX 07"
+        remedies_three_html: "Send a letter by post (free of charge, do not put a stamp) to the following address
+          <p class=\"fr-mb-2w\">Défenseur des droits
+          <br >Libre réponse 71120
+          <br>75342 Paris CEDEX 07</p>"
     prefill_descriptions:
       edit:
         intro_html: "You'd like to allow your users to <strong>create a prefilled file</strong>, with data you already have, for the procedure « %{libelle} »."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -111,32 +111,43 @@ fr:
         line_five: "Siège social : 2 rue Kellermann - 59100 Roubaix - France."
     accessibility_statement:
       title: "Déclaration d’accessibilité"
-      line_one: "La DINUM s’engage à rendre son service accessible, conformément à l’article 47 de la loi n° 2005-102 du 11 février 2005."
-      line_two: "Cette déclaration d’accessibilité s’applique à %{app_name} (%{host})."
+      line_one_html: "La DINUM s’engage à rendre son service accessible, conformément à l’<a href=\"https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000037388867\">article 47 de la loi n° 2005-102 du 11 février 2005</a>."
+      line_two_html: "Cette déclaration d’accessibilité s’applique au site <a href=\"%{host}\">%{app_name}</a>."
       compliance:
         title: "État de conformité"
-        line_one_html: "Le site Démarches simplifiées est <strong>partiellement conforme</strong> avec le référentiel général d’amélioration de l’accessibilité (RGAA) version 4."
+        content_html: "Le site Démarches simplifiées est <strong>partiellement conforme</strong> au <a href=\"https://accessibilite.numerique.gouv.fr/\">Référentiel Général d’Amélioration de l’Accessibilité (RGAA)</a> version 4.1.2 en raison des non-conformités listées ci-après."
       results:
         title: "Résultats des tests"
-        line_one: "En date du 13 juin 2023, le taux moyen de conformité du site est de 80%."
-        line_three: "Les usagers peuvent suivre les mesures engagées par le service pour améliorer l’accessibilité du site à l’adresse suivante :"
+        content: "L'audit réalisé en interne en juin 2023 révèle que le taux de conformité global est de 81,36% sur l'échantillon de pages analysés."
         programme:
-          label: "Suivez le programme d'amélioration continue de DS en matière d'accessibilité"
+          intro: "Les usagers peuvent suivre les mesures engagées par le service pour améliorer l’accessibilité du site grâce au "
+          label: "programme d'amélioration continue de DS en matière d'accessibilité"
           url: "https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues?q=accessibilit%C3%A9+"
-          title: "Suivez le programme d'amélioration continue de DS en matière d'accessibilité - nouvel onglet"
+          title: "programme d'amélioration continue de DS en matière d'accessibilité - nouvel onglet"
       no_accessible:
         title: "Contenus non accessibles"
         subtitle_one: "Non-conformités"
-        examples_html: "Exemples :
+        examples_html: "Liste des critères non conformes :
           <ul>
-            <li>Les pages de documentation ne sont pas entièrement accessibles et sont gérées par un outil tiers.</li>
-            <li>Il en est de même pour les pages de la FAQ.</li>
-          </ul>
-          <p>Nous en tenons compte pour les futures évolutions des pages du site.</p>
-          "
+            <li>1.3 - Des alternatives textuelles d’images porteuses d’informations ne sont pas pertinentes.</li>
+            <li>3.1 - Des informations sont données uniquement par la couleur.</li>
+            <li>6.1 - Des liens ne sont pas explicites.</li>
+            <li>7.1 - Des scripts ne sont pas compatibles avec les technologies d’assistance. </li>
+            <li>7.5 - Des messages de statut ne sont pas correctement restitués par les technologies d’assistance.</li>
+            <li>8.9 - Des balises sont utilisées uniquement à des fins de présentation.</li>
+            <li>9.3 - Des listes ne sont pas correctement structurées.</li>
+            <li>10.14 - Des contenus additionnels apparaissant via les styles CSS uniquement ne peuvent pas être rendus visibles au clavier et par tout dispositif de pointage.</li>
+            <li>11.5 - Des champs de même nature ne sont pas regroupés.</li>
+            <li>11.11 - Des contrôles de saisie ne sont pas accompagnés de suggestions facilitant la correction des erreurs.</li>
+            <li>13.3 - Des documents bureautiques en téléchargement ne possèdent pas de version accessible.</li>
+          </ul>"
+        subtitle_two: "Remarques complémentaires"
+        content_html: "<p class=\"fr-mb-2w\">Les pages de documentation sont gérées par un outil tiers. Elles ne sont pas entièrement accessibles.</p>
+          <p class=\"fr-mb-2w\">La gestion de la FAQ était déléguée à un outil tiers. Elle a été réintégrée à la plateforme en mai 2024 et n'a pas encore été auditée.</p>"
+
       preparation:
         title: "Établissement de cette déclaration d’accessibilité"
-        intro: "Cette déclaration a été établie le 27 avril 2022. Elle a été mise à jour le 1er avril 2023."
+        intro: "Cette déclaration a été établie le 27 avril 2022. Elle a été mise à jour le 14 juin 2024."
         subtitle_one: "Technologies utilisées pour la réalisation du site"
         techno_ruby:
           label: "Ruby on Rails"
@@ -168,17 +179,6 @@ fr:
         page_five:
           label: "Authentification"
         page_six: "Accueil connecté - Résultats de recherche usager"
-        page_seven:
-          label: "FAQ"
-          url: "/faq"
-          title: "FAQ - nouvel onglet"
-        page_eight:
-          label: "FAQ - Usager (dépôt d'un dossier)"
-          url: "/faq#accordion-usager-0"
-          title: "FAQ - Usager (dépôt d'un dossier)"
-        page_nine: "Documentation - Présentation"
-        page_ten: "Documentation - Démarrage"
-        page_eleven: "Documentation - Généralités"
         page_twelve: "Création dossier - Identité"
         page_thirteen: "Création dossier - Brouillon"
         page_fourteen: "Dossier - Résumé"
@@ -192,17 +192,24 @@ fr:
           adress_html: "Par voie postale : DINUM , 20 avenue de Ségur 75007 Paris"
       remedies:
         title: "Voies de recours"
-        line_one: "Si vous constatez un défaut d’accessibilité vous empêchant d’accéder à un contenu ou une fonctionnalité du site, que vous nous le signalez et que vous ne parvenez pas à obtenir une réponse rapide de notre part, vous êtes en droit de faire parvenir vos doléances ou une demande de saisine au Défenseur des droits."
-        line_two: "Plusieurs moyens sont à votre disposition :"
+        line_one: "Si vous constatez un défaut d’accessibilité vous empêchant d’accéder à un contenu ou une fonctionnalité du site, que vous nous le signalez et que vous ne parvenez pas à obtenir une réponse rapide de notre part, vous êtes en droit de contacter l'Arcom ou de saisir le Défenseur des droits."
+        arcom_title: "Contacter l'Arcom"
+        arcom_content_html: "Afin de signaler un ou plusieurs manquement(s) à la réglementation relative à l’accessibilité numérique, rendez-vous sur le <a href=\"https://www.arcom.fr/contact\">formulaire de contact du site web de l'Arcom</a>."
+        ddd_title: "Saisir le Défenseur des droits"
+        ddd_intro: "Pour faire valoir vos droits relatifs à des défauts d'accessibilité que vous avez rencontrés, plusieurs moyens sont à votre disposition :"
         remedies_one:
           label: "Un formulaire de contact"
           url: "https://www.defenseurdesdroits.fr/nous-contacter"
           title: "Un formulaire de contact - nouvel onglet"
+          info: "Choisissez la thématique « Je suis victime de discrimination » puis « Biens et services privés » et enfin « Handicap »."
         remedies_two:
           label: "Contacter le délégué du Défenseur des droits dans votre région"
           url: "https://www.defenseurdesdroits.fr/fr/saisir/delegues"
           title: "Contacter le délégué du Défenseur des droits dans votre région - nouvel onglet"
-        remedies_three: "Envoyer un courrier par la poste (gratuit, ne pas mettre de timbre) Défenseur des droits Libre réponse 71120 75342 Paris CEDEX 07"
+        remedies_three_html: "Envoyer un courrier par la poste (gratuit, ne pas mettre de timbre) à l'adresse suivante :  
+          <p class=\"fr-mb-2w\">Défenseur des droits
+          <br >Libre réponse 71120
+          <br>75342 Paris CEDEX 07</p>"
     prefill_descriptions:
       edit:
         intro_html: "Vous souhaitez permettre à vos usager·ères la <strong>création d'un dossier prérempli</strong>, à partir de données dont vous disposez déjà, pour la démarche « %{libelle} »."


### PR DESCRIPTION
Reprise de la déclaration pour faire état de :
- la version du RGAA utilisée lors de l'audit ;
- le nom et la qualité de l'auditrice ;
- le taux global de conformité (et non pas le taux moyen) ;
- la liste exhaustive des critères invalidés ;
- la voie de recours via l'Arcom.

J'en ai profité pour supprimer de la liste des pages auditées celles indiquées comme NT (Non Testées) dans la grille d'audit.