### PR TITLE
ETQ administrateur, lorsque je gère ma liste d'expert invités sur une démarche, je suis guidé pour eviter les typos

### DIFF
--- a/app/components/procedure/invitation_with_typo_component.rb
+++ b/app/components/procedure/invitation_with_typo_component.rb
@@ -1,11 +1,11 @@
 class Procedure::InvitationWithTypoComponent < ApplicationComponent
-  def initialize(maybe_typo:, url:, title:)
-    @maybe_typo = maybe_typo
+  def initialize(maybe_typos:, url:, title:)
+    @maybe_typos = maybe_typos
     @url = url
     @title = title
   end
 
   def render?
-    @maybe_typo.present?
+    @maybe_typos.present?
   end
 end

--- a/app/components/procedure/invitation_with_typo_component.rb
+++ b/app/components/procedure/invitation_with_typo_component.rb
@@ -8,13 +8,4 @@ class Procedure::InvitationWithTypoComponent < ApplicationComponent
   def render?
     @maybe_typo.present?
   end
-
-  def maybe_typos
-    email_checker = EmailChecker.new
-
-    @maybe_typo.map do |actual_email|
-      suggested_email = email_checker.check(email: actual_email)[:email_suggestions].first
-      [actual_email, suggested_email]
-    end
-  end
 end

--- a/app/components/procedure/invitation_with_typo_component.rb
+++ b/app/components/procedure/invitation_with_typo_component.rb
@@ -1,8 +1,7 @@
 class Procedure::InvitationWithTypoComponent < ApplicationComponent
-  def initialize(maybe_typo:, url:, params:, title:)
+  def initialize(maybe_typo:, url:, title:)
     @maybe_typo = maybe_typo
     @url = url
-    @params = params
     @title = title
   end
 

--- a/app/components/procedure/invitation_with_typo_component.rb
+++ b/app/components/procedure/invitation_with_typo_component.rb
@@ -1,0 +1,21 @@
+class Procedure::InvitationWithTypoComponent < ApplicationComponent
+  def initialize(maybe_typo:, url:, params:, title:)
+    @maybe_typo = maybe_typo
+    @url = url
+    @params = params
+    @title = title
+  end
+
+  def render?
+    @maybe_typo.present?
+  end
+
+  def maybe_typos
+    email_checker = EmailChecker.new
+
+    @maybe_typo.map do |actual_email|
+      suggested_email = email_checker.check(email: actual_email)[:email_suggestions].first
+      [actual_email, suggested_email]
+    end
+  end
+end

--- a/app/components/procedure/invitation_with_typo_component/invitation_with_typo_component.html.haml
+++ b/app/components/procedure/invitation_with_typo_component/invitation_with_typo_component.html.haml
@@ -2,9 +2,9 @@
   - c.with_body do
     %p= @title
     %ul
-      - @maybe_typo.each do |(actual_email, suggested_email)|
+      - @maybe_typos.each do |(actual_email, suggested_email)|
         %li
           = "Je confirme "
-          = button_to "#{actual_email}", @url, method: :POST, params: { maybe_typo: actual_email }, class: 'fr-btn fr-btn--tertiary fr-btn--sm', form: {class: 'inline'}
+          = button_to "#{actual_email}", @url, method: :POST, params: { final_email: actual_email }, class: 'fr-btn fr-btn--tertiary fr-btn--sm', form: {class: 'inline'}
           = " ou "
-          = button_to "#{suggested_email}", @url, method: :POST, params: { maybe_typo: suggested_email }, class: 'fr-btn fr-btn--tertiary fr-btn--sm', form: {class: 'inline'}
+          = button_to "#{suggested_email}", @url, method: :POST, params: { final_email: suggested_email }, class: 'fr-btn fr-btn--tertiary fr-btn--sm', form: {class: 'inline'}

