### PR TITLE
ETQ admin sur une démarche en brouillon, l'attestation v2 est créé en brouillon si on a déjà une v1 active

### DIFF
--- a/app/controllers/administrateurs/attestation_template_v2s_controller.rb
+++ b/app/controllers/administrateurs/attestation_template_v2s_controller.rb
@@ -133,7 +133,13 @@ module Administrateurs
       @procedure.attestation_templates.build(version: 2, json_body: AttestationTemplate::TIPTAP_BODY_DEFAULT, activated: true, state:)
     end
 
-    def should_edit_draft? = !@procedure.brouillon?
+    def should_edit_draft?
+      if @procedure.brouillon?
+        @procedure.attestation_templates.v1.published.any?
+      else
+        true
+      end
+    end
 
     def editor_params
       params.required(:attestation_template).permit(:activated, :official_layout, :label_logo, :label_direction, :tiptap_body, :footer, :logo, :signature, :activated, :state)

--- a/app/views/administrateurs/attestation_template_v2s/edit.html.haml
+++ b/app/views/administrateurs/attestation_template_v2s/edit.html.haml
@@ -20,7 +20,7 @@
           tout en respectant la charte de l’état. Essayez-la et donnez-nous votre avis
           en nous envoyant un email à #{mail_to(Current.contact_email, subject: "Feedback attestation v2")}.
           %br
-          - if !@procedure.feature_enabled?(:attestation_v2)
+          - if !@procedure.feature_enabled?(:attestation_v2) || @procedure.attestation_templates.v1.published.any?
             %strong Les attestations délivrées suivent encore l’ancien format :
             l’activation des attestations basées sur ce format sera bientôt disponible.
             %br

--- a/spec/controllers/administrateurs/attestation_template_v2s_controller_spec.rb
+++ b/spec/controllers/administrateurs/attestation_template_v2s_controller_spec.rb
@@ -142,6 +142,17 @@ describe Administrateurs::AttestationTemplateV2sController, type: :controller do
         expect(assigns(:attestation_template)).to be_draft
         expect(attestation_template.reload).to be_present
       end
+
+      context 'on a draft procedure' do
+        let(:procedure) { create(:procedure, :draft, administrateur: admin, attestation_template:, libelle: "Ma démarche") }
+
+        it 'build v2 as draft' do
+          subject
+          expect(assigns(:attestation_template).version).to eq(2)
+          expect(assigns(:attestation_template)).to be_draft
+          expect(attestation_template.reload).to be_present
+        end
+      end
     end
 
     context 'attestation template published exist without draft' do


### PR DESCRIPTION
https://secure.helpscout.net/conversation/2653440545/2082770?folderId=4539161