### PR TITLE
Tech: nettoyage des listes déroulantes seconde partie

### DIFF
--- a/app/components/editable_champ/drop_down_list_component.rb
+++ b/app/components/editable_champ/drop_down_list_component.rb
@@ -31,7 +31,7 @@ class EditableChamp::DropDownListComponent < EditableChamp::EditableChampBaseCom
       class: 'fr-mt-1w',
       name: @form.field_name(:value),
       selected_key: @champ.selected,
-      items: @champ.drop_down_list_enabled_non_empty_options(other: true).map { _1.is_a?(Array) ? _1 : [_1, _1] },
+      items: @champ.drop_down_options_with_other.map { _1.is_a?(Array) ? _1 : [_1, _1] },
       empty_filter_key: @champ.drop_down_other? ? Champs::DropDownListChamp::OTHER : nil,
       'aria-describedby': @champ.describedby_id,
       'aria-labelledby': @champ.labelledby_id)

--- a/app/components/editable_champ/drop_down_list_component.rb
+++ b/app/components/editable_champ/drop_down_list_component.rb
@@ -23,7 +23,7 @@ class EditableChamp::DropDownListComponent < EditableChamp::EditableChampBaseCom
 
   def contains_long_option?
     max_length = 100
-    @champ.drop_down_list_enabled_non_empty_options.any? { _1.size > max_length }
+    @champ.drop_down_options.any? { _1.size > max_length }
   end
 
   def react_props

--- a/app/components/editable_champ/drop_down_list_component.rb
+++ b/app/components/editable_champ/drop_down_list_component.rb
@@ -23,7 +23,7 @@ class EditableChamp::DropDownListComponent < EditableChamp::EditableChampBaseCom
 
   def contains_long_option?
     max_length = 100
-    @champ.enabled_non_empty_options.any? { _1.size > max_length }
+    @champ.drop_down_list_enabled_non_empty_options.any? { _1.size > max_length }
   end
 
   def react_props
@@ -31,7 +31,7 @@ class EditableChamp::DropDownListComponent < EditableChamp::EditableChampBaseCom
       class: 'fr-mt-1w',
       name: @form.field_name(:value),
       selected_key: @champ.selected,
-      items: @champ.enabled_non_empty_options(other: true).map { _1.is_a?(Array) ? _1 : [_1, _1] },
+      items: @champ.drop_down_list_enabled_non_empty_options(other: true).map { _1.is_a?(Array) ? _1 : [_1, _1] },
       empty_filter_key: @champ.drop_down_other? ? Champs::DropDownListChamp::OTHER : nil,
       'aria-describedby': @champ.describedby_id,
       'aria-labelledby': @champ.labelledby_id)

--- a/app/components/editable_champ/drop_down_list_component/drop_down_list_component.html.haml
+++ b/app/components/editable_champ/drop_down_list_component/drop_down_list_component.html.haml
@@ -22,7 +22,7 @@
     = render ReactComponent.new "ComboBox/SingleComboBox", **react_props
 - else
   = @form.select :value,
-    @champ.drop_down_list_enabled_non_empty_options(other: true),
+    @champ.drop_down_options_with_other,
     { selected: @champ.selected, include_blank: true },
     required: @champ.required?,
     id: @champ.input_id,

--- a/app/components/editable_champ/drop_down_list_component/drop_down_list_component.html.haml
+++ b/app/components/editable_champ/drop_down_list_component/drop_down_list_component.html.haml
@@ -1,6 +1,6 @@
 - if @champ.render_as_radios?
   .fr-fieldset__content
-    - @champ.drop_down_list_enabled_non_empty_options.each_with_index do |option, index|
+    - @champ.drop_down_options.each_with_index do |option, index|
       .fr-radio-group
         = @form.radio_button :value, option, id: dom_id(@champ, "radio_option_#{index}")
         %label.fr-label{ for: dom_id(@champ, "radio_option_#{index}") }

--- a/app/components/editable_champ/drop_down_list_component/drop_down_list_component.html.haml
+++ b/app/components/editable_champ/drop_down_list_component/drop_down_list_component.html.haml
@@ -1,6 +1,6 @@
 - if @champ.render_as_radios?
   .fr-fieldset__content
-    - @champ.enabled_non_empty_options.each_with_index do |option, index|
+    - @champ.drop_down_list_enabled_non_empty_options.each_with_index do |option, index|
       .fr-radio-group
         = @form.radio_button :value, option, id: dom_id(@champ, "radio_option_#{index}")
         %label.fr-label{ for: dom_id(@champ, "radio_option_#{index}") }
@@ -22,7 +22,7 @@
     = render ReactComponent.new "ComboBox/SingleComboBox", **react_props
 - else
   = @form.select :value,
-    @champ.enabled_non_empty_options(other: true),
+    @champ.drop_down_list_enabled_non_empty_options(other: true),
     { selected: @champ.selected, include_blank: true },
     required: @champ.required?,
     id: @champ.input_id,

--- a/app/components/editable_champ/multiple_drop_down_list_component.rb
+++ b/app/components/editable_champ/multiple_drop_down_list_component.rb
@@ -16,7 +16,7 @@ class EditableChamp::MultipleDropDownListComponent < EditableChamp::EditableCham
       class: 'fr-mt-1w',
       name: @form.field_name(:value, multiple: true),
       selected_keys: @champ.selected_options,
-      items: @champ.drop_down_list_enabled_non_empty_options,
+      items: @champ.drop_down_options,
       value_separator: false,
       'aria-label': @champ.libelle,
       'aria-describedby': @champ.describedby_id,

--- a/app/components/editable_champ/multiple_drop_down_list_component.rb
+++ b/app/components/editable_champ/multiple_drop_down_list_component.rb
@@ -16,7 +16,7 @@ class EditableChamp::MultipleDropDownListComponent < EditableChamp::EditableCham
       class: 'fr-mt-1w',
       name: @form.field_name(:value, multiple: true),
       selected_keys: @champ.selected_options,
-      items: @champ.enabled_non_empty_options,
+      items: @champ.drop_down_list_enabled_non_empty_options,
       value_separator: false,
       'aria-label': @champ.libelle,
       'aria-describedby': @champ.describedby_id,

--- a/app/components/editable_champ/multiple_drop_down_list_component/multiple_drop_down_list_component.html.haml
+++ b/app/components/editable_champ/multiple_drop_down_list_component/multiple_drop_down_list_component.html.haml
@@ -1,5 +1,5 @@
 - if @champ.render_as_checkboxes?
-  = @form.collection_check_boxes :value, @champ.drop_down_list_enabled_non_empty_options, :to_s, :to_s do |b|
+  = @form.collection_check_boxes :value, @champ.drop_down_options, :to_s, :to_s do |b|
     - capture do
       .fr-fieldset__element
         .fr-checkbox-group

--- a/app/components/editable_champ/multiple_drop_down_list_component/multiple_drop_down_list_component.html.haml
+++ b/app/components/editable_champ/multiple_drop_down_list_component/multiple_drop_down_list_component.html.haml
@@ -1,5 +1,5 @@
 - if @champ.render_as_checkboxes?
-  = @form.collection_check_boxes :value, @champ.enabled_non_empty_options, :to_s, :to_s do |b|
+  = @form.collection_check_boxes :value, @champ.drop_down_list_enabled_non_empty_options, :to_s, :to_s do |b|
     - capture do
       .fr-fieldset__element
         .fr-checkbox-group

--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
@@ -71,12 +71,12 @@
           - if type_de_champ.drop_down_list?
             .flex.column.justify-start.width-33
               .cell
