### PR TITLE
Technique : retire le feature flag gallery_demande

### DIFF
--- a/app/views/shared/champs/piece_justificative/_show.html.haml
+++ b/app/views/shared/champs/piece_justificative/_show.html.haml
@@ -1,5 +1,5 @@
 .fr-downloads-group
-  - if profile == 'instructeur' && feature_enabled?(:gallery_demande)
+  - if profile == 'instructeur'
     .gallery-items-list
       - champ.piece_justificative_file.attachments.with_all_variant_records.each do |attachment|
         .gallery-item

--- a/app/views/shared/dossiers/_demande.html.haml
+++ b/app/views/shared/dossiers/_demande.html.haml
@@ -2,7 +2,7 @@
   - content_for(:notice_info) do
     = render partial: "shared/dossiers/france_connect_informations_notice", locals: { user_information: dossier.user.france_connect_informations.first }
 
-.counter-start-header-section.dossier-show{ class: class_names('gallery': feature_enabled?(:gallery_demande), 'gallery-demande': feature_enabled?(:gallery_demande), "dossier-show-instructeur" => profile =="instructeur"), "data-controller": "lightbox" }
+.counter-start-header-section.dossier-show.gallery.gallery-demande{ class: class_names("dossier-show-instructeur" => profile =="instructeur"), "data-controller": "lightbox" }
 
   - if profile == 'instructeur' && dossier.termine_and_accuse_lecture?
     = render Dsfr::CalloutComponent.new(title: nil) do |c|

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -29,7 +29,6 @@ features = [
   :export_order_by_revision,
   :export_template,
   :expression_reguliere_type_de_champ,
-  :gallery_demande,
   :groupe_instructeur_api_hack,
   :sva,
   :switch_domain


### PR DESCRIPTION
Le feature flag `gallery_demande` qui permet d'accéder à la galerie de PJs depuis la page demande ETQ instructeur ou usager, est ouvert à toutes les démarches depuis un peu plus d'un mois.
Je retire le feature flag pour laisser la fonctionnalité ouverte en dur  