### PR TITLE
Correction de la structure de navigation

### DIFF
--- a/app/components/dossiers/user_filter_component/user_filter_component.html.haml
+++ b/app/components/dossiers/user_filter_component/user_filter_component.html.haml
@@ -1,6 +1,6 @@
 .fr-grid-row
   .fr-col-12
-    %nav.fr-translate.fr-nav
+    .fr-translate.fr-nav
       .fr-nav__item.custom-fr-translate-flex-end
         %button.fr-translate__btn.translate-no-icon.fr-btn.fr-btn--tertiary.custom-fr-translate-no-icon{ "aria-controls" => "filters", "aria-expanded" => "false", title: t('.button.select_filters') }
           = t('.button.select_filters')

--- a/app/components/main_navigation/instructeur_expert_navigation_component/instructeur_expert_navigation_component.html.haml
+++ b/app/components/main_navigation/instructeur_expert_navigation_component/instructeur_expert_navigation_component.html.haml
@@ -1,4 +1,4 @@
-%nav#header-navigation.fr-nav{ role: :navigation, "aria-label" => t('main_menu', scope: [:layouts, :header]) }
+#header-navigation.fr-nav
   %ul.fr-nav__list
     - if instructeur?
       %li.fr-nav__item

--- a/app/views/administrateurs/_main_navigation.html.haml
+++ b/app/views/administrateurs/_main_navigation.html.haml
@@ -1,4 +1,4 @@
-%nav#header-navigation.fr-nav{ role: 'navigation', 'aria-label': 'Menu principal administrateur' }
+#header-navigation.fr-nav
   %ul.fr-nav__list
     %li.fr-nav__item= link_to 'Mes démarches', admin_procedures_path, class:'fr-nav__link', 'aria-current': current_page?(controller: 'administrateurs/procedures', action: :index) ? 'true' : nil
     - if Rails.application.config.ds_zonage_enabled

--- a/app/views/gestionnaires/groupe_gestionnaires/_main_navigation.html.haml
+++ b/app/views/gestionnaires/groupe_gestionnaires/_main_navigation.html.haml
@@ -1,4 +1,4 @@
 - content_for(:main_navigation) do
-  %nav#header-navigation.fr-nav{ role: 'navigation', 'aria-label': 'Menu principal gestionnaire' }
+  #header-navigation.fr-nav
     %ul.fr-nav__list
       %li.fr-nav__item= link_to 'Mes groupes gestionnaires', gestionnaire_groupe_gestionnaires_path, class:'fr-nav__link', 'aria-current': current_page?(controller: 'groupe_gestionnaires', action: :index) ? 'page' : nil

--- a/app/views/layouts/_account_dropdown.haml
+++ b/app/views/layouts/_account_dropdown.haml
@@ -1,4 +1,4 @@
-%nav.fr-translate.fr-nav{ role: "navigation", "aria-label"=> t('menu_aria_label', scope: [:layouts]) }
+%nav.fr-translate.fr-nav{ role: "navigation", "aria-label"=> t('my_account', scope: [:layouts]) }
   .fr-nav__item
     %button.account-btn.fr-translate__btn.fr-btn{ "aria-controls" => "account", "aria-expanded" => "false", :title => t('my_account', scope: [:layouts]) }
       %span= current_email

--- a/app/views/layouts/_header.haml
+++ b/app/views/layouts/_header.haml
@@ -8,83 +8,84 @@
 - is_user_context = nav_bar_profile == :user
 - is_search_enabled = [params[:controller] == 'recherche', is_instructeur_context, is_expert_context, is_user_context && current_user.dossiers.count].any?
 %header{ class: ["fr-header", content_for?(:notice_info) && "fr-header__with-notice-info"], role: "banner", "data-controller": "dsfr-header" }
