### PR TITLE
A11y fix faq content

### DIFF
--- a/app/assets/stylesheets/01_common.scss
+++ b/app/assets/stylesheets/01_common.scss
@@ -11,6 +11,11 @@ body {
   min-height: 100%;
 }
 
+// Wrap text in pre tag
+pre {
+  white-space: pre-wrap;
+}
+
 // Mobile Safari doesn't bubble mouse events by default, unless:
 //
 // - the target element of the event is a link or a form field.

--- a/app/lib/redcarpet/trusted_renderer.rb
+++ b/app/lib/redcarpet/trusted_renderer.rb
@@ -18,7 +18,7 @@ module Redcarpet
       }
 
       unless href.starts_with?('/')
-        html_options.merge!(title: new_tab_suffix(title), **external_link_attributes)
+        html_options.merge!(title: new_tab_suffix(content), **external_link_attributes)
       end
 
       content_tag(:a, content, html_options, false)


### PR DESCRIPTION
# Force le retour à la ligne du contenu de la balise `<pre>`.

__Après__
<img width="601" alt="" src="https://github.com/user-attachments/assets/812ea0ef-a09a-48ba-b05f-79b0647ad54e">

__Avant__
<img width="602" alt="" src="https://github.com/user-attachments/assets/d5956d31-84f8-40e6-91d1-82d2dab63eb5">

# Ajoute l'intitulé visible des liens à l'attribut `title` des balise `<a href="…">`.

__Après__
<img width="615" alt="" src="https://github.com/user-attachments/assets/310bcf2c-989a-4473-9412-14aaeb0ad3f0">

__Avant__
<img width="537" alt="" src="https://github.com/user-attachments/assets/0a648b7c-7e24-4269-83c6-bc45ec1bf9b2">