### PR TITLE
ETQ administrateur, je peux naviguer dans l'editeur des annotations en utilisant le sommaire façon editeur des champs du formulaire

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -1002,8 +1002,12 @@ class Procedure < ApplicationRecord
     lien_dpo.present? && lien_dpo.match?(/@/)
   end
 
-  def header_sections
+  def draft_revision_header_sections_public
     draft_revision.revision_types_de_champ_public.filter { _1.type_de_champ.header_section? }
+  end
+
+  def draft_revision_header_sections_private
+    draft_revision.revision_types_de_champ_private.filter { _1.type_de_champ.header_section? }
   end
 
   def dossier_for_preview(user)

--- a/app/views/administrateurs/procedures/_champs_summary.html.haml
+++ b/app/views/administrateurs/procedures/_champs_summary.html.haml
@@ -1,8 +1,8 @@
-#summary{ class: @procedure.header_sections.present? ? 'fr-col-12 fr-col-md-3' : '' }
-  - if @procedure.header_sections.present?
+#summary{ class: header_sections.present? ? 'fr-col-12 fr-col-md-3' : '' }
+  - if header_sections.present?
     %nav.fr-sidemenu.sticky.fr-hidden.fr-unhidden-md{ "aria-labelledby" => "fr-summary-title", role: "navigation" }
       %ul.fr-sidemenu__list
-        - @procedure.header_sections.each do |header|
+        - header_sections.each do |header|
           %li.fr-sidemenu__item
             - level = header.type_de_champ.header_section_level_value.to_i
             - if level == 1

--- a/app/views/administrateurs/procedures/annotations.html.haml
+++ b/app/views/administrateurs/procedures/annotations.html.haml
@@ -7,6 +7,7 @@
   %h1.fr-h2 Annotations privées
   = render  NestedForms::FormOwnerComponent.new
   .fr-grid-row
+    = render partial: 'champs_summary', locals: { header_sections: @procedure.draft_revision_header_sections_private }
     .fr-col
       = render TypesDeChampEditor::EditorComponent.new(revision: @procedure.draft_revision, is_annotation: true)
 

--- a/app/views/administrateurs/procedures/annotations.html.haml
+++ b/app/views/administrateurs/procedures/annotations.html.haml
@@ -4,7 +4,11 @@
                     ['Annotations privées']], preview: true }
 
 .fr-container
-  %h1.fr-h2 Annotations privées
+  .flex.justify-between.align-center.fr-mb-3w
+    %h1.fr-h2 Annotations privées
+    - if @procedure.revised?
+      = link_to "Voir l'historique des modifications des annotations", modifications_admin_procedure_path(@procedure), class: 'fr-link'
+
   = render  NestedForms::FormOwnerComponent.new
   .fr-grid-row
     = render partial: 'champs_summary', locals: { header_sections: @procedure.draft_revision_header_sections_private }

--- a/app/views/administrateurs/procedures/champs.html.haml
+++ b/app/views/administrateurs/procedures/champs.html.haml
@@ -11,7 +11,7 @@
 
   = render NestedForms::FormOwnerComponent.new
   .fr-grid-row
-    = render partial: 'champs_summary'
+    = render partial: 'champs_summary', locals: { header_sections: @procedure.draft_revision_header_sections_public }
     .fr-col
       = render TypesDeChampEditor::EditorComponent.new(revision: @procedure.draft_revision, is_annotation: false)
 

--- a/app/views/administrateurs/types_de_champ/_insert.turbo_stream.haml
+++ b/app/views/administrateurs/types_de_champ/_insert.turbo_stream.haml
@@ -14,7 +14,7 @@
 
 = turbo_stream.replace 'errors-summary', render(Procedure::ErrorsSummary.new(procedure: @procedure, validation_context: @coordinate&.private? ? :types_de_champ_private_editor : :types_de_champ_public_editor))
 
