### PR TITLE
Accessibilité : Assure la restitution par les TA du bloc de suggestion de l'adresse mail

### DIFF
--- a/app/components/dsfr/input_component/input_component.en.yml
+++ b/app/components/dsfr/input_component/input_component.en.yml
@@ -4,4 +4,5 @@ en:
     aria_label: "Show password"
     label: "Show"
   email_suggest:
-    wanna_say: 'Do you mean to say ?'
+    mistake: "The address seems wrong"
+    wanna_say: "Do you mean to say:"

--- a/app/components/dsfr/input_component/input_component.fr.yml
+++ b/app/components/dsfr/input_component/input_component.fr.yml
@@ -4,4 +4,5 @@ fr:
     aria_label: "Afficher le mot de passe"
     label: "Afficher"
   email_suggest:
-    wanna_say: 'Voulez-vous dire ?'
+    mistake: "L'adresse semble erronée"
+    wanna_say: "Vouliez-vous écrire :"

--- a/app/components/dsfr/input_component/input_component.html.haml
+++ b/app/components/dsfr/input_component/input_component.html.haml
@@ -29,10 +29,14 @@
       %label.fr--password__checkbox.fr-label{ for: show_password_id }= t('.show_password.label')
 
   - if email?
-    .suspect-email.hidden{ data: { "email-input-target": 'ariaRegion'}, aria: { live: 'off' } }
-      = render Dsfr::AlertComponent.new(title: t('.email_suggest.wanna_say'), state: :info, heading_level: :div) do |c|
+    .suspect-email.hidden{ data: { "email-input-target": 'ariaRegion' }, tabindex: '-1' }
+      = render Dsfr::AlertComponent.new(title: t('.email_suggest.mistake'), state: '', extra_class_names: 'fr-alert--info' ) do |c|
         - c.with_body do
-          %p{ data: { "email-input-target": 'suggestion'} } exemple@gmail.com &nbsp;?
+          %p
+            = t('.email_suggest.wanna_say')
+            %span{ data: { "email-input-target": 'suggestion'} }
+              exemple@gmail.com
+            = "?"
           %p
             = button_tag type: 'button', class: 'fr-btn fr-btn--sm fr-mr-3w', data: { action: 'click->email-input#accept'} do
               = t('utils.yes')

--- a/app/javascript/controllers/email_input_controller.ts
+++ b/app/javascript/controllers/email_input_controller.ts
@@ -39,7 +39,7 @@ export class EmailInputController extends ApplicationController {
     if (data && data.suggestions && data.suggestions.length > 0) {
       this.suggestionTarget.innerHTML = data.suggestions[0];
       show(this.ariaRegionTarget);
-      this.ariaRegionTarget.setAttribute('aria-live', 'assertive');
+      this.ariaRegionTarget.focus();
     }
   }
 

--- a/spec/system/users/dossier_creation_spec.rb
+++ b/spec/system/users/dossier_creation_spec.rb
@@ -77,7 +77,7 @@ describe 'Creating a new dossier:', js: true do
           find('label', text: 'Monsieur').click # force focus out
           within "#identite-form" do
             within '.suspect-email' do
-              expect(page).to have_content("Information : Voulez-vous dire ?")
+              expect(page).to have_content("L'adresse semble erronée Vouliez-vous écrire : prenom.nom@gmail.com ? Oui Non")
               click_button("Oui")
             end
             click_button("Continuer")


### PR DESCRIPTION
# Préambule
En l'état, le bloc de suggestion n'est pas restitué aux technologies d'assistance : le bloc est masqué par défaut et s'affiche lorsque le focus atteint le champs "Mot de passe".   
Mais la place de ce dernier dans le DOM (avant le champ en question) fait qu'il n'est pas annoncé et est invisible pour les utilisateurs qui ne visualisent pas la page.

Pour contourner le problème et assurer la restitution de l'élément tout en conservant le comportement attendu (le bloc est invisible par défaut et il s'affiche lorsque le focus passe sur le champ suivant), la solution la plus pratique apparait être un déplacement de focus sur le bloc de suggestion, dès que ce dernier s'affiche.

__Après__

https://github.com/user-attachments/assets/5fd7a976-6b9f-4ead-9289-f7eb96430e37


__Avant__

https://github.com/user-attachments/assets/4b2a774f-173e-4090-a4cd-33af54ae7475

