### PR TITLE
Correction des listes mal structurées

### DIFF
--- a/app/assets/stylesheets/landing.scss
+++ b/app/assets/stylesheets/landing.scss
@@ -133,7 +133,8 @@ $landing-breakpoint: 1040px;
   }
 
   .number {
-    @extend %horizontal-list-item;
+    display: flex;
+    flex-direction: column;
     width: 320px;
     text-align: center;
 
@@ -143,6 +144,8 @@ $landing-breakpoint: 1040px;
   }
 
   .number-value {
+    padding-bottom: 0;
+    padding-inline-start: 0;
     color: var(--text-action-high-blue-france);
     font-size: 2rem;
     line-height: 2rem;
@@ -150,9 +153,9 @@ $landing-breakpoint: 1040px;
   }
 
   .number-label {
+    order: 2;
     max-width: 10rem;
-    margin: auto;
-    padding-inline-start: 0;
+    margin: 0 auto;
     font-weight: 600;
     font-size: 1.25rem;
     line-height: 1.5rem;
@@ -162,6 +165,10 @@ $landing-breakpoint: 1040px;
   .number-label-third {
     max-width: 13rem;
   }
+}
+
+html[lang="fr"] .landing .number-label-third::before {
+  content: "de ";
 }
 
 $users-breakpoint: 950px;

