### PR TITLE
Emails: réduit légèrement la taille du nom du logo ds.fr

### DIFF
--- a/app/views/layouts/mailers/layout.html.erb
+++ b/app/views/layouts/mailers/layout.html.erb
@@ -98,7 +98,7 @@
                           <td style="word-wrap:break-word;font-size:0px;padding:0;padding-top:0px;padding-bottom:0px;" align="left">
                             <p class="" style="cursor:auto;color:#000091;font-family:Helvetica, Arial, sans-serif;font-size:14px;text-align:center">
                               <img align="middle" alt="Logo <%= "#{Current.application_name}" %>" src="<%= image_url(MAILER_LOGO_SRC) %>" style="max-height:100px; padding:15px 30px 15px 30px; vertical-aligne:middle; display:inline !important; border:0; height:auto; outline:none; text-decoration:none; -ms-interpolation-mode:bicubic;" />
-                              <b style="font-size:28px;font-weight:600;display:inline-block">
+                              <b style="font-size:26px;font-weight:600;display:inline-block">
                                 <%= Current.application_name %>
                               </b>
                             </p>


### PR DESCRIPTION
La taille avait été prévue pour demarches.gouv.fr, mais ds.fr c'est plus long…