### PR TITLE
Clarification du message pour se créer un compte à partir d'une adresse email

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -303,7 +303,7 @@ fr:
     registrations:
       new:
         title: "Creation de compte sur %{name}"
-        subtitle: "Se créer un compte en choisissant un identifiant"
+        subtitle: "Se créer un compte avec une adresse email"
         email_label: 'Email'
         password_label: "Mot de passe (%{min_length} caractères minimum)"
         password_message: "Votre mot de passe doit contenir :"


### PR DESCRIPTION
Bonjour,

Je suis David Bruant de l'équipe Pitchou :bird: 

Le titre "Se créer un compte en choisissant un identifiant" de la page de création de compte parait inadapté. Entre autres choses, aucun "identifiant" n'est "choisi". 
Il s'agit plutôt de créer un compte à partir d'une adresse email, alors je propose un changement pour mieux refléter ce que propose le formulaire.

Dans le choix des mots, j'ai hésité entre "avec une adresse email" et "à partir d'une adresse email", j'ai choisi la forme la plus courte et je n'ai pas d'avis très fort sur le sujet

Merciiii :sunny: 