### PR TITLE
ETQ usager, j'aimerais avoir les champs de type texte long d'une hauteur differente des champs de type texte court 

### DIFF
--- a/app/javascript/controllers/autoresize_controller.ts
+++ b/app/javascript/controllers/autoresize_controller.ts
@@ -3,16 +3,31 @@ import { attach } from '@frsource/autoresize-textarea';
 import { isTextAreaElement } from '@coldwired/utils';
 
 export class AutoresizeController extends ApplicationController {
+  declare observer: IntersectionObserver;
+
   #detach?: () => void;
   connect(): void {
     if (isTextAreaElement(this.element)) {
-      this.#detach = attach(this.element)?.detach;
       this.element.classList.add('resize-none');
+      this.observer = new IntersectionObserver(this.onIntersect.bind(this), {
+        threshold: [0]
+      });
+      this.observer.observe(this.element);
+    }
+  }
+
+  onIntersect(entries: IntersectionObserverEntry[]): void {
+    const visible = entries[0].isIntersecting == true;
+
+    if (visible) {
+      this.#detach = attach(this.element as HTMLTextAreaElement)?.detach;
+      this.observer.unobserve(this.element);
     }
   }
 
   disconnect(): void {
     this.#detach?.();
+    this.observer.unobserve(this.element);
     this.element.classList.remove('resize-none');
   }
 }


### PR DESCRIPTION
Problème : le conditionnel et autoresize-textarea (la librairie JS qui etend le `<textarea>` a la hauteur de son contenu) ne sont pas compatibles. Quand on affiche un textarea apparait suite a une condition valide, celui ci n'a pas la bonne taille.

Solution : on bind autoresize-textarea quand le textarea s'affiche une 1ere fois a l'ecran

apres

https://github.com/user-attachments/assets/46b0872a-72b0-4353-bcf7-640418f3f304

avant

https://github.com/user-attachments/assets/f31c6e51-9512-43e9-b997-ef1d1aaf8c2e


