### PR TITLE
ETQ usager (amélioration) - je ne veux pas de bug d'affichage de message d'information dans la liste des dossiers

### DIFF
--- a/app/views/administrateurs/procedures/_procedures_list.html.haml
+++ b/app/views/administrateurs/procedures/_procedures_list.html.haml
@@ -98,7 +98,7 @@
                 .dropdown-description
                   %h4= t('administrateurs.dropdown_actions.to_close')
 
-          - if procedure.can_be_deleted_by_administrateur? && !procedure.discarded?
+          - if procedure.can_be_deleted_by_administrateur? && !procedure.discarded? && !procedure.publiee?
             - menu.with_item do
               = link_to admin_procedure_path(procedure), role: 'menuitem', method: :delete, data: { confirm: "Voulez-vous vraiment supprimer la démarche ? \nToute suppression est définitive et s'appliquera aux éventuels autres administrateurs de cette démarche !" } do
                 = dsfr_icon('fr-icon-delete-line')

--- a/app/views/users/dossiers/_dossiers_list.html.haml
+++ b/app/views/users/dossiers/_dossiers_list.html.haml
@@ -54,17 +54,17 @@
           - c.with_body do
             %p
               - if dossier.brouillon? && dossier.procedure.closing_reason_internal_procedure?
-                = t('views.users.dossiers.dossiers_list.procedure_closed.brouillon.internal_procedure_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.procedure'), commencer_path(dossier.procedure.replaced_by_procedure.path), **external_link_attributes, title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.closing_details'))).html_safe)
-              - elsif dossier.brouillon? && dossier.procedure.closing_reason_other?
-                = t('views.users.dossiers.dossiers_list.procedure_closed.brouillon.other_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.more_details'), closing_details_path(dossier.procedure.path), **external_link_attributes, title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.closing_details'))).html_safe)
+                = t('views.users.dossiers.dossiers_list.procedure_closed.brouillon.internal_procedure_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.procedure'), commencer_path(dossier.procedure.replaced_by_procedure.path), **external_link_attributes, title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_new_procedure'))).html_safe)
+              - elsif dossier.brouillon?
+                = t('views.users.dossiers.dossiers_list.procedure_closed.brouillon.other_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.more_details'), closing_details_path(dossier.procedure.path), **external_link_attributes, title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_closing_details'))).html_safe)
               - elsif dossier.en_construction_ou_instruction? && dossier.procedure.closing_reason_internal_procedure?
-                = t('views.users.dossiers.dossiers_list.procedure_closed.en_cours.internal_procedure_html')
-              - elsif dossier.en_construction_ou_instruction? && dossier.procedure.closing_reason_other?
-                = t('views.users.dossiers.dossiers_list.procedure_closed.en_cours.other_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.more_details'), closing_details_path(dossier.procedure.path), **external_link_attributes, title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.closing_details'))).html_safe)
+                = t('views.users.dossiers.dossiers_list.procedure_closed.en_cours.internal_procedure_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.procedure'), commencer_path(dossier.procedure.replaced_by_procedure.path), **external_link_attributes, title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_new_procedure'))).html_safe)
+              - elsif dossier.en_construction_ou_instruction?
+                = t('views.users.dossiers.dossiers_list.procedure_closed.en_cours.other_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.more_details'), closing_details_path(dossier.procedure.path), **external_link_attributes, title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_closing_details'))).html_safe)
               - elsif dossier.termine? && dossier.procedure.closing_reason_internal_procedure?
-                = t('views.users.dossiers.dossiers_list.procedure_closed.termine.internal_procedure_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.this_procedure'), commencer_path(dossier.procedure.replaced_by_procedure.path), **external_link_attributes, title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.closing_details'))).html_safe)
-              - elsif dossier.termine? && dossier.procedure.closing_reason_other?
-                = t('views.users.dossiers.dossiers_list.procedure_closed.termine.other_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.more_details'), closing_details_path(dossier.procedure.path), **external_link_attributes, title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.closing_details'))).html_safe)
+                = t('views.users.dossiers.dossiers_list.procedure_closed.termine.internal_procedure_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.this_procedure'), commencer_path(dossier.procedure.replaced_by_procedure.path), **external_link_attributes, title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_new_procedure'))).html_safe)
+              - elsif dossier.termine?
+                = t('views.users.dossiers.dossiers_list.procedure_closed.termine.other_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.more_details'), closing_details_path(dossier.procedure.path), **external_link_attributes, title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_closing_details'))).html_safe)
 
       - if dossier.pending_correction?
         = render Dsfr::AlertComponent.new(state: :warning, size: :sm, extra_class_names: "fr-mb-2w") do |c|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -151,7 +151,6 @@ en:
         content_html: "<p class=\"fr-mb-2w\">The documentation pages are managed by a third-party tool. They are not fully accessible.</p>
           <p class=\"fr-mb-2w\">FAQ management was delegated to a third-party tool. It was reintegrated into the platform in May 2024 and has not yet been audited.</p>"
 
-          
       preparation:
         title: "Preparation of this accessibility declaration"
         intro: "This declaration was drawn up on 27 April 2022. It was updated on 14 June 2024."
@@ -519,15 +518,16 @@ en:
           deleted: Deleted at %{date}
           procedure_closed:
             brouillon:
-              internal_procedure_html: This procedure is closed, you cannot submit this file. We invite you to submit a new one on the %{link} which replaces it
-              other_html: This process is closed, you cannot submit this file. %{link}
+              internal_procedure_html: This procedure is closed. You cannot submit this file. We invite you to submit a new one on the %{link} which replaces it.
+              other_html: This process is closed. You cannot submit this file, nor submit a new one for this procedure. %{link}
             en_cours:
