### PR TITLE
Opendata : fichier de stats sur les personnes morales

### DIFF
--- a/app/jobs/cron/datagouv/procedure_per_legal_entity_by_month_job.rb
+++ b/app/jobs/cron/datagouv/procedure_per_legal_entity_by_month_job.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class Cron::Datagouv::ProcedurePerLegalEntityByMonthJob < Cron::CronJob
+  include DatagouvCronSchedulableConcern
+  self.schedule_expression = "every month at 3:50"
+  FILE_NAME = "procedure_effectuees_par_personne_morale_par_mois"
+  HEADERS = ["mois", "siret", "procedure_id"]
+
+  def perform(*args)
+    GenerateOpenDataCsvService.save_csv_to_tmp(FILE_NAME, HEADERS, data) do |file|
+      begin
+        APIDatagouv::API.upload(file, :statistics_dataset)
+      ensure
+        FileUtils.rm(file)
+      end
+    end
+  end
+
+  def data
+    # possible adjustment: procedure with at least 300 folders
+    Etablissement
+      .joins('INNER JOIN dossiers ON etablissements.dossier_id = dossiers.id')
+      .merge(Dossier.visible_by_user_or_administration.where(depose_at: 1.month.ago.all_month))
+      .joins('INNER JOIN procedures ON dossiers.revision_id = procedures.published_revision_id')
+      .merge(Procedure.where(estimated_dossiers_count: 300.., opendata: true, for_individual: false))
+      .order('procedures.id')
+      .pluck('procedures.id', 'etablissements.siret', 'dossiers.depose_at')
+  end
+end

--- a/spec/jobs/cron/datagouv/procedure_per_legal_entity_by_month_job_spec.rb
+++ b/spec/jobs/cron/datagouv/procedure_per_legal_entity_by_month_job_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+RSpec.describe Cron::Datagouv::ProcedurePerLegalEntityByMonthJob, type: :job do
+  let(:status) { 200 }
+  let(:body) { "ok" }
+  let(:stub) { stub_request(:post, /https:\/\/www.data.gouv.fr\/api\/.*\/upload\//) }
+
+  describe '#perform' do
+    before do
+      stub
+    end
+
+    subject { Cron::Datagouv::ProcedurePerLegalEntityByMonthJob.perform_now }
+
+    it 'send POST request to datagouv' do
+      subject
+      expect(stub).to have_been_requested
+    end
+  end
+
+  describe '#data' do
+    let!(:procedure) { create(:procedure, :published, for_individual: false, estimated_dossiers_count: 300, opendata: true) }
+    let!(:dossier) { create(:dossier, depose_at: 1.month.ago, procedure:) }
+    let!(:etablissement) { create(:etablissement, dossier:) }
+
+    subject { Cron::Datagouv::ProcedurePerLegalEntityByMonthJob.new.data }
+
+    context 'when all conditions are met' do
+      it 'returns the correct data and structure' do
+        expect(subject).to match_array(
+          [[procedure.id, etablissement.siret, dossier.depose_at]]
+        )
+      end
+    end
+
+    context 'when the procedure is for individual' do
+      before do
+        procedure.update(for_individual: true)
+      end
+
+      it 'does not include the procedure' do
+        expect(subject).to be_empty
+      end
+    end
+
+    context 'when the procedure is not opendata' do
+      before do
+        procedure.update(opendata: false)
+      end
+
+      it 'does not include the procedure' do
+        expect(subject).to be_empty
+      end
+    end
+
+    context 'when the procedure has insufficient number of dossiers' do
+      before do
+        procedure.update(estimated_dossiers_count: 299)
+      end
+
+      it 'does not include the procedure' do
+        expect(subject).to be_empty
+      end
+    end
+
+    context 'when the procedure has several revisions' do
+      before do
+        procedure.publish_revision!
+      end
+
+      it 'only considers the published revision' do
+        expect(subject).to be_empty
+      end
+    end
+
+    context 'when the file has not been deposed during the previous month' do
+      it 'does not include the file' do
+        dossier.update(depose_at: Date.current.beginning_of_month.to_time)
+        expect(subject).to be_empty
+        dossier.update(depose_at: 2.months.ago)
+        expect(subject).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
En lien avec l'issue : https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/10615

Il s'agit là du jdd autour des "démarches réalisées par les personnes morales".

Ceci viendrait enrichir le jdd data.gouv "utilisation du service", avec donc chaque mois les données suivantes :

siret
id procedure
date de dépôt

A définir : l'horaire du job