-                = form.label :drop_down_list_value, "Options de la liste", for: dom_id(type_de_champ, :drop_down_list_value)
-                = form.text_area :drop_down_list_value,
+                = form.label :drop_down_options_from_text, "Options de la liste", for: dom_id(type_de_champ, :drop_down_options_from_text)
+                = form.text_area :drop_down_options_from_text,
                   value: type_de_champ.drop_down_options.join("\r\n"),
                   class: 'fr-input small-margin small width-100',
                   rows: 7,
-                  id: dom_id(type_de_champ, :drop_down_list_value)
+                  id: dom_id(type_de_champ, :drop_down_options_from_text)
             - if type_de_champ.simple_drop_down_list?
               .cell
                 = form.label :drop_down_other, for: dom_id(type_de_champ, :drop_down_other) do

--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
@@ -72,7 +72,11 @@
             .flex.column.justify-start.width-33
               .cell
                 = form.label :drop_down_list_value, "Options de la liste", for: dom_id(type_de_champ, :drop_down_list_value)
-                = form.text_area :drop_down_list_value, class: 'fr-input small-margin small width-100', rows: 7, id: dom_id(type_de_champ, :drop_down_list_value)
+                = form.text_area :drop_down_list_value,
+                  value: type_de_champ.drop_down_options.join("\r\n"),
+                  class: 'fr-input small-margin small width-100',
+                  rows: 7,
+                  id: dom_id(type_de_champ, :drop_down_list_value)
             - if type_de_champ.simple_drop_down_list?
               .cell
                 = form.label :drop_down_other, for: dom_id(type_de_champ, :drop_down_other) do

--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -153,7 +153,7 @@ module Administrateurs
         :libelle,
         :description,
         :mandatory,
-        :drop_down_list_value,
+        :drop_down_options_from_text,
         :drop_down_other,
         :drop_down_secondary_libelle,
         :drop_down_secondary_description,

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -53,19 +53,23 @@ class RootController < ApplicationController
               repetition_after_stable_id = repetition_type_de_champ.stable_id
             end
           elsif type_de_champ.linked_drop_down_list?
-            type_de_champ.drop_down_list_value =
-              "-- section 1 --
-              option A
-              option B
-              -- section 2 --
-              option C"
+            type_de_champ.drop_down_options =
+              [
+                "-- section 1 --",
+                "option A",
+                "option B",
+                "-- section 2 --",
+                "option C"
+              ]
             type_de_champ.save
           elsif type_de_champ.drop_down_list?
-            type_de_champ.drop_down_list_value =
-              "option A
-              option B
-              -- avant l'option C --
-              option C"
+            type_de_champ.drop_down_options =
+              [
+                "option A",
+                "option B",
+                "-- avant l'option C --",
+                "option C"
+              ]
             type_de_champ.save
           end
         end

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -31,7 +31,7 @@ class Champ < ApplicationRecord
     :description,
     :drop_down_options,
     :drop_down_other?,
-    :drop_down_list_enabled_non_empty_options,
+    :drop_down_options_with_other,
     :drop_down_secondary_libelle,
     :drop_down_secondary_description,
     :collapsible_explanation_enabled?,

--- a/app/models/champs/drop_down_list_champ.rb
+++ b/app/models/champs/drop_down_list_champ.rb
@@ -9,11 +9,11 @@ class Champs::DropDownListChamp < Champ
   validate :value_is_in_options, if: -> { !(value.blank? || drop_down_other?) && validate_champ_value_or_prefill? }
 
   def render_as_radios?
-    drop_down_list_enabled_non_empty_options.size <= THRESHOLD_NB_OPTIONS_AS_RADIO
+    drop_down_options.size <= THRESHOLD_NB_OPTIONS_AS_RADIO
   end
 
   def render_as_combobox?
-    drop_down_list_enabled_non_empty_options.size >= THRESHOLD_NB_OPTIONS_AS_AUTOCOMPLETE
+    drop_down_options.size >= THRESHOLD_NB_OPTIONS_AS_AUTOCOMPLETE
   end
 
   def html_label?
@@ -29,7 +29,7 @@ class Champs::DropDownListChamp < Champ
   end
 
   def other?
-    drop_down_other? && (other || (value.present? && drop_down_list_enabled_non_empty_options.exclude?(value)))
+    drop_down_other? && (other || (value.present? && drop_down_options.exclude?(value)))
   end
 
   def value=(value)
@@ -67,7 +67,7 @@ class Champs::DropDownListChamp < Champ
   private
 
   def value_is_in_options
-    return if drop_down_list_enabled_non_empty_options.include?(value)
+    return if drop_down_options.include?(value)
 
     errors.add(:value, :not_in_options)
   end

--- a/app/models/champs/drop_down_list_champ.rb
+++ b/app/models/champs/drop_down_list_champ.rb
@@ -9,11 +9,11 @@ class Champs::DropDownListChamp < Champ
   validate :value_is_in_options, if: -> { !(value.blank? || drop_down_other?) && validate_champ_value_or_prefill? }
 
   def render_as_radios?
-    enabled_non_empty_options.size <= THRESHOLD_NB_OPTIONS_AS_RADIO
+    drop_down_list_enabled_non_empty_options.size <= THRESHOLD_NB_OPTIONS_AS_RADIO
   end
 
   def render_as_combobox?
-    enabled_non_empty_options.size >= THRESHOLD_NB_OPTIONS_AS_AUTOCOMPLETE
+    drop_down_list_enabled_non_empty_options.size >= THRESHOLD_NB_OPTIONS_AS_AUTOCOMPLETE
   end
 
   def html_label?
@@ -28,12 +28,8 @@ class Champs::DropDownListChamp < Champ
     other? ? OTHER : value
   end
 
-  def enabled_non_empty_options(other: false)
-    drop_down_list_enabled_non_empty_options(other:)
-  end
-
   def other?
-    drop_down_other? && (other || (value.present? && enabled_non_empty_options.exclude?(value)))
+    drop_down_other? && (other || (value.present? && drop_down_list_enabled_non_empty_options.exclude?(value)))
   end
 
   def value=(value)
@@ -71,7 +67,7 @@ class Champs::DropDownListChamp < Champ
   private
 
   def value_is_in_options
-    return if enabled_non_empty_options.include?(value)
+    return if drop_down_list_enabled_non_empty_options.include?(value)
 
     errors.add(:value, :not_in_options)
   end

--- a/app/models/champs/multiple_drop_down_list_champ.rb
+++ b/app/models/champs/multiple_drop_down_list_champ.rb
@@ -3,10 +3,6 @@
 class Champs::MultipleDropDownListChamp < Champ
   validate :values_are_in_options, if: -> { value.present? && validate_champ_value_or_prefill? }
 
-  def enabled_non_empty_options
-    drop_down_list_enabled_non_empty_options
-  end
-
   THRESHOLD_NB_OPTIONS_AS_CHECKBOX = 5
 
   def search_terms
@@ -18,7 +14,7 @@ class Champs::MultipleDropDownListChamp < Champ
   end
 
   def render_as_checkboxes?
-    enabled_non_empty_options.size <= THRESHOLD_NB_OPTIONS_AS_CHECKBOX
+    drop_down_list_enabled_non_empty_options.size <= THRESHOLD_NB_OPTIONS_AS_CHECKBOX
   end
 
   def html_label?
@@ -51,7 +47,7 @@ class Champs::MultipleDropDownListChamp < Champ
   end
 
   def focusable_input_id
