### PR TITLE
Pied de page - correction des titres de liens

### DIFF
--- a/app/views/application/_general_footer_row.html.haml
+++ b/app/views/application/_general_footer_row.html.haml
@@ -12,7 +12,7 @@
   %li.fr-footer__bottom-item
     = link_to t("links.footer.mentions_legales.label"), MENTIONS_LEGALES_URL, class: "fr-footer__bottom-link", rel: "noopener noreferrer"
   %li.fr-footer__bottom-item
-    = link_to t("links.footer.cookies.label"), suivi_path, class: "fr-footer__bottom-link"
+    = link_to t("links.footer.cookies.label"), suivi_path, class: "fr-footer__bottom-link", hreflang: "fr"
   %li.fr-footer__bottom-item
     %button.fr-footer__bottom-link.fr-icon-theme-fill.fr-btn--icon-left{ aria: {controls: "fr-theme-modal" }, data: {'fr-opened': "false" } }
       = t('links.footer.display_params')

--- a/app/views/application/_general_footer_row.html.haml
+++ b/app/views/application/_general_footer_row.html.haml
@@ -8,11 +8,11 @@
     %li.fr-footer__bottom-item
       = link_to t("links.footer.vote_feature.label"), FEATURE_UPVOTE_URL, title: t("links.footer.vote_feature.title"), class: "fr-footer__bottom-link", target: "_blank", rel: "noopener noreferrer"
   %li.fr-footer__bottom-item
-    = link_to t("links.footer.accessibilite.label"), ACCESSIBILITE_URL, title: t("links.footer.accessibilite.title"), class: "fr-footer__bottom-link", rel: "noopener noreferrer"
+    = link_to t("links.footer.accessibilite.label"), ACCESSIBILITE_URL, class: "fr-footer__bottom-link", rel: "noopener noreferrer"
   %li.fr-footer__bottom-item
-    = link_to t("links.footer.mentions_legales.label"), MENTIONS_LEGALES_URL, title: t("links.footer.mentions_legales.title"), class: "fr-footer__bottom-link", rel: "noopener noreferrer"
+    = link_to t("links.footer.mentions_legales.label"), MENTIONS_LEGALES_URL, class: "fr-footer__bottom-link", rel: "noopener noreferrer"
   %li.fr-footer__bottom-item
-    = link_to t("links.footer.cookies.label"), suivi_path, title: t("links.footer.cookies.title"), class: "fr-footer__bottom-link"
+    = link_to t("links.footer.cookies.label"), suivi_path, class: "fr-footer__bottom-link"
   %li.fr-footer__bottom-item
     %button.fr-footer__bottom-link.fr-icon-theme-fill.fr-btn--icon-left{ aria: {controls: "fr-theme-modal" }, data: {'fr-opened': "false" } }
       = t('links.footer.display_params')

--- a/app/views/root/_footer.html.haml
+++ b/app/views/root/_footer.html.haml
@@ -21,8 +21,10 @@
               = link_to t("links.footer.stats.label"), stats_path, title: t("links.footer.stats.title"), class: "fr-footer__top-link"
             %li.fr-footer__top_link
               = link_to t("links.footer.carte.label"), carte_path, title: t("links.footer.carte.title"), class: "fr-footer__top-link"
-            %li.fr-footer__top-link
-              = link_to t("links.footer.cgu.label"), t("links.footer.cgu.url"), title: t("links.footer.cgu.title"), class: "fr-footer__top-link", rel: "noopener noreferrer"
+            %li.fr-footer__top-link                
+              %a{ :href => t("links.footer.cgu.url"), :class => "fr-footer__top-link", :rel => "noopener noreferrer" }
+                %abbr{ title: t("links.footer.cgu.title") }
+                  = t("links.footer.cgu.label")
         .fr-col-12.fr-col-sm-3.fr-col-md-3
           %h3.fr-footer__top-cat= t("links.footer.top_labels.resources")
           %ul.fr-footer__top-list
@@ -31,7 +33,9 @@
             %li.fr-footer__top-link
               = link_to t("links.footer.api_doc.label"), t("links.footer.api_doc.url"), title: t("links.footer.api_doc.title"), class: "fr-footer__top-link", rel: "noopener noreferrer"
             %li.fr-footer__top-link
