### PR TITLE
ETQ usager, j'ai une indication sur le format de date à saisir en fonction de mon navigateur

### DIFF
--- a/app/components/editable_champ/cojo_component/cojo_component.en.yml
+++ b/app/components/editable_champ/cojo_component/cojo_component.en.yml
@@ -3,5 +3,6 @@ en:
   accreditation_number_label: Accreditation number
   accreditation_number_notice: Identification number issued by Paris 2024
   accreditation_birthdate_label: Date of birth
+  accreditation_birthdate_hint: 'Format: MM/JJ/AAAA'
   accreditation_number_error: Invalid accreditation number
   accreditation_number_verification_pending: Accreditation number verification in progress

--- a/app/components/editable_champ/cojo_component/cojo_component.fr.yml
+++ b/app/components/editable_champ/cojo_component/cojo_component.fr.yml
@@ -3,5 +3,6 @@ fr:
   accreditation_number_label: Numéro d‘accréditation
   accreditation_number_notice: Numéro d‘identification délivré par Paris 2024
   accreditation_birthdate_label: Date de naissance
+  accreditation_birthdate_hint: 'Format : JJ/MM/AAAA'
   accreditation_number_error: Le numéro d‘accréditation est incorrect
   accreditation_number_verification_pending: Vérification du numéro d‘accréditation en cours

--- a/app/components/editable_champ/cojo_component/cojo_component.html.haml
+++ b/app/components/editable_champ/cojo_component/cojo_component.html.haml
@@ -17,6 +17,7 @@
 .fr-input-group{ class: input_group_class }
   = @form.label :accreditation_birthdate, for: @champ.accreditation_birthdate_input_id, class: 'fr-label' do
     - safe_join [t('.accreditation_birthdate_label'), @champ.required? ? render(EditableChamp::AsteriskMandatoryComponent.new) : ''], ' '
+  %p.fr-hint-text{ data: { controller: 'date-input-hint' } }= t('.accreditation_birthdate_hint')
   = @form.date_field :accreditation_birthdate,
     required: @champ.required?,
     aria: { describedby: dom_id(@champ, :accreditation_birthdate) },


### PR DESCRIPTION
Même principe que le "vrai" champ date, du JS vient remplacer le format du hint si nécessaire
<img width="417" alt="Capture d’écran 2024-08-22 à 11 07 26" src="https://github.com/user-attachments/assets/701869c8-63c0-4dd9-be94-4f378ec3c1e7">
