### PR TITLE
ETQ instructeur, corrige l'affichage expliquant la raison pour laquelle l'usager a supprimé (ou expiré) un dossier

### DIFF
--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -144,7 +144,7 @@
                       - else
                         %a.cell-link{ href: path }
                           = column
-                          = "- #{t('views.instructeurs.dossiers.deleted_reason', reason: p.hidden_by_reason)}" if p.hidden_by_user_at.present?
+                          = "- #{t("views.instructeurs.dossiers.deleted_reason.#{p.hidden_by_reason}")}" if p.hidden_by_user_at.present?
 
                   %td.status-col
                     - status = [status_badge(p.state)]


### PR DESCRIPTION
## APRES
![Capture d’écran 2024-08-20 à 16 14 47](https://github.com/user-attachments/assets/246deba1-ad01-4838-b043-c89098e255ee)


## AVANT
![Capture d’écran 2024-08-20 à 12 53 15](https://github.com/user-attachments/assets/1b1fb56d-8a77-44f0-a72f-08b9157c6685)
