### PR TITLE
ETQ operateur DS, je souhaite pouvoir corriger les champs de type commune ayant de la bad data

### DIFF
--- a/spec/tasks/maintenance/fix_champs_commune_having_value_but_not_external_id_task_spec.rb
+++ b/spec/tasks/maintenance/fix_champs_commune_having_value_but_not_external_id_task_spec.rb
@@ -8,7 +8,9 @@ module Maintenance
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :communes }]) }
       let(:dossier) { create(:dossier, state, :with_populated_champs, procedure:) }
       let(:champ) { dossier.champs.first }
-      subject(:process) { described_class.process(champ) }
+      subject(:process) do
+        described_class.process(champ)
+      end
 
       context 'when search find one result', vcr: { cassette_name: 'fix-champs-commune-with-one-results' } do
         let(:state) { [:en_instruction, :en_construction].sample }


### PR DESCRIPTION
hs: https://secure.helpscout.net/conversation/2697031887/2092781/

pske se serait trop simple si ca fonctionnait comme d'habitude... https://www.demarches-simplifiees.fr/manager/maintenance_tasks/tasks/Maintenance::FixChampsCommuneHavingValueButNotExternalIdTask