### PR TITLE
Tech: cookies avec flag `secure` et `httponly`

### DIFF
--- a/app/controllers/agent_connect/agent_controller.rb
+++ b/app/controllers/agent_connect/agent_controller.rb
@@ -12,8 +12,8 @@ class AgentConnect::AgentController < ApplicationController
   def login
     uri, state, nonce = AgentConnectService.authorization_uri
 
-    cookies.encrypted[STATE_COOKIE_NAME] = state
-    cookies.encrypted[NONCE_COOKIE_NAME] = nonce
+    cookies.encrypted[STATE_COOKIE_NAME] = { value: state, secure: Rails.env.production? }
+    cookies.encrypted[NONCE_COOKIE_NAME] = { value: nonce, secure: Rails.env.production? }
 
     redirect_to uri, allow_other_host: true
   end

--- a/app/controllers/agent_connect/agent_controller.rb
+++ b/app/controllers/agent_connect/agent_controller.rb
@@ -12,8 +12,8 @@ class AgentConnect::AgentController < ApplicationController
   def login
     uri, state, nonce = AgentConnectService.authorization_uri
 
-    cookies.encrypted[STATE_COOKIE_NAME] = { value: state, secure: Rails.env.production? }
-    cookies.encrypted[NONCE_COOKIE_NAME] = { value: nonce, secure: Rails.env.production? }
+    cookies.encrypted[STATE_COOKIE_NAME] = { value: state, secure: Rails.env.production?, httponly: true }
+    cookies.encrypted[NONCE_COOKIE_NAME] = { value: nonce, secure: Rails.env.production?, httponly: true }
 
     redirect_to uri, allow_other_host: true
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -117,7 +117,7 @@ class ApplicationController < ActionController::Base
 
   def set_locale(locale)
     if locale && locale.to_sym.in?(I18n.available_locales)
-      cookies[:locale] = { value: locale, secure: Rails.env.production? }
+      cookies[:locale] = { value: locale, secure: Rails.env.production?, httponly: true }
       if user_signed_in?
         current_user.update(locale: locale)
       end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -117,7 +117,7 @@ class ApplicationController < ActionController::Base
 
   def set_locale(locale)
     if locale && locale.to_sym.in?(I18n.available_locales)
-      cookies[:locale] = locale
+      cookies[:locale] = { value: locale, secure: Rails.env.production? }
       if user_signed_in?
         current_user.update(locale: locale)
       end

--- a/app/controllers/application_controller/long_lived_authenticity_token.rb
+++ b/app/controllers/application_controller/long_lived_authenticity_token.rb
@@ -24,7 +24,8 @@ module ApplicationController::LongLivedAuthenticityToken
     cookies.signed[COOKIE_NAME] = {
       value: csrf_token,
       expires: 1.year.from_now,
-      httponly: true
+      httponly: true,
+      secure: Rails.env.production?
     }
     session[:_csrf_token] = csrf_token
 

--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -248,7 +248,8 @@ module Instructeurs
       @export_templates = current_instructeur.export_templates_for(@procedure).includes(:groupe_instructeur)
       cookies.encrypted[cookies_export_key] = {
         value: DateTime.current,
-        expires: Export::MAX_DUREE_GENERATION + Export::MAX_DUREE_CONSERVATION_EXPORT
+        expires: Export::MAX_DUREE_GENERATION + Export::MAX_DUREE_CONSERVATION_EXPORT,
+        secure: Rails.env.production?
       }
 
       respond_to do |format|

--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -249,6 +249,7 @@ module Instructeurs
       cookies.encrypted[cookies_export_key] = {
         value: DateTime.current,
         expires: Export::MAX_DUREE_GENERATION + Export::MAX_DUREE_CONSERVATION_EXPORT,
+        httponly: true,
         secure: Rails.env.production?
       }
 

--- a/app/models/concerns/trusted_device_concern.rb
+++ b/app/models/concerns/trusted_device_concern.rb
@@ -8,7 +8,8 @@ module TrustedDeviceConcern
     cookies.encrypted[TRUSTED_DEVICE_COOKIE_NAME] = {
       value: JSON.generate({ created_at: start_at }),
       expires: start_at + TRUSTED_DEVICE_PERIOD,
-      httponly: true
+      httponly: true,
+      secure: Rails.env.production?
     }
   end
 

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_DS_session'
+Rails.application.config.session_store :cookie_store, key: '_DS_session', secure: Rails.env.production?

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_DS_session', secure: Rails.env.production?
+Rails.application.config.session_store :cookie_store, key: '_DS_session', secure: Rails.env.production?, httponly: true


### PR DESCRIPTION
![Capture d’écran 2024-07-03 à 12 37 00](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/1956bad8-4a42-44e0-ba3c-f8958dfd1385)

Ça déconnecte pas, et même mieux, Rails réécrit les cookies existants en secure.
J'ai pas testé les cookies agent connect & trusted device

Reste à configurer (mais je doute que ce soit possible) :

- crisp
- matomo 
- cookie `amp` (vient avec crisp ?)