### PR TITLE
ETQ admin, créé les balises "date de mise à jour" du dossier et "date prévisionnelle SVA/SVR"

### DIFF
--- a/app/models/concerns/mail_template_concern.rb
+++ b/app/models/concerns/mail_template_concern.rb
@@ -50,6 +50,6 @@ module MailTemplateConcern
   end
 
   def dossier_tags
-    TagsSubstitutionConcern::DOSSIER_TAGS + TagsSubstitutionConcern::DOSSIER_TAGS_FOR_MAIL
+    super + TagsSubstitutionConcern::DOSSIER_TAGS_FOR_MAIL
   end
 end

--- a/app/models/concerns/tags_substitution_concern.rb
+++ b/app/models/concerns/tags_substitution_concern.rb
@@ -103,6 +103,13 @@ module TagsSubstitutionConcern
       available_for_states: Dossier::TERMINE
     },
     {
+      id: 'dossier_last_champ_updated_at',
+      libelle: 'date de mise à jour',
+      description: 'Date de dernière mise à jour d’un champ du dossier',
+      lambda: -> (d) { format_date(d.last_champ_updated_at) },
+      available_for_states: Dossier::SOUMIS
+    },
+    {
       id: 'dossier_procedure_libelle',
       libelle: 'libellé démarche',
       description: '',

--- a/app/models/concerns/tags_substitution_concern.rb
+++ b/app/models/concerns/tags_substitution_concern.rb
@@ -158,6 +158,14 @@ module TagsSubstitutionConcern
     }
   ]
 