-              = link_to t("links.common.faq.label"), t("links.common.faq.url"), title: t("links.common.faq.title"), class: "fr-footer__top-link", rel: "noopener noreferrer"
+              %a{ :href => t("links.common.faq.url"), :class => "fr-footer__top-link", :rel => "noopener noreferrer" }
+                %abbr{ title: t("links.common.faq.title") }
+                  = t("links.common.faq.label")
             %li.fr-footer__top-link
               = link_to t("links.footer.code.label"), t("links.footer.code.url"), title: t("links.footer.code.title"), class: "fr-footer__top-link", rel: "noopener noreferrer"
         .fr-col-12.fr-col-sm-3.fr-col-md-3

--- a/app/views/root/_footer.html.haml
+++ b/app/views/root/_footer.html.haml
@@ -9,16 +9,16 @@
             %li
               = link_to t("links.footer.releases.label"), t("links.footer.releases.url"), title: t("links.footer.releases.title"), class: "fr-footer__top-link", hreflang: "fr"
             %li
-              = link_to t("links.footer.contact.label"), contact_path, title: t("links.footer.contact.title"), class: "fr-footer__top-link"
+              = link_to t("links.footer.contact.label"), contact_path, class: "fr-footer__top-link"
         .fr-col-12.fr-col-sm-3.fr-col-md-3
           %h3.fr-footer__top-cat= t("links.footer.top_labels.legals")
           %ul.fr-footer__top-list
             %li
-              = link_to t("links.footer.mentions_legales.label"), MENTIONS_LEGALES_URL, title: t("links.footer.mentions_legales.title"), class: "fr-footer__top-link", rel: "noopener noreferrer"
+              = link_to t("links.footer.mentions_legales.label"), MENTIONS_LEGALES_URL, class: "fr-footer__top-link", rel: "noopener noreferrer"
             %li
-              = link_to t("links.footer.suivi.label"), suivi_path, title: t("links.footer.suivi.title"), class: "fr-footer__top-link", hreflang: "fr"
+              = link_to t("links.footer.suivi.label"), suivi_path, class: "fr-footer__top-link", hreflang: "fr"
             %li
-              = link_to t("links.footer.stats.label"), stats_path, title: t("links.footer.stats.title"), class: "fr-footer__top-link", hreflang: "fr"
+              = link_to t("links.footer.stats.label"), stats_path, class: "fr-footer__top-link", hreflang: "fr"
             %li
               = link_to t("links.footer.carte.label"), carte_path, title: t("links.footer.carte.title"), class: "fr-footer__top-link"
             %li
@@ -37,7 +37,7 @@
                 %abbr{ title: t("links.common.faq.title") }
                   = t("links.common.faq.label")
             %li
-              = link_to t("links.footer.code.label"), t("links.footer.code.url"), title: t("links.footer.code.title"), class: "fr-footer__top-link", rel: "noopener noreferrer", hreflang: "fr"
+              = link_to t("links.footer.code.label"), t("links.footer.code.url"), class: "fr-footer__top-link", rel: "noopener noreferrer", hreflang: "fr"
         .fr-col-12.fr-col-sm-3.fr-col-md-3
           %h3.fr-footer__top-cat= t("links.footer.top_labels.diagnostic")
           %ul.fr-footer__top-list

--- a/app/views/root/_footer.html.haml
+++ b/app/views/root/_footer.html.haml
@@ -7,7 +7,7 @@
           %h3.fr-footer__top-cat= t("links.footer.top_labels.communication")
           %ul.fr-footer__top-list
             %li
-              = link_to t("links.footer.releases.label"), t("links.footer.releases.url"), title: t("links.footer.releases.title"), class: "fr-footer__top-link"
+              = link_to t("links.footer.releases.label"), t("links.footer.releases.url"), title: t("links.footer.releases.title"), class: "fr-footer__top-link", hreflang: "fr"
             %li
               = link_to t("links.footer.contact.label"), contact_path, title: t("links.footer.contact.title"), class: "fr-footer__top-link"
         .fr-col-12.fr-col-sm-3.fr-col-md-3
@@ -16,35 +16,35 @@
             %li
               = link_to t("links.footer.mentions_legales.label"), MENTIONS_LEGALES_URL, title: t("links.footer.mentions_legales.title"), class: "fr-footer__top-link", rel: "noopener noreferrer"
             %li
