### PR TITLE
ETQ usager, pas d'erreur sur la page stats quand je viens de la page commencer (à cause de la navbar)

### DIFF
--- a/app/controllers/concerns/nav_bar_profile_concern.rb
+++ b/app/controllers/concerns/nav_bar_profile_concern.rb
@@ -16,6 +16,12 @@ module NavBarProfileConcern
 
     private
 
+    def nav_bar_user_or_guest
+      # when instanciating manually the controller (see below),
+      # we don't have request and current_user would fail
+      request && current_user ? :user : :guest
+    end
+
     # Shared controllers (search, errors, release notes…) don't have specific context
     # Simple attempt to try to re-use the profile from the previous page
     # so user does'not feel lost.

--- a/app/controllers/concerns/nav_bar_profile_concern.rb
+++ b/app/controllers/concerns/nav_bar_profile_concern.rb
@@ -34,6 +34,10 @@ module NavBarProfileConcern
 
       controller_instance = controller_class.new
       controller_instance.try(:nav_bar_profile)
+    rescue StandardError => e # we don't want broken logic in nav bar profile to fail the request
+      Sentry.capture_exception(e)
+
+      nil
     end
 
     # Fallback for shared controllers from user account

--- a/app/controllers/users/commencer_controller.rb
+++ b/app/controllers/users/commencer_controller.rb
@@ -87,9 +87,7 @@ module Users
       retrieve_procedure
     end
 
-    def nav_bar_profile
-      current_user ? :user : :guest
-    end
+    def nav_bar_profile = nav_bar_user_or_guest
 
     def closing_details
       @procedure = Procedure.find_by(path: params[:path])

--- a/app/controllers/users/statistiques_controller.rb
+++ b/app/controllers/users/statistiques_controller.rb
@@ -2,6 +2,8 @@
 
 module Users
   class StatistiquesController < ApplicationController
+    def nav_bar_profile = nav_bar_user_or_guest
+
     def statistiques
       @procedure = procedure
       return procedure_not_found if @procedure.blank? || @procedure.brouillon?


### PR DESCRIPTION
Fix https://demarches-simplifiees.sentry.io/issues/5862238397/events/2179d86f7c5348f2b20ab2c919e4a004/?project=1429550


Double correctif : 
- quand on fallback sur le contexte du referrer de la page Commencer, on n'a pas de request donc l'appel à current_user échouerait
- défini la vraie logique de navbar pour la page statistiques d'une démarche (qui est la même que la page commencer : usager ou anonyme, elles n'héritent pas de UsersController)

Et on rescue au cas où le fallback car c'est du code pas très joli-joli  et qu'on veut pas faire échouer la page à cause de ça
