### PR TITLE
ETQ superadmin, je peux accéder aux informations essentielles des dernières démarches publiées

### DIFF
--- a/app/controllers/manager/published_procedures_controller.rb
+++ b/app/controllers/manager/published_procedures_controller.rb
@@ -1,0 +1,20 @@
+module Manager
+  class PublishedProceduresController < Manager::ApplicationController
+    def index
+      @records_per_page = params[:records_per_page] || "25"
+      resources = Procedure
+        .publiee
+        .order(published_at: :desc)
+        .page(params[:_page])
+        .per(@records_per_page)
+      page = Administrate::Page::Collection.new(dashboard)
+
+      render locals: {
+        resources: resources,
+        page: page,
+        show_search_bar: false,
+        search_term: nil
+      }
+    end
+  end
+end

--- a/app/dashboards/published_procedure_dashboard.rb
+++ b/app/dashboards/published_procedure_dashboard.rb
@@ -1,0 +1,14 @@
+require "administrate/base_dashboard"
+
+class PublishedProcedureDashboard < Administrate::BaseDashboard
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    libelle: Field::Text.with_options(truncate: 1000),
+    description: Field::Text.with_options(truncate: 1000),
+    service: Field::HasOne,
+    published_at: Field::DateTime
+  }.freeze
+  COLLECTION_ATTRIBUTES = [:id, :published_at, :libelle, :description, :service].freeze
+  COLLECTION_FILTERS = {}.freeze
+  SHOW_PAGE_ATTRIBUTES = {}
+end

--- a/app/models/published_procedure.rb
+++ b/app/models/published_procedure.rb
@@ -1,0 +1,4 @@
+class PublishedProcedure
+  extend ActiveModel::Naming
+  extend ActiveModel::Translation
+end

--- a/app/views/manager/published_procedures/index.html.erb
+++ b/app/views/manager/published_procedures/index.html.erb
@@ -1,0 +1,66 @@
+<%#
+# Index
+
+This view is the template for the index page.
+It is responsible for rendering the search bar, header and pagination.
+It renders the `_table` partial to display details about the resources.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Collection][1].
+  Contains helper methods to help display a table,
+  and knows which attributes should be displayed in the resource's table.
+- `resources`:
+  An instance of `ActiveRecord::Relation` containing the resources
+  that match the user's search criteria.
+  By default, these resources are passed to the table partial to be displayed.
+- `search_term`:
+  A string containing the term the user has searched for, if any.
+- `show_search_bar`:
+  A boolean that determines if the search bar should be shown.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
+%>
+
+<% content_for(:title) do %>
+  <%= display_resource_name(page.resource_name) %>
+<% end %>
+
+<header class="main-content__header" role="banner">
+  <h1 class="main-content__page-title" id="page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <% if show_search_bar %>
+    <%= render(
+      "search",
+      search_term: search_term,
+      resource_name: display_resource_name(page.resource_name)
+    ) %>
+  <% end %>
+
+  <div>
+    <%= link_to(
+      t(
+        "administrate.actions.new_resource",
+        name: display_resource_name(page.resource_name, singular: true).downcase
+      ),
+      [:new, namespace, page.resource_path.to_sym],
+      class: "button",
+    ) if valid_action?(:new) && show_action?(:new, new_resource) %>
+  </div>
+</header>
+
+<section class="main-content__body main-content__body--flush">
+  <%= render(
+    "collection",
+    collection_presenter: page,
+    collection_field_name: resource_name,
+    page: page,
+    resources: resources,
+    table_title: "page-title"
+  ) %>
+
+  <%= render "pagination", resources: resources %>
+</section>

--- a/config/locales/models/published_procedure/fr.yml
+++ b/config/locales/models/published_procedure/fr.yml
@@ -1,0 +1,10 @@
+fr:
+  activemodel:
+    models:
+      published_procedure:
+        one: Démarche publiée
+        other: Démarches publiées
+    attributes:
+      published_procedure:
+        published_at: Publiée le
+        libelle: Libellé

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,6 +97,7 @@ Rails.application.routes.draw do
     end
 
     resources :dubious_procedures, only: [:index]
+    resources :published_procedures, only: [:index]
     resources :outdated_procedures, only: [:index] do
       patch :bulk_update, on: :collection
     end


### PR DESCRIPTION
Voir #10564

Nouvelle page du manager permettant de balayer d‘un coup d‘oeil les dernières démarches publiées 
 
<img width="1678" alt="Capture d’écran 2024-06-28 à 18 12 45" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/29131404/fc9f93d4-4417-4b04-8d3c-2dcaabbe3954">
