### PR TITLE
Restaure la visibilité de la prise de focus dans le sélecteur de langue

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -627,7 +627,7 @@ textarea::placeholder {
   fill: currentColor;
 }
 
-.fr-menu__list {
+:not(.fr-translate) .fr-menu__list {
   padding: $default-spacer;
   overflow-y: auto;
 


### PR DESCRIPTION
__Après__
<img width="172" alt="" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/d73b2388-4c75-4b1b-83c0-676cbfda5400">
<img width="316" alt="" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/04060403-beeb-4481-a15f-b73b3e0b5916">

__Avant__
<img width="180" alt="" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/2b4f9ea0-24dd-4efb-982d-5d52fbb60ac7">
<img width="317" alt="" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/2088264/1fb35b27-4d1f-46cd-a412-fb049a42cd9c">