--- a/app/components/procedure/invitation_with_typo_component/invitation_with_typo_component.html.haml
+++ b/app/components/procedure/invitation_with_typo_component/invitation_with_typo_component.html.haml
@@ -5,6 +5,6 @@
       - maybe_typos.each do |(actual_email, suggested_email)|
         %li
           = "Je confirme "
-          = button_to "#{actual_email}", @url, method: :POST, params: @params.call(actual_email), class: 'fr-btn fr-btn--tertiary fr-btn--sm', form: {class: 'inline'}
+          = button_to "#{actual_email}", @url, method: :POST, params: { maybe_typo: actual_email }, class: 'fr-btn fr-btn--tertiary fr-btn--sm', form: {class: 'inline'}
           = " ou "
-          = button_to "#{suggested_email}", @url, method: :POST, params: @params.call(suggested_email), class: 'fr-btn fr-btn--tertiary fr-btn--sm', form: {class: 'inline'}
+          = button_to "#{suggested_email}", @url, method: :POST, params: { maybe_typo: suggested_email }, class: 'fr-btn fr-btn--tertiary fr-btn--sm', form: {class: 'inline'}

--- a/app/components/procedure/invitation_with_typo_component/invitation_with_typo_component.html.haml
+++ b/app/components/procedure/invitation_with_typo_component/invitation_with_typo_component.html.haml
@@ -1,0 +1,10 @@
+= render Dsfr::AlertComponent.new(title: "nous pensons avoir identifié une faute de frappe : ", state: :warning, extra_class_names: 'fr-mb-3w') do |c|
+  - c.with_body do
+    %p= @title
+    %ul
+      - maybe_typos.each do |(actual_email, suggested_email)|
+        %li
+          = "Je confirme "
+          = button_to "#{actual_email}", @url, method: :POST, params: @params.call(actual_email), class: 'fr-btn fr-btn--tertiary fr-btn--sm', form: {class: 'inline'}
+          = " ou "
+          = button_to "#{suggested_email}", @url, method: :POST, params: @params.call(suggested_email), class: 'fr-btn fr-btn--tertiary fr-btn--sm', form: {class: 'inline'}

--- a/app/components/procedure/invitation_with_typo_component/invitation_with_typo_component.html.haml
+++ b/app/components/procedure/invitation_with_typo_component/invitation_with_typo_component.html.haml
@@ -2,7 +2,7 @@
   - c.with_body do
     %p= @title
     %ul
-      - maybe_typos.each do |(actual_email, suggested_email)|
+      - @maybe_typo.each do |(actual_email, suggested_email)|
         %li
           = "Je confirme "
           = button_to "#{actual_email}", @url, method: :POST, params: { maybe_typo: actual_email }, class: 'fr-btn fr-btn--tertiary fr-btn--sm', form: {class: 'inline'}

--- a/app/components/procedure/invitation_with_typo_component/invitation_with_typo_component.html.haml
+++ b/app/components/procedure/invitation_with_typo_component/invitation_with_typo_component.html.haml
@@ -1,7 +1,7 @@
 = render Dsfr::AlertComponent.new(title: "nous pensons avoir identifié une faute de frappe : ", state: :warning, extra_class_names: 'fr-mb-3w') do |c|
   - c.with_body do
     %p= @title
-    %ul
+    %ul#maybe_typos_errors
       - @maybe_typos.each do |(actual_email, suggested_email)|
         %li
           = "Je confirme "

--- a/app/controllers/administrateurs/experts_procedures_controller.rb
+++ b/app/controllers/administrateurs/experts_procedures_controller.rb
@@ -9,17 +9,11 @@ module Administrateurs
     end
 
     def create
-      email_checker = EmailChecker.new
       emails = params['emails'].presence || [].to_json
       emails = JSON.parse(emails).map { EmailSanitizer.sanitize(_1) }