-  .fr-header__body
-    .fr-container
-      .fr-header__body-row
-        .fr-header__brand.fr-enlarge-link
-          .fr-header__brand-top
-            .fr-header__logo
-              %p.fr-logo{ lang: "fr" }
-                République
-                = succeed "Française" do
-                  %br/
-            .fr-header__navbar
-              - if is_search_enabled
-                %button.fr-btn--search.fr-btn{ "aria-controls" => "search-modal", "data-fr-opened" => "false", :title => t('views.users.dossiers.search.search_file') }= t('views.users.dossiers.search.search_file')
-              %button#navbar-burger-button.fr-btn--menu.fr-btn{ "aria-controls" => "modal-header__menu", "data-fr-opened" => "false", title: "Menu" } Menu
-          .fr-header__service
-            - root_profile_link, root_profile_libelle = root_path_info_for_profile(nav_bar_profile)
+  %nav{ :role => "navigation", "aria-label" => t('layouts.header.main_menu') }
+    .fr-header__body
+      .fr-container
+        .fr-header__body-row
+          .fr-header__brand.fr-enlarge-link
+            .fr-header__brand-top
+              .fr-header__logo
+                %p.fr-logo{ lang: "fr" }
+                  République
+                  = succeed "Française" do
+                    %br/
+              .fr-header__navbar
+                - if is_search_enabled
+                  %button.fr-btn--search.fr-btn{ "aria-controls" => "search-modal", "data-fr-opened" => "false", :title => t('views.users.dossiers.search.search_file') }= t('views.users.dossiers.search.search_file')
+                %button#navbar-burger-button.fr-btn--menu.fr-btn{ "aria-controls" => "modal-header__menu", "data-fr-opened" => "false", title: "Menu" } Menu
+            .fr-header__service
+              - root_profile_link, root_profile_libelle = root_path_info_for_profile(nav_bar_profile)
 
-            = link_to root_profile_link, title: "#{root_profile_libelle} — #{Current.application_name}" do
-              %span.fr-header__service-title{ lang: "fr" }= Current.application_name
+              = link_to root_profile_link, title: "#{root_profile_libelle} — #{Current.application_name}" do
+                %span.fr-header__service-title{ lang: "fr" }= Current.application_name
 
-        .fr-header__tools
-          .fr-header__tools-links.relative
+          .fr-header__tools
+            .fr-header__tools-links.relative
 
-            %ul.fr-btns-group.flex.align-center
-              - if instructeur_signed_in? || user_signed_in?
+              %ul.fr-btns-group.flex.align-center
+                - if instructeur_signed_in? || user_signed_in?
+                  %li
+                    = render partial: 'layouts/account_dropdown', locals: { nav_bar_profile: nav_bar_profile, dossier: dossier }
+                - elsif (request.path != new_user_session_path && request.path !=agent_connect_path)
+                  - if request.path == new_user_registration_path
+                    %li.fr-hidden-sm.fr-unhidden-lg.fr-link--sm.fr-mb-2w.fr-mr-1v= t('views.shared.account.already_user_question')
+                  %li= link_to 'Agent', agent_connect_path, class: "fr-btn fr-btn--tertiary fr-icon-government-fill fr-btn--icon-left"
+                  %li= link_to t('views.shared.account.signin'), new_user_session_path, class: "fr-btn fr-btn--tertiary fr-icon-account-circle-fill fr-btn--icon-left"
+
                 %li
-                  = render partial: 'layouts/account_dropdown', locals: { nav_bar_profile: nav_bar_profile, dossier: dossier }
-              - elsif (request.path != new_user_session_path && request.path !=agent_connect_path)
-                - if request.path == new_user_registration_path
-                  %li.fr-hidden-sm.fr-unhidden-lg.fr-link--sm.fr-mb-2w.fr-mr-1v= t('views.shared.account.already_user_question')
-                %li= link_to 'Agent', agent_connect_path, class: "fr-btn fr-btn--tertiary fr-icon-government-fill fr-btn--icon-left"
-                %li= link_to t('views.shared.account.signin'), new_user_session_path, class: "fr-btn fr-btn--tertiary fr-icon-account-circle-fill fr-btn--icon-left"
+                  - if dossier.present? && nav_bar_profile == :user
+                    = render partial: 'shared/help/help_dropdown_dossier', locals: { dossier: dossier }
 
-              %li
-                - if dossier.present? && nav_bar_profile == :user
-                  = render partial: 'shared/help/help_dropdown_dossier', locals: { dossier: dossier }
+                  - elsif procedure.present? && (nav_bar_profile == :user || nav_bar_profile == :guest)
+                    = render partial: 'shared/help/help_dropdown_procedure', locals: { procedure: procedure }
 
-                - elsif procedure.present? && (nav_bar_profile == :user || nav_bar_profile == :guest)
-                  = render partial: 'shared/help/help_dropdown_procedure', locals: { procedure: procedure }
-
-                - elsif nav_bar_profile == :instructeur
-                  = render partial: 'shared/help/help_dropdown_instructeur'
-                - else
-                  // NB: on mobile in order to have links correctly aligned, we need a left icon
-                  = link_to t('help'), t("links.common.faq.url"), class: 'fr-btn dropdown-button', title: t('help')
+                  - elsif nav_bar_profile == :instructeur
+                    = render partial: 'shared/help/help_dropdown_instructeur'
+                  - else
+                    // NB: on mobile in order to have links correctly aligned, we need a left icon
+                    = link_to t('help'), t("links.common.faq.url"), class: 'fr-btn dropdown-button', title: t('help')
 
 
 
