### PR TITLE
Sécurité: évite une injection XSS dans la gallerie de PJ par le nom du fichier

### DIFF
--- a/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.html.haml
+++ b/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.html.haml
@@ -23,7 +23,7 @@
           - when TypeDeChamp.type_champs.fetch(:multiple_drop_down_list)
             = render partial: "shared/champs/multiple_drop_down_list/show", locals: { champ: champ }
           - when TypeDeChamp.type_champs.fetch(:piece_justificative), TypeDeChamp.type_champs.fetch(:titre_identite)
-            = render partial: "shared/champs/piece_justificative/show", locals: { champ: champ }
+            = render partial: "shared/champs/piece_justificative/show", locals: { champ: champ, profile: @profile  }
           - when TypeDeChamp.type_champs.fetch(:siret)
             = render partial: "shared/champs/siret/show", locals: { champ: champ, profile: @profile }
           - when TypeDeChamp.type_champs.fetch(:iban)

--- a/app/views/instructeurs/dossiers/pieces_jointes.html.haml
+++ b/app/views/instructeurs/dossiers/pieces_jointes.html.haml
@@ -8,7 +8,7 @@
       .gallery-item
         - blob = attachment.blob
         - if displayable_pdf?(blob)
-          = link_to blob.url, id: blob.id, data: { iframe: true, src: blob.url }, class: 'gallery-link', type: blob.content_type, title: "#{libelle} -- #{blob.filename}" do
+          = link_to blob.url, id: blob.id, data: { iframe: true, src: blob.url }, class: 'gallery-link', type: blob.content_type, title: "#{libelle} -- #{sanitize(blob.filename.to_s)}" do
             .thumbnail
               = image_tag(preview_url_for(attachment), loading: :lazy)
               .fr-btn.fr-btn--tertiary.fr-btn--icon-left.fr-icon-eye{ role: :button }
@@ -18,7 +18,7 @@
           = render Attachment::ShowComponent.new(attachment: attachment, truncate: true)
 
         - elsif displayable_image?(blob)
-          = link_to image_url(blob_url(attachment)), title: "#{libelle} -- #{blob.filename}", data: { src: blob.url }, class: 'gallery-link' do
+          = link_to image_url(blob_url(attachment)), title: "#{libelle} -- #{sanitize(blob.filename.to_s)}", data: { src: blob.url }, class: 'gallery-link' do
             .thumbnail
               = image_tag(variant_url_for(attachment), loading: :lazy)
               .fr-btn.fr-btn--tertiary.fr-btn--icon-left.fr-icon-eye{ role: :button }

--- a/app/views/shared/champs/piece_justificative/_show.html.haml
+++ b/app/views/shared/champs/piece_justificative/_show.html.haml
@@ -5,14 +5,14 @@
         .gallery-item
           - blob = attachment.blob
           - if displayable_pdf?(blob)
-            = link_to blob.url, id: blob.id, data: { iframe: true, src: blob.url }, class: 'gallery-link', type: blob.content_type, title: "#{champ.libelle} -- #{blob.filename}" do
+            = link_to blob.url, id: blob.id, data: { iframe: true, src: blob.url }, class: 'gallery-link', type: blob.content_type, title: "#{champ.libelle} -- #{sanitize(blob.filename.to_s)}" do
               .thumbnail
                 = image_tag(preview_url_for(attachment), loading: :lazy)
                 .fr-btn.fr-btn--tertiary.fr-btn--icon-left.fr-icon-eye{ role: :button }
                   = 'Visualiser'
 
           - elsif displayable_image?(blob)
-            = link_to image_url(blob_url(attachment)), title: "#{champ.libelle} -- #{blob.filename}", data: { src: blob.url }, class: 'gallery-link' do
+            = link_to image_url(blob_url(attachment)), title: "#{champ.libelle} -- #{sanitize(blob.filename.to_s)}", data: { src: blob.url }, class: 'gallery-link' do
               .thumbnail
                 = image_tag(variant_url_for(attachment), loading: :lazy)
                 .fr-btn.fr-btn--tertiary.fr-btn--icon-left.fr-icon-eye{ role: :button }

--- a/app/views/shared/champs/piece_justificative/_show.html.haml
+++ b/app/views/shared/champs/piece_justificative/_show.html.haml
@@ -1,5 +1,5 @@
 .fr-downloads-group
-  - if instructeur_signed_in? && feature_enabled?(:gallery_demande)
+  - if profile == 'instructeur' && feature_enabled?(:gallery_demande)
     .gallery-items-list
       - champ.piece_justificative_file.attachments.with_all_variant_records.each do |attachment|
         .gallery-item


### PR DESCRIPTION
J'ai échoué à réussir à écrire un vrai test sans devoir hardcoder un long truc car la réponse contient le filename à d'autres endroits. C'est avec le title que le navigateur pouvait être trompé et rattrapait le DOM, pouvant exécuter du JS.