+  DOSSIER_SVA_SVR_DECISION_DATE_TAG = {
+    id: 'dossier_sva_svr_decision_on',
+    libelle: 'date prévisionnelle SVA/SVR',
+    description: 'Date prévisionnelle de décision automatique par le SVA/SVR',
+    lambda: -> (d) { format_date(d.sva_svr_decision_on) },
+    available_for_states: Dossier.states.fetch(:en_instruction)
+  }
+
   INDIVIDUAL_TAGS = [
     {
       id: 'individual_gender',
@@ -335,7 +343,13 @@ module TagsSubstitutionConcern
 
   def dossier_tags
     # Overridden by MailTemplateConcern
-    DOSSIER_TAGS
+    DOSSIER_TAGS + contextual_dossier_tags
+  end
+
+  def contextual_dossier_tags
+    tags = []
+    tags << DOSSIER_SVA_SVR_DECISION_DATE_TAG if respond_to?(:procedure) && procedure.sva_svr_enabled?
+    tags
   end
 
   def tags_for_dossier_state(tags)

--- a/spec/models/concerns/mail_template_concern_spec.rb
+++ b/spec/models/concerns/mail_template_concern_spec.rb
@@ -141,6 +141,14 @@ describe MailTemplateConcern do
       let(:mail) { create(:without_continuation_mail, procedure: procedure) }
       it_behaves_like 'inserting the --lien document justificatif-- tag'
     end
+
+    context 'sva/svr' do
+      let(:procedure) { create(:procedure, :sva) }
+      let(:received_mail) { create(:received_mail, procedure:) }
+      it "treats date de passage en instruction as a tag" do
+        expect(received_mail.tags).to include(include({ libelle: 'date prévisionnelle SVA/SVR' }))
+      end
+    end
   end
 
   describe '#replace_tags' do

--- a/spec/models/concerns/tags_substitution_concern_spec.rb
+++ b/spec/models/concerns/tags_substitution_concern_spec.rb
@@ -413,6 +413,20 @@ describe TagsSubstitutionConcern, type: :model do
       end
     end
 
+    context "with date decision sva/svr" do
+      let(:template) { '--date prévisionnelle SVA/SVR--' }
+      let(:procedure) { create(:procedure, :published, :sva) }
+      let(:state) { dossier.state }
+
+      before do
+        dossier.passer_en_construction!
+        dossier.process_sva_svr!
+        dossier.update(sva_svr_decision_on: Date.parse("2024-09-20"))
+      end
+
+      it { is_expected.to eq('20/09/2024') }
+    end
+
     context "when the template has a libellé démarche tag" do
       let(:template) { 'body --libellé démarche--' }
 

--- a/spec/models/concerns/tags_substitution_concern_spec.rb
+++ b/spec/models/concerns/tags_substitution_concern_spec.rb
@@ -375,13 +375,17 @@ describe TagsSubstitutionConcern, type: :model do
 
     context "when using a date tag" do
       before do
-        Timecop.freeze(Time.zone.local(2001, 2, 3))
+        travel_to Time.zone.local(2001, 2, 3)
         dossier.passer_en_construction!
-        Timecop.freeze(Time.zone.local(2004, 5, 6))
+
+        travel_to Time.zone.local(2003, 1, 3)
+        dossier.touch(:last_champ_updated_at)
+
+        travel_to Time.zone.local(2004, 5, 6)
         dossier.passer_en_instruction!(instructeur: instructeur)
-        Timecop.freeze(Time.zone.local(2007, 8, 9))
+
+        travel_to Time.zone.local(2007, 8, 9)
         dossier.accepter!(instructeur: instructeur)
-        Timecop.return
       end
 
       context "with date de dépôt" do
@@ -400,6 +404,12 @@ describe TagsSubstitutionConcern, type: :model do
         let(:template) { '--date de décision--' }
 
         it { is_expected.to eq('09/08/2007') }
+      end
+
+      context "with date last ,champ updated at" do
+        let(:template) { '--date de mise à jour--' }
+
+        it { is_expected.to eq('03/01/2003') }
       end
     end
 

--- a/spec/models/export_template_spec.rb
+++ b/spec/models/export_template_spec.rb
@@ -67,24 +67,30 @@ describe ExportTemplate do
     context 'for entreprise procedure' do
       let(:for_individual) { false }
       let(:expected_tags) do
-        ['entreprise_siren', 'entreprise_numero_tva_intracommunautaire', 'entreprise_siret_siege_social', 'entreprise_raison_sociale', 'entreprise_adresse', 'dossier_depose_at', 'dossier_procedure_libelle', 'dossier_service_name', 'dossier_number', 'dossier_groupe_instructeur']
+        [
+          'entreprise_siren', 'entreprise_numero_tva_intracommunautaire', 'entreprise_siret_siege_social', 'entreprise_raison_sociale', 'entreprise_adresse',
+          'dossier_depose_at', 'dossier_procedure_libelle', 'dossier_service_name', 'dossier_number', 'dossier_groupe_instructeur', 'dossier_last_champ_updated_at'
+        ]
       end
 
       it do
-        expect(export_template.tags.map { _1[:id] }).to eq(expected_tags)
-        expect(export_template.pj_tags.map { _1[:id] }).to eq(expected_tags + ['original-filename'])
+        expect(export_template.tags.map { _1[:id] }).to match_array(expected_tags)
+        expect(export_template.pj_tags.map { _1[:id] }).to match_array(expected_tags + ['original-filename'])
       end
     end
 
     context 'for individual procedure' do
       let(:for_individual) { true }
       let(:expected_tags) do
-        ['individual_gender', 'individual_last_name', 'individual_first_name', 'dossier_depose_at', 'dossier_procedure_libelle', 'dossier_service_name', 'dossier_number', 'dossier_groupe_instructeur']
+        [
+          'individual_gender', 'individual_last_name', 'individual_first_name',
+          'dossier_depose_at', 'dossier_procedure_libelle', 'dossier_service_name', 'dossier_number', 'dossier_groupe_instructeur', 'dossier_last_champ_updated_at'
+        ]
       end
 
       it do
-        expect(export_template.tags.map { _1[:id] }).to eq(expected_tags)
-        expect(export_template.pj_tags.map { _1[:id] }).to eq(expected_tags + ['original-filename'])
+        expect(export_template.tags.map { _1[:id] }).to match_array(expected_tags)
+        expect(export_template.pj_tags.map { _1[:id] }).to match_array(expected_tags + ['original-filename'])
       end
     end
   end


### PR DESCRIPTION
- la balise `date de mise à jour` du dossier est toujours disponible
- la balise `date prévisionnelle SVA/SVR` n'est disponible que pour les modèles d'emails d'un dossier qui n'est pas encore traité, (sauf accusé de réception, car la date n'est pas encore définie)

Closes #9825 
Closes #10033 