-      @maybe_typo, emails = emails.map do |email|
-          result = email_checker.check(email: email)
-          if result[:email_suggestions].present?
-            [email, result[:email_suggestions].first]
-          else
-            [email, nil]
-          end
-        end.partition { _1[1].present? }
+      @maybe_typo, emails = emails
+        .map { |email| [email, EmailChecker.check(email:)[:suggestions]&.first] }
+        .partition { _1[1].present? }
       errors = if !@maybe_typo.empty?
         ["Attention, nous pensons avoir identifié une faute de frappe dans les invitations : #{@maybe_typo.map(&:first).join(', ')}"]
       else

--- a/app/controllers/administrateurs/experts_procedures_controller.rb
+++ b/app/controllers/administrateurs/experts_procedures_controller.rb
@@ -15,7 +15,7 @@ module Administrateurs
         .map { |email| [email, EmailChecker.check(email:)[:suggestions]&.first] }
         .partition { _1[1].present? }
       errors = if !@maybe_typos.empty?
-        ["Attention, nous pensons avoir identifié une faute de frappe dans les invitations : #{@maybe_typos.map(&:first).join(', ')}"]
+        ["Attention, nous pensons avoir identifié une faute de frappe dans les invitations : #{@maybe_typos.map(&:first).join(', ')}. Veuillez, #{view_context.link_to(" verifier l'orthographe", "#maybe_typos_errors")} des invitations."]
       else
         []
       end

--- a/app/controllers/administrateurs/experts_procedures_controller.rb
+++ b/app/controllers/administrateurs/experts_procedures_controller.rb
@@ -45,13 +45,13 @@ module Administrateurs
           end
         end
 
-        flash[:notice] = t('.experts_assignment',
+        flash.now[:notice] = t('.experts_assignment',
           count: valid_users.count,
           value: valid_users.map(&:email).join(', '),
           procedure: @procedure.id)
       end
 
-      flash[:alert] = errors.join(". ") if !errors.empty?
+      flash.now[:alert] = errors.join(". ") if !errors.empty?
       render :index
     end
 

--- a/app/controllers/email_checker_controller.rb
+++ b/app/controllers/email_checker_controller.rb
@@ -1,5 +1,5 @@
 class EmailCheckerController < ApplicationController
   def show
-    render json: EmailChecker.new.check(email: params[:email])
+    render json: EmailChecker.check(email: params[:email])
   end
 end

--- a/app/javascript/controllers/email_input_controller.ts
+++ b/app/javascript/controllers/email_input_controller.ts
@@ -4,7 +4,7 @@ import { ApplicationController } from './application_controller';
 
 type checkEmailResponse = {
   success: boolean;
-  email_suggestions: string[];
+  suggestions: string[];
 };
 
 export class EmailInputController extends ApplicationController {
@@ -36,8 +36,8 @@ export class EmailInputController extends ApplicationController {
       url.toString()
     ).json();
 
-    if (data && data.email_suggestions && data.email_suggestions.length > 0) {
-      this.suggestionTarget.innerHTML = data.email_suggestions[0];
+    if (data && data.suggestions && data.suggestions.length > 0) {
+      this.suggestionTarget.innerHTML = data.suggestions[0];
       show(this.ariaRegionTarget);
       this.ariaRegionTarget.setAttribute('aria-live', 'assertive');
     }

--- a/app/lib/email_checker.rb
+++ b/app/lib/email_checker.rb
@@ -615,7 +615,7 @@ class EmailChecker
     'ac-toulous.fr'
   ].freeze
 
-  def check(email:)
+  def self.check(email:)
     return { success: false } if email.blank?
 
     parsed_email = Mail::Address.new(EmailSanitizableConcern::EmailSanitizer.sanitize(email))
@@ -626,29 +626,29 @@ class EmailChecker
     similar_domains = closest_domains(domain: parsed_email.domain)
     return { success: true } if similar_domains.empty?
 
-    { success: true, email_suggestions: email_suggestions(parsed_email:, similar_domains:) }
+    { success: true, suggestions: suggestions(parsed_email:, similar_domains:) }
   rescue Mail::Field::IncompleteParseError
     return { success: false }
   end
 
   private
 
-  def closest_domains(domain:)
+  def self.closest_domains(domain:)
     KNOWN_DOMAINS.filter do |known_domain|
       close_by_distance_of(domain, known_domain, distance: 1) ||
       with_same_chars_and_close_by_distance_of(domain, known_domain, distance: 2)
     end
   end
 
-  def close_by_distance_of(a, b, distance:)
+  def self.close_by_distance_of(a, b, distance:)
     String::Similarity.levenshtein_distance(a, b) == distance
   end
 
-  def with_same_chars_and_close_by_distance_of(a, b, distance:)
+  def self.with_same_chars_and_close_by_distance_of(a, b, distance:)
     close_by_distance_of(a, b, distance: 2) && a.chars.sort == b.chars.sort
   end
 
-  def email_suggestions(parsed_email:, similar_domains:)
+  def self.suggestions(parsed_email:, similar_domains:)
     similar_domains.map { Mail::Address.new("#{parsed_email.local}@#{_1}").to_s }
   end
 end

--- a/app/views/administrateurs/experts_procedures/index.html.haml
+++ b/app/views/administrateurs/experts_procedures/index.html.haml
@@ -58,6 +58,7 @@
 
       - if @procedure.experts_require_administrateur_invitation?
         .card
+          = render Procedure::InvitationWithTypoComponent.new(maybe_typo: @maybe_typo, url: admin_procedure_experts_path(@procedure), params: ->(email) { { maybe_typo: email } }, title: "Avant d'ajouter l'email à la liste d'expert prédéfinie, veuillez confirmer" )
           = form_for :experts_procedure,
             url: admin_procedure_experts_path(@procedure),
             html: { class: 'form' } do |f|

--- a/app/views/administrateurs/experts_procedures/index.html.haml
+++ b/app/views/administrateurs/experts_procedures/index.html.haml
@@ -58,7 +58,7 @@
 
       - if @procedure.experts_require_administrateur_invitation?
         .card
-          = render Procedure::InvitationWithTypoComponent.new(maybe_typo: @maybe_typo, url: admin_procedure_experts_path(@procedure), title: "Avant d'ajouter l'email à la liste d'expert prédéfinie, veuillez confirmer" )
+          = render Procedure::InvitationWithTypoComponent.new(maybe_typos: @maybe_typos, url: admin_procedure_experts_path(@procedure), title: "Avant d'ajouter l'email à la liste d'expert prédéfinie, veuillez confirmer" )
           = form_for :experts_procedure,
             url: admin_procedure_experts_path(@procedure),
             html: { class: 'form' } do |f|

--- a/app/views/administrateurs/experts_procedures/index.html.haml
+++ b/app/views/administrateurs/experts_procedures/index.html.haml
@@ -58,7 +58,7 @@
 
       - if @procedure.experts_require_administrateur_invitation?
         .card
-          = render Procedure::InvitationWithTypoComponent.new(maybe_typo: @maybe_typo, url: admin_procedure_experts_path(@procedure), params: ->(email) { { maybe_typo: email } }, title: "Avant d'ajouter l'email à la liste d'expert prédéfinie, veuillez confirmer" )
+          = render Procedure::InvitationWithTypoComponent.new(maybe_typo: @maybe_typo, url: admin_procedure_experts_path(@procedure), title: "Avant d'ajouter l'email à la liste d'expert prédéfinie, veuillez confirmer" )
           = form_for :experts_procedure,
             url: admin_procedure_experts_path(@procedure),
             html: { class: 'form' } do |f|

--- a/spec/controllers/administrateurs/experts_procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/experts_procedures_controller_spec.rb
@@ -43,7 +43,7 @@ describe Administrateurs::ExpertsProceduresController, type: :controller do
       render_views
       it 'warns' do
         expect(flash.alert).to be_present
-        expect(assigns(:maybe_typo)).to eq(['martin@oraneg.fr'])
+        expect(assigns(:maybe_typo)).to eq([['martin@oraneg.fr', 'martin@orange.fr']])
         expect(response).to have_http_status(:success)
       end
     end

--- a/spec/controllers/administrateurs/experts_procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/experts_procedures_controller_spec.rb
@@ -33,7 +33,7 @@ describe Administrateurs::ExpertsProceduresController, type: :controller do
         expect(procedure.experts.include?(expert)).to be_truthy
         expect(procedure.experts.include?(expert2)).to be_truthy
         expect(flash.notice).to be_present
-        expect(assigns(:maybe_typo)).to eq([])
+        expect(assigns(:maybe_typos)).to eq([])
         expect(response).to have_http_status(:success)
       end
     end
@@ -43,22 +43,24 @@ describe Administrateurs::ExpertsProceduresController, type: :controller do
       render_views
       it 'warns' do
         expect(flash.alert).to be_present
-        expect(assigns(:maybe_typo)).to eq([['martin@oraneg.fr', 'martin@orange.fr']])
+        expect(assigns(:maybe_typos)).to eq([['martin@oraneg.fr', 'martin@orange.fr']])
         expect(response).to have_http_status(:success)
       end
     end
 
     context 'when forcing email with typos' do
-      let(:maybe_typo) { 'martin@oraneg.fr' }
-      let(:params) { { procedure_id: procedure.id, maybe_typo: } }
+      render_views
+      let(:final_email) { 'martin@oraneg.fr' }
+      let(:params) { { procedure_id: procedure.id, final_email: } }
 
       it 'works' do
-        created_user = User.where(email: maybe_typo).first
+        created_user = User.where(email: final_email).first
         expect(created_user).to be_an_instance_of(User)
         expect(created_user.expert).to be_an_instance_of(Expert)
         expect(procedure.experts.include?(created_user.expert)).to be_truthy
         expect(flash.notice).to be_present
         expect(response).to have_http_status(:success)
+        expect(response.body).to have_content(final_email)
       end
     end
   end

--- a/spec/controllers/email_checker_controller_spec.rb
+++ b/spec/controllers/email_checker_controller_spec.rb
@@ -16,7 +16,7 @@ describe EmailCheckerController, type: :controller do
       let(:params) { { email: 'martin@orane.fr' } }
       it do
         expect(response).to have_http_status(:success)
-        expect(body).to eq({ success: true, email_suggestions: ['martin@orange.fr'] })
+        expect(body).to eq({ success: true, suggestions: ['martin@orange.fr'] })
       end
     end
 

--- a/spec/lib/email_checker_spec.rb
+++ b/spec/lib/email_checker_spec.rb
@@ -1,6 +1,6 @@
 describe EmailChecker do
   describe 'check' do
-    subject { described_class.new }
+    subject { described_class }
 
     it 'works with identified use cases' do
       expect(subject.check(email: nil)).to eq({ success: false })
@@ -10,22 +10,22 @@ describe EmailChecker do
       # allow same domain
       expect(subject.check(email: "martin@orange.fr")).to eq({ success: true })
       # find difference of 1 lev distance
-      expect(subject.check(email: "martin@orane.fr")).to eq({ success: true, email_suggestions: ['martin@orange.fr'] })
+      expect(subject.check(email: "martin@orane.fr")).to eq({ success: true, suggestions: ['martin@orange.fr'] })
       # find difference of 2 lev distance, only with same chars
-      expect(subject.check(email: "martin@oragne.fr")).to eq({ success: true, email_suggestions: ['martin@orange.fr'] })
+      expect(subject.check(email: "martin@oragne.fr")).to eq({ success: true, suggestions: ['martin@orange.fr'] })
       # ignore unknown domain
       expect(subject.check(email: "martin@ore.fr")).to eq({ success: true })
     end
 
     it 'passes through real use cases, with levenshtein_distance 1' do
-      expect(subject.check(email: "martin@asn.com")).to eq({ success: true, email_suggestions: ['martin@msn.com'] })
-      expect(subject.check(email: "martin@gamail.com")).to eq({ success: true, email_suggestions: ['martin@gmail.com'] })
-      expect(subject.check(email: "martin@glail.com")).to eq({ success: true, email_suggestions: ['martin@gmail.com'] })
-      expect(subject.check(email: "martin@gmail.coml")).to eq({ success: true, email_suggestions: ['martin@gmail.com'] })
-      expect(subject.check(email: "martin@gmail.con")).to eq({ success: true, email_suggestions: ['martin@gmail.com'] })
-      expect(subject.check(email: "martin@hotmil.fr")).to eq({ success: true, email_suggestions: ['martin@hotmail.fr'] })
-      expect(subject.check(email: "martin@mail.com")).to eq({ success: true, email_suggestions: ["martin@gmail.com", "martin@ymail.com", "martin@mailo.com"] })
-      expect(subject.check(email: "martin@msc.com")).to eq({ success: true, email_suggestions: ["martin@msn.com", "martin@mac.com"] })
+      expect(subject.check(email: "martin@asn.com")).to eq({ success: true, suggestions: ['martin@msn.com'] })
+      expect(subject.check(email: "martin@gamail.com")).to eq({ success: true, suggestions: ['martin@gmail.com'] })
+      expect(subject.check(email: "martin@glail.com")).to eq({ success: true, suggestions: ['martin@gmail.com'] })
+      expect(subject.check(email: "martin@gmail.coml")).to eq({ success: true, suggestions: ['martin@gmail.com'] })
+      expect(subject.check(email: "martin@gmail.con")).to eq({ success: true, suggestions: ['martin@gmail.com'] })
+      expect(subject.check(email: "martin@hotmil.fr")).to eq({ success: true, suggestions: ['martin@hotmail.fr'] })
+      expect(subject.check(email: "martin@mail.com")).to eq({ success: true, suggestions: ["martin@gmail.com", "martin@ymail.com", "martin@mailo.com"] })
+      expect(subject.check(email: "martin@msc.com")).to eq({ success: true, suggestions: ["martin@msn.com", "martin@mac.com"] })
       expect(subject.check(email: "martin@ymail.com")).to eq({ success: true })
     end
 


### PR DESCRIPTION
follows_up : https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/10499
cf: https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/10418
> les saisies en batch cherchent les typos dans les batchs

# problème, COI

le contexte global est que : en gros, sur l'internet mondial il y a trop de spam et des gens mécontant. les services devraient garantir/valider que les mails saisis sont bien les personnes a qui le mail saisi appartient de sorte a ne pas spammer un voisin en saisissant son mail sur un site. 

# solution, 

on a deja une 'solution' pr eviter les typos quand on s'inscrit sur DS (création de compte). 

sauf qu'on a aussi des retours d'instructeurs/expert qui nous disent avoir mis des mails ayant des typos dans les comptes d'instructeurs et experts qu'ils ont eux même invités. en parallel, un des "gardiens" de l'antispam de l'internet mondial nous dit qu'on est des spammeurs. 

Aujourd'hui on cherche donc a faire des efforts sur ce sujet. Ici on a donc un petit pas : quand un admin saisi un mail, on tente de détecter des typos parmis les noms de domaines que nous connaissons. L'idée est de : 
1. remonter l'erreur
2. proposer un choix (typo ou pas typo ?)
3. effectuer un choix

resultat (validé par Marlène)
<img width="1223" alt="Capture d’écran 2024-06-20 à 3 28 03 PM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/85b24496-18d5-4bc1-b3c4-9deac015b4a7">
