### PR TITLE
[Tech] Retirer la colonne obsolète 'hidden_at' des dossiers (part 1)

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -1,5 +1,5 @@
 class Dossier < ApplicationRecord
-  self.ignored_columns += [:re_instructed_at, :search_terms, :private_search_terms]
+  self.ignored_columns += [:re_instructed_at, :search_terms, :private_search_terms, :hidden_at]
 
   include DossierCloneConcern
   include DossierCorrectableConcern

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -1214,10 +1214,6 @@ describe Instructeurs::DossiersController, type: :controller do
         expect(DeletedDossier.where(dossier_id: dossier.id).count).to eq(0)
       end
 
-      it 'does not discard the dossier' do
-        expect(dossier.reload.hidden_at).to eq(nil)
-      end
-
       it 'fill hidden by reason' do
         expect(dossier.reload.hidden_by_reason).not_to eq(nil)
         expect(dossier.reload.hidden_by_reason).to eq("instructeur_request")
@@ -1240,7 +1236,7 @@ describe Instructeurs::DossiersController, type: :controller do
 
     context 'with dossier in batch_operation' do
       let(:batch_operation) { create(:batch_operation, operation: :archiver, dossiers: [dossier], instructeur: instructeur) }
-      it { expect { subject }.not_to change { dossier.reload.hidden_at } }
+      it { expect { subject }.not_to change { dossier.reload.hidden_by_administration_at } }
       it { is_expected.to redirect_to(instructeur_dossier_path(dossier.procedure, dossier)) }
       it 'flashes message' do
        subject

--- a/spec/factories/dossier.rb
+++ b/spec/factories/dossier.rb
@@ -110,10 +110,6 @@ FactoryBot.define do
       archived { false }
     end
 
-    trait :discarded do
-      hidden_at { Time.zone.now }
-    end
-
     trait :hidden_by_expired do
       hidden_by_expired_at { 1.day.ago }
       hidden_by_reason { DeletedDossier.reasons.fetch(:expired) }

--- a/spec/mailers/dossier_mailer_spec.rb
+++ b/spec/mailers/dossier_mailer_spec.rb
@@ -127,12 +127,8 @@ RSpec.describe DossierMailer, type: :mailer do
   end
 
   describe '.notify_automatic_deletion_to_user' do
-    # let(:deleted_dossier) { create(:deleted_dossier, dossier: dossier, reason: :expired) }
-    # let(:hidden_dossier) { build(:dossier, :en_construction, hidden_at: Time.zone.now, hidden_by_reason: 'expired') }
-
     describe 'en_construction' do
-      # let(:dossier) { create(:dossier, :en_construction) }
-      let(:hidden_dossier) { create(:dossier, :en_construction, hidden_at: Time.zone.now, hidden_by_reason: 'expired') }
+      let(:hidden_dossier) { create(:dossier, :en_construction, hidden_by_expired_at: Time.zone.now, hidden_by_reason: 'expired') }
 
       subject { described_class.notify_automatic_deletion_to_user([hidden_dossier], hidden_dossier.user.email) }
 
@@ -145,7 +141,7 @@ RSpec.describe DossierMailer, type: :mailer do
     end
 
     describe 'termine' do
-      let(:hidden_dossier) { create(:dossier, :accepte, hidden_at: Time.zone.now, hidden_by_reason: 'expired') }
+      let(:hidden_dossier) { create(:dossier, :accepte, hidden_by_expired_at: Time.zone.now, hidden_by_reason: 'expired') }
 
       subject { described_class.notify_automatic_deletion_to_user([hidden_dossier], hidden_dossier.user.email) }
 
@@ -159,9 +155,7 @@ RSpec.describe DossierMailer, type: :mailer do
   end
 
   describe '.notify_automatic_deletion_to_administration' do
-    # let(:dossier) { create(:dossier, :en_construction) }
-    let(:hidden_dossier) { create(:dossier, :accepte, hidden_at: Time.zone.now, hidden_by_reason: 'expired') }
-    # let(:deleted_dossier) { create(:deleted_dossier, dossier: dossier, reason: :expired) }
+    let(:hidden_dossier) { create(:dossier, :accepte, hidden_by_expired_at: Time.zone.now, hidden_by_reason: 'expired') }
 
     subject { described_class.notify_automatic_deletion_to_administration([hidden_dossier], hidden_dossier.user.email) }
 

--- a/spec/models/champ_spec.rb
+++ b/spec/models/champ_spec.rb
@@ -60,13 +60,6 @@ describe Champ do
 
   describe "associations" do
     it { is_expected.to belong_to(:dossier) }
-
-    context 'when the parent dossier is discarded' do
-      let(:discarded_dossier) { create(:dossier, :discarded) }
-      subject(:champ) { discarded_dossier.champs_public.first }
-
-      it { expect(champ.reload.dossier).to eq discarded_dossier }
-    end
   end
 
   describe "normalization" do

--- a/spec/models/concerns/dossier_clone_concern_spec.rb
+++ b/spec/models/concerns/dossier_clone_concern_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe DossierCloneConcern do
       expect(new_dossier.en_instruction_at).to be_nil
       expect(new_dossier.for_procedure_preview).to be_falsey
       expect(new_dossier.groupe_instructeur_updated_at).to be_nil
-      expect(new_dossier.hidden_at).to be_nil
       expect(new_dossier.hidden_by_administration_at).to be_nil
       expect(new_dossier.hidden_by_reason).to be_nil
       expect(new_dossier.hidden_by_user_at).to be_nil

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -933,7 +933,6 @@ describe Dossier, type: :model do
 
     context 'en_construction' do
       it 'hide the dossier but does not discard' do
-        expect(dossier.hidden_at).to be_nil
         expect(dossier.hidden_by_user_at).to be_present
       end
 

--- a/spec/services/expired/expired_users_deletion_service_spec.rb
+++ b/spec/services/expired/expired_users_deletion_service_spec.rb
@@ -72,7 +72,7 @@ describe Expired::UsersDeletionService do
 
         context 'when dossier termine' do
           let(:dossier) { create(:dossier, :accepte, user:, created_at: last_signed_in_expired) }
-          it 'marks dossier as hidden_at due to user_removal and remove user' do
+          it 'marks dossier as hidden by user due to user_removal and remove user' do
             expect { subject }.to change { dossier.reload.hidden_by_user_at }.from(nil).to(anything)
             expect { user.reload }.to raise_error(ActiveRecord::RecordNotFound)
           end


### PR DESCRIPTION
Suite à la PR https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/10488
Nettoyage du code pour la colonne hidden_at qui est obsolète.
Une fois déployée il y aura la 2e PR pour supprimer la colonne avec une migration.