### PR TITLE
Accessibilité: permet au markdown FAQ d'intégrer n'importe quel attribut html dans les `<img>`

### DIFF
--- a/app/lib/redcarpet/trusted_renderer.rb
+++ b/app/lib/redcarpet/trusted_renderer.rb
@@ -34,8 +34,26 @@ module Redcarpet
       end
     end
 
-    def image(link, title, alt)
-      view_context.image_tag(link, title:, alt:, loading: :lazy)
+    def image(link, title, alt_text)
+      # Extrait les attributs personnalisés s'ils existent sous la forme { aria-hidden=true } dans les []
+      custom_attributes = {}
+      if alt_text =~ /\s*\{(.+)\}$/
+        attr_string = Regexp.last_match(1)
+        alt_text = alt_text.sub(/\s*\{.+\}$/, '').strip
+        attr_string.split(' ').each do |attr|
+          key, value = attr.split('=')
+          custom_attributes[key.strip] = value.strip.delete('"')
+        end
+      end
+
+      # Combine les attributs standard et personnalisés
+      image_options = {
+        alt: alt_text,
+        title:,
+        loading: :lazy
+      }.merge(custom_attributes)
+
+      view_context.image_tag(link, image_options)
     end
 
     # rubocop:disable Rails/OutputSafety

--- a/doc/faqs/administrateur/ajouter-plusieurs-administrateurs-sur-une-meme-demarche.fr.md
+++ b/doc/faqs/administrateur/ajouter-plusieurs-administrateurs-sur-une-meme-demarche.fr.md
@@ -13,7 +13,7 @@ Il est possible d’avoir plusieurs administrateurs sur une même démarche. Cel
 
 **Nous conseillons vivement à chaque administrateur de nommer un co-administrateur pour assurer une gestion continue de la démarche.**
 
-![Capture d’écran de la page gérant la liste des administrateurs](faq/administrateur-add-administrateur.png)
+![Capture d’écran de la page gérant la liste des administrateurs {aria-hidden="true"}](faq/administrateur-add-administrateur.png)
 
 ## Comment ajouter un autre administrateur sur votre démarche ?
 

--- a/doc/faqs/administrateur/comment-clore-une-demarche.fr.md
+++ b/doc/faqs/administrateur/comment-clore-une-demarche.fr.md
@@ -17,21 +17,21 @@ Cliquez sur le bouton **« Clore »** situé à droite de la démarche.
 
 Bien que l’accès à la démarche soit restreint, les dossiers déjà déposés ne sont pas affectés et leur instruction peut se poursuivre normalement.
 
-![Capture d’écran de la page de clôture de la demarche](faq/administrateur-procedure-action-close.png)
+![Capture d’écran de la page de clôture de la demarche {aria-hidden="true"}](faq/administrateur-procedure-action-close.png)
 
 ## Informer les usagers accédant à la démarche close
 
  Un usager qui suit un lien vers la démarche sera informé qu’elle est close. Cependant au moment de la clôture vous pouvez indiquer quelle démarche la remplace (nous le redigerons vers celle-ci), ou la raison pour laquelle est close.
 