-              = link_to t("links.footer.suivi.label"), suivi_path, title: t("links.footer.suivi.title"), class: "fr-footer__top-link"
+              = link_to t("links.footer.suivi.label"), suivi_path, title: t("links.footer.suivi.title"), class: "fr-footer__top-link", hreflang: "fr"
             %li
-              = link_to t("links.footer.stats.label"), stats_path, title: t("links.footer.stats.title"), class: "fr-footer__top-link"
+              = link_to t("links.footer.stats.label"), stats_path, title: t("links.footer.stats.title"), class: "fr-footer__top-link", hreflang: "fr"
             %li
               = link_to t("links.footer.carte.label"), carte_path, title: t("links.footer.carte.title"), class: "fr-footer__top-link"
             %li
-              %a{ :href => t("links.footer.cgu.url"), :class => "fr-footer__top-link", :rel => "noopener noreferrer" }
+              %a{ :href => t("links.footer.cgu.url"), :class => "fr-footer__top-link", :rel => "noopener noreferrer", :hreflang => "fr" }
                 %abbr{ title: t("links.footer.cgu.title") }
                   = t("links.footer.cgu.label")
         .fr-col-12.fr-col-sm-3.fr-col-md-3
           %h3.fr-footer__top-cat= t("links.footer.top_labels.resources")
           %ul.fr-footer__top-list
             %li
-              = link_to t("links.footer.doc.label"), t("links.footer.doc.url"), title: t("links.footer.doc.title"), class: "fr-footer__top-link", rel: "noopener noreferrer"
+              = link_to t("links.footer.doc.label"), t("links.footer.doc.url"), title: t("links.footer.doc.title"), class: "fr-footer__top-link", rel: "noopener noreferrer", hreflang: "fr"
             %li
-              = link_to t("links.footer.api_doc.label"), t("links.footer.api_doc.url"), title: t("links.footer.api_doc.title"), class: "fr-footer__top-link", rel: "noopener noreferrer"
+              = link_to t("links.footer.api_doc.label"), t("links.footer.api_doc.url"), title: t("links.footer.api_doc.title"), class: "fr-footer__top-link", rel: "noopener noreferrer", hreflang: "fr"
             %li
               %a{ :href => t("links.common.faq.url"), :class => "fr-footer__top-link", :rel => "noopener noreferrer" }
                 %abbr{ title: t("links.common.faq.title") }
                   = t("links.common.faq.label")
             %li
-              = link_to t("links.footer.code.label"), t("links.footer.code.url"), title: t("links.footer.code.title"), class: "fr-footer__top-link", rel: "noopener noreferrer"
+              = link_to t("links.footer.code.label"), t("links.footer.code.url"), title: t("links.footer.code.title"), class: "fr-footer__top-link", rel: "noopener noreferrer", hreflang: "fr"
         .fr-col-12.fr-col-sm-3.fr-col-md-3
           %h3.fr-footer__top-cat= t("links.footer.top_labels.diagnostic")
           %ul.fr-footer__top-list
             %li
-              = link_to t("links.footer.status_page.label"), t("links.footer.status_page.url"), title: t("links.footer.status_page.title"), class: "fr-footer__top-link", rel: "noopener noreferrer"
+              = link_to t("links.footer.status_page.label"), t("links.footer.status_page.url"), title: t("links.footer.status_page.title"), class: "fr-footer__top-link", rel: "noopener noreferrer", hreflang: "fr"
             %li
-              = link_to t("links.footer.security.label"), t("links.footer.security.url"), title: t("links.footer.security.title"), class: "fr-footer__top-link", rel: "noopener noreferrer"
+              = link_to t("links.footer.security.label"), t("links.footer.security.url"), title: t("links.footer.security.title"), class: "fr-footer__top-link", rel: "noopener noreferrer", hreflang: "fr"
   .fr-container
     .fr-footer__body
       .fr-footer__brand.fr-enlarge-link{ lang: "fr" }

--- a/app/views/root/_footer.html.haml
+++ b/app/views/root/_footer.html.haml
@@ -6,44 +6,44 @@
         .fr-col-12.fr-col-sm-3.fr-col-md-3
           %h3.fr-footer__top-cat= t("links.footer.top_labels.communication")
           %ul.fr-footer__top-list
-            %li.fr-footer__top-link
+            %li
               = link_to t("links.footer.releases.label"), t("links.footer.releases.url"), title: t("links.footer.releases.title"), class: "fr-footer__top-link"
