### PR TITLE
ETQ tech c'est finalement par le manager qui définit si le flag pour masquer l'email des instructeurs

### DIFF
--- a/app/components/procedure/instructeurs_options_component/instructeurs_options_component.html.haml
+++ b/app/components/procedure/instructeurs_options_component/instructeurs_options_component.html.haml
@@ -15,17 +15,6 @@
           hint: "L’autogestion des instructeurs permet aux instructeurs de gérer eux-mêmes la liste des instructeurs de la démarche.#{ 'Nous recommandons de laisser l’autogestion des instructeurs activée.' if @procedure.routing_enabled? }",
           disabled: false)
 
-    %li
-      = form_for @procedure,
-        method: :patch,
-        url: update_hide_instructeurs_email_admin_procedure_groupe_instructeurs_path(@procedure),
-        data: { controller: 'autosubmit', turbo: 'true' } do |f|
-
-        = render Dsfr::ToggleComponent.new(form: f,
-          target: :hide_instructeurs_email,
-          title: "Anonymat des instructeurs",
-          hint: "Permet de cacher l'adresse mail des instructeurs aux usagers lors de leurs interactions par le biais de la messagerie. Cette option est à activer pour les démarches sensibles.",
-          disabled: false)
   %hr
   %p.fr-mt-2w Routage
   %p.fr-mt-2w= t('.routing_configuration_notice_1')

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -320,13 +320,6 @@ module Administrateurs
       notice: "L’autogestion des instructeurs est #{procedure.instructeurs_self_management_enabled? ? "activée" : "désactivée"}."
     end
 
-    def update_hide_instructeurs_email
-      procedure.update!(hide_instructeurs_email_params)
-
-      redirect_to options_admin_procedure_groupe_instructeurs_path(procedure),
-      notice: "L'anonymisation des instructeurs est #{procedure.hide_instructeurs_email? ? "activée" : "désactivée"}."
-    end
-
     def import
       if procedure.publiee_or_close?
         if !CSV_ACCEPTED_CONTENT_TYPES.include?(csv_file.content_type) && !CSV_ACCEPTED_CONTENT_TYPES.include?(marcel_content_type)

--- a/app/dashboards/procedure_dashboard.rb
+++ b/app/dashboards/procedure_dashboard.rb
@@ -51,7 +51,8 @@ class ProcedureDashboard < Administrate::BaseDashboard
     for_tiers_enabled: Field::Boolean,
     replaced_by_procedure_id: Field::String,
     tags: Field::Text,
-    template: Field::Boolean
+    template: Field::Boolean,
+    hide_instructeurs_email: Field::Boolean
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -113,6 +114,7 @@ class ProcedureDashboard < Administrate::BaseDashboard
     :estimated_duration_visible,
     :piece_justificative_multiple,
     :for_tiers_enabled,
+    :hide_instructeurs_email,
     :replaced_by_procedure_id
   ].freeze
 
@@ -126,6 +128,7 @@ class ProcedureDashboard < Administrate::BaseDashboard
     :estimated_duration_visible,
     :piece_justificative_multiple,
     :for_tiers_enabled,
+    :hide_instructeurs_email,
     :replaced_by_procedure_id
   ].freeze
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -672,7 +672,6 @@ Rails.application.routes.draw do
           post 'create_simple_routing'
           delete 'destroy_all_groups_but_defaut'
           patch 'update_instructeurs_self_management_enabled'
-          patch 'update_hide_instructeurs_email'
           post 'import'
           get 'export_groupe_instructeurs'
         end

--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -995,41 +995,4 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
       expect(gi_1_1.signature).to be_attached
     end
   end
-
-  describe '#update_hide_instructeurs_email' do
-    let(:administrateur) { administrateurs(:default_admin) }
-    let(:procedure) { create(:procedure, administrateurs: [administrateur]) }
-
-    before do
-      sign_in(administrateur.user)
-    end
-
-    context 'when activating hide_instructeurs_email' do
-      it 'updates the procedure and redirects with correct notice' do
-        patch :update_hide_instructeurs_email, params: {
-          procedure_id: procedure.id,
-          procedure: { hide_instructeurs_email: "1" }
-        }
-
-        expect(procedure.reload.hide_instructeurs_email).to be true
-        expect(response).to redirect_to(options_admin_procedure_groupe_instructeurs_path(procedure))
-        expect(flash[:notice]).to eq("L'anonymisation des instructeurs est activée.")
-      end
-    end
-
-    context 'when deactivating hide_instructeurs_email' do
-      let(:procedure) { create(:procedure, hide_instructeurs_email: true, administrateurs: [administrateur]) }
-
-      it 'updates the procedure and redirects with correct notice' do
-        patch :update_hide_instructeurs_email, params: {
-          procedure_id: procedure.id,
-          procedure: { hide_instructeurs_email: "0" }
-        }
-
-        expect(procedure.reload.hide_instructeurs_email).to be false
-        expect(response).to redirect_to(options_admin_procedure_groupe_instructeurs_path(procedure))
-        expect(flash[:notice]).to eq("L'anonymisation des instructeurs est désactivée.")
-      end
-    end
-  end
 end


### PR DESCRIPTION
- retire le toggle admin introduit par #10721
- activation par le manager
- corrige l'after party qui mélangeait pas les bons ids
