### PR TITLE
ETQ usager et admin, je suis prévenu au moment de commencer un dossier sur une démarche ou révision en test

### DIFF
--- a/app/components/dsfr/alert_component.rb
+++ b/app/components/dsfr/alert_component.rb
@@ -2,6 +2,17 @@
 class Dsfr::AlertComponent < ApplicationComponent
   renders_one :body
 
+  attr_reader :state, :title, :size, :block, :extra_class_names, :heading_level
+
+  def initialize(state:, title: '', size: '', extra_class_names: nil, heading_level: 'h3')
+    @state = state
+    @title = title
+    @size = size
+    @block = block
+    @extra_class_names = extra_class_names
+    @heading_level = heading_level
+  end
+
   def prefix_for_state
     case state
     when :error then "Erreur : "
@@ -19,19 +30,4 @@ class Dsfr::AlertComponent < ApplicationComponent
       extra_class_names => true
     )
   end
-
-  private
-
-  def initialize(state:, title: '', size: '', extra_class_names: nil, heading_level: 'h3')
-    @state = state
-    @title = title
-    @size = size
-    @block = block
-    @extra_class_names = extra_class_names
-    @heading_level = heading_level
-  end
-
-  attr_reader :state, :title, :size, :block, :extra_class_names, :heading_level
-
-  private
 end

--- a/app/components/procedure_draft_warning_component.rb
+++ b/app/components/procedure_draft_warning_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class ProcedureDraftWarningComponent < ApplicationComponent
+  attr_reader :revision
+  attr_reader :current_administrateur
+  attr_reader :extra_class_names
+
+  def initialize(revision:, current_administrateur:, extra_class_names: nil)
+    @revision = revision
+    @current_administrateur = current_administrateur
+    @extra_class_names = extra_class_names
+  end
+
+  def render?
+    revision.draft?
+  end
+
+  def admin?
+    current_administrateur.present? && revision.procedure.administrateurs.include?(current_administrateur)
+  end
+end

--- a/app/components/procedure_draft_warning_component/procedure_draft_warning_component.en.yml
+++ b/app/components/procedure_draft_warning_component/procedure_draft_warning_component.en.yml
@@ -1,0 +1,13 @@
+---
+en:
+  title: Procedure in testing
+  intro_procedure_brouillon_html: This procedure is currently in <b>testing</b>
+  intro_revision_draft_html: This page allows you to <b>test</b> a new version of the procedure
+  body_general_html: |
+    and this page is reserved for the administration in charge of its deployment.
+    If you start or submit a file, it may be <b>deleted at any time</b> without notice, even if it is accepted later.
+  body_user: |
+    If this link was shared with you, please contact the service in charge of this procedure
+    to obtain the public link for the procedure in order to submit your application.
+  body_admin_procedure_brouillon: Do not share this link with your users. When you publish the procedure, you will access the public link for the procedure to be shared.
+  body_admin_revision_draft: Do not share this link with your users, but rather the public link for the procedure displayed in your administrator dashboard.

--- a/app/components/procedure_draft_warning_component/procedure_draft_warning_component.fr.yml
+++ b/app/components/procedure_draft_warning_component/procedure_draft_warning_component.fr.yml
@@ -1,0 +1,13 @@
+---
+fr:
+  title: Démarche en test
+  intro_procedure_brouillon_html: Cette démarche est actuellement en <b>test</b>
+  intro_revision_draft_html: Cette page permet de <b>tester</b> une nouvelle version de la démarche
+  body_general_html: |
+    et cette page est réservée à l’administration en charge de son déploiement.
+    Si vous commencez ou déposez un dossier, il pourra être <b>supprimé à tout moment</b> et sans préavis, même après avoir été accepté.
+  body_user: |
+    Si ce lien vous a été communiqué, contactez le service en charge de cette démarche
+    pour obtenir le lien public de la démarche afin de déposer votre dossier.
+  body_admin_procedure_brouillon: Ne communiquez pas ce lien à vos usagers. Lorsque vous publierez la démarche, vous accéderez au lien public de la démarche à communiquer.
+  body_admin_revision_draft: Ne communiquez pas ce lien à vos usagers, mais le lien public de la démarche affiché dans votre tableau de bord administrateur.

--- a/app/components/procedure_draft_warning_component/procedure_draft_warning_component.html.haml
+++ b/app/components/procedure_draft_warning_component/procedure_draft_warning_component.html.haml
@@ -1,0 +1,10 @@
+= render Dsfr::AlertComponent.new(state: :warning, extra_class_names:, title: t(".title")) do |c|
+  - c.with_body do
+    %p
+      = revision.procedure.brouillon? ? t(".intro_procedure_brouillon_html") : t(".intro_revision_draft_html")
+      = t(".body_general_html")
+
+    - if admin?
+      %p= revision.procedure.brouillon? ? t(".body_admin_procedure_brouillon") : t(".body_admin_revision_draft")
+    - else
+      %p= t(".body_user")