-            %li.fr-footer__top-link
+            %li
               = link_to t("links.footer.contact.label"), contact_path, title: t("links.footer.contact.title"), class: "fr-footer__top-link"
         .fr-col-12.fr-col-sm-3.fr-col-md-3
           %h3.fr-footer__top-cat= t("links.footer.top_labels.legals")
           %ul.fr-footer__top-list
-            %li.fr-footer__top-link
+            %li
               = link_to t("links.footer.mentions_legales.label"), MENTIONS_LEGALES_URL, title: t("links.footer.mentions_legales.title"), class: "fr-footer__top-link", rel: "noopener noreferrer"
-            %li.fr-footer__top-link
+            %li
               = link_to t("links.footer.suivi.label"), suivi_path, title: t("links.footer.suivi.title"), class: "fr-footer__top-link"
-            %li.fr-footer__top-link
+            %li
               = link_to t("links.footer.stats.label"), stats_path, title: t("links.footer.stats.title"), class: "fr-footer__top-link"
-            %li.fr-footer__top_link
+            %li
               = link_to t("links.footer.carte.label"), carte_path, title: t("links.footer.carte.title"), class: "fr-footer__top-link"
-            %li.fr-footer__top-link                
+            %li
               %a{ :href => t("links.footer.cgu.url"), :class => "fr-footer__top-link", :rel => "noopener noreferrer" }
                 %abbr{ title: t("links.footer.cgu.title") }
                   = t("links.footer.cgu.label")
         .fr-col-12.fr-col-sm-3.fr-col-md-3
           %h3.fr-footer__top-cat= t("links.footer.top_labels.resources")
           %ul.fr-footer__top-list
-            %li.fr-footer__top-link
+            %li
               = link_to t("links.footer.doc.label"), t("links.footer.doc.url"), title: t("links.footer.doc.title"), class: "fr-footer__top-link", rel: "noopener noreferrer"
-            %li.fr-footer__top-link
+            %li
               = link_to t("links.footer.api_doc.label"), t("links.footer.api_doc.url"), title: t("links.footer.api_doc.title"), class: "fr-footer__top-link", rel: "noopener noreferrer"
-            %li.fr-footer__top-link
+            %li
               %a{ :href => t("links.common.faq.url"), :class => "fr-footer__top-link", :rel => "noopener noreferrer" }
                 %abbr{ title: t("links.common.faq.title") }
                   = t("links.common.faq.label")
-            %li.fr-footer__top-link
+            %li
               = link_to t("links.footer.code.label"), t("links.footer.code.url"), title: t("links.footer.code.title"), class: "fr-footer__top-link", rel: "noopener noreferrer"
         .fr-col-12.fr-col-sm-3.fr-col-md-3
           %h3.fr-footer__top-cat= t("links.footer.top_labels.diagnostic")
           %ul.fr-footer__top-list
-            %li.fr-footer__top-link
+            %li
               = link_to t("links.footer.status_page.label"), t("links.footer.status_page.url"), title: t("links.footer.status_page.title"), class: "fr-footer__top-link", rel: "noopener noreferrer"
-            %li.fr-footer__top-link
+            %li
               = link_to t("links.footer.security.label"), t("links.footer.security.url"), title: t("links.footer.security.title"), class: "fr-footer__top-link", rel: "noopener noreferrer"
   .fr-container
     .fr-footer__body

--- a/app/views/root/_footer.html.haml
+++ b/app/views/root/_footer.html.haml
@@ -50,14 +50,14 @@
       .fr-footer__brand.fr-enlarge-link{ lang: "fr" }
         %p.fr-logo
           gouvernement
-        = link_to t("links.footer.dinum.url"), title: t("links.footer.dinum.title"), class: "fr-footer__brand-link" do
+        = link_to t("links.footer.dinum.url"), title: t("links.footer.dinum.title"), hreflang:'fr', class: "fr-footer__brand-link" do
           = image_tag("footer/logo-dinum.svg", class: "fr-footer__logo logo-beta-gouv-fr", alt: t("links.footer.dinum.alt"))
       .fr-footer__content
         %p.fr-footer__content-desc
           = t('links.footer.description_1')
