### PR TITLE
Correctif: lors de l‘import en masse d'instructeurs, les nouveaux instructeurs reçoivent un lien pour vérifier leur email

### DIFF
--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -348,9 +348,15 @@ module Administrateurs
 
             added_instructeurs_by_group.each do |groupe, added_instructeurs|
               if added_instructeurs.present?
-                GroupeInstructeurMailer
-                  .notify_added_instructeurs(groupe, added_instructeurs, current_administrateur.email)
-                  .deliver_later
+                known_instructeurs, new_instructeurs = added_instructeurs.partition { |instructeur| instructeur.user.email_verified_at }
+
+                new_instructeurs.each { InstructeurMailer.confirm_and_notify_added_instructeur(_1, groupe, current_administrateur.email).deliver_later }
+
+                if known_instructeurs.present?
+                  GroupeInstructeurMailer
+                    .notify_added_instructeurs(groupe, known_instructeurs, current_administrateur.email)
+                    .deliver_later
+                end
               end
               flash_message_for_import(invalid_emails)
             end
@@ -360,9 +366,15 @@ module Administrateurs
 
             added_instructeurs, invalid_emails = InstructeursImportService.import_instructeurs(procedure, instructors_emails)
             if added_instructeurs.present?
-              GroupeInstructeurMailer
-                .notify_added_instructeurs(groupe_instructeur, added_instructeurs, current_administrateur.email)
-                .deliver_later
+              known_instructeurs, new_instructeurs = added_instructeurs.partition { |instructeur| instructeur.user.email_verified_at }
+
+              new_instructeurs.each { InstructeurMailer.confirm_and_notify_added_instructeur(_1, groupe_instructeur, current_administrateur.email).deliver_later }
+
+              if known_instructeurs.present?
+                GroupeInstructeurMailer
+                  .notify_added_instructeurs(groupe_instructeur, known_instructeurs, current_administrateur.email)
+                  .deliver_later
+              end
             end
             flash_message_for_import(invalid_emails)
           else

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -348,15 +348,7 @@ module Administrateurs
 
             added_instructeurs_by_group.each do |groupe, added_instructeurs|
               if added_instructeurs.present?
-                known_instructeurs, new_instructeurs = added_instructeurs.partition { |instructeur| instructeur.user.email_verified_at }
-
-                new_instructeurs.each { InstructeurMailer.confirm_and_notify_added_instructeur(_1, groupe, current_administrateur.email).deliver_later }
-
-                if known_instructeurs.present?
-                  GroupeInstructeurMailer
-                    .notify_added_instructeurs(groupe, known_instructeurs, current_administrateur.email)
-                    .deliver_later
-                end
+                notify_instructeurs(groupe, added_instructeurs)
               end
               flash_message_for_import(invalid_emails)
             end
@@ -366,15 +358,7 @@ module Administrateurs
 
             added_instructeurs, invalid_emails = InstructeursImportService.import_instructeurs(procedure, instructors_emails)
             if added_instructeurs.present?
-              known_instructeurs, new_instructeurs = added_instructeurs.partition { |instructeur| instructeur.user.email_verified_at }
-
-              new_instructeurs.each { InstructeurMailer.confirm_and_notify_added_instructeur(_1, groupe_instructeur, current_administrateur.email).deliver_later }
-
-              if known_instructeurs.present?
-                GroupeInstructeurMailer
-                  .notify_added_instructeurs(groupe_instructeur, known_instructeurs, current_administrateur.email)
-                  .deliver_later
-              end
+              notify_instructeurs(groupe_instructeur, added_instructeurs)
             end
             flash_message_for_import(invalid_emails)
           else
@@ -520,6 +504,18 @@ module Administrateurs
           .groupe_instructeurs
           .find_or_create_by(label: label)
           .update(instructeurs: [current_administrateur.instructeur], routing_rule:)
+      end
+    end
+
+    def notify_instructeurs(groupe, added_instructeurs)
+      known_instructeurs, new_instructeurs = added_instructeurs.partition { |instructeur| instructeur.user.email_verified_at }
+
+      new_instructeurs.each { InstructeurMailer.confirm_and_notify_added_instructeur(_1, groupe, current_administrateur.email).deliver_later }
+
+      if known_instructeurs.present?
+        GroupeInstructeurMailer
+          .notify_added_instructeurs(groupe, known_instructeurs, current_administrateur.email)
+          .deliver_later
       end
     end
   end

--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -601,6 +601,8 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
         before do
           allow(GroupeInstructeurMailer).to receive(:notify_added_instructeurs)
             .and_return(double(deliver_later: true))
+          allow(InstructeurMailer).to receive(:confirm_and_notify_added_instructeur)
+            .and_return(double(deliver_later: true))
           subject
         end
 
@@ -608,7 +610,8 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
           expect(procedure.groupe_instructeurs.pluck(:label)).to match_array(["Auvergne-Rhône-Alpes", "Vendée", "défaut", "deuxième groupe"])
           expect(flash.notice).to be_present
           expect(flash.notice).to eq("La liste des instructeurs a été importée avec succès")
