### PR TITLE
amelioration ETQ tech/ops, on souhaite ne pas avoir d'index non utilisé (et plus maintenu)

### DIFF
--- a/db/migrate/20240919145757_drop_unused_index.rb
+++ b/db/migrate/20240919145757_drop_unused_index.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class DropUnusedIndex < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    remove_index :champs, :type_de_champ_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_09_19_130351) do
+ActiveRecord::Schema[7.0].define(version: 2024_09_19_145757) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_stat_statements"
@@ -275,7 +275,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_19_130351) do
     t.index ["row_id"], name: "index_champs_on_row_id"
     t.index ["stable_id"], name: "index_champs_on_stable_id"
     t.index ["type"], name: "index_champs_on_type"
-    t.index ["type_de_champ_id"], name: "index_champs_on_type_de_champ_id"
   end
 
   create_table "closed_mails", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
Les nouveaux champs ne remplissent plus le type_de_champ_id, on peut supprimer cet index.

```
                table                 |                           index                            | index_size | index_scans 
--------------------------------------+------------------------------------------------------------+------------+-------------
 public.champs                        | index_champs_on_type_de_champ_id                           | 3467 MB    |           0
 ```