-          = link_to(t('links.footer.link_1_label'), t('links.footer.link_1_url'), title: new_tab_suffix(t('links.footer.link_1_label')), **external_link_attributes) + "."
+          = link_to(t('links.footer.link_1_label'), t('links.footer.link_1_url'), title: new_tab_suffix(t('links.footer.link_1_label')), hreflang:'fr', **external_link_attributes) + "."
         %p.fr-footer__content-desc
-          = link_to t('links.footer.link_2_label'), t("links.footer.code.url"), title: new_tab_suffix(t('links.footer.link_2_label')), **external_link_attributes
+          = link_to t('links.footer.link_2_label'), t("links.footer.code.url"), title: new_tab_suffix(t('links.footer.link_2_label')), hreflang:'fr', **external_link_attributes
           = t('links.footer.description_2')
         = render partial: "shared/footer_content_list"
 

--- a/app/views/root/_footer.html.haml
+++ b/app/views/root/_footer.html.haml
@@ -22,7 +22,7 @@
             %li
               = link_to t("links.footer.carte.label"), carte_path, title: t("links.footer.carte.title"), class: "fr-footer__top-link"
             %li
-              %a{ :href => t("links.footer.cgu.url"), :class => "fr-footer__top-link", :rel => "noopener noreferrer", :hreflang => "fr" }
+              %a.fr-footer__top-link{ :href => t("links.footer.cgu.url"), :rel => "noopener noreferrer", :hreflang => "fr" }
                 %abbr{ title: t("links.footer.cgu.title") }
                   = t("links.footer.cgu.label")
         .fr-col-12.fr-col-sm-3.fr-col-md-3
@@ -33,7 +33,7 @@
             %li
               = link_to t("links.footer.api_doc.label"), t("links.footer.api_doc.url"), title: t("links.footer.api_doc.title"), class: "fr-footer__top-link", rel: "noopener noreferrer", hreflang: "fr"
             %li
-              %a{ :href => t("links.common.faq.url"), :class => "fr-footer__top-link", :rel => "noopener noreferrer" }
+              %a.fr-footer__top-link{ :href => t("links.common.faq.url"), :rel => "noopener noreferrer" }
                 %abbr{ title: t("links.common.faq.title") }
                   = t("links.common.faq.label")
             %li

--- a/app/views/shared/_footer_content_list.html.haml
+++ b/app/views/shared/_footer_content_list.html.haml
@@ -1,9 +1,9 @@
 %ul.fr-footer__content-list
   %li.fr-footer__content-item
-    = link_to t('users.procedure_footer.official_links.legifrance.title'), t('users.procedure_footer.official_links.legifrance.url'), title: new_tab_suffix(t('users.procedure_footer.official_links.legifrance.title')), class: 'fr-footer__content-link', **external_link_attributes
+    = link_to t('users.procedure_footer.official_links.legifrance.title'), t('users.procedure_footer.official_links.legifrance.url'), title: new_tab_suffix(t('users.procedure_footer.official_links.legifrance.title')), class: 'fr-footer__content-link', hreflang: 'fr', **external_link_attributes
   %li.fr-footer__content-item
-    = link_to t('users.procedure_footer.official_links.gouvernement.title'), t('users.procedure_footer.official_links.gouvernement.url'), title: new_tab_suffix(t('users.procedure_footer.official_links.gouvernement.title')), class: 'fr-footer__content-link', **external_link_attributes
+    = link_to t('users.procedure_footer.official_links.gouvernement.title'), t('users.procedure_footer.official_links.gouvernement.url'), title: new_tab_suffix(t('users.procedure_footer.official_links.gouvernement.title')), class: 'fr-footer__content-link', hreflang:'fr', **external_link_attributes
   %li.fr-footer__content-item
-    = link_to t('users.procedure_footer.official_links.service_public.title'), t('users.procedure_footer.official_links.service_public.url'), title: new_tab_suffix(t('users.procedure_footer.official_links.service_public.title')), class: 'fr-footer__content-link', **external_link_attributes
+    = link_to t('users.procedure_footer.official_links.service_public.title'), t('users.procedure_footer.official_links.service_public.url'), title: new_tab_suffix(t('users.procedure_footer.official_links.service_public.title')), class: 'fr-footer__content-link', hreflang:'fr', **external_link_attributes
   %li.fr-footer__content-item