-= turbo_stream.replace 'summary', render(partial: 'administrateurs/procedures/champs_summary')
+= turbo_stream.replace 'summary', render(partial: 'administrateurs/procedures/champs_summary', locals: { header_sections: @coordinate&.private? ? @procedure.draft_revision_header_sections_private : @procedure.draft_revision_header_sections_public})
 
 - unless flash.alert
   = turbo_stream.show 'autosave-notice'

--- a/spec/system/administrateurs/annotations_spec.rb
+++ b/spec/system/administrateurs/annotations_spec.rb
@@ -1,4 +1,5 @@
 describe 'As an administrateur I can edit annotation', js: true do
+  include ActionView::RecordIdentifier
   let(:administrateur) { procedure.administrateurs.first }
   let(:procedure) { create(:procedure) }
 
@@ -7,11 +8,35 @@ describe 'As an administrateur I can edit annotation', js: true do
     visit annotations_admin_procedure_path(procedure)
   end
 
-  scenario "adding a new champ" do
+  scenario 'with private tdc, having invalid order, it pops up errors summary' do
     click_on 'Ajouter une annotation'
 
-    select('Carte', from: 'Type de champ')
-    # ensure UI update is ok
-    check 'Cadastres'
+    select('Titre de section', from: 'Type de champ')
+    wait_until { procedure.reload.active_revision.types_de_champ_private.first&.type_champ == TypeDeChamp.type_champs.fetch(:header_section) }
+    first_header = procedure.active_revision.types_de_champ_private.first
+    select('Titre de niveau 1', from: dom_id(first_header, :header_section_level))
+
+    within(find('.type-de-champ-add-button', match: :first)) {
+      click_on 'Ajouter une annotation'
+    }
+
+    wait_until { procedure.reload.active_revision.types_de_champ_private.count == 2 }
+    second_header = procedure.active_revision.types_de_champ_private.last
+    select('Titre de section', from: dom_id(second_header, :type_champ))
+    wait_until { procedure.reload.active_revision.types_de_champ_private.last&.type_champ == TypeDeChamp.type_champs.fetch(:header_section) }
+    select('Titre de niveau 2', from: dom_id(second_header, :header_section_level))
+
+    within(".types-de-champ-block li:first-child") do
+      page.accept_alert do
+        click_on 'Supprimer'
+      end
+    end
+
+    expect(page).to have_content("devrait être précédé d'un titre de niveau 1")
+
+    # check summary
+    procedure.reload.active_revision.types_de_champ_private.each do |header_section|
+      expect(page).to have_link(header_section.libelle)
+    end
   end
 end

--- a/spec/system/administrateurs/types_de_champ_spec.rb
+++ b/spec/system/administrateurs/types_de_champ_spec.rb
@@ -206,7 +206,7 @@ describe 'As an administrateur I can edit types de champ', js: true do
   end
 
   context 'header section' do
-    scenario 'invalid order, it pops up errors summary' do
+    scenario 'with public tdc, having invalid order, it pops up errors summary' do
       add_champ
       select('Titre de section', from: 'Type de champ')
       wait_until { procedure.reload.active_revision.types_de_champ_public.first&.type_champ == TypeDeChamp.type_champs.fetch(:header_section) }
@@ -229,6 +229,11 @@ describe 'As an administrateur I can edit types de champ', js: true do
         end
       end
       expect(page).to have_content("devrait être précédé d'un titre de niveau 1")
+
+      # check summary refresh
+      procedure.reload.active_revision.types_de_champ_private.each do |header_section|
+        expect(page).to have_link(header_section.libelle)
+      end
     end
   end
 


### PR DESCRIPTION
Ajoute le `champ_summary` sur la page des annotations privées
Ajoute le lien d'historique de modification de la démarche sur la page des annotations privées

<img width="1219" alt="Capture d’écran 2024-06-21 à 4 40 01 AM" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/125964/f658e81e-38b7-47c0-ac90-fc81913ec908">

