### PR TITLE
ETQ expert, la vue d'un dossier respecte le bon layout

### DIFF
--- a/app/views/experts/avis/show.html.haml
+++ b/app/views/experts/avis/show.html.haml
@@ -2,4 +2,9 @@
 
 = render partial: 'header', locals: { avis: @avis, dossier: @dossier }
 
-= render partial: 'shared/dossiers/demande', locals: { dossier: @dossier, demande_seen_at: nil, profile: 'expert' }
+.fr-container
+  .fr-grid-row.fr-grid-row--center
+    - summary = ViewableChamp::HeaderSectionsSummaryComponent.new(dossier: @dossier, is_private: false)
+    = render summary
+    %div{ class: class_names("fr-col-12", "fr-col-xl-9" => summary.render?, "fr-col-xl-8" => !summary.render?) }
+      = render partial: "shared/dossiers/demande", locals: { dossier: @dossier, demande_seen_at: nil, profile: 'expert' }


### PR DESCRIPTION
Reprend le même affichage que pour les instructeurs, et avec les sections pour les écrans XL

APRES:
<img width="1257" alt="Capture d’écran 2024-07-09 à 19 38 56" src="https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/150279/31c84681-ff82-4fa7-b25e-c53ce460ee64">


AVANT:
pas de container donc 100% de la largeur de l'écran