-          expect(GroupeInstructeurMailer).to have_received(:notify_added_instructeurs).twice
+          expect(GroupeInstructeurMailer).not_to have_received(:notify_added_instructeurs)
+          expect(InstructeurMailer).to have_received(:confirm_and_notify_added_instructeur).exactly(4).times
         end
       end
 
@@ -690,6 +693,8 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
         before do
           allow(GroupeInstructeurMailer).to receive(:notify_added_instructeurs)
             .and_return(double(deliver_later: true))
+          allow(InstructeurMailer).to receive(:confirm_and_notify_added_instructeur)
+            .and_return(double(deliver_later: true))
           subject
         end
 
@@ -698,11 +703,8 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
           expect(procedure_non_routee.instructeurs.pluck(:email)).to match_array(["kara@beta-gouv.fr", "philippe@mail.com", "lisa@gouv.fr"])
           expect(flash.alert).to be_present
           expect(flash.alert).to eq("Import terminé. Cependant les emails suivants ne sont pas pris en compte: eric")
-          expect(GroupeInstructeurMailer).to have_received(:notify_added_instructeurs).with(
-            procedure_non_routee.defaut_groupe_instructeur,
-            any_args,
-            admin.email
-          )
+          expect(InstructeurMailer).to have_received(:confirm_and_notify_added_instructeur).exactly(3).times
+          expect(GroupeInstructeurMailer).not_to have_received(:notify_added_instructeurs)
         end
       end
 
@@ -768,6 +770,54 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
         it 'verifies email validity in CSV imports and checks for mailer not being called' do
           expect(flash.alert).to include("Import terminé. Cependant les emails suivants ne sont pas pris en compte:")
           expect(GroupeInstructeurMailer).not_to have_received(:notify_added_instructeurs)
+        end
+      end
+
+      context 'when instructeurs accounts exist' do
+        let(:csv_file) { fixture_file_upload('spec/fixtures/files/two-instructeurs-file.csv', 'text/csv') }
+        let(:user_1) { create(:user, :with_email_verified, email: 'instructeur1@gouv.fr') }
+        let(:user_2) { create(:user, :with_email_verified, email: 'instructeur2@gouv.fr') }
+        let!(:instructeur_1) { create(:instructeur, user: user_1) }
+        let!(:instructeur_2) { create(:instructeur, user: user_2) }
+
+        before do
+          allow(GroupeInstructeurMailer).to receive(:notify_added_instructeurs)
+            .and_return(double(deliver_later: true))
+          allow(InstructeurMailer).to receive(:confirm_and_notify_added_instructeur)
+            .and_return(double(deliver_later: true))
+          subject
+        end
+
+        it 'sends notification without confirmation link' do
+          expect(procedure_non_routee.instructeurs.pluck(:email)).to match_array(["instructeur1@gouv.fr", "instructeur2@gouv.fr"])
+          expect(flash.notice).to be_present
+          expect(flash.notice).to eq("La liste des instructeurs a été importée avec succès")
+          expect(GroupeInstructeurMailer).to have_received(:notify_added_instructeurs)
+          expect(InstructeurMailer).not_to have_received(:confirm_and_notify_added_instructeur)
+        end
+      end
+
+      context 'when instructeurs accounts do not exist' do
+        let(:csv_file) { fixture_file_upload('spec/fixtures/files/two-instructeurs-file.csv', 'text/csv') }
+        let(:user_1) { create(:user, email: 'instructeur1@gouv.fr') }
+        let(:user_2) { create(:user, email: 'instructeur2@gouv.fr') }
+        let!(:instructeur_1) { create(:instructeur, user: user_1) }
+        let!(:instructeur_2) { create(:instructeur, user: user_2) }
+
+        before do
+          allow(GroupeInstructeurMailer).to receive(:notify_added_instructeurs)
+            .and_return(double(deliver_later: true))
+          allow(InstructeurMailer).to receive(:confirm_and_notify_added_instructeur)
+            .and_return(double(deliver_later: true))
+          subject
+        end
+
+        it 'sends notification without confirmation link' do
+          expect(procedure_non_routee.instructeurs.pluck(:email)).to match_array(["instructeur1@gouv.fr", "instructeur2@gouv.fr"])
+          expect(flash.notice).to be_present
+          expect(flash.notice).to eq("La liste des instructeurs a été importée avec succès")
+          expect(GroupeInstructeurMailer).not_to have_received(:notify_added_instructeurs)
+          expect(InstructeurMailer).to have_received(:confirm_and_notify_added_instructeur).twice
         end
       end
     end

--- a/spec/fixtures/files/two-instructeurs-file.csv
+++ b/spec/fixtures/files/two-instructeurs-file.csv
@@ -1,0 +1,3 @@
+Email
+instructeur1@gouv.fr
+instructeur2@gouv.fr


### PR DESCRIPTION
closes #10681
