### PR TITLE
Technique: nettoyage des options ignorées des types de champ drop_down_list

### DIFF
--- a/lib/tasks/deployment/20240912091625_clean_drop_down_options.rake
+++ b/lib/tasks/deployment/20240912091625_clean_drop_down_options.rake
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+namespace :after_party do
+  desc 'Deployment task: clean_drop_down_options'
+  task clean_drop_down_options: :environment do
+    puts "Running deploy task 'clean_drop_down_options'"
+
+    ids = TypeDeChamp
+      .where(type_champ: ['drop_down_list', 'multiple_drop_down_list'])
+      .where("EXISTS ( select 1 FROM jsonb_array_elements_text(options->'drop_down_options') AS element WHERE element ~ '^--.*--$')").ids
+
+    progress = ProgressReport.new(ids.count)
+
+    TypeDeChamp.where(id: ids).find_each do |type_de_champ|
+      type_de_champ.drop_down_options = type_de_champ.drop_down_options.reject { |option| option.match?(/^--.*--$/) }
+      type_de_champ.save!(validate: false)
+
+      progress.inc
+    end
+
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/lib/tasks/deployment/20240912091625_clean_drop_down_options.rake_spec.rb
+++ b/spec/lib/tasks/deployment/20240912091625_clean_drop_down_options.rake_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+describe '20240912091625_clean_drop_down_options.rake' do
+  let(:rake_task) { Rake::Task['after_party:clean_drop_down_options'] }
+
+  let!(:dashed_drop_down_list) do
+    drop_down_list_value = ['1', '-- nop --', '2'].join("\r\n")
+    create(:type_de_champ_drop_down_list, drop_down_list_value:)
+  end
+
+  let!(:witness_drop_down_list) do
+    drop_down_list_value = ['1', 'hi', '2'].join("\r\n")
+    create(:type_de_champ_drop_down_list, drop_down_list_value:)
+  end
+
+  let!(:multiple_drop_down_list) do
+    drop_down_list_value = ['1', '-- nop --', '2'].join("\r\n")
+    create(:type_de_champ_multiple_drop_down_list, drop_down_list_value:)
+  end
+
+  before do
+    rake_task.invoke
+
+    [dashed_drop_down_list, witness_drop_down_list, multiple_drop_down_list].each(&:reload)
+  end
+
+  after { rake_task.reenable }
+
+  it 'removes the hidden options' do
+    expect(dashed_drop_down_list.drop_down_list_value).to eq(['1', '2'].join("\r\n"))
+    expect(witness_drop_down_list.drop_down_list_value).to eq(['1', 'hi', '2'].join("\r\n"))
+    expect(multiple_drop_down_list.drop_down_list_value).to eq(['1', '2'].join("\r\n"))
+  end
+end


### PR DESCRIPTION
Le code concernant les liste déroulantes est devenu compliqué au fil des années.

Par exemple, la logique concernant les options désactivées est aujourd'hui périmée : nous n'affichons plus les options de la forme `-- * --`.

En supprimant directement les options concernées, on pourra supprimer la méthode `drop_down_list_disabled_options` réalisant le filtrage.