### PR TITLE
Opendata: fichier de stats sur les services

### DIFF
--- a/app/jobs/cron/datagouv/procedure_service_instructeur_expert_by_month_job.rb
+++ b/app/jobs/cron/datagouv/procedure_service_instructeur_expert_by_month_job.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class Cron::Datagouv::ProcedureServiceInstructeurExpertByMonthJob < Cron::CronJob
+  include DatagouvCronSchedulableConcern
+  self.schedule_expression = "every month at 3:40"
+  FILE_NAME = "procedure_service_instructeur_expert"
+  HEADERS = ["mois", "procedure_id", "service_siret", "service_adresse", "nb_groupe_instructeur", "nb_instructeur", "nb_expert"]
+
+  def perform(*args)
+    GenerateOpenDataCsvService.save_csv_to_tmp(FILE_NAME, HEADERS, data) do |file|
+      begin
+        APIDatagouv::API.upload(file, :statistics_dataset)
+      ensure
+        FileUtils.rm(file)
+      end
+    end
+  end
+
+  def data
+    # possible adjustment: procedure with at least 300 folders
+    Procedure.publiee
+      .where(estimated_dossiers_count: 300.., opendata: true)
+      .left_joins([:service, :groupe_instructeurs, :instructeurs, :experts])
+      .group('procedures.id, services.siret')
+      .pluck(
+        'procedures.id',
+        'services.siret',
+        Arel.sql('COUNT(DISTINCT groupe_instructeurs.id)'),
+        Arel.sql('COUNT(DISTINCT instructeurs.id)'),
+        Arel.sql('COUNT(DISTINCT experts.id)')
+      )
+  end
+end

--- a/app/services/serializer_service.rb
+++ b/app/services/serializer_service.rb
@@ -360,7 +360,7 @@ class SerializerService
       tags
       zones
       datePublication
-      service { nom organisme typeOrganisme }
+      service { nom organisme siret typeOrganisme }
       demarcheUrl
       dpoUrl
       noticeUrl

--- a/spec/jobs/cron/datagouv/procedure_service_instructeur_expert_by_month_job_spec.rb
+++ b/spec/jobs/cron/datagouv/procedure_service_instructeur_expert_by_month_job_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+RSpec.describe Cron::Datagouv::ProcedureServiceInstructeurExpertByMonthJob, type: :job do
+  let(:status) { 200 }
+  let(:body) { "ok" }
+  let(:stub) { stub_request(:post, /https:\/\/www.data.gouv.fr\/api\/.*\/upload\//) }
+
+  describe '#perform' do
+    before do
+      stub
+    end
+
+    subject { Cron::Datagouv::ProcedureServiceInstructeurExpertByMonthJob.perform_now }
+
+    it 'send POST request to datagouv' do
+      subject
+      expect(stub).to have_been_requested
+    end
+  end
+
+  describe '#data' do
+    let!(:procedure) { create(:procedure, :published, estimated_dossiers_count: 300, opendata: true, service:) }
+    let!(:service) { create(:service) }
+    let!(:groupe_instructeur) { procedure.defaut_groupe_instructeur }
+    let!(:assign_to) { create(:assign_to, groupe_instructeur:, instructeur:) }
+    let!(:instructeur) { create(:instructeur) }
+    let!(:experts_procedure) { create(:experts_procedure, procedure:, expert:) }
+    let!(:expert) { create(:expert) }
+
+    subject { Cron::Datagouv::ProcedureServiceInstructeurExpertByMonthJob.new.data }
+
+    context 'when all conditions are met' do
+      it 'returns the correct data and structure' do
+        expect(subject).to match_array(
+          [[procedure.id, '35600082800018', 1, 1, 1]]
+        )
+      end
+    end
+
+    context 'when the procedure is not opendata' do
+      before do
+        procedure.update(opendata: false)
+      end
+
+      it 'does not include the procedure' do
+        expect(subject).to be_empty
+      end
+    end
+
+    context 'when the procedure has insufficient number of dossiers' do
+      before do
+        procedure.update(estimated_dossiers_count: 299)
+      end
+
+      it 'does not include the procedure' do
+        expect(subject).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
En lien avec l'issue : https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/10615

Il s'agit là du jdd autour des "services".

Ceci viendrait enrichir le jdd data.gouv "utilisation du service", avec donc chaque mois les données suivantes :

id procédure (dont la dernière révision a été publiée le mois dernier)
siret du service
nb groupes d'instructeurs
nb d'instructeurs
nb experts

A définir : l'horaire du job

Autre point, afin de faciliter les jointures avec le fichier existant "Descriptif des démarches", je propose d'ajouter l'info SIRET sur celui-ci