-              - if localization_enabled?
-                %li= render partial: 'layouts/locale_dropdown'
+                - if localization_enabled?
+                  %li= render partial: 'layouts/locale_dropdown'
 
 
-          - if params[:controller] == 'recherche'
-            = render partial: 'layouts/search_dossiers_form'
+            - if params[:controller] == 'recherche'
+              = render partial: 'layouts/search_dossiers_form'
 
-          - if is_instructeur_context
-            = render partial: 'layouts/search_dossiers_form'
+            - if is_instructeur_context
+              = render partial: 'layouts/search_dossiers_form'
 
-          - if is_expert_context
-            = render partial: 'layouts/search_dossiers_form'
+            - if is_expert_context
+              = render partial: 'layouts/search_dossiers_form'
 
-  = render SwitchDomainBannerComponent.new(user: current_user)
+    = render SwitchDomainBannerComponent.new(user: current_user)
 
-  #modal-header__menu.fr-header__menu.fr-modal{ "aria-labelledby": "navbar-burger-button" }
-    .fr-container
-      %button.fr-btn--close.fr-btn{ "aria-controls" => "modal-header__menu", title: t('close_modal', scope: [:layouts, :header]) }= t('close_modal', scope: [:layouts, :header])
-      .fr-header__menu-links
-        -# populated by dsfr js
+    #modal-header__menu.fr-header__menu.fr-modal{ "aria-labelledby": "navbar-burger-button" }
+      .fr-container
+        %button.fr-btn--close.fr-btn{ "aria-controls" => "modal-header__menu", title: t('close_modal', scope: [:layouts, :header]) }= t('close_modal', scope: [:layouts, :header])
+        .fr-header__menu-links
+          -# populated by dsfr js
 
-      - if content_for?(:main_navigation)
-        = yield(:main_navigation)
-      - elsif is_administrateur_context
-        = render 'administrateurs/main_navigation'
-      - elsif is_instructeur_context || is_expert_context
-        = render MainNavigation::InstructeurExpertNavigationComponent.new
-      - elsif is_user_context
-        = render 'users/main_navigation'
+        - if content_for?(:main_navigation)
+          = yield(:main_navigation)
+        - elsif is_administrateur_context
+          = render 'administrateurs/main_navigation'
+        - elsif is_instructeur_context || is_expert_context
+          = render MainNavigation::InstructeurExpertNavigationComponent.new
+        - elsif is_user_context
+          = render 'users/main_navigation'
 
 
-  = yield(:notice_info)
+    = yield(:notice_info)

--- a/app/views/layouts/_header.haml
+++ b/app/views/layouts/_header.haml
@@ -53,7 +53,7 @@
                     = render partial: 'shared/help/help_dropdown_instructeur'
                   - else
                     // NB: on mobile in order to have links correctly aligned, we need a left icon
-                    = link_to t('help'), t("links.common.faq.url"), class: 'fr-btn dropdown-button', title: t('help')
+                    = link_to t('help'), t("links.common.faq.url"), class: 'fr-btn dropdown-button'
 
 
 

--- a/app/views/layouts/_locale_dropdown.html.haml
+++ b/app/views/layouts/_locale_dropdown.html.haml
@@ -1,4 +1,4 @@
-%nav.fr-translate.fr-nav{ :role => "navigation", title: t('.select_locale') }
+.fr-translate.fr-nav
   .fr-nav__item
     %button.fr-translate__btn.fr-btn{ "aria-controls" => "translate", "aria-expanded" => "false", :title => t('.select_locale') }
       = I18n.locale.upcase

--- a/app/views/super_admins/release_notes/_main_navigation.html.haml
+++ b/app/views/super_admins/release_notes/_main_navigation.html.haml
@@ -1,5 +1,5 @@
 - content_for(:main_navigation) do
-  %nav.fr-nav#header-navigation{ role: "navigation", aria: { label: 'Menu principal annonces' } }
+  #header-navigation.fr-nav
     %ul.fr-nav__list
       %li.fr-nav__item
         = link_to "Toutes les annonces", super_admins_release_notes_path, class: "fr-nav__link", target: "_self", aria: { current: action == :index ? "page" : nil }

--- a/app/views/users/_main_navigation.html.haml
+++ b/app/views/users/_main_navigation.html.haml
@@ -1,4 +1,4 @@
-%nav#header-navigation.fr-nav{ role: :navigation, "aria-label" => t('main_menu', scope: [:layouts, :header]) }
+#header-navigation.fr-nav
   %ul.fr-nav__list
     - if params[:controller] == 'users/commencer'
       %li.fr-nav__item