-![Capture d'écran du remplacement de démarche](faq/administrateur-procedure-close-replace.png)
+![Capture d'écran du remplacement de démarche {aria-hidden="true"}](faq/administrateur-procedure-close-replace.png)
 
-![Capture d'écran pour saisir le motif de cloture de démarche](faq/administrateur-procedure-close-message.png)
+![Capture d'écran pour saisir le motif de cloture de démarche {aria-hidden="true"}](faq/administrateur-procedure-close-message.png)
 
 ## Comment prévoir la clôture automatique d’une démarche ?
 
 Si vous anticipez la clôture de votre démarche à une date et/ou heure spécifique, il est possible de programmer cette clôture. Rendez-vous dans l’onglet **« Présentation »** de votre démarche, section **« Options avancées »**, pour définir les paramètres de clôture automatique.
 
-![Capture d’écran de la configuration de fermeture à une date donnée](faq/administrateur-procedure-auto-archive.png)
+![Capture d’écran de la configuration de fermeture à une date donnée {aria-hidden="true"}](faq/administrateur-procedure-auto-archive.png)
 
 Lorsqu’une démarche se clôture automatiquement, tous les dossiers en construction passent automatiquement au statut *« en instruction »* à la date limite de dépôt des dossiers.
 

--- a/doc/faqs/administrateur/comment-comprendre-mon-tableau-de-bord-administrateur.fr.md
+++ b/doc/faqs/administrateur/comment-comprendre-mon-tableau-de-bord-administrateur.fr.md
@@ -11,7 +11,7 @@ title: "Comment comprendre mon tableau de bord administrateur ?"
 
 Votre tableau de bord présente l'ensemble de vos démarches, classées en 4 catégories :
 
-![Capture d'écran du tableau de bord administrateur](faq/administrateur-procedures-list-header.png)
+![Capture d'écran du tableau de bord administrateur {aria-hidden="true"}](faq/administrateur-procedures-list-header.png)
 
 ## Publiées
 

--- a/doc/faqs/administrateur/comment-creer-une-demarche-declarative.fr.md
+++ b/doc/faqs/administrateur/comment-creer-une-demarche-declarative.fr.md
@@ -22,6 +22,6 @@ Une démarche déclarative est une démarche pour laquelle certaines étapes de 
 
 Pour configurer une démarche comme déclarative, accédez à la partie **« Présentation »** de la démarche depuis le tableau de bord administrateur. En bas de la page, dans l’onglet **« Options avancées »**, sélectionnez l’option souhaitée (*« En instruction »* ou *« Accepté »*) et enregistrez les modifications.
 
-![Capture d'écran de la page de configuration de la demarche déclarative](faq/administrateur-create-declarative.png)
+![Capture d'écran de la page de configuration de la demarche déclarative {aria-hidden="true"}](faq/administrateur-create-declarative.png)
 
 Vous avez la possibilité de revenir en arrière ou de modifier le type de démarche déclarative à tout moment, même après publication.

--- a/doc/faqs/administrateur/comment-limiter-une-demarche-dans-le-temps.fr.md
+++ b/doc/faqs/administrateur/comment-limiter-une-demarche-dans-le-temps.fr.md
@@ -22,6 +22,6 @@ Pour mettre en place la clôture automatique :
 1. Accédez à l’onglet « _Présentation_ » de votre démarche depuis le tableau de bord administrateur.
 2. Dans les « _Options avancées_ », recherchez le champ intitulé « _Date limite de dépôt des dossiers_ » et renseignez la date souhaitée.
 
-![Saisie de la date limite de dépôt](faq/administrateur-set-auto-close-date.png)
+![Saisie de la date limite de dépôt {aria-hidden="true"}](faq/administrateur-set-auto-close-date.png)
 
 **Attention** : Si vous fixez la date de clôture au « 14 septembre », la fin de dépôt des dossiers sera effective le **14 septembre à 23h59 (heure de Paris)**.

--- a/doc/faqs/administrateur/comment-mettre-en-forme-le-texte-de-ma-demarche.fr.md
+++ b/doc/faqs/administrateur/comment-mettre-en-forme-le-texte-de-ma-demarche.fr.md
@@ -33,12 +33,12 @@ Pour cela, utilisez les balises HTML, identifiées par les caractères `<` et `>
   - Exemple : « `Mon texte en <em>italique</em>` » affiche « Mon texte en *italique* »
 
 - **Souligner un texte**
-  - Balise ouvrante : `<u>` 
+  - Balise ouvrante : `<u>`
   - Balise fermante : `</u>`
   - Exemple : `« Mon texte <u>souligné</u> »` affiche « Mon texte <u>souligné</u> »
 
 - **Mettre un texte en gras**
-  - Balise ouvrante : `<strong>` 
+  - Balise ouvrante : `<strong>`
   - Balise fermante : `</strong>`
   - Exemple : `« Mon texte en <strong>gras</strong> »` donne « Mon texte en **gras** »
 
@@ -53,8 +53,8 @@ Pour cela, utilisez les balises HTML, identifiées par les caractères `<` et `>
 
 Exemple dans la description de la démarche :
 
-![Démonstration de texte qui contient des balises HTML de mises en forme](faq/administrateur-example-markup.png)
+![Saisie de texte utilisant les balises b, i et u](faq/administrateur-example-markup.png)
 
 Rendu côté usager :
 
-![Aperçu du même texte dans la description de la démarche lisible par l’usager](faq/administrateur-example-markup-preview.png)
+![Aperçu de ce même texte faisant état d'une mise en gras, d'une mise en italique et d'un soulignement](faq/administrateur-example-markup-preview.png)

--- a/doc/faqs/administrateur/guide-de-bonnes-pratiques-pour-tester-une-demarche.fr.md
+++ b/doc/faqs/administrateur/guide-de-bonnes-pratiques-pour-tester-une-demarche.fr.md
@@ -24,7 +24,7 @@ Le test d’une démarche se déroule en trois étapes :
 2. le test de la partie instructeur (instruction du dossier)
 3. le test des fonctionnalités secondaires
 
-Vous pouvez faire tester la partie usager (étape 1) et instructeur (étape 2) par des collaborateurs. Cependant, nous vous recommandons fortement de les tester vous-même une première fois. 
+Vous pouvez faire tester la partie usager (étape 1) et instructeur (étape 2) par des collaborateurs. Cependant, nous vous recommandons fortement de les tester vous-même une première fois.
 
 **Vous pouvez effectuer toutes les modifications que vous souhaitez sur votre démarche pendant cette phase de test.**
 
@@ -32,21 +32,21 @@ Bien évidemment, avant de tester la démarche, il faut l’avoir créé. Pour c
 
 ## Étape 1 : Déposer un dossier de test côté usager
 
-Vous devez commencer par cette étape afin de tester le parcours d’un usager pour déposer un dossier. De plus, sans dossier déposé, vous ne pourrez pas tester les fonctionnalités relatives à l’instruction. 
+Vous devez commencer par cette étape afin de tester le parcours d’un usager pour déposer un dossier. De plus, sans dossier déposé, vous ne pourrez pas tester les fonctionnalités relatives à l’instruction.
 
 1. Utilisez le bouton **« Tester la démarche »** (ou suivez le lien de la démarche), accessibles depuis votre interface administrateur. Toute personne ayant connaissance du lien pourra remplir des dossiers test sur votre démarche qui seront supprimés plus tard.
-  ![Bouton Tester la démarche depuis la tableau de bord de la démarche](faq/administrateur-procedure-test-button.png)
-  ![Affichage du lien de test de la démarche](faq/administrateur-procedure-test-link.png)
+  ![Bouton Tester la démarche depuis la tableau de bord de la démarche {aria-hidden="true"}](faq/administrateur-procedure-test-button.png)
+  ![Affichage du lien de test de la démarche {aria-hidden="true"}](faq/administrateur-procedure-test-link.png)
 
 2. Commencez à remplir votre dossier en suivant le bouton **« Commencer la démarche »**.
-  ![Page d’accueil usager de la démarche](faq/administrateur-procedure-test-commencer.png)
+  ![Page d’accueil usager de la démarche {aria-hidden="true"}](faq/administrateur-procedure-test-commencer.png)
 
 3. Après avoir complété le dossier et éventuellement testé les fonctionnalités dédiées à l'interface usagers (invitation à compléter un dossier…), cliquez sur **« Déposer le dossier »** pour finaliser le dépôt et voir le message de confirmation de dépôt.
-  ![Test de la démarche par l’usager](faq/administrateur-procedure-test-usager.png)
+  ![Test de la démarche par l’usager {aria-hidden="true"}](faq/administrateur-procedure-test-usager.png)
 
 Une fois votre dossier de test déposé, un message de confirmation de dépôt sera affiché :
 
-![Message de confirmation de dépôt d’un dossier](faq/administrateur-procedure-test-thanks.png)
+![Message de confirmation de dépôt d’un dossier {aria-hidden="true"}](faq/administrateur-procedure-test-thanks.png)
 
 N’hésitez pas à [transmettre le lien vers la démarche test à vos collègues](/faq/administrateur/faire-tester-une-demarche-par-un-collegue) afin qu’ils puissent la tester et vous transmettre leur retour. Gardez à l’esprit que **tous les dossiers déposés pendant le test seront supprimés** lorsque la démarche sera modifiée ou publiée.
 
@@ -56,23 +56,23 @@ Vous avez déposé à l’étape précédente un premier dossier. Rendez-vous d�
 
 Passez à l’interface instructeur via le lien [%{application_base_url}/procedures](/procedures) ou en changeant de profil depuis le menu en haut à droite en cliquant sur votre adresse email.
 
-![Menu pour passer instructeur](faq/administrateur-profile-switch.png)
+![Menu pour passer instructeur {aria-hidden="true"}](faq/administrateur-profile-switch.png)
 
 ⚠️ **Vous devez être instructeur de la démarche pour accéder aux dossiers déposés**. Par défaut, en tant que créateur de la démarche (administrateur), vous êtes instructeur de celle-ci. Si vous ne testez pas vous-même cette partie, ajoutez votre collaborateur en tant qu’instructeur.
 
-Vous arrivez alors sur l’interface instructeur. Il vous suffit de cliquer sur l’onglet **« En test »** puis suivez le lien de votre démarche avec un dossier **« à suivre »** . 
+Vous arrivez alors sur l’interface instructeur. Il vous suffit de cliquer sur l’onglet **« En test »** puis suivez le lien de votre démarche avec un dossier **« à suivre »** .
 
-![Page d’accueil instructeur de la démarche](faq/administrateur-procedures-list.png)
+![Page d’accueil instructeur de la démarche {aria-hidden="true"}](faq/administrateur-procedures-list.png)
 
 Trouvez le dossier à suivre, puis testez l’instruction du dossier.
 
-![Dossier à suivre](faq/administrateur-test-instruction-dossiers-list.png)
+![Dossier à suivre {aria-hidden="true"}](faq/administrateur-test-instruction-dossiers-list.png)
 
 Voici le tutoriel pour instruire un dossier en tant qu’instructeur : [Tutoriel Instructeur](https://doc.demarches-simplifiees.fr/tutoriels/tutoriel-instructeur)
 
 ## Étape 3 : Tester les fonctionnalités secondaires
 
-Vous pourrez ici tester différents éléments secondaires : 
+Vous pourrez ici tester différents éléments secondaires :
 
 - Demande d’**avis externe** (partie instruction) . Pour plus d’information, vous pouvez consulter [notre tutoriel expert invité](https://doc.demarches-simplifiees.fr/tutoriels/tutoriel-expert-invite)
 - **Vérifiez les e-mails** d’accusé de réception, de passage en instruction, d’acceptation, de refus et de classement sans suite (partie usager)
@@ -89,7 +89,7 @@ En cas d’erreur et/ou en fonction des retours de vos collègues suite à la ph
 Après avoir minutieusement testé votre démarche, il est temps de la rendre accessible à tous en la publiant.
 
 1. **Accédez au tableau de bord administrateur** de votre démarche et cliquez sur le bouton **« Publier »** situé en haut à droite.
-  ![Bouton Publier](faq/administrateur-procedure-test-publish.png)
+  ![Bouton Publier {aria-hidden="true"}](faq/administrateur-procedure-test-publish.png)
 
 2. **Personnalisez le lien** du formulaire pour le diffuser plus facilement à vos usagers. Cette étape vous permet de simplifier l’accès à votre démarche.
 

--- a/doc/faqs/administrateur/je-ne-trouve-pas-ma-demarche-dans-le-catalogue-de-demarches.fr.md
+++ b/doc/faqs/administrateur/je-ne-trouve-pas-ma-demarche-dans-le-catalogue-de-demarches.fr.md
@@ -12,7 +12,7 @@ title: "Je ne trouve pas ma démarche dans le catalogue de démarches"
 Si vous avez publié votre démarche et qu’un collègue souhaite la cloner mais ne la trouve pas sous « _Nouvelle démarche_ » dans le catalogue _Créer une nouvelle démarche à partir d’une démarche existante_, voici quelques étapes à suivre :
 
 1. Utiliser la fonction de recherche du navigateur (Ctrl + F) pour chercher par mot clé plutôt que par le titre complet de la démarche et vérifier sa présence.
-2. Si la démarche n’est pas trouvée, cela peut être dû au critère de répertoriation qui requiert que 30 dossiers soient déposés sur la démarche pour figurer dans le catalogue. 
+2. Si la démarche n’est pas trouvée, cela peut être dû au critère de répertoriation qui requiert que 30 dossiers soient déposés sur la démarche pour figurer dans le catalogue.
 
 ## Partager la démarche
 Dans cette situation, vous pouvez partager directement votre démarche avec votre collègue :
@@ -25,11 +25,11 @@ Dans cette situation, vous pouvez partager directement votre démarche avec votr
 
 Votre collègue trouvera alors une copie de votre démarche dans ses démarches « En test ».
 
-![Capture d’écran du bouton Envoyer une copie de ma démarche](faq/administrateur-button-copy-procedure.png)
+![Capture d’écran du bouton Envoyer une copie de ma démarche {aria-hidden="true"}](faq/administrateur-button-copy-procedure.png)
 
 ## Recherche dans « Toutes les démarches »
 
 Vous pouvez également rechercher la démarche depuis la page « _Toutes les démarches_ », où il est possible de filtrer les démarches par zones, statut, SIRET ou tags, y compris celles avec moins de 30 dossiers déposés.
 
-![Capture d’écran du lien vers la page Toute les démarches](faq/administrateur-link-all-procedures.png)
-![Capture d’écran de la page Toutes les démarches](faq/administrateur-all-procedures.png)
+![Capture d’écran du lien vers la page Toute les démarches {aria-hidden="true"}](faq/administrateur-link-all-procedures.png)
+![Capture d’écran de la page Toutes les démarches {aria-hidden="true"}](faq/administrateur-all-procedures.png)

--- a/doc/faqs/administrateur/les-blocs-repetables.fr.md
+++ b/doc/faqs/administrateur/les-blocs-repetables.fr.md
@@ -20,19 +20,19 @@ Imaginez une situation où l’usager doit saisir plusieurs fois une commune. L�
 ## Comment configurer un bloc répétable ?
 
 1. Sélectionnez comme type de champ le **« Bloc répétable »** et ajoutez son libellé. Dans notre exemple ce sera *Localisation*.
-  ![Exemple de choix du champ Bloc répétable](faq/administrateur-list-champs-repetition.png)
+  ![Exemple de choix du champ Bloc répétable {aria-hidden="true"}](faq/administrateur-list-champs-repetition.png)
 
 2. Renseignez les différents champs à inclure au sein de ce bloc répétable en cliquant sur **« Ajouter un champ »** à l’intérieur du bloc. Vous pouvez ajouter tous les types de champ (texte, zone de texte, entier, etc…)
   Dans l’exemple d’une liste de communes, l’administrateur ajoute donc le champ « Commune » mais d’autres champs pourraient être ajoutés.
-  ![Exemple de configuration d’une répétition](faq/administrateur-repetition-create.png)
+  ![Exemple de configuration d’une répétition {aria-hidden="true"}](faq/administrateur-repetition-create.png)
 
 ## Comment fonctionne-t-il pour l’usager ?
 
 - L’usager voit le champ répétable, vide par défaut, et peut cliquer sur **« Ajouter un élément »** pour saisir une nouvelle instance du bloc.
-  ![Vue usager vide du bloc répétable](faq/administrateur-repetition-view-usager-empty.png)
+  ![Vue usager vide du bloc répétable {aria-hidden="true"}](faq/administrateur-repetition-view-usager-empty.png)
 
 - Après avoir ajouté un élément, il peut continuer à ajouter de nouvelles valeurs aussi souvent que nécessaire.
-  ![Vue usager remplie avec 2 communes du bloc répétable](faq/administrateur-repetition-view-usager-fill.png)
+  ![Vue usager remplie avec 2 communes du bloc répétable {aria-hidden="true"}](faq/administrateur-repetition-view-usager-fill.png)
 
 - Si nécessaire, l’usager a la possibilité de supprimer un élément précédemment ajouté.
 

--- a/doc/faqs/instructeur/a-quoi-correspondent-les-differentes-categories-de-dossiers.fr.md
+++ b/doc/faqs/instructeur/a-quoi-correspondent-les-differentes-categories-de-dossiers.fr.md
@@ -20,4 +20,4 @@ Pour chaque démarche, les dossiers sont répartis dans plusieurs onglets :
 
 Notez qu’**un dossier peut être suivi par plusieurs instructeurs**. Vous pourrez donc retrouver les dossiers que vous ne suivez pas dans l’onglet **au total**. La somme des onglets *à suivre*, *suivis* et *traités* n’est donc pas nécessairement égale au nombre affiché *au total*.
 
-![Différents onglets répartissant les dossiers d’une démarche.](faq/instructeur-procedure-show.png)
+![Différents onglets répartissant les dossiers d’une démarche {aria-hidden="true"}](faq/instructeur-procedure-show.png)

--- a/doc/faqs/instructeur/comment-ajouter-un-justificatif-lors-de-l-acceptation-d-un-dossier.fr.md
+++ b/doc/faqs/instructeur/comment-ajouter-un-justificatif-lors-de-l-acceptation-d-un-dossier.fr.md
@@ -11,7 +11,7 @@ title: "Comment ajouter un justificatif lors de l’acceptation d’un dossier"
 
 Lorsque vous acceptez, refusez ou classez sans suite un dossier, il est possible de joindre un document après avoir indiqué la raison derrière ce choix.
 
-![L’interface de l’instructeur pour accepter, refuser ou classer sans suite un dossier.](faq/instructeur-accepter-add-justificatif.png)
+![L’interface de l’instructeur pour accepter, refuser ou classer sans suite un dossier {aria-hidden="true"}](faq/instructeur-accepter-add-justificatif.png)
 
 ## Note importante
 

--- a/doc/faqs/instructeur/comment-filtrer-la-liste-des-dossiers.fr.md
+++ b/doc/faqs/instructeur/comment-filtrer-la-liste-des-dossiers.fr.md
@@ -23,23 +23,23 @@ Pour appliquer un filtre à une liste de dossiers :
 
 ![Capture d’écran de l’interface de saisie d’un filtre {aria-hidden="true"}](faq/instructeur-filtres-dropdown.png)
 
-![Capture d’écran de toutes les colonnes filtres](faq/instructeur-filtres-list.png)
+![Capture d’écran de toutes les colonnes filtres {aria-hidden="true"}](faq/instructeur-filtres-list.png)
 
 ## Appliquer plusieurs filtres
 
 Vous pouvez appliquer plusieurs filtres à une même liste. Quand vous appliquez des filtres sur des **types de champs différents**, les dossiers affichés sont ceux qui correspondent à **tous les filtres**.
 
-![Capture d’écran récapitulant une combinaison de filtres différents addifitifs](faq/instructeur-filtres-and.png)
+![Capture d’écran récapitulant une combinaison de filtres différents addifitifs {aria-hidden="true"}](faq/instructeur-filtres-and.png)
 
 Quand vous appliquez des filtres sur les **mêmes types de champs**, les dossiers affichés sont ceux qui correspondent à **l’une ou l’autre des valeurs**.
 
-![Capture d’écran récapitulant une combinaison de filtres sur une même colonne](faq/instructeur-filtres-and.png)
+![Capture d’écran récapitulant une combinaison de filtres sur une même colonne {aria-hidden="true"}](faq/instructeur-filtres-or.png)
 
 ## Appliquer un filtre à une date
 
 Pour appliquer un filtre sur une colonne de date, rentrez la date au format « JJ/MM/AAAA ».
 
-![Capture d’écran illustrant un filtre sur une date](faq/instructeur-filtres-date.png)
+![Capture d’écran illustrant un filtre sur une date {aria-hidden="true"}](faq/instructeur-filtres-date.png)
 
 ## Conseils sur les filtres
 
@@ -49,4 +49,4 @@ Pour appliquer un filtre sur une colonne de date, rentrez la date au format « J
 
 En complément, vous pouvez également utiliser le bouton **« Personnaliser le tableau »** afin d’avoir une idée des informations du dossier avant de l’instruire.
 
-![Capture d'écran de l’interface de personnalisation du tableau](faq/instructeur-dossiers-list-header.png)
+![Capture d'écran de l’interface de personnalisation du tableau {aria-hidden="true"}](faq/instructeur-dossiers-list-header.png)

--- a/doc/faqs/instructeur/comment-filtrer-la-liste-des-dossiers.fr.md
+++ b/doc/faqs/instructeur/comment-filtrer-la-liste-des-dossiers.fr.md
@@ -21,7 +21,7 @@ Pour appliquer un filtre à une liste de dossiers :
 4. Sélectionnez ensuite la valeur à filtrer.
 5. Cliquez enfin sur **« Ajouter le filtre »**.
 
-![Capture d’écran de l’interface de saisie d’un filtre](faq/instructeur-filtres-dropdown.png)
+![Capture d’écran de l’interface de saisie d’un filtre {aria-hidden="true"}](faq/instructeur-filtres-dropdown.png)
 
 ![Capture d’écran de toutes les colonnes filtres](faq/instructeur-filtres-list.png)
 

--- a/doc/faqs/instructeur/comment-recevoir-un-email-chaque-fois-qu-un-dossier-est-depose.fr.md
+++ b/doc/faqs/instructeur/comment-recevoir-un-email-chaque-fois-qu-un-dossier-est-depose.fr.md
@@ -19,10 +19,10 @@ Il suffit de configurer vos notifications pour recevoir un email. En effet, pour
 
 Pour paramétrer vos notifications en tant qu’instructeur, vous devez cliquer sur la démarche pour laquelle vous souhaitez recevoir l’email, puis cliquer sur **« Gestion des notifications »** :
 
-![Écran d’en-tête d’une démarche affichant le lien vers la page de gestion des notifications](faq/instructeur-procedure-header.png)
+![Écran d’en-tête d’une démarche affichant le lien vers la page de gestion des notifications {aria-hidden="true"}](faq/instructeur-procedure-header.png)
 
 Sélectionnez les notifications que vous souhaitez recevoir par email et cliquez sur le bouton **« Enregistrer »** :
 
-![Capture d’écran de la page de gestion des notifications](faq/instructeur-procedure-notifications.png)
+![Capture d’écran de la page de gestion des notifications {aria-hidden="true"}](faq/instructeur-procedure-notifications.png)
 
 **Il est nécessaire de répéter cette opération pour chaque démarche pour laquelle vous souhaitez recevoir des notifications par email.**

--- a/doc/faqs/instructeur/comment-repasser-un-dossier-en-instruction.fr.md
+++ b/doc/faqs/instructeur/comment-repasser-un-dossier-en-instruction.fr.md
@@ -9,7 +9,7 @@ title: "Comment repasser un dossier en instruction ?"
 
 # Comment repasser un dossier en instruction ?
 
-Une fois un dossier clôturé, vous avez la possibilité de le repasser en instruction, notamment si vous souhaitez que l’usager vous apporte des éléments complémentaires. 
+Une fois un dossier clôturé, vous avez la possibilité de le repasser en instruction, notamment si vous souhaitez que l’usager vous apporte des éléments complémentaires.
 
 Toutefois, **l’acceptation d’un dossier génère des droits pour l’usager**. De ce fait, **votre responsabilité peut être engagée en cas de retour sur des droits qui ont été octroyés**.
 

--- a/doc/faqs/usager/01_comment-trouver-ma-demarche.fr.md
+++ b/doc/faqs/usager/01_comment-trouver-ma-demarche.fr.md
@@ -58,10 +58,10 @@ Pour compléter un dossier, [connectez-vous sur votre espace %{application_name}
 
 Pour commencer un nouveau dossier sur une démarche déjà réalisée, [connectez-vous](/users/sign_in) et cliquez sur **« Actions »** puis **« Commencer un autre dossier vide »**.
 
-![Image montrant le lien pour Commencer un autre dossier vide](faq/usager-dossier-actions-menu-start-new.png)
+![Image montrant le lien pour Commencer un autre dossier vide {aria-hidden="true"}](faq/usager-dossier-actions-menu-start-new.png)
 
 ### Si le bouton "Commencer un autre dossier vide" n’est pas affiché cela signifie que la démarche a été clôturée.
 
 Pour connaitre le nouveau lien vers la démarche en ligne, nous vous invitons à contacter le service en charge de la démarche. Vous trouverez les informations de contact en bas du formulaire dans la partie **« Poser une questions sur la démarche »** (en cliquant sur le numéro de dossier).
 
-![Image montrant comment trouver les informations de contact d’une démarche](faq/usager-procedure-close-focus-contact.png)
+![Image montrant comment trouver les informations de contact d’une démarche {aria-hidden="true"}](faq/usager-procedure-close-focus-contact.png)

--- a/doc/faqs/usager/comment-deposer-un-autre-dossier-pour-une-meme-demarche.fr.md
+++ b/doc/faqs/usager/comment-deposer-un-autre-dossier-pour-une-meme-demarche.fr.md
@@ -11,4 +11,4 @@ title: "Comment déposer un autre dossier pour une même démarche ?"
 
 Pour commencer un nouveau dossier sur une démarche que vous avez déjà réalisée, cliquez sur le bouton **« Actions »** du dossier correspondant à la démarche que vous souhaitez faire. Sélectionnez enfin le bouton **« Commencer un autre dossier vide »**.
 
-![Image montrant le lien pour Commencer un autre dossier vide](faq/usager-dossier-actions-menu-start-new.png)
+![Image montrant le lien pour Commencer un autre dossier vide {aria-hidden="true"}](faq/usager-dossier-actions-menu-start-new.png)

--- a/doc/faqs/usager/comment-dupliquer-un-dossier-deja-depose.fr.md
+++ b/doc/faqs/usager/comment-dupliquer-un-dossier-deja-depose.fr.md
@@ -13,11 +13,11 @@ En tant qu’usager, vous avez la possibilité de dupliquer un dossier existant 
 
 Pour cela, il vous suffit de cliquer sur le bouton **« Dupliquer ce dossier »** depuis le menu déroulant **« Actions »** situé à droite du dossier concerné :
 
-![Image illustrant le menu Dupliquer ce dossier](faq/usager-dossier-actions-menu-clone.png)
+![Image illustrant le menu Dupliquer ce dossier {aria-hidden="true"}](faq/usager-dossier-actions-menu-clone.png)
 
 Votre nouveau dossier sera alors automatiquement prérempli avec les informations et les pièces justificatives déjà transmises lors du dépôt de votre précédent dossier.
 
-![Image montrant le dossier dupliqué en brouillon](faq/usager-dossier-cloned-draft.png)
+![Image montrant le dossier dupliqué en brouillon {aria-hidden="true"}](faq/usager-dossier-cloned-draft.png)
 
 Vous avez la possibilité de :
 

--- a/doc/faqs/usager/je-veux-changer-mon-adresse-email.fr.md
+++ b/doc/faqs/usager/je-veux-changer-mon-adresse-email.fr.md
@@ -22,10 +22,10 @@ Pour changer l’adresse email associée à votre compte, suivez les étapes sui
 
 1. [Connectez-vous](/users/sign_in) à votre compte sur %{application_name} ;
 2. Cliquez sur le menu contenant votre adresse email en haut à droite de la page, puis sur _« Voir mon profil »_, ou [suivez directement ce lien si vous êtes déjà connecté(e)](/profil).
-![Menu Usager avec lien Voir mon profil](faq/usager-dropdown.png)
+![Menu Usager avec lien Voir mon profil {aria-hidden="true"}](faq/usager-dropdown.png)
 
 3. Dans l’encadré _« Coordonnées »_, renseignez la nouvelle adresse email que vous souhaitez utiliser. Puis cliquez sur _« Changer mon adresse »_. **Attention** : Cette adresse ne doit pas être déjà utilisée par un autre compte sur %{application_name}.
-![Section Coordonées avec formulaire de modification d’email](faq/usager-edit-email.png)
+![Section Coordonées avec formulaire de modification d’email {aria-hidden="true"}](faq/usager-edit-email.png)
 
 4. Ouvrez la boîte email de votre nouvelle adresse, et cliquez sur le lien de confirmation que nous vous avons envoyé.
 

--- a/doc/faqs/usager/je-veux-contacter-le-service-en-charge-de-ma-demarche.fr.md
+++ b/doc/faqs/usager/je-veux-contacter-le-service-en-charge-de-ma-demarche.fr.md
@@ -19,11 +19,11 @@ Pour contacter les services en charge de votre démarche, vous pouvez :
 
     Pour cela, suivez le lien **« Messagerie »** depuis le dossier concerné, et envoyez-leur un message.
 
-    ![Vue de l’interface de messagerie avec le service traitant un dossier](faq/usager-messagerie.png)
+    ![Vue de l’interface de messagerie avec le service traitant un dossier {aria-hidden="true"}](faq/usager-messagerie.png)
 
 2. Contacter **les services compétents aux contacts renseignés pour la démarche**
 
     Si des contacts d’adresse email ou numéro de téléphone sont spécifiés pour la démarche que vous suivez, vous pouvez les utiliser pour obtenir des renseignements supplémentaires ou pour toute question spécifique concernant votre dossier.
     Ces informations se retrouvent dans le pied de page du dossier.
 
-    ![Coordonnées de contact du service traitant un dossier](faq/usager-footer-contact.png)
+    ![Coordonnées de contact du service traitant un dossier {aria-hidden="true"}](faq/usager-footer-contact.png)

--- a/doc/faqs/usager/je-veux-enregistrer-mon-formulaire-pour-le-reprendre-plus-tard.fr.md
+++ b/doc/faqs/usager/je-veux-enregistrer-mon-formulaire-pour-le-reprendre-plus-tard.fr.md
@@ -15,17 +15,17 @@ Lorsque vous remplissez un formulaire sur %{application_name}, les informations 
 
 Si vous souhaitez terminer de remplir le formulaire plus tard, **il suffit de fermer la page du formulaire**. Lorsque vous retournerez sur %{application_name}, vous pourrez reprendre votre démarche là où vous l’avez laissée.
 
-![Le formulaire est enregistré automatiquement](faq/usager-form-footer-submit.png)
+![Le formulaire est enregistré automatiquement {aria-hidden="true"}](faq/usager-form-footer-submit.png)
 
 ## Comment reprendre mon formulaire plus tard ?
 
 Si vous avez déjà commencé à remplir une démarche, vous pouvez retrouver votre dossier déjà rempli. Pour cela :
 
 1. Connectez-vous à %{application_name}, utilisez votre identifiant et votre mot de passe, ou bien FranceConnect.
-  ![La page de connexion de %{application_name}](faq/sign-in-page.png)
+  ![La page de connexion de %{application_name} {aria-hidden="true"}](faq/sign-in-page.png)
 
 2. Dans [la liste de vos dossiers](/dossiers), **cliquez sur le dossier en brouillon** que vous souhaitez reprendre. Vous pouvez également faire une **recherche par numéro de dossier, mots-clés ou en filtrant par démarches**.
-  ![La liste de mes dossiers](faq/usager-dossiers-list.png)
+  ![La liste de mes dossiers {aria-hidden="true"}](faq/usager-dossiers-list.png)
 
 Vous pouvez alors reprendre votre formulaire là où vous l’aviez laissé en cliquant sur le bouton **« Continuer à remplir »**. Une fois que vous avez rempli le formulaire, cliquez sur **« Déposer le dossier »** pour l’envoyer à l’administration.
 

--- a/doc/faqs/usager/je-veux-savoir-ou-en-est-l-instruction-de-ma-demarche.fr.md
+++ b/doc/faqs/usager/je-veux-savoir-ou-en-est-l-instruction-de-ma-demarche.fr.md
@@ -17,7 +17,7 @@ Pour contacter les services en charge de votre démarche, vous pouvez :
 
     Pour cela, il vous suffit de cliquer sur le lien **« Messagerie »** depuis le dossier concerné.
 
-    ![Vue de l’interface de messagerie avec le service traitant un dossier](faq/usager-messagerie.png)
+    ![Vue de l’interface de messagerie avec le service traitant un dossier {aria-hidden="true"}](faq/usager-messagerie.png)
 
     N’oubliez pas de cliquer sur le bouton **« Envoyer le message »**.
 
@@ -25,4 +25,4 @@ Pour contacter les services en charge de votre démarche, vous pouvez :
 
     La messagerie peut être désactivée lorsque le dossier est archivé ou fait l’objet d’une décision finale. Dans ce cas, vous pouvez contacter le service grâce aux informations de contact situées en bas du formulaire.
 
-    ![Coordonnées de contact du service traitant un dossier](faq/usager-footer-contact.png)
+    ![Coordonnées de contact du service traitant un dossier {aria-hidden="true"}](faq/usager-footer-contact.png)

--- a/doc/faqs/usager/modification-de-l-identite-du-demandeur-d-un-dossier.fr.md
+++ b/doc/faqs/usager/modification-de-l-identite-du-demandeur-d-un-dossier.fr.md
@@ -15,11 +15,11 @@ En tant qu’usager, vous avez la possibilité de modifier l’identité associ�
 
 Pour modifier votre dossier en brouillon, il suffit de cliquer sur le dossier concerné puis de cliquer sur le bouton _« Mon identité »_ situé à droite de l’écran comme ci-dessous :
 
-![Image montrant où cliquer pour modifier l’identité d’un dossier en brouillon](faq/usager-edit-identity-brouillon-1.png)
+![Image montrant où cliquer pour modifier l’identité d’un dossier en brouillon {aria-hidden="true"}](faq/usager-edit-identity-brouillon-1.png)
 
 Vous pourrez ensuite modifier votre identité depuis le bouton _« Modifier l’identité »_ :
 
-![Image montrant le bouton pour modifier l’identité](faq/usager-edit-identity-brouillon-2.png)
+![Image montrant le bouton pour modifier l’identité {aria-hidden="true"}](faq/usager-edit-identity-brouillon-2.png)
 
 ## Le dossier est en "construction"
 
@@ -27,11 +27,11 @@ Une fois votre dossier déposé, il devient _en construction_ (tant que l’admi
 
 Pour cela, cliquez sur le bouton _« Modifier le dossier »_ depuis la liste de vos dossiers.
 
-![Image illustrant où cliquer pour modifier un dossier en construction](faq/usager-edit-identity-construction-1.png)
+![Image illustrant où cliquer pour modifier un dossier en construction {aria-hidden="true"}](faq/usager-edit-identity-construction-1.png)
 
 Après avoir cliqué sur l’onglet _« Demande »_, suivez le lien _« Modifier l’identité »_ comme ci-dessous :
 
-![Image montrant où modifier l’identité dans un dossier en construction](faq/usager-edit-identity-construction-2.png)
+![Image montrant où modifier l’identité dans un dossier en construction {aria-hidden="true"}](faq/usager-edit-identity-construction-2.png)
 
 ## Le dossier a un autre statut
 

--- a/doc/faqs/usager/mon-dossier-a-ete-depose-par-un-tiers-et-je-souhaite-y-acceder.fr.md
+++ b/doc/faqs/usager/mon-dossier-a-ete-depose-par-un-tiers-et-je-souhaite-y-acceder.fr.md
@@ -14,8 +14,8 @@ Vous devez **contacter la personne qui a déposé le dossier** et lui demander d
 
 Pour cela, la personne doit cliquer sur le bouton **« Action »** (ou _« Autres actions »_), situé à droite du dossier depuis son interface :
 
-![Image illustration le bouton Autres actions avec le menu de transfert de dossier](faq/usager-dossier-actions-menu-transfer.png)
+![Image illustration le bouton Autres actions avec le menu de transfert de dossier {aria-hidden="true"}](faq/usager-dossier-actions-menu-transfer.png)
 
 Et ensuite cliquer sur **« Transférer le dossier »** en indiquant votre adresse mail.
 
-![Image illustration l’interface de transfert de dossier vers un autre compte](faq/usager-transfer-dossier.png)
+![Image illustration l’interface de transfert de dossier vers un autre compte {aria-hidden="true"}](faq/usager-transfer-dossier.png)

--- a/spec/lib/redcarpet/trusted_renderer_spec.rb
+++ b/spec/lib/redcarpet/trusted_renderer_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe Redcarpet::TrustedRenderer do
       markdown = "![A cute cat](http://example.com/cat.jpg)"
       expect(renderer.render(markdown)).to include('<img alt="A cute cat" loading="lazy" src="http://example.com/cat.jpg" />')
     end
+
+    it 'renders additional attribute' do
+      markdown = "![A cute cat { aria-hidden=\"true\" }](http://example.com/cat.jpg)"
+      expect(renderer.render(markdown)).to include('<img alt="A cute cat" loading="lazy" aria-hidden="true" src="http://example.com/cat.jpg" />')
+    end
   end
 
   context 'when autolinking' do


### PR DESCRIPTION
Besoin remonté par @inseo qui rajoutera ensuite les attributs sur les images concernées

(solution directement inspirée de la syntaxe kramdown)