-    render_as_checkboxes? ? checkbox_id(enabled_non_empty_options.first) : input_id
+    render_as_checkboxes? ? checkbox_id(drop_down_list_enabled_non_empty_options.first) : input_id
   end
 
   def checkbox_id(value)
@@ -67,7 +63,7 @@ class Champs::MultipleDropDownListChamp < Champ
   end
 
   def unselected_options
-    enabled_non_empty_options - selected_options
+    drop_down_list_enabled_non_empty_options - selected_options
   end
 
   def value=(value)
@@ -97,7 +93,7 @@ class Champs::MultipleDropDownListChamp < Champ
   def values_are_in_options
     json = selected_options.compact_blank
     return if json.empty?
-    return if (json - enabled_non_empty_options).empty?
+    return if (json - drop_down_list_enabled_non_empty_options).empty?
 
     errors.add(:value, :not_in_options)
   end

--- a/app/models/champs/multiple_drop_down_list_champ.rb
+++ b/app/models/champs/multiple_drop_down_list_champ.rb
@@ -14,7 +14,7 @@ class Champs::MultipleDropDownListChamp < Champ
   end
 
   def render_as_checkboxes?
-    drop_down_list_enabled_non_empty_options.size <= THRESHOLD_NB_OPTIONS_AS_CHECKBOX
+    drop_down_options.size <= THRESHOLD_NB_OPTIONS_AS_CHECKBOX
   end
 
   def html_label?
@@ -47,7 +47,7 @@ class Champs::MultipleDropDownListChamp < Champ
   end
 
   def focusable_input_id
-    render_as_checkboxes? ? checkbox_id(drop_down_list_enabled_non_empty_options.first) : input_id
+    render_as_checkboxes? ? checkbox_id(drop_down_options.first) : input_id
   end
 
   def checkbox_id(value)
@@ -63,7 +63,7 @@ class Champs::MultipleDropDownListChamp < Champ
   end
 
   def unselected_options
-    drop_down_list_enabled_non_empty_options - selected_options
+    drop_down_options - selected_options
   end
 
   def value=(value)
@@ -93,7 +93,7 @@ class Champs::MultipleDropDownListChamp < Champ
   def values_are_in_options
     json = selected_options.compact_blank
     return if json.empty?
-    return if (json - drop_down_list_enabled_non_empty_options).empty?
+    return if (json - drop_down_options).empty?
 
     errors.add(:value, :not_in_options)
   end

--- a/app/models/logic/champ_value.rb
+++ b/app/models/logic/champ_value.rb
@@ -128,7 +128,7 @@ class Logic::ChampValue < Logic::Term
     elsif operator_name.in?([Logic::InDepartementOperator.name, Logic::NotInDepartementOperator.name]) || tdc.type_champ.in?([MANAGED_TYPE_DE_CHAMP.fetch(:communes), MANAGED_TYPE_DE_CHAMP.fetch(:epci), MANAGED_TYPE_DE_CHAMP.fetch(:departements), MANAGED_TYPE_DE_CHAMP.fetch(:address)])
       APIGeoService.departements.map { ["#{_1[:code]} – #{_1[:name]}", _1[:code]] }
     else
-      tdc.drop_down_list_enabled_non_empty_options(other: true).map { _1.is_a?(Array) ? _1 : [_1, _1] }
+      tdc.drop_down_options_with_other.map { _1.is_a?(Array) ? _1 : [_1, _1] }
     end
   end
 

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -490,14 +490,6 @@ class TypeDeChamp < ApplicationRecord
     end
   end
 
-  def drop_down_list_value
-    if drop_down_options.present?
-      drop_down_options.reject(&:empty?).join("\r\n")
-    else
-      ''
-    end
-  end
-
   def drop_down_list_value=(value)
     self.drop_down_options = value.to_s.lines.map(&:strip).reject(&:empty?)
   end

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -778,9 +778,9 @@ class TypeDeChamp < ApplicationRecord
       self.drop_down_options = nil
     elsif !drop_down_options_changed?
       self.drop_down_options = if linked_drop_down_list?
-        ['', '--Fromage--', 'bleu de sassenage', 'picodon', '--Dessert--', 'éclair', 'tarte aux pommes']
+        ['--Fromage--', 'bleu de sassenage', 'picodon', '--Dessert--', 'éclair', 'tarte aux pommes']
       else
-        ['', 'Premier choix', 'Deuxième choix']
+        ['Premier choix', 'Deuxième choix']
       end
     end
   end

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -559,7 +559,7 @@ class TypeDeChamp < ApplicationRecord
       APIGeoService.regions.map { [_1[:name], _1[:code]] }
     elsif choice_type?
       if drop_down_list?
-        drop_down_list_enabled_non_empty_options
+        drop_down_options
       elsif yes_no?
         Champs::YesNoChamp.options
       elsif checkbox?

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -480,16 +480,16 @@ class TypeDeChamp < ApplicationRecord
     Array.wrap(super)
   end
 
+  def drop_down_options_from_text=(text)
+    self.drop_down_options = text.to_s.lines.map(&:strip).reject(&:empty?)
+  end
+
   def drop_down_options_with_other
     if drop_down_other?
       drop_down_options + [[I18n.t('shared.champs.drop_down_list.other'), Champs::DropDownListChamp::OTHER]]
     else
       drop_down_options
     end
-  end
-
-  def drop_down_list_value=(value)
-    self.drop_down_options = value.to_s.lines.map(&:strip).reject(&:empty?)
   end
 
   def header_section_level_value

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -481,12 +481,10 @@ class TypeDeChamp < ApplicationRecord
   end
 
   def drop_down_list_enabled_non_empty_options(other: false)
-    list_options = drop_down_options.reject(&:empty?)
-
     if other && drop_down_other?
-      list_options + [[I18n.t('shared.champs.drop_down_list.other'), Champs::DropDownListChamp::OTHER]]
+      drop_down_options + [[I18n.t('shared.champs.drop_down_list.other'), Champs::DropDownListChamp::OTHER]]
     else
-      list_options
+      drop_down_options
     end
   end
 

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -480,8 +480,8 @@ class TypeDeChamp < ApplicationRecord
     Array.wrap(super)
   end
 
-  def drop_down_list_enabled_non_empty_options(other: false)
-    if other && drop_down_other?
+  def drop_down_options_with_other
+    if drop_down_other?
       drop_down_options + [[I18n.t('shared.champs.drop_down_list.other'), Champs::DropDownListChamp::OTHER]]
     else
       drop_down_options

--- a/app/models/types_de_champ/linked_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/linked_drop_down_list_type_de_champ.rb
@@ -89,9 +89,7 @@ class TypesDeChamp::LinkedDropDownListTypeDeChamp < TypesDeChamp::TypeDeChampBas
   end
 
   def unpack_options
-    chunked = drop_down_options
-      .reject(&:empty?) # TODO: remove after removing empty options
-      .slice_before(PRIMARY_PATTERN)
+    chunked = drop_down_options.slice_before(PRIMARY_PATTERN)
 
     chunked.map do |chunk|
       primary, *secondary = chunk
@@ -101,8 +99,7 @@ class TypesDeChamp::LinkedDropDownListTypeDeChamp < TypesDeChamp::TypeDeChampBas
   end
 
   def check_presence_of_primary_options
-    # TODO: replace by `drop_down_options.first` when the empty options are removed
-    if !PRIMARY_PATTERN.match?(drop_down_options.find(&:present?))
+    if !PRIMARY_PATTERN.match?(drop_down_options.first)
       errors.add(libelle.presence || "La liste", "doit commencer par une entrée de menu primaire de la forme <code style='white-space: pre-wrap;'>--texte--</code>")
     end
   end

