### PR TITLE
Correctif: ETQ usager/instructeur, je souhaite pouvoir visualiser les dossiers ayant un champ fondation dont celle ci a ete supprimé du registre

### DIFF
--- a/app/tasks/maintenance/populate_rnf_json_value_task.rb
+++ b/app/tasks/maintenance/populate_rnf_json_value_task.rb
@@ -9,7 +9,7 @@ module Maintenance
     include Dry::Monads[:result]
 
     def collection
-      Champs::RNFChamp.where(value_json: nil)
+      Champs::RNFChamp.where("external_id != null and data != null") # had been found
       # Collection to be iterated over
       # Must be Active Record Relation or Array
     end
@@ -23,8 +23,9 @@ module Maintenance
         rescue ActiveRecord::RecordInvalid
           # some champ might have dossier nil
         end
-      else
-        # not found
+      else # fondation was removed, but we kept API data in data:, use it to restore stuff
+
+        champ.update_with_external_data!(data: champ.data.with_indifferent_access)
       end
     end
 

--- a/spec/tasks/maintenance/populate_rnf_json_value_task_spec.rb
+++ b/spec/tasks/maintenance/populate_rnf_json_value_task_spec.rb
@@ -46,25 +46,51 @@ module Maintenance
 
       subject(:process) { described_class.process(element) }
 
-      before do
-        allow_any_instance_of(Champs::RNFChamp).to receive(:fetch_external_data).and_return(Success(data))
+      context 'when api respond ok' do
+        before do
+          allow_any_instance_of(Champs::RNFChamp).to receive(:fetch_external_data).and_return(Success(data))
+        end
+
+        it 'updates value_json' do
+          expect { subject }.to change { element.reload.value_json }
+            .from(nil)
+            .to({
+              "street_number" => "16",
+              "street_name" => "Rue du Général de Boissieu",
+              "street_address" => "16 Rue du Général de Boissieu",
+              "postal_code" => "75015",
+              "city_name" => "Paris 15e Arrondissement",
+              "city_code" => "75115",
+              "departement_code" => "75",
+              "departement_name" => "Paris",
+              "region_code" => "11",
+              "region_name" => "Île-de-France"
+            })
+        end
       end
 
-      it 'updates value_json' do
-        expect { subject }.to change { element.reload.value_json }
-          .from(nil)
-          .to({
-            "street_number" => "16",
-            "street_name" => "Rue du Général de Boissieu",
-            "street_address" => "16 Rue du Général de Boissieu",
-            "postal_code" => "75015",
-            "city_name" => "Paris 15e Arrondissement",
-            "city_code" => "75115",
-            "departement_code" => "75",
-            "departement_name" => "Paris",
-            "region_code" => "11",
-            "region_name" => "Île-de-France"
-          })
+      context 'when api respond KO' do
+        before do
+          element.update(data:)
+          allow_any_instance_of(Champs::RNFChamp).to receive(:fetch_external_data).and_return(Failure(code: 404, reason: :removed))
+        end
+
+        it 'updates value_json' do
+          expect { subject }.to change { element.reload.value_json }
+            .from(nil)
+            .to({
+              "street_number" => "16",
+              "street_name" => "Rue du Général de Boissieu",
+              "street_address" => "16 Rue du Général de Boissieu",
+              "postal_code" => "75015",
+              "city_name" => "Paris 15e Arrondissement",
+              "city_code" => "75115",
+              "departement_code" => "75",
+              "departement_name" => "Paris",
+              "region_code" => "11",
+              "region_name" => "Île-de-France"
+            })
+        end
       end
     end
   end


### PR DESCRIPTION
sentry: https://demarches-simplifiees.sentry.io/issues/5824823351/events/094b306f25704716b1e2caa638554893/?project=1429550&query=&referrer=previous-event&statsPeriod=14d&stream_index=12
hs: https://secure.helpscout.net/conversation/2705560785/2094541?folderId=1653799

## Problème
On a des champs RNF qui pointent vers des fondations qu'on arrive pas a retrouver via l'api. ex:

```ruby
Champ.find(787697362).external_id # 077-FE-00001-04
Champ.find(842945837).external_id #  034-FE-00001-01
```
(rappel, l'`champs.external_id` etait utilisé pr requeter les fondations, donc on a trouvé les fondations a une epoque, mais la on retrouve pas)

## Solution

on stockait le resultat de la payload dans `champs.data`. Plutot que de re-requeter, on re-utilise la data
