### PR TITLE
ETQ usager mon attestation v2 n'a pas ses titres chevauchés lorsqu'ils passent sur 2 lignes

### DIFF
--- a/app/assets/stylesheets/attestation.scss
+++ b/app/assets/stylesheets/attestation.scss
@@ -140,13 +140,11 @@
 
   h2 {
     margin: 0;
-    line-height: 8pt;
   }
 
   h3 {
     font-size: 10pt; // same as text
     font-weight: bold;
-    line-height: 4pt;
   }
 
   li p {


### PR DESCRIPTION
## APRES
![Capture d’écran 2024-07-25 à 16 35 50](https://github.com/user-attachments/assets/1367adb3-db59-4eab-b0c6-661133d5a0a2)


## AVANT
![Capture d’écran 2024-07-25 à 16 36 03](https://github.com/user-attachments/assets/45b4846f-d545-41fb-ae7d-477bfe2fcac3)
