### PR TITLE
ETQ instructeur, ne plante pas en essayant de formater une date quand c'est pas une date

### DIFF
--- a/app/services/dossier_projection_service.rb
+++ b/app/services/dossier_projection_service.rb
@@ -75,10 +75,11 @@ class DossierProjectionService
           .pluck(:id, *fields.map { |f| f[COLUMN].to_sym })
           .each do |id, *columns|
             fields.zip(columns).each do |field, value|
-              if [state_field, archived_field, hidden_by_user_at_field, hidden_by_administration_at_field, hidden_by_reason_field, for_tiers_field, batch_operation_field, sva_svr_decision_on_field].include?(field)
-                field[:id_value_h][id] = value
+              # SVA must remain a date: in other column we compute remaining delay with it
+              field[:id_value_h][id] = if value.respond_to?(:strftime) && field != sva_svr_decision_on_field
+                I18n.l(value.to_date)
               else
-                field[:id_value_h][id] = value&.strftime('%d/%m/%Y') # other fields are datetime
+                value
               end
             end
           end


### PR DESCRIPTION
Fix https://demarches-simplifiees.sentry.io/issues/5734361725/

Exception pour le SVA mentionnée en commentaire, j'ai pas vu d'autres cas particuliers

J'en profite pour mieux gérer l'i18n et le format de date anglophone (par défaut YYYY-MM-DD de rails-i18n), ça reste JJ/MM/YYY en français