-    = link_to t('users.procedure_footer.official_links.data_gouv.title'), t('users.procedure_footer.official_links.data_gouv.url'), title: new_tab_suffix(t('users.procedure_footer.official_links.data_gouv.title')), class: 'fr-footer__content-link', **external_link_attributes
+    = link_to t('users.procedure_footer.official_links.data_gouv.title'), t('users.procedure_footer.official_links.data_gouv.url'), title: new_tab_suffix(t('users.procedure_footer.official_links.data_gouv.title')), class: 'fr-footer__content-link', hreflang:'fr', **external_link_attributes

--- a/app/views/shared/_footer_copy.html.haml
+++ b/app/views/shared/_footer_copy.html.haml
@@ -1,2 +1,2 @@
 .fr-footer__bottom-copy
-  %p= t("links.footer.copy_html", link: link_to(t("links.footer.license"), "https://github.com/etalab/licence-ouverte/blob/master/LO.md", title: new_tab_suffix(t("links.footer.license")), **external_link_attributes))
+  %p= t("links.footer.copy_html", link: link_to(t("links.footer.license"), "https://github.com/etalab/licence-ouverte/blob/master/LO.md", title: new_tab_suffix(t("links.footer.license")), hreflang: "fr", **external_link_attributes))

--- a/app/views/shared/_footer_copy.html.haml
+++ b/app/views/shared/_footer_copy.html.haml
@@ -1,2 +1,2 @@
 .fr-footer__bottom-copy
-  %p= t("links.footer.copy_html", link: link_to(t("links.footer.license"), "https://github.com/etalab/licence-ouverte/blob/master/LO.md", title: new_tab_suffix("licence etalab-2.0"), **external_link_attributes))
+  %p= t("links.footer.copy_html", link: link_to(t("links.footer.license"), "https://github.com/etalab/licence-ouverte/blob/master/LO.md", title: new_tab_suffix(t("links.footer.license")), **external_link_attributes))

--- a/config/locales/links.en.yml
+++ b/config/locales/links.en.yml
@@ -31,7 +31,7 @@ en:
         label: "Accessibility: partially compliant"
       api_doc:
         label: "API Documentation"
-        title: "API Documentation"
+        title: "Graphql API Documentation"
         url: "https://doc.demarches-simplifiees.fr/api-graphql"
       dinum:
         title: "Le site de la DINUM — Direction interministérielle du numérique"
@@ -46,7 +46,7 @@ en:
         url: "https://doc.demarches-simplifiees.fr/cgu"
       doc:
         label: "Documentation"
-        title: "Our Documentation"
+        title: "User Documentation"
         url: "https://doc.demarches-simplifiees.fr"
       vote_feature:
         label: "Improve the site"
@@ -55,18 +55,18 @@ en:
         label: "Legal notices"
       releases:
         label: "Releases notes"
-        title: "Our last updates"
+        title: "Releases notes: Our last updates"
         url: "https://github.com/demarches-simplifiees/demarches-simplifiees.fr/releases"
       security:
         label: "Security"
-        title: "Security policy"
+        title: "Security policy and procedures"
         url: "https://github.com/betagouv/demarches-simplifiees.fr/blob/main/SECURITY.md"
       carte:
         label: "Deployment map"
         title: "Deployment map by department"
       status_page:
         label: "Disponibility"
-        title: "Disponibility and availability"
+        title: "Disponibility and availability statistics"
         url: "https://status.demarches-simplifiees.fr"
       suivi:
         label: "Audience tracking and privacy"

--- a/config/locales/links.en.yml
+++ b/config/locales/links.en.yml
@@ -29,7 +29,6 @@ en:
       license: "licensed under etalab 2.0"
       accessibilite:
         label: "Accessibility: partially compliant"
-        title: "Accessibility declaration"
       api_doc:
         label: "API Documentation"
         title: "API Documentation"
@@ -40,7 +39,6 @@ en:
         alt: "Direction interministérielle du numérique"
       code:
         label: "Source code"
-        title: "Our Source code is open source"
         url: "https://github.com/demarches-simplifiees/demarches-simplifiees.fr"
       cgu:
         label: "ToS"
@@ -55,7 +53,6 @@ en:
         title: "Vote for your priority improvements or share your own ideas"
       mentions_legales:
         label: "Legal notices"
-        title: "Legal notices regarding our platform"
       releases:
         label: "Releases notes"
         title: "Our last updates"
@@ -73,11 +70,8 @@ en:
         url: "https://status.demarches-simplifiees.fr"
       suivi:
         label: "Audience tracking and privacy"
