### PR TITLE
Tech: task pour copier les secrets OTP vers les encrypted attributes

### DIFF
--- a/app/tasks/maintenance/copy_super_admin_otp_secret_to_rails7_encrypted_attr_task.rb
+++ b/app/tasks/maintenance/copy_super_admin_otp_secret_to_rails7_encrypted_attr_task.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class CopySuperAdminOtpSecretToRails7EncryptedAttrTask < MaintenanceTasks::Task
+    # Cette tâche finalise la mise à niveau vers devies-two-factor 5
+    # qui utilise les encrypted attributes de Rails 7.
+    # Elle copie les secrets OTP des super admins vers la nouvelle colonne
+    # avant une suppression plus tard des anciennes colonnes.
+    # Plus d'informations : https://github.com/devise-two-factor/devise-two-factor/blob/main/UPGRADING.md
+    # Introduit 2024-08-29, https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/10722
+    def collection
+      SuperAdmin.all
+    end
+
+    def process(super_admin)
+      # From https://github.com/devise-two-factor/devise-two-factor/blob/main/UPGRADING.md
+      otp_secret = super_admin.otp_secret # read from otp_secret column, fall back to legacy columns if new column is empty
+      # This is NOOP when otp_secret column has already the same value
+      super_admin.update!(otp_secret: otp_secret)
+    end
+
+    def count
+      SuperAdmin.count
+    end
+  end
+end

--- a/spec/tasks/maintenance/copy_super_admin_otp_secret_to_rails7_encrypted_attr_task_spec.rb
+++ b/spec/tasks/maintenance/copy_super_admin_otp_secret_to_rails7_encrypted_attr_task_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe CopySuperAdminOtpSecretToRails7EncryptedAttrTask do
+    describe "#process" do
+      let(:super_admin) { create(:super_admin) }
+      subject(:process) { described_class.process(super_admin) }
+
+      context "when otp_secret is not set" do
+        let(:legacy_otp_secret) { "legacy_secret" }
+
+        before do
+          super_admin.update_column(:otp_secret, nil)
+          allow(super_admin).to receive(:otp_secret).and_return(legacy_otp_secret)
+        end
+
+        it "copies the legacy otp_secret to the new column" do
+          expect { process }.to change { super_admin.reload.read_attribute(:otp_secret) }.from(nil).to(legacy_otp_secret)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Nouvelle étape de migration de `devise-two-factor` 5 qui utilise maintenant les encrypted attributes. Cette tâche migre les anciens OTP des super admins générés < 2024 avec la v4 (les réinitialisations faites depuis sont déjà au nouveau format).

Ensuite on pourra supprimer  les anciennes colonnes et la méthode `SuperAdmin#legacy_otp_secret` .

Pas d'impact prévu pour les super admins. Sans cette tâche, ceux qui n'auraient pas encore réinitialisé leur OTP en 2024 devront le faire une fois le vieux code supprimé.
