### PR TITLE
ETQ usager, améliore la page après envoi du mot de passe oublié

### DIFF
--- a/app/views/users/passwords/reset_link_sent.html.haml
+++ b/app/views/users/passwords/reset_link_sent.html.haml
@@ -3,34 +3,25 @@
 - content_for :footer do
   = render partial: 'root/footer'
 
-.fr-container.fr-mt-4w.fr-mb-3w
+.fr-container.fr-my-4w
   .fr-grid-row.fr-grid-row--center
     .fr-col-12.fr-col-md-9.fr-col-lg-7
-      .center
-        = image_tag('user/confirmation-email.svg', alt: "")
-        %h1.fr-mb-6w
-          = t('views.users.passwords.reset_link_sent.got_it')
-          %br
-          = t('views.users.passwords.reset_link_sent.open_your_mailbox')
+      %h1.fr-h2
+        = t('views.users.passwords.reset_link_sent.email_sent_html', email: @email, application_name: Current.application_name)
 
-      .fr-callout.fr-callout--green-emeraude.fr-mb-6w
-        %p.fr-callout__text.fr-mb-2w
-          = t('views.users.passwords.reset_link_sent.email_sent_html', email: @email, application_name: Current.application_name)
-        %p.fr-callout__text.fr-mb-2w
-          = t('views.users.passwords.reset_link_sent.click_link_to_reset_password')
-        %p.fr-callout__text
-          = t('views.users.shared.email_can_take_a_while_html')
-
-      %h2= t('views.users.passwords.reset_link_sent.no_mail')
-      %ol
-        %li
-          = t('views.users.passwords.reset_link_sent.check_spams')
-        %li
-          = t('views.users.passwords.reset_link_sent.check_account', email: @email, application_name: Current.application_name)
-        - if FranceConnectService.enabled?
-          %li
-            = t('views.users.passwords.reset_link_sent.check_france_connect_html', href: france_connect_particulier_path)
-        %li
-          = t('views.users.passwords.reset_link_sent.check_gpdr')
-      %p
-        = t('views.users.shared.contact_us_if_any_trouble_html', href: contact_url)
+      = render Dsfr::AlertComponent.new(title: t('views.users.passwords.reset_link_sent.no_mail'), state: '', extra_class_names: 'fr-alert--info' ) do |c|
+        - c.with_body do
+          %ol
+            %li
+              = t('views.users.shared.email_can_take_a_while_html')
+            %li
+              = t('views.users.passwords.reset_link_sent.check_spams')
+            %li
+              = t('views.users.passwords.reset_link_sent.check_account', email: @email, application_name: Current.application_name)
+            - if FranceConnectService.enabled?
+              %li
+                = t('views.users.passwords.reset_link_sent.check_france_connect_html', href: france_connect_particulier_path)
+            %li
+              = t('views.users.passwords.reset_link_sent.check_gpdr')
+          %p
+            = t('views.users.shared.contact_us_if_any_trouble_html', href: contact_url)

--- a/app/views/users/passwords/reset_link_sent.html.haml
+++ b/app/views/users/passwords/reset_link_sent.html.haml
@@ -17,7 +17,7 @@
             %li
               = t('views.users.passwords.reset_link_sent.check_spams')
             %li
-              = t('views.users.passwords.reset_link_sent.check_account', email: @email, application_name: Current.application_name)
+              = t('views.users.passwords.reset_link_sent.check_account_html', email: @email, application_name: Current.application_name)
             - if FranceConnectService.enabled?
               %li
                 = t('views.users.passwords.reset_link_sent.check_france_connect_html', href: france_connect_particulier_path)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -577,7 +577,7 @@ en:
           email_sent_html: "If an account exists with the address <strong>%{email}</strong>, we have sent you an email."
           no_mail: Didn't receive the email?
           check_spams: Check your junk or spam email.
-          check_account: Have you created a %{application_name} account with the adress %{email}? You will not receive any message if no account is linked to your email adress.
+          check_account_html: Have you created a <strong> %{application_name} </strong>account with the adress <strong> %{email}</strong>? You will not receive any message if no account is linked to your email adress.
           check_france_connect_html: Have you once logged in with France Connect? If yes, <a href=\"%{href}\">try again with France Connect</a>.
           check_gpdr: "The account may have been deleted in the event of prolonged inactivity and no current file. In this case you will have to recreate an account from a procedure."
           title: "Password reset link sent"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -574,15 +574,13 @@ en:
           submit: Change password
           submit_loading: Sending…
         reset_link_sent:
