### PR TITLE
correct: ETQ administrateur, je souhaite que les types de champ liens vers un dossier pointent vers un dossier valide si ils sont obligatoire

### DIFF
--- a/app/components/editable_champ/dossier_link_component/dossier_link_component.html.haml
+++ b/app/components/editable_champ/dossier_link_component/dossier_link_component.html.haml
@@ -1,8 +1,4 @@
 = @form.text_field(:value, input_opts(id: @champ.input_id, aria: { describedby: @champ.describedby_id }, inputmode: :numeric, min: 1, pattern: "[0-9]{1,12}", autocomplete: 'off', required: @champ.required?, class: "width-33-desktop #{@champ.blank? ? '' : 'small-margin'}"))
 
-- if !@champ.blank?
-  - if dossier.blank?
-    .fr-error-text.fr-mb-4w
-      = t('.not_found')
-  - else
-    .fr-info-text.fr-mb-4w= sanitize(dossier.text_summary)
+- if !@champ.blank? && !dossier.blank?
+  .fr-info-text.fr-mb-4w= sanitize(dossier.text_summary)

--- a/app/models/champs/dossier_link_champ.rb
+++ b/app/models/champs/dossier_link_champ.rb
@@ -2,8 +2,15 @@
 
 class Champs::DossierLinkChamp < Champ
   validate :value_integerable, if: -> { value.present? }, on: :prefill
+  validate :dossier_exists, if: -> { validate_champ_value? && !value.nil? }
 
   private
+
+  def dossier_exists
+    if mandatory? && !Dossier.exists?(value)
+      errors.add(:value, :not_found)
+    end
+  end
 
   def value_integerable
     Integer(value)

--- a/config/locales/models/champs/dossier_link_champ/en.yml
+++ b/config/locales/models/champs/dossier_link_champ/en.yml
@@ -4,3 +4,10 @@ en:
       champs/dossier_link_champ:
         hints:
           value: "File number"
+
+    errors:
+      models:
+        champs/dossier_link_champ:
+          attributes:
+            value:
+              not_found: "File not found"

--- a/config/locales/models/champs/dossier_link_champ/fr.yml
+++ b/config/locales/models/champs/dossier_link_champ/fr.yml
@@ -4,3 +4,11 @@ fr:
       champs/dossier_link_champ:
         hints:
           value: "Numéro de dossier"
+
+
+    errors:
+      models:
+        champs/dossier_link_champ:
+          attributes:
+            value:
+              not_found: "Le dossier n'existe pas"

--- a/spec/models/champs/dossier_link_champ_spec.rb
+++ b/spec/models/champs/dossier_link_champ_spec.rb
@@ -36,4 +36,34 @@ describe Champs::DossierLinkChamp, type: :model do
       end
     end
   end
+
+  describe 'validation' do
+    let(:champ) { Champs::DossierLinkChamp.new(value:, dossier: build(:dossier)) }
+
+    before do
+      allow(champ).to receive(:type_de_champ).and_return(build(:type_de_champ_dossier_link, mandatory:))
+      champ.run_callbacks(:validation)
+    end
+
+    subject { champ.validate(:champs_public_value) }
+
+    context 'when not mandatory' do
+      let(:mandatory) { false }
+      let(:value) { nil }
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when mandatory' do
+      let(:mandatory) { true }
+      context 'when valid id' do
+        let(:value) { create(:dossier).id }
+        it { is_expected.to be_truthy }
+      end
+
+      context 'when invalid id' do
+        let(:value) { 'kthxbye' }
+        it { is_expected.to be_falsey }
+      end
+    end
+  end
 end


### PR DESCRIPTION
remonté par les Fonds Vert : https://mattermost.incubateur.net/betagouv/pl/una34qqhdfb5xgryjnuwex9awh

## problème

ETQ usager, je peux deposer un dossier contenant un champ obligatoire de type lien vers un dossier en renseignant juste une chaine de caractère dans ce champ

https://github.com/user-attachments/assets/adb0b4d1-5cee-44da-b2ab-50b25450caa9


## solution 

On applique une validation pour vérifier que la valeur du champ trouve un dossier.

https://github.com/user-attachments/assets/06fb3259-5b1c-4778-9882-8b26aa57a876

