### PR TITLE
ETQ usager, redirige les utilisateurs déjà confirmés qui réutilisent le lien de confirmation

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -13,9 +13,19 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
   # end
 
   # GET /resource/confirmation?confirmation_token=abcdef
-  # def show
-  #   super
-  # end
+  def show
+    super do
+      # When email was already confirmed, default is to render :new with a specific error.
+      # Because our :new is customized with the email and a form to resend a confirmation,
+      # we redirect to after confirmation page instead.
+      if resource.errors.of_kind?(:email, :already_confirmed)
+        respond_with_navigational(resource) do
+          flash.notice = t('.email_already_confirmed')
+          redirect_to after_confirmation_path_for(resource_name, resource) and return
+        end
+      end
+    end
+  end
 
   # protected
 

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -6,3 +6,7 @@ en:
     sessions:
       signed_in_multiple_profile: "You are connected ! You can switch between your multiple profiles : %{roles}."
       signed_out: You are now disconnected.
+  users:
+    confirmations:
+      show:
+        email_already_confirmed: 'Your account has already been activated.'

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -6,3 +6,7 @@ fr:
     sessions:
       signed_in_multiple_profile: "Vous êtes connecté(e) ! Vous pouvez à tout moment alterner entre vos différents profils : %{roles}."
       signed_out: Vous êtes maintenant déconnecté(e).
+  users:
+    confirmations:
+      show:
+        email_already_confirmed: 'Votre compte a déjà été activé.'

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -5,3 +5,11 @@ User-agent: *
 Disallow: /commencer*
 Disallow: /rails/
 Disallow: /super_admins/
+Disallow: /manager/
+Disallow: /users/
+Allow: /users/sign_in
+Allow: /users/sign_up
+Disallow: /connexion-par-jeton/
+Disallow: */reset-link-sent*
+Disallow: /lien-envoye
+Disallow: /france_connect/

--- a/spec/controllers/users/confirmations_controller_spec.rb
+++ b/spec/controllers/users/confirmations_controller_spec.rb
@@ -51,5 +51,21 @@ describe Users::ConfirmationsController, type: :controller do
         expect(subject).to redirect_to(new_user_session_path)
       end
     end
+
+    context 'when account was already confirmed long time ago' do
+      let!(:user) { create(:user, confirmed_at: 3.hours.ago, confirmation_sent_at: 4.hours.ago, confirmation_token: "mytoken") }
+      render_views
+
+      subject do
+        get :show, params: { confirmation_token: confirmation_token }
+      end
+
+      it 'redirect and does not expose the email' do
+        expect(user).to be_confirmed
+        expect(subject).to redirect_to(new_user_session_path)
+        expect(subject.body).not_to include(user.email)
+        expect(flash.notice).to include("Votre compte a déjà été activé")
+      end
+    end
   end
 end


### PR DESCRIPTION
**Contexte**:
un utilisateur avec un compte confirmé qui réutilise le lien de confirmation voit une page : "veuillez confirmer votre compte" qui ré-affiche son email, car nous avons personnalisé cette page de confirmation, ainsi que pour automatiquement connecter l'usager via ce lien s'il est récent

D'une part c'est confusant, et d'autre part ces emails peuvent être indexés dans la nature.

**Correction**:
- On intercepte les accès de compte déjà confirmés pour rediriger vers la page adéquat.
- On interdit l'indexation de  pages susceptibles d'exposer email ou token.