--- a/config/locales/views/layouts/_account_dropdown.en.yml
+++ b/config/locales/views/layouts/_account_dropdown.en.yml
@@ -2,7 +2,6 @@ en:
   layouts:
     header:
       files: My files
-    menu_aria_label: 'Menu my profile'
     go_superadmin: "Switch to super-admin"
     go_user: "Switch to user"
     go_instructor: "Switch to instructor"
@@ -11,7 +10,7 @@ en:
     go_gestionnaire: "Switch to admins group manager"
     profile: "See my profile"
     logout: "Log out"
-    my_account: "My account"
+    my_account: "My profile"
     connected_as: "connected as %{profile}"
     instructeur: instructor
     administrateur: admin

--- a/config/locales/views/layouts/_account_dropdown.fr.yml
+++ b/config/locales/views/layouts/_account_dropdown.fr.yml
@@ -2,7 +2,6 @@ fr:
   layouts:
     header:
       files: Mes dossiers
-    menu_aria_label: 'Menu mon profil'
     go_superadmin: "Passer en super-admin"
     go_user: "Passer en usager"
     go_instructor: "Passer en instructeur"
@@ -11,7 +10,7 @@ fr:
     go_gestionnaire: "Passer en gestionnaire"
     profile: "Voir mon profil"
     logout: "Se déconnecter"
-    my_account: "Mon compte"
+    my_account: "Mon profil"
     connected_as: "connecté en tant qu’%{profile}"
     instructeur: instructeur
     administrateur: administrateur

--- a/public/500.html
+++ b/public/500.html
@@ -2110,7 +2110,6 @@
                     <!-- / NB: on mobile in order to have links correctly aligned, we need a left icon -->
                     <a
                       class="fr-btn dropdown-button"
-                      title="Aide"
                       href="/faq"
                       >Aide</a
                     >

--- a/public/502.html
+++ b/public/502.html
@@ -2109,7 +2109,6 @@
                     <!-- / NB: on mobile in order to have links correctly aligned, we need a left icon -->
                     <a
                       class="fr-btn dropdown-button"
-                      title="Aide"
                       href="/faq"
                       >Aide</a
                     >

--- a/public/503.html
+++ b/public/503.html
@@ -2109,7 +2109,6 @@
                     <!-- / NB: on mobile in order to have links correctly aligned, we need a left icon -->
                     <a
                       class="fr-btn dropdown-button"
-                      title="Aide
                       href="/faq"
                       >Aide</a
                     >

--- a/public/504.html
+++ b/public/504.html
@@ -2109,7 +2109,6 @@
                     <!-- / NB: on mobile in order to have links correctly aligned, we need a left icon -->
                     <a
                       class="fr-btn dropdown-button"
-                      title="Aide"
                       href="/faq"
                       >Aide</a
                     >

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -130,7 +130,7 @@ module SystemHelpers
 
   def log_out
     within('.fr-header .fr-container .fr-header__tools .fr-btns-group') do
-      click_button(title: 'Mon compte')
+      click_button(title: 'Mon profil')
       expect(page).to have_selector('#account.fr-collapse--expanded', visible: true)
       click_on 'Se déconnecter'
     end


### PR DESCRIPTION
# Système de navigation principal 
* Remplacement de la balise `<nav>` par une balise `<div>` autour du sélecteur de langue.
![Capture d’écran 2024-06-18 à 14 58 59](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/540d1cdb-2671-4eec-85b2-3848c9c225bf)
* Ajout d'une balise `<nav>`englobant le système de navigation principal dans son ensemble.
![Capture d’écran 2024-06-18 à 14 33 34](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/dd973584-7b67-4836-aae0-3299fd09db2a)
![Capture d’écran 2024-06-18 à 14 49 16](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/417bb7f8-721b-4491-938b-820124ea99ca)

# Uniformisation et nettoyage
* Suppression du titre inutile sur le lien "Aide".
![Capture d’écran 2024-06-18 à 14 59 55](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/765e2e0a-668f-44c9-9829-4d97e9208a6d)
* Suppression du terme "Menu" dans l'intitulé de la zone de navigation "Mon profil" pour éviter la redondance par les Technologies d'Assistance.
* Remplacement du terme "Mon compte" par "Mon profil" pour des raisons d'uniformité.
![Capture d’écran 2024-06-18 à 15 00 53](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/b79223f9-3a7a-4dbd-bda2-c9126d47ec08)
* Remplacement de la balise `<nav>` par une balise `<div>` autour du bouton permettant d'ouvrir la modale de filtre.
![Capture d’écran 2024-06-18 à 14 57 20](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/d921daff-c3d2-44dd-9c75-3ce16b8f4ce2)

