### PR TITLE
[Tech] Retirer la colonne obsolète 'hidden_at' des dossiers (part 2)

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Dossier < ApplicationRecord
-  self.ignored_columns += [:re_instructed_at, :search_terms, :private_search_terms, :hidden_at]
+  self.ignored_columns += [:re_instructed_at, :search_terms, :private_search_terms]
 
   include DossierCloneConcern
   include DossierCorrectableConcern

--- a/db/migrate/20240918132319_remove_hidden_at_column_from_dossiers.rb
+++ b/db/migrate/20240918132319_remove_hidden_at_column_from_dossiers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveHiddenAtColumnFromDossiers < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured { remove_columns :dossiers, :hidden_at }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -483,7 +483,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_19_145757) do
     t.boolean "forced_groupe_instructeur", default: false, null: false
     t.bigint "groupe_instructeur_id"
     t.datetime "groupe_instructeur_updated_at", precision: nil
-    t.datetime "hidden_at", precision: nil
     t.datetime "hidden_by_administration_at", precision: nil
     t.datetime "hidden_by_expired_at"
     t.string "hidden_by_reason"


### PR DESCRIPTION
suite de la PR #10710 
Nettoyage du code pour la colonne hidden_at qui est obsolète. Pr pour supprimer la colonne avec une migration.