-        title: "Tracking and privacy of demarches-simplifiees"
       cookies:
         label: Cookies
-        title: Cookies
       contact:
         label: Contact
-        title: Contact
       display_params: Display params

--- a/config/locales/links.fr.yml
+++ b/config/locales/links.fr.yml
@@ -33,7 +33,7 @@ fr:
         label: "Accessibilité : partiellement conforme"
       api_doc:
         label: "Documentation de l’API"
-        title: "Documentation graphql de l’API"
+        title: "Documentation de l’API au format graphql"
         url: "https://doc.demarches-simplifiees.fr/api-graphql"
       dinum:
         title: "Le site de la DINUM — Direction interministérielle du numérique"
@@ -60,11 +60,11 @@ fr:
         label: "Mentions légales"
       releases:
         label: "Nouveautés"
-        title: "Les dernière mises à jour de la plateforme"
+        title: "Nouveautés : Les dernière mises à jour de la plateforme"
         url: "https://github.com/demarches-simplifiees/demarches-simplifiees.fr/releases"
       security:
         label: "Sécurité"
-        title: "Vous avez identifié une faille, comment nous en informer"
+        title: "Politique et procédure de sécurité"
         url: "https://github.com/betagouv/demarches-simplifiees.fr/blob/main/SECURITY.md"
       stats:
         label: "Statistiques"
@@ -73,7 +73,7 @@ fr:
         title: "Carte de déploiement par département"
       status_page:
         label: "Disponibilité"
-        title: "Disponibilité du site demarches-simplifiees"
+        title: "Statistiques de disponibilité du site demarches-simplifiees"
         url: "https://status.demarches-simplifiees.fr"
       suivi:
         label: "Suivi d’audience et vie privée"

--- a/config/locales/links.fr.yml
+++ b/config/locales/links.fr.yml
@@ -31,7 +31,6 @@ fr:
       license: "licence etalab 2.0"
       accessibilite:
         label: "Accessibilité : partiellement conforme"
-        title: "Consulter notre déclaration d’accessibilité"
       api_doc:
         label: "Documentation de l’API"
         title: "Documentation graphql de l’API"
@@ -46,7 +45,6 @@ fr:
         url: "https://doc.demarches-simplifiees.fr/cgu"
       code:
         label: "Code source"
-        title: "Le code ouvert de demarches-simplifiees"
         url: "https://github.com/demarches-simplifiees/demarches-simplifiees.fr"
       contact_technique:
         label: "Contact technique"
@@ -60,7 +58,6 @@ fr:
         title: "Votez pour vos améliorations prioritaires ou proposez votre propre idée"
       mentions_legales:
         label: "Mentions légales"
-        title: "Consulter nos Mentions légales"
       releases:
         label: "Nouveautés"
         title: "Les dernière mises à jour de la plateforme"
@@ -71,7 +68,6 @@ fr:
         url: "https://github.com/betagouv/demarches-simplifiees.fr/blob/main/SECURITY.md"
       stats:
         label: "Statistiques"
-        title: "Statistiques d’usage"
       carte:
         label: "Carte de déploiement"
         title: "Carte de déploiement par département"
@@ -81,15 +77,12 @@ fr:
         url: "https://status.demarches-simplifiees.fr"
       suivi:
         label: "Suivi d’audience et vie privée"
-        title: "Consulter notre politique de respect de la vie privée"
       solidarite_numerique:
         label: "Besoin d’aide avec vos démarches en ligne ?"
         title: "Avez-vous besoin d’aide concernant vos démarchez informatisées, essayez solidarite-numerique.fr"
         url: "https://www.solidarite-numerique.fr/cartographie/"
       cookies:
         label: Gestion des cookies
-        title: Gestion des cookies
       contact:
         label: Nous contacter
-        title: Nous contacter
       display_params: Paramètres d'affichage


### PR DESCRIPTION
* Suppression des titres inutiles (faisant un doublon de l'intitulé sans apporter d'information complémentaire) ;
* Mise à jour des titres de liens pour que l'intitulé visible soit toujours repris en intégralité ;
* Remplacement des titres de lien par des balises `abbr` sur les abréviations "CGU" et "FAQ" ;
* Suppression des classes `fr-footer__top-link` placées sur les mauvais noeuds ;
* Ajout des attribut `hreflang` sur les liens pointant vers des contenus français.