-              internal_procedure_html: This procedure is closed. Your file has been submitted and can be investigated by the administration
-              other_html: This procedure is closed. Your file has been submitted and can be processed by the administration. %{link}
+              internal_procedure_html: This procedure is closed. Your file has been submitted and can be investigated by the administration. If necessary, you can submit a new file on the %{link} that replaces it.
+              other_html: This procedure is closed. Your file has been submitted and can be processed by the administration. You cannot submit a new file for this procedure. %{link}
             termine:
-              internal_procedure_html: This procedure is closed and replaced by %{link}. Your file has been processed by the administration
-              other_html: This process is closed, you cannot submit a new file. %{link}
-            closing_details: Details on the closed procedure
+              internal_procedure_html: This procedure is closed. Your file has been processed by the administration. If necessary, you can submit a new file on the %{link} that replaces it.
+              other_html: This process is closed. Your file has been processed by the administration. You cannot submit a new file for this procedure. %{link}
+            title_new_procedure: New procedure available
+            title_closing_details: More information on the closing procedure
             more_details: More information
             procedure: procedure
             this_procedure: this procedure

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -516,15 +516,16 @@ fr:
           no_result_reset_filter: Réinitialiser les filtres
           procedure_closed:
             brouillon:
-              internal_procedure_html: Cette démarche est close, vous ne pouvez pas déposer ce dossier. Nous vous invitons à en déposer un nouveau sur la %{link} qui la remplace
-              other_html: Cette démarche est close, vous ne pouvez pas déposer ce dossier. %{link}
+              internal_procedure_html: Cette démarche est close. Vous ne pouvez pas déposer ce dossier. Nous vous invitons à en déposer un nouveau sur la %{link} qui la remplace.
+              other_html: Cette démarche est close. Vous ne pouvez pas déposer ce dossier, ni en déposer un nouveau pour cette démarche. %{link}
             en_cours:
-              internal_procedure_html: Cette démarche est close. Votre dossier est bien déposé et peut être instruit par l’administration
-              other_html: Cette démarche est close. Votre dossier est bien déposé et peut être instruit par l'administration. Vous ne pouvez pas déposer de nouveau dossier. %{link}
+              internal_procedure_html: Cette démarche est close. Votre dossier est bien déposé et peut être instruit par l’administration. Au besoin, vous pouvez déposer un nouveau dossier sur la %{link} qui la remplace.
+              other_html: Cette démarche est close. Votre dossier est bien déposé et peut être instruit par l'administration. Vous ne pouvez pas déposer de nouveau dossier pour cette démarche. %{link}
             termine:
-              internal_procedure_html: Cette démarche est close et remplacée par %{link}. Votre dossier a été traité par l'administration
-              other_html: Cette démarche est close, vous ne pourrez pas déposer de nouveau dossier à partir du lien de la démarche. %{link}
-            closing_details: Détails sur la fermeture de la démarche
+              internal_procedure_html: Cette démarche est close. Votre dossier a bien été traité par l'administration. Au besoin, vous pouvez déposer un nouveau dossier sur la %{link} qui la remplace.
+              other_html: Cette démarche est close. Votre dossier a bien été traité par l'administration. Vous ne pouvez pas déposer de nouveau dossier pour cette démarche. %{link}
+            title_new_procedure: Nouvelle démarche disponible
+            title_closing_details: Plus d'informations sur la clôture de la démarche
             more_details: Plus d’informations
             procedure: démarche
             this_procedure: cette démarche

--- a/config/locales/views/users/procedure_footer/fr.yml
+++ b/config/locales/views/users/procedure_footer/fr.yml
@@ -35,7 +35,7 @@ fr:
         data_gouv:
           title: data.gouv.fr
           url: "https://data.gouv.fr"
-      dematerialisation: 
+      dematerialisation:
         header: Dématérialisation
         title_1: Télécharger le formulaire PDF
         title_2: Trouver une maison France Services


### PR DESCRIPTION
issue : https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/10648

Le bug d'affichage se produit lorsque l'attribut "closing_reason" de la procédure est nil, ce qui implique lorsque l'on génère un bloc info (suite à la clôture de la procédure), que aucune condition ne soit remplie. 

1. le fait d'obtenir nil n'est pas un comportement normal : ceci est dû au fait que, pour les procédures publiées, on laisse en choix d'action, soit de "clôturer" la procédure, soit de la "supprimer". Si l'admin choisit de "supprimer", cela ne le fait pas passer par le process de clôture, et donc on se retrouve avec nil dans l'attribut
![Capture d’écran 2024-08-07 à 17 36 59](https://github.com/user-attachments/assets/ad8e0b34-90c6-4480-8ee4-64066f3a1b7b)

=> pour éviter au passage la confusion, il est proposé de supprimer l'action "supprimer" laissant ainsi la seule possibilité de passer par "clôturer" lorsque l'admin souhaite mettre un terme à la procédure 
![Capture d’écran 2024-08-07 à 17 36 31](https://github.com/user-attachments/assets/577511a8-8368-479b-bbd8-a688d95f50e0)

2. dans l'hyp où dans la BD on a des procédures qui ont été supprimées de la sorte, cad qui ont l'attribut clossing_reason à nil, on ne peut donc dans dossierss_list conserver les conditions telles quelles.
=> il est proposé de supprimer la condition faisant appel à closing_reason_other? afin que l'on puisse également englober dans ces cas les procédures qui sont à clossing_reason = nil

3. j'ai profité par ailleurs de cette PR pour homogénéiser les messages d'information présentés à l'usager