### PR TITLE
Refonte du menu d'aide

### DIFF
--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -243,6 +243,44 @@ ul.dropdown-items {
   margin-bottom: 0;
 }
 
+// Apply custom styles to DSFR fr-translate component
+.fr-translate__btn.fr-btn.help-btn::before {
+  content: none;
+}
+
+.help__content.fr-menu ul.fr-menu__list {
+  text-align: left;
+  font-size: 1rem;
+
+  @media (min-width: 62em) {
+    font-size: 0.875rem;
+    padding: 0;
+    width: 360px;
+  }
+}
+
+.help__content.fr-menu ul.fr-menu__list li {
+  padding: 0.75rem 1rem;
+
+  @media (min-width: 62em) {
+    padding-right: 1rem;
+    padding-left: 1rem;
+  }
+}
+
+.help__content.fr-menu ul.fr-menu__list li:not(:last-child) {
+  @media (min-width: 62em) {
+    border-bottom: 1px solid $border-grey;
+  }
+}
+
+.help__content.fr-menu ul.fr-menu__list {
+  h1, p {
+    font-size: inherit;
+    line-height: inherit;
+  }
+}
+
 .dropdown-items {
   li {
     display: flex;

--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -248,7 +248,7 @@ ul.dropdown-items {
   content: none;
 }
 
-.help__content.fr-menu ul.fr-menu__list {
+.help-content.fr-menu ul.fr-menu__list {
   text-align: left;
   font-size: 1rem;
 
@@ -259,7 +259,7 @@ ul.dropdown-items {
   }
 }
 
-.help__content.fr-menu ul.fr-menu__list li {
+.help-content.fr-menu ul.fr-menu__list li {
   padding: 0.75rem 1rem;
 
   @media (min-width: 62em) {
@@ -268,14 +268,15 @@ ul.dropdown-items {
   }
 }
 
-.help__content.fr-menu ul.fr-menu__list li:not(:last-child) {
+.help-content.fr-menu ul.fr-menu__list li:not(:last-child) {
   @media (min-width: 62em) {
     border-bottom: 1px solid $border-grey;
   }
 }
 
-.help__content.fr-menu ul.fr-menu__list {
-  h1, p {
+.help-content.fr-menu ul.fr-menu__list {
+  h1,
+  p {
     font-size: inherit;
     line-height: inherit;
   }

--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -249,6 +249,7 @@ ul.dropdown-items {
 }
 
 .help-content.fr-menu ul.fr-menu__list {
+  --text-decoration: underline;
   text-align: left;
   font-size: 1rem;
 
@@ -279,6 +280,17 @@ ul.dropdown-items {
   p {
     font-size: inherit;
     line-height: inherit;
+  }
+
+  dd {
+    word-break: break-all;
+  }
+}
+
+.help-content a[href]:hover,
+.help-content a[href]:active {
+  @media (hover: hover) and (pointer: fine) {
+    --text-decoration: none;
   }
 }
 

--- a/app/assets/stylesheets/help_dropdown.scss
+++ b/app/assets/stylesheets/help_dropdown.scss
@@ -23,8 +23,3 @@
     color: $blue-france-500;
   }
 }
-
-.help-dropdown-service-item {
-  margin-top: $default-spacer;
-  line-height: 18px;
-}

--- a/app/assets/stylesheets/help_dropdown.scss
+++ b/app/assets/stylesheets/help_dropdown.scss
@@ -7,10 +7,6 @@
   }
 }
 
-.help-dropdown-title {
-  font-weight: bold;
-}
-
 .dropdown-items li.help-dropdown-service {
   cursor: default;
 

--- a/app/assets/stylesheets/help_dropdown.scss
+++ b/app/assets/stylesheets/help_dropdown.scss
@@ -24,13 +24,7 @@
   }
 }
 
-.help-dropdown-service-action {
-  margin-top: $default-padding;
-  margin-bottom: $default-spacer;
-}
-
 .help-dropdown-service-item {
   margin-top: $default-spacer;
   line-height: 18px;
 }
-

--- a/app/views/shared/help/_help_dropdown_dossier.html.haml
+++ b/app/views/shared/help/_help_dropdown_dossier.html.haml
@@ -16,5 +16,5 @@
             = render partial: 'shared/help/dropdown_items/service_item',
               locals: { service: dossier.procedure.service, title: title }
 
-        %li
+        %li.flex
           = render partial: 'shared/help/dropdown_items/faq_item'

--- a/app/views/shared/help/_help_dropdown_dossier.html.haml
+++ b/app/views/shared/help/_help_dropdown_dossier.html.haml
@@ -3,7 +3,7 @@
     %button.help-btn.fr-translate__btn.fr-btn{ "aria-controls" => "help-menu", "aria-expanded" => "false" }
       = t('help')
 
-    #help-menu.help__content.fr-collapse.fr-menu
+    #help-menu.help-content.fr-collapse.fr-menu
       - title = dossier.brouillon? ? t("help_dropdown.help_brouillon_title") : t("help_dropdown.help_filled_dossier")
       %ul.fr-menu__list
 

--- a/app/views/shared/help/_help_dropdown_dossier.html.haml
+++ b/app/views/shared/help/_help_dropdown_dossier.html.haml
@@ -1,17 +1,20 @@
-= render Dropdown::MenuComponent.new(wrapper: :span, wrapper_options: { class: ['help-dropdown']}, menu_options: { id: "help-menu" }) do |menu|
-  - menu.with_button_inner_html do
-    = t('help')
+.fr-translate.fr-nav
+  .fr-nav__item
+    %button.help-btn.fr-translate__btn.fr-btn{ "aria-controls" => "help-menu", "aria-expanded" => "false" }
+      = t('help')
 
-  - title = dossier.brouillon? ? t("help_dropdown.help_brouillon_title") : t("help_dropdown.help_filled_dossier")
+    #help-menu.help__content.fr-collapse.fr-menu
+      - title = dossier.brouillon? ? t("help_dropdown.help_brouillon_title") : t("help_dropdown.help_filled_dossier")
+      %ul.fr-menu__list
 
-  - if dossier.messagerie_available?
-    - menu.with_item do
-      = render partial: 'shared/help/dropdown_items/messagerie_item', locals: { dossier: dossier, title: title }
+        - if dossier.messagerie_available?
+          %li.flex
+            = render partial: 'shared/help/dropdown_items/messagerie_item', locals: { dossier: dossier, title: title }
 
-  - elsif dossier.procedure.service.present?
-    - menu.with_item do
-      = render partial: 'shared/help/dropdown_items/service_item',
-        locals: { service: dossier.procedure.service, title: title }
+        - elsif dossier.procedure.service.present?
+          %li.flex
+            = render partial: 'shared/help/dropdown_items/service_item',
+              locals: { service: dossier.procedure.service, title: title }
 
-  - menu.with_item do
-    = render partial: 'shared/help/dropdown_items/faq_item'
+        %li
+          = render partial: 'shared/help/dropdown_items/faq_item'

--- a/app/views/shared/help/_help_dropdown_instructeur.html.haml
+++ b/app/views/shared/help/_help_dropdown_instructeur.html.haml
@@ -3,7 +3,7 @@
     %button.help-btn.fr-translate__btn.fr-btn{ "aria-controls" => "help-menu", "aria-expanded" => "false" }
       = t('help')
 
-    #help-menu.help__content.fr-collapse.fr-menu
+    #help-menu.help-content.fr-collapse.fr-menu
       %ul.fr-menu__list
         %li.flex
           = render partial: 'shared/help/dropdown_items/faq_item'

--- a/app/views/shared/help/_help_dropdown_instructeur.html.haml
+++ b/app/views/shared/help/_help_dropdown_instructeur.html.haml
@@ -1,8 +1,11 @@
-= render Dropdown::MenuComponent.new(wrapper: :span, wrapper_options: { class: ['help-dropdown']}, menu_options: { id: "help-menu" }) do |menu|
-  - menu.with_button_inner_html do
-    = t('help')
+.fr-translate.fr-nav
+  .fr-nav__item
+    %button.help-btn.fr-translate__btn.fr-btn{ "aria-controls" => "help-menu", "aria-expanded" => "false" }
+      = t('help')
 
-  - menu.with_item do
-    = render partial: 'shared/help/dropdown_items/faq_item'
-  - menu.with_item do
-    = render partial: 'shared/help/dropdown_items/email_item'
+    #help-menu.help__content.fr-collapse.fr-menu
+      %ul.fr-menu__list
+        %li.flex
+          = render partial: 'shared/help/dropdown_items/faq_item'
+        %li
+          = render partial: 'shared/help/dropdown_items/email_item'

--- a/app/views/shared/help/_help_dropdown_procedure.html.haml
+++ b/app/views/shared/help/_help_dropdown_procedure.html.haml
@@ -3,7 +3,7 @@
     %button.help-btn.fr-translate__btn.fr-btn{ "aria-controls" => "help-menu", "aria-expanded" => "false" }
       = t('help')
 
-    #help-menu.help__content.fr-collapse.fr-menu
+    #help-menu.help-content.fr-collapse.fr-menu
       %ul.fr-menu__list
         - if procedure.service.present?
           %li.flex

--- a/app/views/shared/help/_help_dropdown_procedure.html.haml
+++ b/app/views/shared/help/_help_dropdown_procedure.html.haml
@@ -1,9 +1,12 @@
-= render Dropdown::MenuComponent.new(wrapper: :span, wrapper_options: { class: ['help-dropdown']}, menu_options: { id: "help-menu" }) do |menu|
-  - menu.with_button_inner_html do
-    = t('help')
+.fr-translate.fr-nav
+  .fr-nav__item
+    %button.help-btn.fr-translate__btn.fr-btn{ "aria-controls" => "help-menu", "aria-expanded" => "false" }
+      = t('help')
 
-  - if procedure.service.present?
-    - menu.with_item do
-      = render partial: 'shared/help/dropdown_items/service_item', locals: { service: procedure.service, title: t('help_dropdown.procedure_title') }
-  - menu.with_item do
-    = render partial: 'shared/help/dropdown_items/faq_item'
+    #help-menu.help__content.fr-collapse.fr-menu
+      %ul.fr-menu__list
+        - if procedure.service.present?
+          %li.flex
+            = render partial: 'shared/help/dropdown_items/service_item', locals: { service: procedure.service, title: t('help_dropdown.procedure_title') }
+        %li.flex
+          = render partial: 'shared/help/dropdown_items/faq_item'

--- a/app/views/shared/help/dropdown_items/_email_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_email_item.html.haml
@@ -1,5 +1,5 @@
 = mail_to CONTACT_EMAIL, role: 'menuitem' do
   %span.fr-icon-mail-fill.fr-text-action-high--blue-france{ "aria-hidden": "true" }
-  .dropdown-description.fr-text--sm
-    %span.help-dropdown-title= t('help_dropdown.technical_contact_title')
+  .fr-pl-1w
+    %h1.fr-text--sm= t('help_dropdown.technical_contact_title')
     %p.fr-text--sm= t('help_dropdown.technical_contact_description', contact_email: CONTACT_EMAIL)

--- a/app/views/shared/help/dropdown_items/_email_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_email_item.html.haml
@@ -1,5 +1,5 @@
-= mail_to CONTACT_EMAIL, role: 'menuitem' do
+= mail_to CONTACT_EMAIL, class: 'flex' do
   %span.fr-icon-mail-fill.fr-text-action-high--blue-france{ "aria-hidden": "true" }
   .fr-pl-1w
-    %h1.fr-text--sm= t('help_dropdown.technical_contact_title')
-    %p.fr-text--sm= t('help_dropdown.technical_contact_description', contact_email: CONTACT_EMAIL)
+    %h1= t('help_dropdown.technical_contact_title')
+    %p= t('help_dropdown.technical_contact_description', contact_email: CONTACT_EMAIL)

--- a/app/views/shared/help/dropdown_items/_faq_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_faq_item.html.haml
@@ -1,6 +1,5 @@
 = link_to t("links.common.faq.url"), title: new_tab_suffix(t('help_dropdown.general_title')), **external_link_attributes, role: 'menuitem' do
   %span.fr-icon-question-fill.fr-text-action-high--blue-france{ "aria-hidden": "true" }
-  .fr-pl-1w.fr-text--sm
-    %span.help-dropdown-title
-      = t('help_dropdown.problem_title')
+  .fr-pl-1w
+    %h1.fr-text--sm= t('help_dropdown.problem_title')
     %p.fr-text--sm= t('help_dropdown.problem_description')

--- a/app/views/shared/help/dropdown_items/_faq_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_faq_item.html.haml
@@ -1,5 +1,5 @@
-= link_to t("links.common.faq.url"), title: new_tab_suffix(t('help_dropdown.general_title')), **external_link_attributes, role: 'menuitem' do
+= link_to t("links.common.faq.url"), class: 'flex', title: new_tab_suffix(t('help_dropdown.general_title')), **external_link_attributes do
   %span.fr-icon-question-fill.fr-text-action-high--blue-france{ "aria-hidden": "true" }
   .fr-pl-1w
-    %h1.fr-text--sm= t('help_dropdown.problem_title')
-    %p.fr-text--sm= t('help_dropdown.problem_description')
+    %h1= t('help_dropdown.problem_title')
+    %p= t('help_dropdown.problem_description')

--- a/app/views/shared/help/dropdown_items/_faq_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_faq_item.html.haml
@@ -1,6 +1,6 @@
 = link_to t("links.common.faq.url"), title: new_tab_suffix(t('help_dropdown.general_title')), **external_link_attributes, role: 'menuitem' do
   %span.fr-icon-question-fill.fr-text-action-high--blue-france{ "aria-hidden": "true" }
-  .dropdown-description.fr-text--sm
+  .fr-pl-1w.fr-text--sm
     %span.help-dropdown-title
       = t('help_dropdown.problem_title')
     %p.fr-text--sm= t('help_dropdown.problem_description')

--- a/app/views/shared/help/dropdown_items/_faq_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_faq_item.html.haml
@@ -1,5 +1,4 @@
-= link_to t("links.common.faq.url"), class: 'flex', title: new_tab_suffix(t('help_dropdown.general_title')), **external_link_attributes do
-  %span.fr-icon-question-fill.fr-text-action-high--blue-france{ "aria-hidden": "true" }
-  .fr-pl-1w
-    %h1= t('help_dropdown.problem_title')
-    %p= t('help_dropdown.problem_description')
+%span.fr-icon-question-fill.fr-text-action-high--blue-france{ "aria-hidden": "true" }
+.fr-pl-1w
+  %h1= t('help_dropdown.problem_title')
+  = link_to t('help_dropdown.problem_description'), t("links.common.faq.url"), title: new_tab_suffix(t('help_dropdown.problem_description')), **external_link_attributes

--- a/app/views/shared/help/dropdown_items/_messagerie_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_messagerie_item.html.haml
@@ -1,5 +1,4 @@
-= link_to messagerie_dossier_path(dossier), class: 'flex' do
-  %span.fr-icon-mail-fill.fr-text-action-high--blue-france{ "aria-hidden": "true" }
-  .fr-pl-1w
-    %h1= title
-    %p= t('help_dropdown.contact_instructeur')
+%span.fr-icon-mail-fill.fr-text-action-high--blue-france{ "aria-hidden": "true" }
+.fr-pl-1w
+  %h1= title
+  = link_to t('help_dropdown.contact_instructeur'), messagerie_dossier_path(dossier)

--- a/app/views/shared/help/dropdown_items/_messagerie_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_messagerie_item.html.haml
@@ -1,5 +1,5 @@
-= link_to messagerie_dossier_path(dossier), role: 'menuitem' do
+= link_to messagerie_dossier_path(dossier), class: 'flex' do
   %span.fr-icon-mail-fill.fr-text-action-high--blue-france{ "aria-hidden": "true" }
   .fr-pl-1w
-    %h1.fr-text--sm= title
-    %p.fr-text--sm= t('help_dropdown.contact_instructeur')
+    %h1= title
+    %p= t('help_dropdown.contact_instructeur')

--- a/app/views/shared/help/dropdown_items/_messagerie_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_messagerie_item.html.haml
@@ -1,5 +1,5 @@
 = link_to messagerie_dossier_path(dossier), role: 'menuitem' do
   %span.fr-icon-mail-fill.fr-text-action-high--blue-france{ "aria-hidden": "true" }
-  .dropdown-description.fr-text--sm
-    %span.help-dropdown-title= title
+  .fr-pl-1w
+    %h1.fr-text--sm= title
     %p.fr-text--sm= t('help_dropdown.contact_instructeur')

--- a/app/views/shared/help/dropdown_items/_service_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_service_item.html.haml
@@ -3,12 +3,19 @@
   %span.help-dropdown-title= title
   .help-dropdown-service-action
     %p.fr-text--sm= t('help_dropdown.contact_administration')
-    %p.fr-text--sm.help-dropdown-service-item
-      %span.fr-icon-mail-fill.fr-icon--sm{ "aria-label": t('layouts.mailers.service_footer.by_email') }
-      = link_to service.email, "mailto:#{service.email}", role: 'menuitem'
-    %p.fr-text--sm
-      %span.fr-icon-phone-fill.fr-icon--sm{ "aria-label": t('layouts.mailers.service_footer.by_phone') }
-      = link_to service.telephone, service.telephone_url, role: 'menuitem'
-    %p.fr-text--sm
-      %span.fr-icon-time-fill.fr-icon--sm{ "aria-label": t('layouts.mailers.service_footer.schedule') }
-      = service.horaires
+    %dl.fr-text--sm
+      .flex.fr-mb-1w
+        %dt.fr-mr-1v
+          %span.help-dropdown-service-item.fr-icon-mail-fill.fr-icon--sm{ "aria-label": t('layouts.mailers.service_footer.by_email') }
+        %dd
+          = link_to service.email, "mailto:#{service.email}", role: 'menuitem'
+      .flex.fr-mb-1w
+        %dt.fr-mr-1v
+          %span.fr-icon-phone-fill.fr-icon--sm{ "aria-label": t('layouts.mailers.service_footer.by_phone') }
+        %dd
+          = link_to service.telephone, service.telephone_url, role: 'menuitem'
+      .flex.fr-mb-1w
+        %dt.fr-mr-1v
+          %span.fr-icon-time-fill.fr-icon--sm{ "aria-label": t('layouts.mailers.service_footer.schedule') }
+        %dd
+          = service.horaires

--- a/app/views/shared/help/dropdown_items/_service_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_service_item.html.haml
@@ -1,20 +1,20 @@
 %span.fr-icon-user-fill.fr-text-action-high--blue-france{ "aria-hidden": "true" }
 .fr-pl-1w
-  %h1.fr-text--sm= title
-  %p.fr-mt-2w.fr-mb-1w.fr-text--sm= t('help_dropdown.contact_administration')
-  %dl.fr-text--sm
-    .flex.fr-mb-1w
+  %h1= title
+  %p.fr-mb-1w= t('help_dropdown.contact_administration')
+  %dl
+    .flex.fr-mb-1v
       %dt.fr-mr-1v
         %span.fr-icon-mail-fill.fr-icon--sm{ "aria-hidden": "true" }
         %span.visually-hidden= t('layouts.mailers.service_footer.by_email')
       %dd
-        = link_to service.email, "mailto:#{service.email}", role: 'menuitem'
-    .flex.fr-mb-1w
+        = link_to service.email, "mailto:#{service.email}"
+    .flex.fr-mb-1v
       %dt.fr-mr-1v
         %span.fr-icon-phone-fill.fr-icon--sm{ "aria-hidden": "true" }
         %span.visually-hidden= t('layouts.mailers.service_footer.by_phone')
       %dd
-        = link_to service.telephone, service.telephone_url, role: 'menuitem'
+        = link_to service.telephone, service.telephone_url
     .flex
       %dt.fr-mr-1v
         %span.fr-icon-time-fill.fr-icon--sm{ "aria-hidden": "true" }

--- a/app/views/shared/help/dropdown_items/_service_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_service_item.html.haml
@@ -6,16 +6,19 @@
     %dl.fr-text--sm
       .flex.fr-mb-1w
         %dt.fr-mr-1v
-          %span.help-dropdown-service-item.fr-icon-mail-fill.fr-icon--sm{ "aria-label": t('layouts.mailers.service_footer.by_email') }
+          %span.help-dropdown-service-item.fr-icon-mail-fill.fr-icon--sm{ "aria-hidden": "true" }
+          %span.visually-hidden= t('layouts.mailers.service_footer.by_email')
         %dd
           = link_to service.email, "mailto:#{service.email}", role: 'menuitem'
       .flex.fr-mb-1w
         %dt.fr-mr-1v
-          %span.fr-icon-phone-fill.fr-icon--sm{ "aria-label": t('layouts.mailers.service_footer.by_phone') }
+          %span.help-dropdown-service-item.fr-icon-phone-fill.fr-icon--sm{ "aria-hidden": "true" }
+          %span.visually-hidden= t('layouts.mailers.service_footer.by_phone')
         %dd
           = link_to service.telephone, service.telephone_url, role: 'menuitem'
       .flex.fr-mb-1w
         %dt.fr-mr-1v
-          %span.fr-icon-time-fill.fr-icon--sm{ "aria-label": t('layouts.mailers.service_footer.schedule') }
+          %span.help-dropdown-service-item.fr-icon-time-fill.fr-icon--sm{ "aria-hidden": "true" }
+          %span.visually-hidden= t('layouts.mailers.service_footer.schedule')
         %dd
           = service.horaires

--- a/app/views/shared/help/dropdown_items/_service_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_service_item.html.haml
@@ -4,11 +4,11 @@
   .help-dropdown-service-action
     %p.fr-text--sm= t('help_dropdown.contact_administration')
     %p.fr-text--sm.help-dropdown-service-item
-      %span.fr-icon-mail-fill.fr-icon--sm{ "aria-hidden": "true" }
+      %span.fr-icon-mail-fill.fr-icon--sm{ "aria-label": t('layouts.mailers.service_footer.by_email') }
       = link_to service.email, "mailto:#{service.email}", role: 'menuitem'
     %p.fr-text--sm
-      %span.fr-icon-phone-fill.fr-icon--sm{ "aria-hidden": "true" }
+      %span.fr-icon-phone-fill.fr-icon--sm{ "aria-label": t('layouts.mailers.service_footer.by_phone') }
       = link_to service.telephone, service.telephone_url, role: 'menuitem'
     %p.fr-text--sm
-      %span.fr-icon-time-fill.fr-icon--sm{ "aria-hidden": "true" }
+      %span.fr-icon-time-fill.fr-icon--sm{ "aria-label": t('layouts.mailers.service_footer.schedule') }
       = service.horaires

--- a/app/views/shared/help/dropdown_items/_service_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_service_item.html.haml
@@ -1,24 +1,23 @@
 %span.fr-icon-user-fill.fr-text-action-high--blue-france{ "aria-hidden": "true" }
-.dropdown-description.fr-text--sm
-  %span.help-dropdown-title= title
-  .help-dropdown-service-action
-    %p.fr-text--sm= t('help_dropdown.contact_administration')
-    %dl.fr-text--sm
-      .flex.fr-mb-1w
-        %dt.fr-mr-1v
-          %span.help-dropdown-service-item.fr-icon-mail-fill.fr-icon--sm{ "aria-hidden": "true" }
-          %span.visually-hidden= t('layouts.mailers.service_footer.by_email')
-        %dd
-          = link_to service.email, "mailto:#{service.email}", role: 'menuitem'
-      .flex.fr-mb-1w
-        %dt.fr-mr-1v
-          %span.help-dropdown-service-item.fr-icon-phone-fill.fr-icon--sm{ "aria-hidden": "true" }
-          %span.visually-hidden= t('layouts.mailers.service_footer.by_phone')
-        %dd
-          = link_to service.telephone, service.telephone_url, role: 'menuitem'
-      .flex.fr-mb-1w
-        %dt.fr-mr-1v
-          %span.help-dropdown-service-item.fr-icon-time-fill.fr-icon--sm{ "aria-hidden": "true" }
-          %span.visually-hidden= t('layouts.mailers.service_footer.schedule')
-        %dd
-          = service.horaires
+.fr-pl-1w
+  %h1.fr-text--sm= title
+  %p.fr-mt-2w.fr-mb-1w.fr-text--sm= t('help_dropdown.contact_administration')
+  %dl.fr-text--sm
+    .flex.fr-mb-1w
+      %dt.fr-mr-1v
+        %span.fr-icon-mail-fill.fr-icon--sm{ "aria-hidden": "true" }
+        %span.visually-hidden= t('layouts.mailers.service_footer.by_email')
+      %dd
+        = link_to service.email, "mailto:#{service.email}", role: 'menuitem'
+    .flex.fr-mb-1w
+      %dt.fr-mr-1v
+        %span.fr-icon-phone-fill.fr-icon--sm{ "aria-hidden": "true" }
+        %span.visually-hidden= t('layouts.mailers.service_footer.by_phone')
+      %dd
+        = link_to service.telephone, service.telephone_url, role: 'menuitem'
+    .flex
+      %dt.fr-mr-1v
+        %span.fr-icon-time-fill.fr-icon--sm{ "aria-hidden": "true" }
+        %span.visually-hidden= t('layouts.mailers.service_footer.schedule')
+      %dd
+        = service.horaires

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,7 +34,6 @@ en:
     sentence_for_humans: 'If you are a human, ignore this field'
   help: 'Help'
   help_dropdown:
-    general_title: "A problem with the website? Find your answer in the online help."
     procedure_title: "Do you have a question about this procedure?"
     problem_title: A problem with the website?
     problem_description: Find your answer in the online help.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,9 +34,9 @@ en:
     sentence_for_humans: 'If you are a human, ignore this field'
   help: 'Help'
   help_dropdown:
-    general_title: "Online help"
+    general_title: "A problem with the website? Find your answer in the online help."
     procedure_title: "Do you have a question about this procedure?"
-    problem_title: A problem with the website ?
+    problem_title: A problem with the website?
     problem_description: Find your answer in the online help.
     technical_contact_title: Technical contact
     technical_contact_description: Send us a message to %{contact_email}.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -24,7 +24,6 @@ fr:
     sentence_for_humans: 'Si vous êtes un humain, laissez ce champ vide'
   help: 'Aide'
   help_dropdown:
-    general_title: "Un problème avec le site ? Trouvez votre réponse dans l’aide en ligne."
     procedure_title: "Une question sur cette démarche ?"
     problem_title: Un problème avec le site ?
     problem_description: Trouvez votre réponse dans l’aide en ligne.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -24,7 +24,7 @@ fr:
     sentence_for_humans: 'Si vous êtes un humain, laissez ce champ vide'
   help: 'Aide'
   help_dropdown:
-    general_title: "Aide en ligne"
+    general_title: "Un problème avec le site ? Trouvez votre réponse dans l’aide en ligne."
     procedure_title: "Une question sur cette démarche ?"
     problem_title: Un problème avec le site ?
     problem_description: Trouvez votre réponse dans l’aide en ligne.

--- a/spec/system/accessibilite/wcag_usager_spec.rb
+++ b/spec/system/accessibilite/wcag_usager_spec.rb
@@ -101,7 +101,7 @@ describe 'wcag rules for usager', js: true do
     scenario 'commencer page, help dropdown' do
       visit commencer_path(path: procedure.reload.path)
 
-      page.find("#help-menu_button").click
+      page.find(".fr-header__body .help-btn").click
       test_expect_axe_clean_without_main_navigation
     end
   end

--- a/spec/system/help_spec.rb
+++ b/spec/system/help_spec.rb
@@ -16,7 +16,7 @@ describe 'Getting help:' do
         expect(page).to have_help_menu
       end
 
-      within('.help__content') do
+      within('.help-content') do
         expect(page).to have_content(procedure.service.email)
         expect(page).to have_content(procedure.service.telephone)
         expect(page).to have_link(nil, href: I18n.t("links.common.faq.url"))
@@ -49,7 +49,7 @@ describe 'Getting help:' do
           expect(page).to have_help_menu
         end
 
-        within('.help__content') do
+        within('.help-content') do
           expect(page).to have_content(dossier.procedure.service.email)
           expect(page).to have_content(dossier.procedure.service.telephone)
           expect(page).to have_link(nil, href: I18n.t("links.common.faq.url"))
@@ -67,7 +67,7 @@ describe 'Getting help:' do
           expect(page).to have_help_menu
         end
 
-        within('.help__content') do
+        within('.help-content') do
           expect(page).to have_link(nil, href: messagerie_dossier_path(dossier))
           expect(page).to have_link(nil, href: I18n.t("links.common.faq.url"))
         end

--- a/spec/system/help_spec.rb
+++ b/spec/system/help_spec.rb
@@ -16,7 +16,7 @@ describe 'Getting help:' do
         expect(page).to have_help_menu
       end
 
-      within('.help-dropdown') do
+      within('.help__content') do
         expect(page).to have_content(procedure.service.email)
         expect(page).to have_content(procedure.service.telephone)
         expect(page).to have_link(nil, href: I18n.t("links.common.faq.url"))
@@ -49,7 +49,7 @@ describe 'Getting help:' do
           expect(page).to have_help_menu
         end
 
-        within('.help-dropdown') do
+        within('.help__content') do
           expect(page).to have_content(dossier.procedure.service.email)
           expect(page).to have_content(dossier.procedure.service.telephone)
           expect(page).to have_link(nil, href: I18n.t("links.common.faq.url"))
@@ -67,7 +67,7 @@ describe 'Getting help:' do
           expect(page).to have_help_menu
         end
 
-        within('.help-dropdown') do
+        within('.help__content') do
           expect(page).to have_link(nil, href: messagerie_dossier_path(dossier))
           expect(page).to have_link(nil, href: I18n.t("links.common.faq.url"))
         end
@@ -95,6 +95,6 @@ describe 'Getting help:' do
   end
 
   def have_help_menu
-    have_selector('.help-dropdown')
+    have_selector("#help-menu")
   end
 end

--- a/spec/views/layouts/_header_spec.rb
+++ b/spec/views/layouts/_header_spec.rb
@@ -36,7 +36,7 @@ describe 'layouts/_header', type: :view do
       end
 
       it 'displays the Help dropdown menu' do
-        expect(subject).to have_css(".help-dropdown")
+        expect(subject).to have_selector("#help-menu")
       end
     end
   end
@@ -65,7 +65,7 @@ describe 'layouts/_header', type: :view do
     it { is_expected.to have_selector(:button, user.email, class: "account-btn") }
 
     it 'displays the Help dropdown menu' do
-      expect(subject).to have_css(".help-dropdown")
+      expect(subject).to have_selector("#help-menu")
     end
   end
 end


### PR DESCRIPTION
# Restaure l'accès aux éléments non interactifs du menu pour les technologies d'assistance
__Après__

https://github.com/user-attachments/assets/ca13ba01-c287-41a3-884c-e19f1662c1df

__Avant__

https://github.com/user-attachments/assets/cddcff0e-4639-4298-9c55-4c4ae943f7aa 

# Applique la sémantique appropriée aux titres du menu
__Après__
![Capture d’écran 2024-08-08 à 11 28 06](https://github.com/user-attachments/assets/cf2fdee7-fdd7-4b4a-9281-806a0428c4c9)

__Avant__
![Capture d’écran 2024-08-08 à 11 28 45](https://github.com/user-attachments/assets/8221bccc-6e1b-4498-a264-4b9dfdd53637)


# Donne une alternative textuelle aux icônes porteuses de sens affichées en CSS
__Après__
![Capture d’écran 2024-08-08 à 11 30 13](https://github.com/user-attachments/assets/6353140f-615c-4b17-a605-addd247776a9)

__Avant__
![Capture d’écran 2024-08-08 à 11 30 42](https://github.com/user-attachments/assets/137097cf-aa06-4239-9869-50b8547ae09d)


# Rétabli l'affichage des éléments en version mobile
__Après__
![Capture d’écran 2024-08-08 à 11 20 25](https://github.com/user-attachments/assets/c92ac9cd-ee67-4b8e-8960-15e1b812169b)

__Avant__
![Capture d’écran 2024-08-05 à 14 41 47](https://github.com/user-attachments/assets/9a60d4f4-1f24-48a7-bf40-ac62404ed2cd)


# Distingue les liens du texte courant 
__Après__
![Capture d’écran 2024-08-08 à 11 11 46](https://github.com/user-attachments/assets/6e683c26-a391-4f98-8369-5f5ad6a22f70)

__Avant__
![Capture d’écran 2024-08-08 à 11 34 38](https://github.com/user-attachments/assets/8758d169-40d0-4f8a-97b4-8cd983b91610)

# Balise les couples clefs / valeurs avec une liste `dl`
__Après__
![Capture d’écran 2024-08-08 à 11 38 52](https://github.com/user-attachments/assets/33b1178e-e276-439a-bf49-fcb58b66e568)

__Avant__
![Capture d’écran 2024-08-08 à 11 38 18](https://github.com/user-attachments/assets/a0e924cf-de10-4658-9fed-b1da4321c72d)


# Corrige un attribut `title` ne reprenant pas l'intitulé visible du lien qu'il explicite 
__Après__
![Capture d’écran 2024-08-08 à 11 35 34](https://github.com/user-attachments/assets/49840194-d452-4019-ac1f-67315da1a18a)

__Avant__
![Capture d’écran 2024-08-08 à 11 35 11](https://github.com/user-attachments/assets/49cff69d-b544-4d60-9929-b866ea3a1ade)


# Transforme un `<span>`en un `<div>` pour éviter une erreur d'imbrication
__Après__
![Capture d’écran 2024-08-08 à 11 36 35](https://github.com/user-attachments/assets/fc6706b3-280a-4249-a785-9629fc2a3a9b)

__Avant__
![Capture d’écran 2024-08-08 à 11 37 04](https://github.com/user-attachments/assets/73392f2f-370f-4c4e-afd0-45d76c17e76f)

