### PR TITLE
Améliore l'accessibilité de la page d'authentification

### DIFF
--- a/app/assets/stylesheets/procedure_context.scss
+++ b/app/assets/stylesheets/procedure_context.scss
@@ -56,14 +56,6 @@ $procedure-context-breakpoint: $two-columns-breakpoint;
   }
 }
 
-.no-procedure-presentation {
-  margin-bottom: 1.6rem;
-
-  p {
-    margin: 0;
-  }
-}
-
 .procedure-context-content {
   @media (max-width: $procedure-context-breakpoint) {
     input[type=submit] {

--- a/app/assets/stylesheets/procedure_context.scss
+++ b/app/assets/stylesheets/procedure_context.scss
@@ -4,15 +4,6 @@
 $procedure-context-breakpoint: $two-columns-breakpoint;
 
 .procedure-preview {
-  .paperless-logo {
-    width: 100%;
-    margin-bottom: 60px;
-
-    @media (max-width: $procedure-context-breakpoint) {
-      display: none;
-    }
-  }
-
   .simple {
     margin-bottom: 0.2rem;
     font-size: 1.5rem;

--- a/app/views/agent_connect/agent/index.html.haml
+++ b/app/views/agent_connect/agent/index.html.haml
@@ -67,4 +67,4 @@
           - c.with_body do
             = t('.full_deploy_body')
         %h2.fr-h6= t('.whats_ds', application_name: Current.application_name)
-        = image_tag "landing/hero/dematerialiser.svg", class: "paperless-logo", alt: ""
+        = image_tag "landing/hero/dematerialiser.svg", class: "fr-responsive-img", alt: ""

--- a/app/views/agent_connect/agent/index.html.haml
+++ b/app/views/agent_connect/agent/index.html.haml
@@ -38,7 +38,7 @@
                   = t('views.users.sessions.new.for_tiers_alert')
 
               .fr-fieldset__element
-                %p.fr-text--sm= t('utils.mandatory_champs')
+                %p.fr-text--sm= t('utils.asterisk_html')
 
               .fr-fieldset__element
                 = render Dsfr::InputComponent.new(form: f, attribute: :email, input_type: :email_field, opts: { autocomplete: 'email' }) do |c|

--- a/app/views/agent_connect/agent/index.html.haml
+++ b/app/views/agent_connect/agent/index.html.haml
@@ -55,14 +55,12 @@
                     = f.check_box :remember_me
                     = f.label :remember_me, t('views.users.sessions.new.remember_me'), class: 'remember-me'
 
-            %ul.fr-btns-group
-              %li= f.submit t('views.users.sessions.new.connection'), class: "fr-btn"
+                .fr-btns-group= f.submit t('views.users.sessions.new.connection'), class: "fr-btn"
 
           %hr
 
           %h2.fr-h6= t('.you_are_a_citizen')
-          %ul.fr-btns-group
-            %li= link_to t('.citizen_page'), new_user_session_path, class: "fr-btn fr-btn--secondary width-100"
+          .fr-btns-group= link_to t('.citizen_page'), new_user_session_path, class: "fr-btn fr-btn--secondary"
 
       .fr-col-lg.fr-p-6w
         = render Dsfr::CalloutComponent.new(title: t('.full_deploy_title'), icon: 'fr-icon-information-line') do |c|

--- a/app/views/layouts/commencer/_no_procedure.html.haml
+++ b/app/views/layouts/commencer/_no_procedure.html.haml
@@ -1,10 +1,8 @@
 .no-procedure
-  = image_tag "landing/hero/dematerialiser.svg", class: "paperless-logo", alt: ""
+  = image_tag "landing/hero/dematerialiser.svg", class: "paperless-logo fr-mb-1v", alt: ""
   .baseline.center
     .no-procedure-presentation
-      %p.simple= t('.line1')
-      %p= t('.line2')
-      %p= t('.line3')
+      %p.fr-m-6v= t('.text')
     %hr
     %p.small-simple= t('.are_you_new', app_name: Current.application_name)
     = link_to t('views.users.sessions.new.find_procedure'), t("links.common.faq.comment_trouver_ma_demarche_url"), title: new_tab_suffix(t('views.users.sessions.new.find_procedure')), class: "fr-btn fr-btn--secondary"

--- a/app/views/layouts/commencer/_no_procedure.html.haml
+++ b/app/views/layouts/commencer/_no_procedure.html.haml
@@ -1,8 +1,6 @@
-.no-procedure
-  = image_tag "landing/hero/dematerialiser.svg", class: "paperless-logo fr-mb-1v", alt: ""
-  .baseline.center
-    .no-procedure-presentation
-      %p.fr-m-6v= t('.text')
-    %hr
-    %p.small-simple= t('.are_you_new', app_name: Current.application_name)
-    = link_to t('views.users.sessions.new.find_procedure'), t("links.common.faq.comment_trouver_ma_demarche_url"), title: new_tab_suffix(t('views.users.sessions.new.find_procedure')), class: "fr-btn fr-btn--secondary"
+.center
+  = image_tag "landing/hero/dematerialiser.svg", class: "fr-mb-1v", alt: ""
+  %p.fr-m-6v= t('.text')
+  %hr
+  %p= t('.are_you_new', app_name: Current.application_name)
+  = link_to t('views.users.sessions.new.find_procedure'), t("links.common.faq.comment_trouver_ma_demarche_url"), title: new_tab_suffix(t('views.users.sessions.new.find_procedure')), class: "fr-btn fr-btn--secondary"

--- a/app/views/layouts/commencer/_no_procedure.html.haml
+++ b/app/views/layouts/commencer/_no_procedure.html.haml
@@ -1,6 +1,6 @@
 .center
-  = image_tag "landing/hero/dematerialiser.svg", class: "fr-mb-1v", alt: ""
-  %p.fr-m-6v= t('.text')
+  = image_tag "landing/hero/dematerialiser.svg", class: "fr-responsive-img fr-mb-1v", alt: ""
+  %p.fr-m-4w= t('.text')
   %hr
   %p= t('.are_you_new', app_name: Current.application_name)
   = link_to t('views.users.sessions.new.find_procedure'), t("links.common.faq.comment_trouver_ma_demarche_url"), title: new_tab_suffix(t('views.users.sessions.new.find_procedure')), class: "fr-btn fr-btn--secondary"

--- a/app/views/support/index.html.haml
+++ b/app/views/support/index.html.haml
@@ -18,8 +18,9 @@
         .fr-input-group
           = label_tag :email, class: 'fr-label' do
             Email
-            = t('.notice_email')
             = render EditableChamp::AsteriskMandatoryComponent.new
+            %span.fr-hint-text
+              = t('.notice_email')
           = email_field_tag :email, params[:email], required: true, autocomplete: 'email', class: 'fr-input'
 
       %fieldset.fr-fieldset{ name: "type" }

--- a/app/views/users/sessions/new.html.haml
+++ b/app/views/users/sessions/new.html.haml
@@ -30,11 +30,9 @@
             = f.label :remember_me, t('views.users.sessions.new.remember_me'), class: 'remember-me'
 
       .fr-fieldset__element
-        %ul.fr-btns-group
-          %li= f.submit t('views.users.sessions.new.connection'), class: "fr-btn fr-btn--lg"
+        .fr-btns-group= f.submit t('views.users.sessions.new.connection'), class: "fr-btn"
 
   - if AgentConnectService.enabled?
     %p.fr-hr-or= t('views.shared.france_connect_login.separator')
     %h2.important-header.mb-1= t('views.users.sessions.new.state_civil_servant')
-    %ul.fr-btns-group
-      %li= link_to t('views.users.sessions.new.connect_with_agent_connect'), agent_connect_path, class: "fr-btn fr-btn--secondary"
+    .fr-btns-group= link_to t('views.users.sessions.new.connect_with_agent_connect'), agent_connect_path, class: "fr-btn fr-btn--secondary"

--- a/app/views/users/sessions/new.html.haml
+++ b/app/views/users/sessions/new.html.haml
@@ -13,7 +13,7 @@
         %h2.fr-h6= I18n.t('views.users.sessions.new.subtitle')
 
       .fr-fieldset__element
-        %p.fr-text--sm= t('utils.mandatory_champs')
+        %p.fr-text--sm= t('utils.asterisk_html')
 
       .fr-fieldset__element= render Dsfr::InputComponent.new(form: f, attribute: :email, input_type: :email_field, opts: { autocomplete: 'email', autofocus: true })
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,9 +77,7 @@ en:
   layouts:
     commencer:
       no_procedure:
-        line1: A simple tool
-        line2: to manage dematerialized
-        line3: administrative forms.
+        text: A simple tool to manage dematerialized administrative forms.
         are_you_new: First time on %{app_name}?
     my_account: My account
     header:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -279,7 +279,7 @@ en:
           textarea: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
           decimal_number: 49.3
           integer_number: 42
-          email: personne@fournisseur.fr
+          email: address@mail.com
           phone: 0612345678
           iban: FR7611315000011234567890138
           yes_no: "true"
@@ -611,7 +611,7 @@ en:
         password: 'Password'
         requested_merge_into: 'new email address'
         hints:
-          email: "Expected format : john.doe@example.com"
+          email: 'Expected format : address@mail.com'
       user:
         siret: 'SIRET number'
         << : *default_attributes
@@ -644,7 +644,7 @@ en:
         not_a_phone: 'Invalid phone number'
         not_a_rna: 'Invalid RNA number'
         url: 'is not a valid link'
-        invalid_email_format: "is invalid. Please fill in a valid email ex: john.doe@exemple.fr"
+        invalid_email_format: 'is invalid. Please fill in a valid email ex: address@mail.com'
       models:
         attestation_template:
           attributes:
@@ -661,9 +661,9 @@ en:
             reset_password_token:
               invalid: ": is expired. Ask a new one"
             email:
-              blank: "is empty. Fill in the email"
-              invalid: "is invalid. Fill in a valid email address, example: john.doe@example.fr"
-              taken: "already in use. Fill in another email"
+              blank: 'is empty. Fill in the email'
+              invalid: 'is invalid. Fill in a valid email address, example: address@mail.com'
+              taken: 'already in use. Fill in another email'
             password:
               too_short: "is too short. Fill in a password with at least 8 characters"
               not_strong: "not strong enough. Fill in a stronger password"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -271,7 +271,7 @@ fr:
           textarea: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
           decimal_number: 49.3
           integer_number: 42
-          email: personne@fournisseur.fr
+          email: adresse@mail.com
           phone: 0612345678
           iban: FR7611315000011234567890138
           yes_no: "true"
@@ -329,7 +329,7 @@ fr:
         modal_highlight: Les invités ont le droit de voir et modifier votre dossier.
         title: Ajouter un invité
         email: Adresse mail
-        email_hint: "Exemple : camilya.martin@exemple.fr"
+        email_hint: 'Exemple : adresse@mail.com'
         invite_message: Ajouter un message à la personne invitée (optionnel)
         send_invitation: Envoyer une invitation
         withdraw_permission: "Révoquer l’autorisation"
@@ -611,7 +611,7 @@ fr:
         password: 'Mot de passe'
         requested_merge_into: 'La nouvelle adresse email'
         hints:
-          email: "Format attendu : john.doe@exemple.fr"
+          email: 'Format attendu : adresse@mail.com'
       user:
         siret: 'Numéro SIRET'
         << : *default_attributes
@@ -644,7 +644,7 @@ fr:
         not_a_phone: 'Numéro de téléphone invalide'
         not_a_rna: 'Numéro RNA invalide'
         url: 'n’est pas un lien valide'
-        invalid_email_format: "est invalide. Saisir une adresse électronique valide, exemple : john.doe@exemple.fr"
+        invalid_email_format: 'est invalide. Saisir une adresse électronique valide, exemple : adresse@mail.com'
       models:
         attestation_template:
           attributes:
@@ -659,9 +659,9 @@ fr:
             reset_password_token:
               invalid: ": Votre lien de nouveau mot de passe a expiré. Merci d’en demander un nouveau."
             email:
-              blank: "est vide. Saisir une adresse électronique"
-              invalid: "est invalide. Saisir une adresse électronique valide, exemple : john.doe@exemple.fr"
-              taken: "déjà utilisé. Saisir une autre adresse électronique."
+              blank: 'est vide. Saisir une adresse électronique'
+              invalid: 'est invalide. Saisir une adresse électronique valide, exemple : adresse@mail.com'
+              taken: 'déjà utilisé. Saisir une autre adresse électronique.'
             password:
               too_short: "est trop court. Saisir un mot de passe avec au moins 8 caractères"
               not_strong: "n’est pas assez complexe. Saisir un mot de passe plus complexe"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -68,9 +68,7 @@ fr:
   layouts:
     commencer:
       no_procedure:
-        line1: Un outil simple
-        line2: pour gérer les formulaires
-        line3: administratifs dématérialisés.
+        text: Un outil simple pour gérer les formulaires administratifs dématérialisés.
         are_you_new: Vous êtes nouveau sur %{app_name} ?
     my_account: Mon compte
     header:

--- a/config/locales/models/champs/email_champ/en.yml
+++ b/config/locales/models/champs/email_champ/en.yml
@@ -3,4 +3,4 @@ en:
     attributes:
       champs/email_champ:
         hints:
-          value: "Expected format: name@domain.fr"
+          value: 'Expected format: address@mail.com'

--- a/config/locales/models/champs/email_champ/fr.yml
+++ b/config/locales/models/champs/email_champ/fr.yml
@@ -3,4 +3,4 @@ fr:
     attributes:
       champs/email_champ:
         hints:
-          value: "Format attendu : nom@domaine.fr"
+          value: 'Format attendu : adresse@mail.com'

--- a/config/locales/views/support/en.yml
+++ b/config/locales/views/support/en.yml
@@ -2,9 +2,10 @@ en:
   support:
     index:
       contact: Contact
-      intro_html: "<p>Contact us via this form and we will answer you as quickly as possible.</p>
-        <p>Make sure you provide all the required information so we can help you in the best way.</p>"
-      notice_email: "(example: myaddress@mymail.com)"
+      intro_html:
+        '<p>Contact us via this form and we will answer you as quickly as possible.</p>
+        <p>Make sure you provide all the required information so we can help you in the best way.</p>'
+      notice_email: '(example: address@mail.com)'
       your_question: Your question
       our_answer: Our answer
       notice_pj_product: A screenshot can help us identify the element to improve.

--- a/config/locales/views/support/en.yml
+++ b/config/locales/views/support/en.yml
@@ -5,7 +5,7 @@ en:
       intro_html:
         '<p>Contact us via this form and we will answer you as quickly as possible.</p>
         <p>Make sure you provide all the required information so we can help you in the best way.</p>'
-      notice_email: '(example: address@mail.com)'
+      notice_email: 'Expected format:  address@mail.com'
       your_question: Your question
       our_answer: Our answer
       notice_pj_product: A screenshot can help us identify the element to improve.

--- a/config/locales/views/support/fr.yml
+++ b/config/locales/views/support/fr.yml
@@ -2,9 +2,10 @@ fr:
   support:
     index:
       contact: Contact
-      intro_html: "<p>Contactez-nous via ce formulaire et nous vous répondrons dans les plus brefs délais.</p>
-        <p>Pensez bien à nous donner le plus d’informations possible pour que nous puissions vous aider au mieux.</p>"
-      notice_email: "(exemple : monadresse@monmail.com)"
+      intro_html:
+        '<p>Contactez-nous via ce formulaire et nous vous répondrons dans les plus brefs délais.</p>
+        <p>Pensez bien à nous donner le plus d’informations possible pour que nous puissions vous aider au mieux.</p>'
+      notice_email: '(exemple : adresse@mail.com)'
       your_question: Votre question
       our_answer: Notre réponse
       notice_pj_product: Une capture d’écran peut nous aider à identifier plus facilement l’endroit à améliorer.

--- a/config/locales/views/support/fr.yml
+++ b/config/locales/views/support/fr.yml
@@ -5,7 +5,7 @@ fr:
       intro_html:
         '<p>Contactez-nous via ce formulaire et nous vous répondrons dans les plus brefs délais.</p>
         <p>Pensez bien à nous donner le plus d’informations possible pour que nous puissions vous aider au mieux.</p>'
-      notice_email: '(exemple : adresse@mail.com)'
+      notice_email: 'Format attendu : adresse@mail.com'
       your_question: Votre question
       our_answer: Notre réponse
       notice_pj_product: Une capture d’écran peut nous aider à identifier plus facilement l’endroit à améliorer.

--- a/spec/controllers/experts/avis_controller_spec.rb
+++ b/spec/controllers/experts/avis_controller_spec.rb
@@ -399,7 +399,7 @@ describe Experts::AvisController, type: :controller do
 
         it do
           expect(response).to render_template :instruction
-          expect(flash.alert).to eq(["toto.fr : Le champ « Email » est invalide. Saisir une adresse électronique valide, exemple : john.doe@exemple.fr"])
+          expect(flash.alert).to eq(["toto.fr : Le champ « Email » est invalide. Saisir une adresse électronique valide, exemple : adresse@mail.com"])
           expect(Avis.last).to eq(previous_avis)
           expect(dossier.last_avis_updated_at).to eq(nil)
         end
@@ -430,7 +430,7 @@ describe Experts::AvisController, type: :controller do
 
         it do
           expect(response).to render_template :instruction
-          expect(flash.alert).to eq(["toto.fr : Le champ « Email » est invalide. Saisir une adresse électronique valide, exemple : john.doe@exemple.fr"])
+          expect(flash.alert).to eq(["toto.fr : Le champ « Email » est invalide. Saisir une adresse électronique valide, exemple : adresse@mail.com"])
           expect(flash.notice).to eq("Une demande d’avis a été envoyée à titi@titimail.com")
           expect(Avis.count).to eq(old_avis_count + 1)
         end

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -817,7 +817,7 @@ describe Instructeurs::DossiersController, type: :controller do
         before { subject }
 
         it { expect(response).to render_template :avis }
-        it { expect(flash.alert).to eq(["emaila.com : Le champ « Email » est invalide. Saisir une adresse électronique valide, exemple : john.doe@exemple.fr"]) }
+        it { expect(flash.alert).to eq(["emaila.com : Le champ « Email » est invalide. Saisir une adresse électronique valide, exemple : adresse@mail.com"]) }
         it { expect { subject }.not_to change(Avis, :count) }
         it { expect(dossier.last_avis_updated_at).to eq(nil) }
       end
@@ -839,7 +839,7 @@ describe Instructeurs::DossiersController, type: :controller do
         before { subject }
 
         it { expect(response).to render_template :avis }
-        it { expect(flash.alert).to eq(["toto.fr : Le champ « Email » est invalide. Saisir une adresse électronique valide, exemple : john.doe@exemple.fr"]) }
+        it { expect(flash.alert).to eq(["toto.fr : Le champ « Email » est invalide. Saisir une adresse électronique valide, exemple : adresse@mail.com"]) }
         it { expect(flash.notice).to eq("Une demande d’avis a été envoyée à titi@titimail.com") }
         it { expect(Avis.count).to eq(old_avis_count + 1) }
         it { expect(saved_avis.expert.email).to eq("titi@titimail.com") }

--- a/spec/controllers/manager/dossiers_controller_spec.rb
+++ b/spec/controllers/manager/dossiers_controller_spec.rb
@@ -54,7 +54,7 @@ describe Manager::DossiersController, type: :controller do
 
       it do
         expect { subject }.not_to have_enqueued_mail
-        expect(flash[:alert]).to eq("L’adresse email est invalide. Saisir une adresse électronique valide, exemple : john.doe@exemple.fr")
+        expect(flash[:alert]).to eq("L’adresse email est invalide. Saisir une adresse électronique valide, exemple : adresse@mail.com")
       end
     end
   end

--- a/spec/controllers/manager/users_controller_spec.rb
+++ b/spec/controllers/manager/users_controller_spec.rb
@@ -40,7 +40,7 @@ describe Manager::UsersController, type: :controller do
           subject
 
           expect(User.find_by(id: user.id).email).not_to eq(nouvel_email)
-          expect(flash[:error]).to match("Le champ « Adresse électronique » est invalide. Saisir une adresse électronique valide, exemple : john.doe@exemple.fr")
+          expect(flash[:error]).to match("Le champ « Adresse électronique » est invalide. Saisir une adresse électronique valide, exemple : adresse@mail.com")
         end
       end
     end

--- a/spec/controllers/users/profil_controller_spec.rb
+++ b/spec/controllers/users/profil_controller_spec.rb
@@ -83,7 +83,7 @@ describe Users::ProfilController, type: :controller do
       end
 
       it { expect(response).to redirect_to(profil_path) }
-      it { expect(flash.alert).to eq(["Le champ « Adresse électronique » est invalide. Saisir une adresse électronique valide, exemple : john.doe@exemple.fr"]) }
+      it { expect(flash.alert).to eq(["Le champ « Adresse électronique » est invalide. Saisir une adresse électronique valide, exemple : adresse@mail.com"]) }
     end
 
     context 'when the user has an instructeur role' do

--- a/spec/controllers/users/transfers_controller_spec.rb
+++ b/spec/controllers/users/transfers_controller_spec.rb
@@ -98,7 +98,7 @@ describe Users::TransfersController, type: :controller do
     context "when email is invalid" do
       let(:email) { "not-an-email" }
       it_behaves_like 'email error' do
-        let(:expected_error) { "L’adresse email est invalide. Saisir une adresse électronique valide, exemple : john.doe@exemple.fr" }
+        let(:expected_error) { "L’adresse email est invalide. Saisir une adresse électronique valide, exemple : adresse@mail.com" }
       end
     end
   end

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -31,7 +31,7 @@ describe Invite do
 
         it do
           expect(invite.save).to be false
-          expect(invite.errors.full_messages).to eq(["Le champ « Email » est invalide. Saisir une adresse électronique valide, exemple : john.doe@exemple.fr"])
+          expect(invite.errors.full_messages).to eq(["Le champ « Email » est invalide. Saisir une adresse électronique valide, exemple : adresse@mail.com"])
         end
 
         context 'when an email is empty' do


### PR DESCRIPTION
# Suppression des listes ne contenant qu'un seul item
__Après__
<img width="1093" alt="" src="https://github.com/user-attachments/assets/75250845-4208-474c-bf92-885c59fd3e93">

__Avant__
<img width="1087" alt="" src="https://github.com/user-attachments/assets/e498d16d-93b1-49c5-aea5-5a66fe8b3106">

# Regroupement de la phrase d'accroche dans un paragraphe
__Après__
<img width="898" alt="" src="https://github.com/user-attachments/assets/025560a8-21ba-4664-a51a-26486c37c5ab">

__Avant__
<img width="731" alt="" src="https://github.com/user-attachments/assets/c44aa92e-5ffc-4eef-8081-c9cc61fb8850">

# Suppression du double ascenseur sur certaines vues desktop
__Après__
<img width="985" alt="" src="https://github.com/user-attachments/assets/aa296a09-a391-4e47-b87c-9ba1cdf1f225">

__Avant__
<img width="986" alt="" src="https://github.com/user-attachments/assets/96d1bb89-e901-4f29-a81a-911577f6e06c">

# Mises à jour annexes 
- Remplacement de l'indication "Tous les champs sont obligatoires" par "Les champs suivis d’un astérisque (*) sont obligatoires" (afin que la signification de l'astérisque soit explicitée).
- Mise à jour du code HTML pour utiliser les classes du DSFR plutôt que du code custom.

# Mises à jour transverses
- Uniformisation des exemple d'adresse mail : `address@mail.com` pour la version anglaise et `adresse@mail.com` pour la version française.
- Déplacement de ces exemples dans la balise `<span class="fr-hint-text">` lorsqu'ils se trouvaient dans la balise `<label>` directement.

__Après__
<img width="623" alt="" src="https://github.com/user-attachments/assets/9f1e81b6-1465-4c45-9563-ced19580886d">

__Avant__
<img width="446" alt="" src="https://github.com/user-attachments/assets/092ddf6e-9974-41c7-aa77-6fdff6a473a6">

