### PR TITLE
chore(champs): task to move non unique champs to a bad_data stream

### DIFF
--- a/app/tasks/maintenance/remove_non_unique_champs_task.rb
+++ b/app/tasks/maintenance/remove_non_unique_champs_task.rb
@@ -1,0 +1,21 @@
+module Maintenance
+  class RemoveNonUniqueChampsTask < MaintenanceTasks::Task
+    attribute :stable_ids, :string
+    validates :stable_ids, presence: true
+
+    def collection
+      champs = Champ.where(stable_id: stable_ids.split(',').map(&:strip).map(&:to_i))
+      champs
+        .group_by { [_1.dossier_id, _1.stream, _1.stable_id, _1.row_id] }
+        .values
+        .filter { _1.size > 1 }
+    end
+
+    def process(champs)
+      champs_to_remove = champs.sort_by(&:updated_at)[0...-1]
+      champs_to_remove.each do |champ|
+        champ.update_column(:stream, 'bad_data')
+      end
+    end
+  end
+end


### PR DESCRIPTION
sur l'instance DS, il y a qu'un seul stable_id qui pose problème : 2529054