--- a/app/views/commencer/show.html.haml
+++ b/app/views/commencer/show.html.haml
@@ -13,7 +13,11 @@
                 #{Current.application_name}
           %li= link_to t('views.shared.account.already_user'), commencer_sign_in_path(path: @procedure.path, prefill_token: @prefilled_dossier&.prefill_token), class: 'fr-btn fr-btn--secondary'
 
+    = render ProcedureDraftWarningComponent.new(revision: @revision, current_administrateur:, extra_class_names: "fr-mb-2w")
+
   - else
+    = render ProcedureDraftWarningComponent.new(revision: @revision, current_administrateur:, extra_class_names: "fr-mb-2w")
+
     - if @prefilled_dossier
       = render Dsfr::CalloutComponent.new(title: t(".prefilled_draft"), heading_level: 'h2') do |c|
         - c.with_body do

--- a/config/locales/views/layouts/_breadcrumb.fr.yml
+++ b/config/locales/views/layouts/_breadcrumb.fr.yml
@@ -10,7 +10,7 @@ fr:
       since: "depuis le %{date}"
       closed: "Close"
       published: "Publiée"
-      draft: "En test"
+      draft: "En test"
       more_info_on_test: "Pour plus d’information sur la phase de test"
       go_to_FAQ: "consulter la FAQ"
       url_FAQ: "/faq#accordion-administrateur-2"

--- a/spec/views/administrateurs/procedures/show.html.haml_spec.rb
+++ b/spec/views/administrateurs/procedures/show.html.haml_spec.rb
@@ -16,17 +16,11 @@ describe 'administrateurs/procedures/show', type: :view do
         render
       end
 
-      describe 'publish button is visible' do
-        it { expect(rendered).to have_css('#publish-procedure-link') }
-        it { expect(rendered).not_to have_css('#close-procedure-link') }
-      end
-
-      describe 'procedure path is not customized' do
-        it { expect(rendered).to have_content('En test') }
-      end
-
-      describe 'archive button' do
-        it { expect(rendered).not_to have_css('#archive-procedure') }
+      it "render content" do
+        expect(rendered).to have_css('#publish-procedure-link')
+        expect(rendered).not_to have_css('#close-procedure-link')
+        expect(rendered).to have_content('En test')
+        expect(rendered).not_to have_css('#archive-procedure')
       end
     end
   end

--- a/spec/views/commencer/show.html.haml_spec.rb
+++ b/spec/views/commencer/show.html.haml_spec.rb
@@ -7,10 +7,15 @@ RSpec.describe 'commencer/show', type: :view do
   let(:drafts) { [] }
   let(:not_drafts) { [] }
   let(:preview_dossiers) { dossiers.take(3) }
+  let(:user) { nil }
+
+  before do
+    allow(view).to receive(:current_administrateur).and_return(user&.administrateur)
+  end
 
   before do
     assign(:procedure, procedure)
-    assign(:revision, procedure.published_revision)
+    assign(:revision, procedure.active_revision)
     assign(:dossiers, dossiers)
     assign(:drafts, drafts)
     assign(:not_drafts, not_drafts)
@@ -25,8 +30,6 @@ RSpec.describe 'commencer/show', type: :view do
   subject { render }
 
   context 'when no user is signed in' do
-    let(:user) { nil }
-
     it 'renders sign-in and sign-up links' do
       subject
       expect(rendered).to have_link('Créer un compte')
@@ -96,6 +99,37 @@ RSpec.describe 'commencer/show', type: :view do
         expect(rendered).to have_text(time_ago_in_words(prefilled_dossier.created_at))
         expect(rendered).to have_link('Poursuivre mon dossier prérempli', href: brouillon_dossier_path(prefilled_dossier))
       end
+    end
+  end
+
+  context "procedure is draft" do
+    let(:procedure) { create(:procedure, :draft) }
+    let(:user) { create :user }
+
+    it 'renders a warning' do
+      subject
+      expect(rendered).to have_text("Cette démarche est actuellement en test")
+    end
+
+    context "when user is admin" do
+      let(:user) { procedure.administrateurs.first.user }
+
+      it "renders warning about draft" do
+        subject
+        expect(rendered).to have_text("Cette démarche est actuellement en test")
+        expect(rendered).to have_text("Ne communiquez pas ce lien")
+      end
+    end
+  end
+
+  context "revision is draft" do
+    before {
+      assign(:revision, procedure.draft_revision)
+    }
+
+    it "renders warning about draft" do
+      subject
+      expect(rendered).to have_text("Démarche en test")
     end
   end
 end


### PR DESCRIPTION
Le message exact diffère suivant qu'on s'adresse à l'admin ou à un usager, et suivant que la démarche soit encore en brouillon, et qu'on soit sur la révision en brouillon d'une démarche publiée



## A l'ADMIN
![Capture d’écran 2024-07-03 à 15 05 13](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/b8673a9a-3f0d-4930-aebb-e1a104e1a47b)

## A l'USAGER
![Capture d’écran 2024-07-03 à 15 05 20](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/858b0543-efa3-4c3a-9905-7891fab06daf)


## REVISION BROUILLON
![Capture d’écran 2024-07-03 à 16 42 33](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/b35b5631-115a-4371-a74d-720acea745a8)