-          got_it: Got it!
-          open_your_mailbox: Now open your mailbox.
-          email_sent_html: "If a <strong>%{application_name}</strong> account exists with the address <strong>%{email}</strong>, we have sent you an email."
-          click_link_to_reset_password: Click on the link in the email to change your password.
+          email_sent_html: "If an account exists with the address <strong>%{email}</strong>, we have sent you an email."
           no_mail: Didn't receive the email?
           check_spams: Check your junk or spam email.
           check_account: Have you created a %{application_name} account with the adress %{email}? You will not receive any message if no account is linked to your email adress.
           check_france_connect_html: Have you once logged in with France Connect? If yes, <a href=\"%{href}\">try again with France Connect</a>.
           check_gpdr: "The account may have been deleted in the event of prolonged inactivity and no current file. In this case you will have to recreate an account from a procedure."
+          title: "Password reset link sent"
       shared:
         email_can_take_a_while_html: <strong>Please note</strong> that this email can take up to 15 minutes to arrive.
         contact_us_if_any_trouble_html: 'You can contact us <a href="%{href}">through this form</a> if a problem still exists.'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -577,15 +577,12 @@ fr:
           submit: Changer le mot de passe
           submit_loading: Envoi…
         reset_link_sent:
-          email_sent_html: "Si un compte <strong>%{application_name}</strong> existe avec l’adresse <strong>%{email}</strong>, nous vous avons envoyé un email."
-          click_link_to_reset_password: "Cliquez sur le lien contenu dans l’email pour changer votre mot de passe."
+          email_sent_html: "Si un compte existe avec l’adresse <strong>%{email}</strong>, nous vous avons envoyé un email pour réinitialiser votre mot de passe."
           no_mail: "Vous n’avez pas reçu l’email ?"
           check_spams: "Vérifiez la boite Indésirables ou Spam de votre boite email."
           check_account: "Avez-vous bien créé un compte %{application_name} avec l’adresse %{email} ? Si aucun compte n’existe avec cette adresse, vous ne recevrez pas de message."
           check_france_connect_html: "Vous êtes-vous connecté avec France Connect par le passé ? Dans ce cas <a href=\"%{href}\">essayez à nouveau avec France Connect</a>."
           check_gpdr: "Le compte a pu être supprimé en cas d’inactivité prolongée et sans dossier en cours. Dans ce cas vous devrez recréer un compte à partir d’une démarche."
-          got_it: "Bien reçu !"
-          open_your_mailbox: "Maintenant ouvrez votre boite email."
           title: "Lien de réinitialisation du mot de passe envoyé"
       shared:
         email_can_take_a_while_html: "<strong>Attention</strong>, ce courriel peut mettre jusqu’à <strong>15 minutes</strong> pour arriver."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -580,7 +580,7 @@ fr:
           email_sent_html: "Si un compte existe avec l’adresse <strong>%{email}</strong>, nous vous avons envoyé un email pour réinitialiser votre mot de passe."
           no_mail: "Vous n’avez pas reçu l’email ?"
           check_spams: "Vérifiez la boite Indésirables ou Spam de votre boite email."
-          check_account: "Avez-vous bien créé un compte %{application_name} avec l’adresse %{email} ? Si aucun compte n’existe avec cette adresse, vous ne recevrez pas de message."
+          check_account_html: "Avez-vous bien créé un compte <strong>%{application_name}</strong> avec l’adresse <strong>%{email}</strong> ? Si aucun compte n’existe avec cette adresse, vous ne recevrez pas de message."
           check_france_connect_html: "Vous êtes-vous connecté avec France Connect par le passé ? Dans ce cas <a href=\"%{href}\">essayez à nouveau avec France Connect</a>."
           check_gpdr: "Le compte a pu être supprimé en cas d’inactivité prolongée et sans dossier en cours. Dans ce cas vous devrez recréer un compte à partir d’une démarche."
           title: "Lien de réinitialisation du mot de passe envoyé"


### PR DESCRIPTION
suite à [ce message sur Mattermost](https://mattermost.incubateur.net/betagouv/pl/fbitbtodspg9uk96a4ercsjjkr
/Users/lisadurand/code/demarches-simplifiees.fr/app/views/users/passwords/reset_link_sent.html.haml
) 

> Comment éviter que des personnes nous envoie une question au support lors d'une demande de modification d'un mot de passe alors qu'ils n'ont pas de compte

On ne peut malheureusement pas indiquer directement si la personne a un compte ou non pour ne pas créer une faille de sécurité - mais on a essayé d'etre plus clair sur le wording.


**APRES**
<img width="1216" alt="Capture d’écran 2024-09-11 à 11 38 35" src="https://github.com/user-attachments/assets/18242f02-8019-4628-a729-dd66b06ffcf2">


**AVANT** 
<img width="922" alt="Capture d’écran 2024-09-11 à 11 02 34" src="https://github.com/user-attachments/assets/0219d15b-3194-4dfa-b832-edfe449e1251">