--- a/app/models/types_de_champ/prefill_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_drop_down_list_type_de_champ.rb
@@ -3,12 +3,9 @@
 class TypesDeChamp::PrefillDropDownListTypeDeChamp < TypesDeChamp::PrefillTypeDeChamp
   def all_possible_values
     if drop_down_other?
-      drop_down_list_enabled_non_empty_options.insert(
-        0,
-        I18n.t("views.prefill_descriptions.edit.possible_values.drop_down_list_other_html")
-      )
+      [I18n.t("views.prefill_descriptions.edit.possible_values.drop_down_list_other_html")] + drop_down_options
     else
-      drop_down_list_enabled_non_empty_options
+      drop_down_options
     end
   end
 

--- a/app/validators/types_de_champ/no_empty_drop_down_validator.rb
+++ b/app/validators/types_de_champ/no_empty_drop_down_validator.rb
@@ -10,7 +10,7 @@ class TypesDeChamp::NoEmptyDropDownValidator < ActiveModel::EachValidator
   private
 
   def validate_drop_down_not_empty(procedure, attribute, drop_down)
-    if drop_down.drop_down_list_enabled_non_empty_options.empty?
+    if drop_down.drop_down_options.empty?
       procedure.errors.add(
         attribute,
         procedure.errors.generate_message(attribute, :empty_drop_down, { value: drop_down.libelle }),

--- a/app/views/dossiers/dossier_vide.pdf.prawn
+++ b/app/views/dossiers/dossier_vide.pdf.prawn
@@ -163,7 +163,7 @@ def render_single_champ(pdf, revision, type_de_champ)
     add_libelle(pdf, type_de_champ)
     add_optionnal_description(pdf, type_de_champ)
     add_explanation(pdf, 'Cochez la mention applicable, une seule valeur possible')
-    type_de_champ.drop_down_list_enabled_non_empty_options.each do |option|
+    type_de_champ.drop_down_options.each do |option|
       format_with_checkbox(pdf, option)
     end
     pdf.text "\n"
@@ -171,7 +171,7 @@ def render_single_champ(pdf, revision, type_de_champ)
     add_libelle(pdf, type_de_champ)
     add_optionnal_description(pdf, type_de_champ)
     add_explanation(pdf, 'Cochez la mention applicable, plusieurs valeurs possibles')
-    type_de_champ.drop_down_list_enabled_non_empty_options.each do |option|
+    type_de_champ.drop_down_options.each do |option|
       format_with_checkbox(pdf, option)
     end
     pdf.text "\n"

--- a/lib/tasks/deployment/20200618121241_drop_down_list_options_to_json.rake
+++ b/lib/tasks/deployment/20200618121241_drop_down_list_options_to_json.rake
@@ -15,7 +15,7 @@ namespace :after_party do
       progress = ProgressReport.new(types_de_champ.count)
 
       types_de_champ.find_each do |type_de_champ|
-        type_de_champ.drop_down_list_value = type_de_champ.drop_down_list_value
+        type_de_champ.drop_down_options_from_text = type_de_champ.drop_down_list_value
 
         if type_de_champ.save
           type_de_champ.drop_down_list.destroy

--- a/spec/components/previews/types_de_champ_editor/conditions_component_preview.rb
+++ b/spec/components/previews/types_de_champ_editor/conditions_component_preview.rb
@@ -15,7 +15,7 @@ class TypesDeChampEditor::ConditionsComponentPreview < ViewComponent::Preview
   def with_conditions
     surface = TypeDeChamp.create(type_champ: :integer_number, libelle: 'surface')
     appartement = TypeDeChamp.create(type_champ: :yes_no, libelle: 'appartement')
-    type_appartement = TypeDeChamp.create(type_champ: :drop_down_list, libelle: 'type', drop_down_list_value: "T1\r\nT2\r\nT3")
+    type_appartement = TypeDeChamp.create(type_champ: :drop_down_list, libelle: 'type', drop_down_options: ["T1", "T2", "T3"])
     upper_tdcs = [surface, appartement, type_appartement]
 
     condition = ds_and([

--- a/spec/components/procedures/one_group_management_component_spec.rb
+++ b/spec/components/procedures/one_group_management_component_spec.rb
@@ -19,7 +19,7 @@ describe Procedure::OneGroupeManagementComponent, type: :component do
         procedure.draft_revision.add_type_de_champ({
           type_champ: :drop_down_list,
           libelle: 'Votre ville',
-          drop_down_list_value: "Paris\nLyon\nMarseille"
+          drop_down_options: ["Paris", "Lyon", "Marseille"]
         })
         procedure.publish_revision!
         procedure.reload

--- a/spec/components/types_de_champ_editor/conditions_errors_component_spec.rb
+++ b/spec/components/types_de_champ_editor/conditions_errors_component_spec.rb
@@ -77,7 +77,7 @@ describe Conditions::ConditionsErrorsComponent, type: :component do
     context 'when an eq operator applies to a multiple_drop_down' do
       let(:tdc) { create(:type_de_champ_multiple_drop_down_list) }
       let(:source_tdcs) { [tdc] }
-      let(:conditions) { [ds_eq(champ_value(tdc.stable_id), constant(tdc.drop_down_list_enabled_non_empty_options.first))] }
+      let(:conditions) { [ds_eq(champ_value(tdc.stable_id), constant(tdc.drop_down_options.first))] }
 
       it { expect(page).to have_content("« est » ne s'applique pas au choix multiple.") }
     end
@@ -85,7 +85,7 @@ describe Conditions::ConditionsErrorsComponent, type: :component do
     context 'when an not_eq operator applies to a multiple_drop_down' do
       let(:tdc) { create(:type_de_champ_multiple_drop_down_list) }
       let(:source_tdcs) { [tdc] }
-      let(:conditions) { [ds_not_eq(champ_value(tdc.stable_id), constant(tdc.drop_down_list_enabled_non_empty_options.first))] }
+      let(:conditions) { [ds_not_eq(champ_value(tdc.stable_id), constant(tdc.drop_down_options.first))] }
 
       it { expect(page).to have_content("« n’est pas » ne s'applique pas au choix multiple.") }
     end

--- a/spec/factories/dossier.rb
+++ b/spec/factories/dossier.rb
@@ -263,9 +263,9 @@ FactoryBot.define do
         dossier.champs_to_destroy.where(private: false).destroy_all
         dossier.types_de_champ.each do |type_de_champ|
           value = if type_de_champ.simple_drop_down_list?
-            type_de_champ.drop_down_list_enabled_non_empty_options.first
+            type_de_champ.drop_down_options.first
           elsif type_de_champ.multiple_drop_down_list?
-            type_de_champ.drop_down_list_enabled_non_empty_options.first(2).to_json
+            type_de_champ.drop_down_options.first(2).to_json
           end
           attrs = { stable_id: type_de_champ.stable_id, dossier:, value: }.compact
           create(:"champ_do_not_use_#{type_de_champ.type_champ}", **attrs)
@@ -279,9 +279,9 @@ FactoryBot.define do
         dossier.champs_to_destroy.where(private: true).destroy_all
         dossier.types_de_champ_private.each do |type_de_champ|
           value = if type_de_champ.simple_drop_down_list?
-            type_de_champ.drop_down_list_enabled_non_empty_options.first
+            type_de_champ.drop_down_options.first
           elsif type_de_champ.multiple_drop_down_list?
-            type_de_champ.drop_down_list_enabled_non_empty_options.first(2).to_json
+            type_de_champ.drop_down_options.first(2).to_json
           end
           attrs = { stable_id: type_de_champ.stable_id, dossier:, private: true, value: }.compact
           create(:"champ_do_not_use_#{type_de_champ.type_champ}", **attrs)

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -308,13 +308,7 @@ def build_types_de_champ(types_de_champ, revision:, scope: :public, parent: nil)
       end
 
       if type.in?([:drop_down_list, :multiple_drop_down_list, :linked_drop_down_list])
-        if options.delete(:short).present?
-          type_de_champ_attributes[:drop_down_list_value] = "val1\r\nval2\r\n--separateur--\r\nval3"
-        elsif options.delete(:long).present?
-          type_de_champ_attributes[:drop_down_list_value] = "alpha\r\nbravo\r\n--separateur--\r\ncharly\r\ndelta\r\necho\r\nfox-trot\r\ngolf"
-        else
-          type_de_champ_attributes[:drop_down_list_value] = options.join("\r\n")
-        end
+        type_de_champ_attributes[:drop_down_options] = options
       end
     end
 

--- a/spec/factories/type_de_champ.rb
+++ b/spec/factories/type_de_champ.rb
@@ -79,9 +79,9 @@ FactoryBot.define do
     factory :type_de_champ_drop_down_list do
       libelle { 'Choix unique' }
       type_champ { TypeDeChamp.type_champs.fetch(:drop_down_list) }
-      drop_down_list_value { "val1\r\nval2\r\nval3" }
+      drop_down_options { ["val1", "val2", "val3"] }
       trait :long do
-        drop_down_list_value { "alpha\r\nbravo\r\ncharly\r\ndelta\r\necho\r\nfox-trot\r\ngolf" }
+        drop_down_options { ["alpha", "bravo", "charly", "delta", "echo", "fox-trot", "golf"] }
       end
       trait :with_other do
         drop_down_other { true }
@@ -89,14 +89,14 @@ FactoryBot.define do
     end
     factory :type_de_champ_multiple_drop_down_list do
       type_champ { TypeDeChamp.type_champs.fetch(:multiple_drop_down_list) }
-      drop_down_list_value { "val1\r\nval2\r\nval3" }
+      drop_down_options { ["val1", "val2", "val3"] }
       trait :long do
-        drop_down_list_value { "alpha\r\nbravo\r\ncharly\r\ndelta\r\necho\r\nfox-trot\r\ngolf" }
+        drop_down_options { ["alpha", "bravo", "charly", "delta", "echo", "fox-trot", "golf"] }
       end
     end
     factory :type_de_champ_linked_drop_down_list do
       type_champ { TypeDeChamp.type_champs.fetch(:linked_drop_down_list) }
-      drop_down_list_value { "--primary--\r\nsecondary\n" }
+      drop_down_options { ["--primary--", "secondary"] }
     end
     factory :type_de_champ_expression_reguliere do
       type_champ { TypeDeChamp.type_champs.fetch(:expression_reguliere) }

--- a/spec/lib/tasks/deployment/20240912091625_clean_drop_down_options.rake_spec.rb
+++ b/spec/lib/tasks/deployment/20240912091625_clean_drop_down_options.rake_spec.rb
@@ -4,18 +4,18 @@ describe '20240912091625_clean_drop_down_options.rake' do
   let(:rake_task) { Rake::Task['after_party:clean_drop_down_options'] }
 
   let!(:dashed_drop_down_list) do
-    drop_down_list_value = ['1', '-- nop --', '2'].join("\r\n")
-    create(:type_de_champ_drop_down_list, drop_down_list_value:)
+    drop_down_options = ['1', '-- nop --', '2']
+    create(:type_de_champ_drop_down_list, drop_down_options:)
   end
 
   let!(:witness_drop_down_list) do
-    drop_down_list_value = ['1', 'hi', '2'].join("\r\n")
-    create(:type_de_champ_drop_down_list, drop_down_list_value:)
+    drop_down_options = ['1', 'hi', '2']
+    create(:type_de_champ_drop_down_list, drop_down_options:)
   end
 
   let!(:multiple_drop_down_list) do
-    drop_down_list_value = ['1', '-- nop --', '2'].join("\r\n")
-    create(:type_de_champ_multiple_drop_down_list, drop_down_list_value:)
+    drop_down_options = ['1', '-- nop --', '2']
+    create(:type_de_champ_multiple_drop_down_list, drop_down_options:)
   end
 
   before do

--- a/spec/lib/tasks/deployment/20240912091625_clean_drop_down_options.rake_spec.rb
+++ b/spec/lib/tasks/deployment/20240912091625_clean_drop_down_options.rake_spec.rb
@@ -27,8 +27,8 @@ describe '20240912091625_clean_drop_down_options.rake' do
   after { rake_task.reenable }
 
   it 'removes the hidden options' do
-    expect(dashed_drop_down_list.drop_down_list_value).to eq(['1', '2'].join("\r\n"))
-    expect(witness_drop_down_list.drop_down_list_value).to eq(['1', 'hi', '2'].join("\r\n"))
-    expect(multiple_drop_down_list.drop_down_list_value).to eq(['1', '2'].join("\r\n"))
+    expect(dashed_drop_down_list.drop_down_options).to eq(['1', '2'])
+    expect(witness_drop_down_list.drop_down_options).to eq(['1', 'hi', '2'])
+    expect(multiple_drop_down_list.drop_down_options).to eq(['1', '2'])
   end
 end

--- a/spec/models/champs/linked_drop_down_list_champ_spec.rb
+++ b/spec/models/champs/linked_drop_down_list_champ_spec.rb
@@ -78,13 +78,13 @@ describe Champs::LinkedDropDownListChamp do
   end
 
   describe '#mandatory_and_blank' do
-    let(:value) { "--Primary--\r\nSecondary" }
+    let(:options) { ["--Primary--", "Secondary"] }
 
     subject { described_class.new }
     before { allow(subject).to receive(:type_de_champ).and_return(type_de_champ) }
 
     context 'when the champ is not mandatory' do
-      let(:type_de_champ) { build(:type_de_champ_linked_drop_down_list, mandatory: false, drop_down_list_value: value) }
+      let(:type_de_champ) { build(:type_de_champ_linked_drop_down_list, mandatory: false, drop_down_options: options) }
 
       it 'blank is fine' do
         is_expected.not_to be_mandatory_blank
@@ -92,7 +92,7 @@ describe Champs::LinkedDropDownListChamp do
     end
 
     context 'when the champ is mandatory' do
-      let(:type_de_champ) { build(:type_de_champ_linked_drop_down_list, mandatory: true, drop_down_list_value: value) }
+      let(:type_de_champ) { build(:type_de_champ_linked_drop_down_list, mandatory: true, drop_down_options: options) }
 
       context 'when there is no value' do
         it { is_expected.to be_mandatory_blank }
@@ -112,7 +112,7 @@ describe Champs::LinkedDropDownListChamp do
         end
 
         context 'when there is nothing to select for the secondary value' do
-          let(:value) { "--A--\nAbbott\nAbelard\n--B--\n--C--\nCynthia" }
+          let(:options) { ["--A--", "Abbott", "Abelard", "--B--", "--C--", "Cynthia"] }
           before { subject.primary_value = 'B' }
 
           it { is_expected.not_to be_mandatory_blank }

--- a/spec/models/champs/multiple_drop_down_list_champ_spec.rb
+++ b/spec/models/champs/multiple_drop_down_list_champ_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Champs::MultipleDropDownListChamp do
-  let(:type_de_champ) { build(:type_de_champ_multiple_drop_down_list, drop_down_list_value: "val1\r\nval2\r\nval3\r\n[brackets] val4") }
+  let(:type_de_champ) { build(:type_de_champ_multiple_drop_down_list, drop_down_options: ["val1", "val2", "val3", "[brackets] val4"]) }
   let(:value) { nil }
   let(:champ) { Champs::MultipleDropDownListChamp.new(value:, dossier: build(:dossier)) }
   before do

--- a/spec/models/concerns/dossier_clone_concern_spec.rb
+++ b/spec/models/concerns/dossier_clone_concern_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe DossierCloneConcern do
       context 'invalid origin' do
         let(:procedure) do
           create(:procedure, types_de_champ_public: [
-            { type: :drop_down_list, libelle: "Le savez-vous?", stable_id: 992, drop_down_list_value: ["Oui", "Non", "Peut-être"].join("\r\n"), mandatory: true }
+            { type: :drop_down_list, libelle: "Le savez-vous?", stable_id: 992, drop_down_options: ["Oui", "Non", "Peut-être"], mandatory: true }
           ])
         end
 

--- a/spec/models/concerns/dossier_rebase_concern_spec.rb
+++ b/spec/models/concerns/dossier_rebase_concern_spec.rb
@@ -422,7 +422,7 @@ describe DossierRebaseConcern do
     context 'with a procedure with a dropdown tdc' do
       let!(:procedure) do
         create(:procedure).tap do |p|
-          p.draft_revision.add_type_de_champ(type_champ: :drop_down_list, libelle: 'l1', drop_down_list_value: "option\nv1\n")
+          p.draft_revision.add_type_de_champ(type_champ: :drop_down_list, libelle: 'l1', drop_down_options: ["option", "v1"])
           p.publish!
         end
       end
@@ -434,7 +434,7 @@ describe DossierRebaseConcern do
 
           stable_id = procedure.draft_revision.types_de_champ.find_by(libelle: 'l1')
           tdc_to_update = procedure.draft_revision.find_and_ensure_exclusive_use(stable_id)
-          tdc_to_update.update(drop_down_list_value: "option\nupdated\nv1")
+          tdc_to_update.update(drop_down_options: ["option", "updated", "v1"])
         end
 
         it { expect { subject }.not_to change { dossier.champs_public.first.value } }
@@ -446,7 +446,7 @@ describe DossierRebaseConcern do
 
           stable_id = procedure.draft_revision.types_de_champ.find_by(libelle: 'l1')
           tdc_to_update = procedure.draft_revision.find_and_ensure_exclusive_use(stable_id)
-          tdc_to_update.update(drop_down_list_value: "option\nupdated")
+          tdc_to_update.update(drop_down_options: ["option", "updated"])
         end
 
         it { expect { subject }.to change { dossier.champs_public.first.value }.from('v1').to(nil) }
@@ -458,7 +458,7 @@ describe DossierRebaseConcern do
 
           stable_id = procedure.draft_revision.types_de_champ.find_by(libelle: 'l1')
           tdc_to_update = procedure.draft_revision.find_and_ensure_exclusive_use(stable_id)
-          tdc_to_update.update(drop_down_list_value: "v1\nupdated")
+          tdc_to_update.update(drop_down_options: ["v1", "updated"])
         end
 
         it { expect { subject }.not_to change { dossier.champs_public.first.value } }
@@ -468,7 +468,7 @@ describe DossierRebaseConcern do
     context 'with a procedure with a multiple dropdown tdc' do
       let!(:procedure) do
         create(:procedure).tap do |p|
-          p.draft_revision.add_type_de_champ(type_champ: :multiple_drop_down_list, libelle: 'l1', drop_down_list_value: "option\nv1\n")
+          p.draft_revision.add_type_de_champ(type_champ: :multiple_drop_down_list, libelle: 'l1', drop_down_options: ["option", "v1"])
           p.publish!
         end
       end
@@ -480,7 +480,7 @@ describe DossierRebaseConcern do
 
           stable_id = procedure.draft_revision.types_de_champ.find_by(libelle: 'l1')
           tdc_to_update = procedure.draft_revision.find_and_ensure_exclusive_use(stable_id)
-          tdc_to_update.update(drop_down_list_value: "option\nupdated\nv1")
+          tdc_to_update.update(drop_down_options: ["option", "updated", "v1"])
         end
 
         it { expect { subject }.not_to change { dossier.champs_public.first.value } }
@@ -492,7 +492,7 @@ describe DossierRebaseConcern do
 
           stable_id = procedure.draft_revision.types_de_champ.find_by(libelle: 'l1')
           tdc_to_update = procedure.draft_revision.find_and_ensure_exclusive_use(stable_id)
-          tdc_to_update.update(drop_down_list_value: "option\nupdated")
+          tdc_to_update.update(drop_down_options: ["option", "updated"])
         end
 
         it { expect { subject }.to change { dossier.champs_public.first.value }.from('["v1","option"]').to('["option"]') }
@@ -504,7 +504,7 @@ describe DossierRebaseConcern do
 
           stable_id = procedure.draft_revision.types_de_champ.find_by(libelle: 'l1')
           tdc_to_update = procedure.draft_revision.find_and_ensure_exclusive_use(stable_id)
-          tdc_to_update.update(drop_down_list_value: "v1\nupdated")
+          tdc_to_update.update(drop_down_options: ["v1", "updated"])
         end
 
         it { expect { subject }.not_to change { dossier.champs_public.first.value } }
@@ -514,7 +514,7 @@ describe DossierRebaseConcern do
     context 'with a procedure with a linked dropdown tdc' do
       let!(:procedure) do
         create(:procedure).tap do |p|
-          p.draft_revision.add_type_de_champ(type_champ: :linked_drop_down_list, libelle: 'l1', drop_down_list_value: "--titre1--\noption\nv1\n--titre2--\noption2\nv2\n")
+          p.draft_revision.add_type_de_champ(type_champ: :linked_drop_down_list, libelle: 'l1', drop_down_options: ["--titre1--", "option", "v1", "--titre2--", "option2", "v2"])
           p.publish!
         end
       end
@@ -526,7 +526,7 @@ describe DossierRebaseConcern do
 
           stable_id = procedure.draft_revision.types_de_champ.find_by(libelle: 'l1')
           tdc_to_update = procedure.draft_revision.find_and_ensure_exclusive_use(stable_id)
-          tdc_to_update.update(drop_down_list_value: "--titre1--\noption\nv1\nupdated\n--titre2--\noption2\nv2\n")
+          tdc_to_update.update(drop_down_options: ["--titre1--", "option", "v1", "updated", "--titre2--", "option2", "v2"])
         end
 
         it { expect { subject }.not_to change { dossier.champs_public.first.value } }
@@ -538,7 +538,7 @@ describe DossierRebaseConcern do
 
           stable_id = procedure.draft_revision.types_de_champ.find_by(libelle: 'l1')
           tdc_to_update = procedure.draft_revision.find_and_ensure_exclusive_use(stable_id)
-          tdc_to_update.update(drop_down_list_value: "--titre1--\noption\nupdated\n--titre2--\noption2\nv2\n")
+          tdc_to_update.update(drop_down_options: ["--titre1--", "option", "updated", "--titre2--", "option2", "v2"])
         end
 
         it { expect { subject }.to change { dossier.champs_public.first.value }.from('["v1","option2"]').to(nil) }
@@ -550,7 +550,7 @@ describe DossierRebaseConcern do
 
           stable_id = procedure.draft_revision.types_de_champ.find_by(libelle: 'l1')
           tdc_to_update = procedure.draft_revision.find_and_ensure_exclusive_use(stable_id)
-          tdc_to_update.update(drop_down_list_value: "--titre1--\nv1\nupdated\n--titre2--\noption2\nv2\n")
+          tdc_to_update.update(drop_down_options: ["--titre1--", "v1", "updated", "--titre2--", "option2", "v2"])
         end
 
         it { expect { subject }.not_to change { dossier.champs_public.first.value } }

--- a/spec/models/logic/eq_spec.rb
+++ b/spec/models/logic/eq_spec.rb
@@ -22,7 +22,7 @@ describe Logic::Eq do
 
     it do
       multiple_drop_down = create(:type_de_champ_multiple_drop_down_list)
-      first_option = multiple_drop_down.drop_down_list_enabled_non_empty_options.first
+      first_option = multiple_drop_down.drop_down_options.first
 
       expected = {
         operator_name: "Logic::Eq",

--- a/spec/models/logic/not_eq_spec.rb
+++ b/spec/models/logic/not_eq_spec.rb
@@ -22,7 +22,7 @@ describe Logic::NotEq do
 
     it do
       multiple_drop_down = create(:type_de_champ_multiple_drop_down_list)
-      first_option = multiple_drop_down.drop_down_list_enabled_non_empty_options.first
+      first_option = multiple_drop_down.drop_down_options.first
 
       expected = {
         operator_name: "Logic::NotEq",

--- a/spec/models/logic_spec.rb
+++ b/spec/models/logic_spec.rb
@@ -48,7 +48,7 @@ describe Logic do
     context 'when dropdown empty operator true' do
       let(:drop_down) { create(:type_de_champ_drop_down_list) }
       let(:type_de_champs) { [drop_down] }
-      let(:first_option) { drop_down.drop_down_list_enabled_non_empty_options.first }
+      let(:first_option) { drop_down.drop_down_options.first }
       let(:condition) { empty_operator(champ_value(drop_down.stable_id), constant(true)) }
 
       it { is_expected.to eq(ds_eq(champ_value(drop_down.stable_id), constant(first_option))) }
@@ -57,7 +57,7 @@ describe Logic do
     context 'when multiple dropdown empty operator true' do
       let(:multiple_drop_down) { create(:type_de_champ_multiple_drop_down_list) }
       let(:type_de_champs) { [multiple_drop_down] }
-      let(:first_option) { multiple_drop_down.drop_down_list_enabled_non_empty_options.first }
+      let(:first_option) { multiple_drop_down.drop_down_options.first }
       let(:condition) { empty_operator(champ_value(multiple_drop_down.stable_id), constant(true)) }
 
       it { is_expected.to eq(ds_include(champ_value(multiple_drop_down.stable_id), constant(first_option))) }
@@ -70,7 +70,7 @@ describe Logic do
 
     context 'with a dropdown' do
       let(:drop_down) { create(:type_de_champ_drop_down_list) }
-      let(:first_option) { drop_down.drop_down_list_enabled_non_empty_options.first }
+      let(:first_option) { drop_down.drop_down_options.first }
 
       it do
         expect(Logic.compatible_type?(champ_value(drop_down.stable_id), constant('a'), [drop_down])).to be true

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -397,7 +397,7 @@ describe Procedure do
           expect(procedure.errors.messages_for(:draft_types_de_champ_public)).to include(invalid_drop_down_error_message)
 
           drop_down = procedure.draft_revision.types_de_champ_public.find(&:drop_down_list?)
-          drop_down.update!(drop_down_list_value: "--title--\r\nsome value")
+          drop_down.update!(drop_down_options: ["--title--", "some value"])
           procedure.reload.validate(:publication)
           expect(procedure.errors.messages_for(:draft_types_de_champ_public)).not_to include(invalid_drop_down_error_message)
         end

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -196,13 +196,13 @@ describe TypeDeChamp do
     let(:type_de_champ) { create(:type_de_champ_drop_down_list) }
 
     it "splits input" do
-      type_de_champ.drop_down_list_value = nil
+      type_de_champ.drop_down_options_from_text = nil
       expect(type_de_champ.drop_down_options).to eq([])
 
-      type_de_champ.drop_down_list_value = "\n\r"
+      type_de_champ.drop_down_options_from_text = "\n\r"
       expect(type_de_champ.drop_down_options).to eq([])
 
-      type_de_champ.drop_down_list_value = " 1 / 2 \r\n 3"
+      type_de_champ.drop_down_options_from_text = " 1 / 2 \r\n 3"
       expect(type_de_champ.drop_down_options).to eq(['1 / 2', '3'])
     end
   end

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -149,7 +149,7 @@ describe TypeDeChamp do
     let(:type_de_champ) { create(:type_de_champ_linked_drop_down_list) }
 
     it 'should validate without label' do
-      type_de_champ.drop_down_list_value = 'toto'
+      type_de_champ.drop_down_options = ['toto']
       expect(type_de_champ.validate).to be_falsey
       messages = type_de_champ.errors.full_messages
       expect(messages.size).to eq(1)

--- a/spec/models/types_de_champ/linked_drop_down_list_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/linked_drop_down_list_type_de_champ_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe TypesDeChamp::LinkedDropDownListTypeDeChamp do
-  let(:type_de_champ) { build(:type_de_champ_linked_drop_down_list, drop_down_list_value: menu_options) }
+  let(:type_de_champ) { build(:type_de_champ_linked_drop_down_list, drop_down_options: menu_options) }
 
   subject { type_de_champ.dynamic_type }
 
@@ -9,26 +9,22 @@ describe TypesDeChamp::LinkedDropDownListTypeDeChamp do
     context 'It must start with one primary option' do
       context 'valid menu' do
         let(:menu_options) do
-          <<~END_OPTIONS
-            --Primary 1--
-            secondary 1.1
-            secondary 1.2
-            --Primary 2--
-            secondary 2.1
-            secondary 2.2
-            secondary 2.3
-          END_OPTIONS
+          [
+            "--Primary 1--",
+            "secondary 1.1",
+            "secondary 1.2",
+            "--Primary 2--",
+            "secondary 2.1",
+            "secondary 2.2",
+            "secondary 2.3"
+          ]
         end
 
         it { is_expected.to be_valid }
       end
 
       context 'degenerate but valid menu' do
-        let(:menu_options) do
-          <<~END_OPTIONS
-            --Primary 1--
-          END_OPTIONS
-        end
+        let(:menu_options) { ["--Primary 1--"] }
 
         it { is_expected.to be_valid }
       end
@@ -43,26 +39,21 @@ describe TypesDeChamp::LinkedDropDownListTypeDeChamp do
         end
 
         context 'no primary option' do
-          let(:menu_options) do
-            <<~END_OPTIONS
-              secondary 1.1
-              secondary 1.2
-            END_OPTIONS
-          end
+          let(:menu_options) { ["secondary 1.1", "secondary 1.2"] }
 
           it_should_behave_like 'missing primary option'
         end
 
         context 'starting with secondary options' do
           let(:menu_options) do
-            <<~END_OPTIONS
-              secondary 1.1
-              secondary 1.2
-              --Primary 2--
-              secondary 2.1
-              secondary 2.2
-              secondary 2.3
-            END_OPTIONS
+            [
+              "secondary 1.1",
+              "secondary 1.2",
+              "--Primary 2--",
+              "secondary 2.1",
+              "secondary 2.2",
+              "secondary 2.3"
+            ]
           end
 
           it_should_behave_like 'missing primary option'
@@ -73,22 +64,22 @@ describe TypesDeChamp::LinkedDropDownListTypeDeChamp do
 
   describe '#unpack_options' do
     context 'with no options' do
-      let(:menu_options) { '' }
+      let(:menu_options) { [] }
       it { expect(subject.secondary_options).to eq({}) }
       it { expect(subject.primary_options).to eq([]) }
     end
 
     context 'with two primary options' do
       let(:menu_options) do
-        <<~END_OPTIONS
-          --Primary 1--
-          secondary 1.1
-          secondary 1.2
-          --Primary 2--
-          secondary 2.1
-          secondary 2.2
-          secondary 2.3
-        END_OPTIONS
+        [
+          "--Primary 1--",
+          "secondary 1.1",
+          "secondary 1.2",
+          "--Primary 2--",
+          "secondary 2.1",
+          "secondary 2.2",
+          "secondary 2.3"
+        ]
       end
 
       context "mandatory tdc" do
@@ -106,7 +97,7 @@ describe TypesDeChamp::LinkedDropDownListTypeDeChamp do
       end
 
       context "not mandatory" do
-        let(:type_de_champ) { build(:type_de_champ_linked_drop_down_list, drop_down_list_value: menu_options, mandatory: false) }
+        let(:type_de_champ) { build(:type_de_champ_linked_drop_down_list, drop_down_options: menu_options, mandatory: false) }
 
         it do
           expect(subject.secondary_options).to eq(

--- a/spec/models/types_de_champ/prefill_drop_down_list_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_drop_down_list_type_de_champ_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe TypesDeChamp::PrefillDropDownListTypeDeChamp do
 
       it {
         expect(possible_values).to match(
-          ([I18n.t("views.prefill_descriptions.edit.possible_values.drop_down_list_other_html")] + type_de_champ.drop_down_list_enabled_non_empty_options).to_sentence
+          ([I18n.t("views.prefill_descriptions.edit.possible_values.drop_down_list_other_html")] + type_de_champ.drop_down_options).to_sentence
         )
       }
     end
@@ -20,7 +20,7 @@ RSpec.describe TypesDeChamp::PrefillDropDownListTypeDeChamp do
     context "when the drop down list does not accept 'other'" do
       let(:type_de_champ) { build(:type_de_champ_drop_down_list, procedure:) }
 
-      it { expect(possible_values).to match(type_de_champ.drop_down_list_enabled_non_empty_options.to_sentence) }
+      it { expect(possible_values).to match(type_de_champ.drop_down_options.to_sentence) }
     end
   end
 
@@ -29,6 +29,6 @@ RSpec.describe TypesDeChamp::PrefillDropDownListTypeDeChamp do
     let(:type_de_champ) { build(:type_de_champ_drop_down_list, procedure: procedure) }
     subject(:example_value) { described_class.new(type_de_champ, procedure.active_revision).example_value }
 
-    it { expect(example_value).to eq(type_de_champ.drop_down_list_enabled_non_empty_options.first) }
+    it { expect(example_value).to eq(type_de_champ.drop_down_options.first) }
   end
 end

--- a/spec/models/types_de_champ/prefill_multiple_drop_down_list_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_multiple_drop_down_list_type_de_champ_spec.rb
@@ -10,23 +10,23 @@ RSpec.describe TypesDeChamp::PrefillMultipleDropDownListTypeDeChamp do
   end
 
   describe '#example_value' do
-    let(:type_de_champ) { build(:type_de_champ_multiple_drop_down_list, drop_down_list_value: drop_down_list_value, procedure: procedure) }
+    let(:type_de_champ) { build(:type_de_champ_multiple_drop_down_list, drop_down_options_from_text: drop_down_options_from_text, procedure: procedure) }
     subject(:example_value) { described_class.new(type_de_champ, procedure.active_revision).example_value }
 
     context 'when the multiple drop down list has no option' do
-      let(:drop_down_list_value) { "" }
+      let(:drop_down_options_from_text) { "" }
 
       it { expect(example_value).to eq(nil) }
     end
 
     context 'when the multiple drop down list only has one option' do
-      let(:drop_down_list_value) { "value" }
+      let(:drop_down_options_from_text) { "value" }
 
       it { expect(example_value).to eq("value") }
     end
 
     context 'when the multiple drop down list has two options or more' do
-      let(:drop_down_list_value) {  "value1\r\nvalue2\r\nvalue3" }
+      let(:drop_down_options_from_text) { "value1\r\nvalue2\r\nvalue3" }
 
       it { expect(example_value).to eq(["value1", "value2"]) }
     end

--- a/spec/system/users/dossier_prefill_get_spec.rb
+++ b/spec/system/users/dossier_prefill_get_spec.rb
@@ -43,8 +43,8 @@ describe 'Prefilling a dossier (with a GET request):', js: true do
   let(:datetime_value) { "2023-02-01T10:32" }
   let(:multiple_drop_down_list_values) {
     [
-      type_de_champ_multiple_drop_down_list.drop_down_list_enabled_non_empty_options.first,
-      type_de_champ_multiple_drop_down_list.drop_down_list_enabled_non_empty_options.last
+      type_de_champ_multiple_drop_down_list.drop_down_options.first,
+      type_de_champ_multiple_drop_down_list.drop_down_options.last
     ]
   }
   let(:epci_value) { ['01', '200029999'] }

--- a/spec/system/users/dossier_prefill_post_spec.rb
+++ b/spec/system/users/dossier_prefill_post_spec.rb
@@ -43,8 +43,8 @@ describe 'Prefilling a dossier (with a POST request):', js: true do
   let(:datetime_value) { "2023-02-01T10:32" }
   let(:multiple_drop_down_list_values) {
     [
-      type_de_champ_multiple_drop_down_list.drop_down_list_enabled_non_empty_options.first,
-      type_de_champ_multiple_drop_down_list.drop_down_list_enabled_non_empty_options.last
+      type_de_champ_multiple_drop_down_list.drop_down_options.first,
+      type_de_champ_multiple_drop_down_list.drop_down_options.last
     ]
   }
   let(:epci_value) { ['01', '200029999'] }

--- a/spec/views/shared/dossiers/_edit.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_edit.html.haml_spec.rb
@@ -46,7 +46,7 @@ describe 'shared/dossiers/edit', type: :view do
     let(:types_de_champ_public) { [{ type: :drop_down_list, options:, mandatory: }] }
     let(:champ) { dossier.champs_public.first }
     let(:type_de_champ) { champ.type_de_champ }
-    let(:enabled_options) { type_de_champ.drop_down_list_enabled_non_empty_options }
+    let(:enabled_options) { type_de_champ.drop_down_options }
     let(:mandatory) { true }
     let(:options) { nil }
 
@@ -86,7 +86,7 @@ describe 'shared/dossiers/edit', type: :view do
     let(:champ) { dossier.champs.first }
     let(:type_de_champ) { champ.type_de_champ }
     let(:options) { type_de_champ.drop_down_options }
-    let(:enabled_options) { type_de_champ.drop_down_list_enabled_non_empty_options }
+    let(:enabled_options) { type_de_champ.drop_down_options }
 
     context 'when the list is short' do
       let(:options) { ['valid', 'invalid', 'not sure yet'] }

--- a/spec/views/shared/dossiers/_edit.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_edit.html.haml_spec.rb
@@ -71,7 +71,7 @@ describe 'shared/dossiers/edit', type: :view do
 
     context 'when the list is long' do
       let(:value) { 'alpha' }
-      let(:options) { [:long] }
+      let(:options) { ['1', '2', '3', '4', '5', '6'] }
 
       before { champ.update(value:) }
 


### PR DESCRIPTION
Attention le commit `no more empty case` casse le site si la tache `remove_empty_options_from_drop_down_list` n'a pas été jouée.