### PR TITLE
ETQ usager, l'attestation v2 gère mieux les pieds de page

### DIFF
--- a/app/assets/stylesheets/attestation.scss
+++ b/app/assets/stylesheets/attestation.scss
@@ -42,7 +42,7 @@
       flex-direction: column;
       justify-content: space-between; // This will push the footer down
       max-width: 21cm;
-      height: 29.7cm;
+      min-height: 29.7cm;
       padding: 17mm;
       margin: 0 auto;
       background: #FFFFFF;

--- a/app/assets/stylesheets/attestation.scss
+++ b/app/assets/stylesheets/attestation.scss
@@ -47,6 +47,7 @@
       margin: 0 auto;
       background: #FFFFFF;
       box-shadow: 0 0 10px rgba(0, 0, 0, 0.5); // Optional: for better visualization
+      position: relative;
     }
   }
 
@@ -166,10 +167,15 @@
     }
   }
 
-  .footer {
+  footer {
     position: running(footer);
     font-size: 7pt;
     font-weight: 100;
     white-space: nowrap;
+
+    @media screen {
+      position: absolute;
+      bottom: 0;
+    }
   }
 }

--- a/app/assets/stylesheets/attestation.scss
+++ b/app/assets/stylesheets/attestation.scss
@@ -27,6 +27,7 @@
     font-size: 8pt;
     content: counter(page) " / " counter(pages);
     margin-top: 17mm;
+    white-space: nowrap;
   }
 
   @bottom-left {
@@ -169,5 +170,6 @@
     position: running(footer);
     font-size: 7pt;
     font-weight: 100;
+    white-space: nowrap;
   }
 }

--- a/app/views/administrateurs/attestation_template_v2s/show.html.haml
+++ b/app/views/administrateurs/attestation_template_v2s/show.html.haml
@@ -30,12 +30,13 @@
         - if @attestation_template.label_direction.present?
           = simple_format @attestation_template.label_direction, class: "direction"
 
+    - if @attestation_template.footer.present?
+      %footer
+        = simple_format @attestation_template.footer
+
     .main
       = sanitize(@body, attributes: %w[class style], tags: Rails.configuration.action_view.sanitized_allowed_tags + %w[header])
 
       - if @attestation_template.signature.present?
         .signature
           = image_tag(@attestation_template.signature_url)
-
-  - if @attestation_template.footer.present?
-    = simple_format @attestation_template.footer, class: "footer"


### PR DESCRIPTION
- s'étale sur toute la largeur de la ligne plutôt que s'arrêter au milieu
- S'affiche sur toutes les pages (et pas que la dernière). Le trick que j'ai mis 2h+ à comprendre c'est qu'il doit être défini **avant** tout le contenu qui est paginé pour être correctement pris en compte.
- L'affichage HTML (utile au dev) est à peu près conservé

**APRES**
![Capture d’écran 2024-08-19 à 18 31 53](https://github.com/user-attachments/assets/ce2c2839-2298-4b23-a863-15291dea0792)


**AVANT**
![Capture d’écran 2024-08-19 à 18 44 58](https://github.com/user-attachments/assets/982a968f-9c12-4cca-afa2-7a726a46dc2a)

