### PR TITLE
amelioration ETQ tech/ops, on souhaite ne pas avoir d'index non utilisé (et plus maintenu) - bis

### DIFF
--- a/app/models/traitement.rb
+++ b/app/models/traitement.rb
@@ -2,7 +2,7 @@
 
 class Traitement < ApplicationRecord
   belongs_to :dossier, optional: false
-
+  self.ignored_columns += [:process_expired, :process_expired_migrated]
   scope :en_construction, -> { where(state: Dossier.states.fetch(:en_construction)) }
   scope :en_instruction, -> { where(state: Dossier.states.fetch(:en_instruction)) }
   scope :termine, -> { where(state: Dossier::TERMINE) }

--- a/db/migrate/20240919151603_drop_dead_indices.rb
+++ b/db/migrate/20240919151603_drop_dead_indices.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class DropDeadIndices < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :traitements, :process_expired
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_09_19_145757) do
+ActiveRecord::Schema[7.0].define(version: 2024_09_19_151603) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_stat_statements"
@@ -1136,7 +1136,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_19_145757) do
     t.datetime "processed_at", precision: nil
     t.string "state"
     t.index ["dossier_id"], name: "index_traitements_on_dossier_id"
-    t.index ["process_expired"], name: "index_traitements_on_process_expired"
   end
 
   create_table "trusted_device_tokens", force: :cascade do |t|

--- a/spec/factories/traitement.rb
+++ b/spec/factories/traitement.rb
@@ -3,7 +3,6 @@
 FactoryBot.define do
   factory :traitement do
     trait :accepte do
-      process_expired { true }
       state { :accepte }
     end
   end


### PR DESCRIPTION
Un autre index qu'on peut dropper

```
                table                 |                           index                            | index_size | index_scans 
--------------------------------------+------------------------------------------------------------+------------+-------------
 public.traitements                   | index_traitements_on_process_expired                       | 152 MB     |           0
```