### PR TITLE
Correctif, ETQ Tech, je souhaite que la tache qui peuple les adresses normalisées des champs siret ne plante pas a cause de bad data sur les champs

### DIFF
--- a/app/tasks/maintenance/populate_siret_value_json_task.rb
+++ b/app/tasks/maintenance/populate_siret_value_json_task.rb
@@ -13,6 +13,8 @@ module Maintenance
     def process(champ)
       return if champ.etablissement.blank?
       champ.update!(value_json: APIGeoService.parse_etablissement_address(champ.etablissement))
+    rescue ActiveRecord::RecordInvalid
+      # noop, just a champ without dossier
     end
 
     def count


### PR DESCRIPTION
on a des champs sans dossiers, on rescue une err de validation dans cette maintenance task [bloqué a 1M de champs, reste a faire 400k]
cf: https://www.demarches-simplifiees.fr/manager/maintenance_tasks/tasks/Maintenance::PopulateSiretValueJSONTask