--- a/app/assets/stylesheets/landing.scss
+++ b/app/assets/stylesheets/landing.scss
@@ -152,6 +152,7 @@ $landing-breakpoint: 1040px;
   .number-label {
     max-width: 10rem;
     margin: auto;
+    padding-inline-start: 0;
     font-weight: 600;
     font-size: 1.25rem;
     line-height: 1.5rem;

--- a/app/views/layouts/_skiplinks.html.haml
+++ b/app/views/layouts/_skiplinks.html.haml
@@ -1,5 +1,3 @@
 .fr-skiplinks
   %nav.fr-container{ role: "navigation", 'aria-label': t("skiplinks.quick") }
-    %ul.fr-skiplinks__list
-      %li
-        %a.fr-link{ href: "#contenu" }= t('skiplinks.content')
+    %a.fr-link{ href: "#contenu" }= t('skiplinks.content')

--- a/app/views/root/administration.html.haml
+++ b/app/views/root/administration.html.haml
@@ -76,20 +76,20 @@
         %h2.center.fr-mb-4w #{Current.application_name} en chiffres
         %dl.numbers
           .number
-            %dt.number-value
-              = number_with_delimiter(Administrateur.with_publiees_ou_closes.uniq.count, :locale => :fr)
-            %dd.number-label
+            %dt.number-label
               administrations partenaires
+            %dd.number-value
+              = number_with_delimiter(Administrateur.with_publiees_ou_closes.uniq.count, :locale => :fr)
           .number
-            %dt.number-value
-              = number_with_delimiter(Dossier.state_not_brouillon.count, :locale => :fr)
-            %dd.number-label
+            %dt.number-label
               dossiers déposés
+            %dd.number-value
+              = number_with_delimiter(Dossier.state_not_brouillon.count, :locale => :fr)
           .number
-            %dt.number-value
-              = "#{number_with_delimiter(50, :locale => :fr)} %"
-            %dd.number-label
+            %dt.number-label
               de réduction des délais de traitement
+            %dd.number-value
+              = "#{number_with_delimiter(50, :locale => :fr)} %"
 
   = render partial: "root/users" if  LANDING_USERS_ENABLED
 

--- a/app/views/root/administration.html.haml
+++ b/app/views/root/administration.html.haml
@@ -74,25 +74,25 @@
     .fr-py-6w.fr-background-alt--blue-france
       .container
         %h2.center.fr-mb-4w #{Current.application_name} en chiffres
-        %ul.numbers
-          %li.number
-            .number-value
+        %dl.numbers
+          .number
+            %dt.number-value
               = number_with_delimiter(Administrateur.with_publiees_ou_closes.uniq.count, :locale => :fr)
-            .number-label<
+            %dd.number-label<
               administrations
               %br<>
               partenaires
-          %li.number
-            .number-value
+          .number
+            %dt.number-value
               = number_with_delimiter(Dossier.state_not_brouillon.count, :locale => :fr)
-            .number-label<
+            %dd.number-label<
               dossiers
               %br<>
               déposés
-          %li.number
-            .number-value
+          .number
+            %dt.number-value
               = "#{number_with_delimiter(50, :locale => :fr)} %"
-            .number-label<
+            %dd.number-label<
               de réduction
               %br<>
               des délais de traitement

--- a/app/views/root/administration.html.haml
+++ b/app/views/root/administration.html.haml
@@ -78,24 +78,18 @@
           .number
             %dt.number-value
               = number_with_delimiter(Administrateur.with_publiees_ou_closes.uniq.count, :locale => :fr)
-            %dd.number-label<
-              administrations
-              %br<>
-              partenaires
+            %dd.number-label
+              administrations partenaires
           .number
             %dt.number-value
               = number_with_delimiter(Dossier.state_not_brouillon.count, :locale => :fr)
-            %dd.number-label<
-              dossiers
-              %br<>
-              déposés
+            %dd.number-label
+              dossiers déposés
           .number
             %dt.number-value
               = "#{number_with_delimiter(50, :locale => :fr)} %"
-            %dd.number-label<
-              de réduction
-              %br<>
-              des délais de traitement
+            %dd.number-label
+              de réduction des délais de traitement
 
   = render partial: "root/users" if  LANDING_USERS_ENABLED
 

--- a/app/views/root/landing.html.haml
+++ b/app/views/root/landing.html.haml
@@ -30,19 +30,19 @@
     .container
       %h2.center.fr-mb-4w= t(".our_numbers", name: Current.application_name)
       - cache [I18n.locale, "numbers-panel"], expires_in: 3.hours do
-        %ul.numbers
-          %li.number
-            .number-value
+        %dl.numbers
+          .number
+            %dt.number-value
               = number_with_delimiter(@stat&.administrations_partenaires)
-            .number-label= t(".numbers.administrations")
-          %li.number
-            .number-value
+            %dd.number-label= t(".numbers.administrations")
+          .number
+            %dt.number-value
               = number_with_delimiter(@stat&.dossiers_not_brouillon)
-            .number-label= t(".numbers.files")
-          %li.number
-            .number-value
+            %dd.number-label= t(".numbers.files")
+          .number
+            %dt.number-value
               = "#{number_with_delimiter(50)} %"
-            .number-label.number-label-third= t(".numbers.processing_time")
+            %dd.number-label.number-label-third= t(".numbers.processing_time")
 
   .fr-background-alt--blue-france.fr-py-6w
     .container

--- a/app/views/root/landing.html.haml
+++ b/app/views/root/landing.html.haml
@@ -32,17 +32,17 @@
       - cache [I18n.locale, "numbers-panel"], expires_in: 3.hours do
         %dl.numbers
           .number
-            %dt.number-value
+            %dt.number-label= t(".numbers.administrations")
+            %dd.number-value
               = number_with_delimiter(@stat&.administrations_partenaires)
-            %dd.number-label= t(".numbers.administrations")
           .number
-            %dt.number-value
+            %dt.number-label= t(".numbers.files")
+            %dd.number-value
               = number_with_delimiter(@stat&.dossiers_not_brouillon)
-            %dd.number-label= t(".numbers.files")
           .number
-            %dt.number-value
+            %dt.number-label.number-label-third= t(".numbers.processing_time")
+            %dd.number-value
               = "#{number_with_delimiter(50)} %"
-            %dd.number-label.number-label-third= t(".numbers.processing_time")
 
   .fr-background-alt--blue-france.fr-py-6w
     .container

--- a/config/locales/views/root.fr.yml
+++ b/config/locales/views/root.fr.yml
@@ -18,7 +18,7 @@ fr:
           dossiers
           déposés
         processing_time: |
-          de réduction
+          réduction
           des délais de traitement
       question: Une question, un problème ?
       answer_in_faq: La réponse est dans l’aide en ligne


### PR DESCRIPTION
* Suppression de la liste dans les liens d'accès rapides (car ceux-ci comprennent un seul élément) ;
* Remplacement des listes non numérotées par des [listes de description](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl) sur les landing pages.
* Suppression des sauts de ligne en dur sur la landing page "Administration".