### PR TITLE
ETQ usager, je peux saisir le numéro d'accréditation COJO avec le suffixe `-01`

### DIFF
--- a/app/models/champs/cojo_champ.rb
+++ b/app/models/champs/cojo_champ.rb
@@ -50,7 +50,7 @@ class Champs::COJOChamp < Champ
 
   def update_external_id
     if accreditation_number_changed? || accreditation_birthdate_changed?
-      if accreditation_number.present? && accreditation_birthdate.present? && /\A\d+\z/.match?(accreditation_number)
+      if accreditation_number.present? && accreditation_birthdate.present? && /\A[\d-]+\z/.match?(accreditation_number)
         self.external_id = { accreditation_number:, accreditation_birthdate: }.to_json
       else
         self.external_id = nil


### PR DESCRIPTION
https://secure.helpscout.net/conversation/2646221574/2080417?folderId=1653799

Des usagers saisissent le suffixe avec `-` ce qui bloquait l'assignation de l'external id et l'appel API. Cette PR tolère la saisie du `-` (et ce qu'il y a après), qui ne sera de toute façon pas transmis à l'API grâce au `to_i` dans COJOService