### PR TITLE
Tech: suppression de l'attribut maintenant obsolète `virtual` des données des procédures présentations 

### DIFF
--- a/lib/tasks/deployment/20240912151317_clean_virtual_column_from_procedure_presentation.rake
+++ b/lib/tasks/deployment/20240912151317_clean_virtual_column_from_procedure_presentation.rake
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+namespace :after_party do
+  desc 'Deployment task: clean_virtual_column_from_procedure_presentation'
+  task clean_virtual_column_from_procedure_presentation: :environment do
+    ids = ProcedurePresentation.where("jsonb_typeof(displayed_fields) = 'array' AND EXISTS ( select 1 from jsonb_array_elements(displayed_fields) AS element where element ? 'virtual')").ids
+
+    progress = ProgressReport.new(ids.count)
+
+    ProcedurePresentation.where(id: ids).find_each do |procedure_presentation|
+      procedure_presentation.displayed_fields = procedure_presentation.displayed_fields.map do |field|
+        field.except('virtual')
+      end
+      procedure_presentation.save!(validate: false)
+
+      progress.inc
+    end
+
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/lib/tasks/deployment/20240912151317_clean_virtual_column_from_procedure_presentation.rake_spec.rb
+++ b/spec/lib/tasks/deployment/20240912151317_clean_virtual_column_from_procedure_presentation.rake_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+describe '20240912151317_clean_virtual_column_from_procedure_presentation.rake' do
+  let(:rake_task) { Rake::Task['after_party:clean_virtual_column_from_procedure_presentation'] }
+
+  let(:procedure) { create(:procedure) }
+  let(:instructeur) { create(:instructeur) }
+  let(:assign_to) { create(:assign_to, procedure:, instructeur:) }
+
+  let!(:procedure_presentation) do
+    displayed_fields = [{ label: "test1", table: "user", column: "email", virtual: true }]
+
+    create(:procedure_presentation, assign_to:, displayed_fields:)
+  end
+
+  before do
+    rake_task.invoke
+
+    procedure_presentation.reload
+  end
+
+  after { rake_task.reenable }
+
+  it 'removes the virtual field' do
+    expect(procedure_presentation.displayed_fields).to eq([{ "column" => "email", "label" => "test1", "table" => "user" }])
+  end
+end


### PR DESCRIPTION
fait suite à #10735 