### PR TITLE
Améliore l'accessibilité de la page de contact

### DIFF
--- a/app/views/support/index.html.haml
+++ b/app/views/support/index.html.haml
@@ -65,7 +65,7 @@
           = t('.notice_pj_product')
         %p.notice.hidden{ data: { 'contact-type-only': Helpscout::FormAdapter::TYPE_AUTRE } }
           = t('.notice_pj_other')
-        = file_field_tag :piece_jointe, class: 'fr-upload', max: 200.megabytes
+        = file_field_tag :piece_jointe, class: 'fr-upload'
 
       = hidden_field_tag :tags, @tags&.join(',')
 

--- a/app/views/support/index.html.haml
+++ b/app/views/support/index.html.haml
@@ -18,6 +18,7 @@
         .fr-input-group
           = label_tag :email, class: 'fr-label' do
             Email
+            = t('.notice_email')
             = render EditableChamp::AsteriskMandatoryComponent.new
           = email_field_tag :email, params[:email], required: true, autocomplete: 'email', class: 'fr-input'
 

--- a/app/views/support/index.html.haml
+++ b/app/views/support/index.html.haml
@@ -66,7 +66,7 @@
           = t('.notice_pj_product')
         %p.notice.hidden{ data: { 'contact-type-only': Helpscout::FormAdapter::TYPE_AUTRE } }
           = t('.notice_pj_other')
-        = file_field_tag :piece_jointe, class: 'fr-upload'
+        = file_field_tag :piece_jointe, class: 'fr-upload', accept: '.jpg, .jpeg, .png, .pdf'
 
       = hidden_field_tag :tags, @tags&.join(',')
 

--- a/config/locales/views/support/en.yml
+++ b/config/locales/views/support/en.yml
@@ -6,7 +6,7 @@ en:
         <p>Make sure you provide all the required information so we can help you in the best way.</p>"
       notice_email: "(example: myaddress@mymail.com)"
       your_question: Your question
-      our_answer: 👉 Our answer
+      our_answer: Our answer
       notice_pj_product: A screenshot can help us identify the element to improve.
       notice_pj_other: A screenshot can help us identify the issue.
       notice_upload_group: "Maximum size: 200 MB. Supported formats: jpg, png, pdf."

--- a/config/locales/views/support/en.yml
+++ b/config/locales/views/support/en.yml
@@ -4,6 +4,7 @@ en:
       contact: Contact
       intro_html: "<p>Contact us via this form and we will answer you as quickly as possible.</p>
         <p>Make sure you provide all the required information so we can help you in the best way.</p>"
+      notice_email: "(example: myaddress@mymail.com)"
       your_question: Your question
       our_answer: 👉 Our answer
       notice_pj_product: A screenshot can help us identify the element to improve.

--- a/config/locales/views/support/en.yml
+++ b/config/locales/views/support/en.yml
@@ -19,7 +19,7 @@ en:
           <p>If you are facing technical issues on the website, use the form below. We will not be able to inform you about the instruction of your application.</p>"
       product:
         question: I have an idea to improve the website
-        answer_html: "<p>Got an idea? <a href=\"%{link_product}\" rel=\"noopener noreferrer\" target=\"_blank\" title=\"Open features dashboard - New tab\">Please check our enhancement dashboard</a> :</p>
+        answer_html: "<p>Got an idea? <a href=\"%{link_product}\" rel=\"noopener noreferrer\" target=\"_blank\" title=\"Please check our enhancement dashboard - New tab\">Please check our enhancement dashboard</a> :</p>
               <ul><li>Vote for your priority improvements</li>
               <li>Share your own ideas</li></ul>"
       lost_user:

--- a/config/locales/views/support/fr.yml
+++ b/config/locales/views/support/fr.yml
@@ -19,7 +19,7 @@ fr:
           <p>Si vous souhaitez poser une question pour un problème technique sur le site, utilisez le formulaire ci-dessous. Nous ne pourrons pas vous renseigner sur l’instruction de votre dossier.</p>"
       product:
         question: J’ai une idée d’amélioration pour votre site
-        answer_html: "<p>Une idée ? Pensez à <a href=\"%{link_product}\" rel=\"noopener noreferrer\" target=\"_blank\" title=\"Ouvrir le tableau des évolutions - Nouvel onglet\">consulter notre tableau de bord des améliorations</a> :</p>
+        answer_html: "<p>Une idée ? Pensez à <a href=\"%{link_product}\" rel=\"noopener noreferrer\" target=\"_blank\" title=\"Consulter notre tableau de bord des améliorations - Nouvel onglet\">consulter notre tableau de bord des améliorations</a> :</p>
           <ul><li>Votez pour vos améliorations prioritaires,</li>
           <li>Proposez votre propre idée.</li></ul>"
       lost_user:

--- a/config/locales/views/support/fr.yml
+++ b/config/locales/views/support/fr.yml
@@ -4,6 +4,7 @@ fr:
       contact: Contact
       intro_html: "<p>Contactez-nous via ce formulaire et nous vous répondrons dans les plus brefs délais.</p>
         <p>Pensez bien à nous donner le plus d’informations possible pour que nous puissions vous aider au mieux.</p>"
+      notice_email: "(exemple : monadresse@monmail.com)"
       your_question: Votre question
       our_answer: Notre réponse
       notice_pj_product: Une capture d’écran peut nous aider à identifier plus facilement l’endroit à améliorer.


### PR DESCRIPTION
- Corrige un titre de lien qui ne reprends pas l'intitulé visible ;
- Supprime [un attribut `max` non autorisé](https://developer.mozilla.org/fr/docs/Web/HTML/Attributes/max) sur le champ de formulaire `input type="file"` ;
- Ajoute un exemple de type de données attendues sur le champ Email ;
- Supprime une icône de décoration de la version anglaise pour éviter qu'elle ne soit vocalisée par les technologies d'assistance ;
- Ajoute [l'attribut `accept`](https://developer.mozilla.org/fr/docs/Web/HTML/Attributes/accept) au champs d'upload pour limiter la sélection de document à ceux dont le type est autorisé uniquement.