### PR TITLE
ETQ administrateur, je ne souhaite pas voir des dossiers en instruction repasser en construction pour une donnée qui ne m'est pas necessaire

### DIFF
--- a/app/tasks/maintenance/fix_champs_commune_having_value_but_not_external_id_task.rb
+++ b/app/tasks/maintenance/fix_champs_commune_having_value_but_not_external_id_task.rb
@@ -26,13 +26,15 @@ module Maintenance
           champ.code = formated_results.first[:value]
           champ.save!
         else # otherwise, we can't find the expected departement
-          champ.code_departement = nil
-          champ.code_postal = nil
-          champ.external_id = nil
-          champ.value = nil
-          champ.save(validate: false)
+          if champ.dossier.en_construction?
+            champ.code_departement = nil
+            champ.code_postal = nil
+            champ.external_id = nil
+            champ.value = nil
+            champ.save(validate: false)
 
-          ask_user_correction(champ)
+            ask_user_correction(champ)
+          end
         end
       end
     end

--- a/app/tasks/maintenance/resolve_pending_correction_for_dossier_with_invalid_commune_external_id_task.rb
+++ b/app/tasks/maintenance/resolve_pending_correction_for_dossier_with_invalid_commune_external_id_task.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class ResolvePendingCorrectionForDossierWithInvalidCommuneExternalIdTask < MaintenanceTasks::Task
+    DEFAULT_INSTRUCTEUR_EMAIL = ENV.fetch('DEFAULT_INSTRUCTEUR_EMAIL') { CONTACT_EMAIL }
+
+    no_collection
+
+    def process
+      DossierCorrection.joins(:commentaire)
+        .where(commentaire: { instructeur_id: current_instructeur.id })
+        .where(resolved_at: nil)
+        .find_each do |dossier_correction|
+          penultimate_traitement, last_traitement = *dossier_correction.dossier.traitements.last(2)
+          dossier_correction.resolve!
+
+          if last_traitement_by_us?(last_traitement) && last_transition_to_en_construction?(last_traitement, penultimate_traitement)
+            dossier_correction.dossier.passer_en_instruction(instructeur: current_instructeur) if dossier_correction.dossier.validate(:champs_public_value)
+          end
+        end
+    end
+
+    def current_instructeur
+      @current_instructeur = User.find_by(email: DEFAULT_INSTRUCTEUR_EMAIL).instructeur
+    end
+
+    def current_instructeur_id
+      current_instructeur.id
+    end
+
+    def current_instructeur_email
+      current_instructeur.email
+    end
+
+    def last_traitement_by_us?(traitement)
+      traitement.instructeur_email == DEFAULT_INSTRUCTEUR_EMAIL
+    end
+
+    def last_transition_to_en_construction?(last_traitement, penultimate_traitement)
+      last_traitement.state == "en_construction" && penultimate_traitement.state == 'en_instruction'
+    end
+  end
+end

--- a/spec/tasks/maintenance/fix_champs_commune_having_value_but_not_external_id_task_spec.rb
+++ b/spec/tasks/maintenance/fix_champs_commune_having_value_but_not_external_id_task_spec.rb
@@ -30,7 +30,7 @@ module Maintenance
         end
 
         context 'en_instruction (go back to en_construction!), send comment' do
-          let(:state) { [:en_instruction, :en_construction].sample }
+          let(:state) { :en_construction }
 
           it 'flags as pending correction' do
             expect { subject }.to change { champ.reload.value }.from('Marseille').to(nil)

--- a/spec/tasks/maintenance/resolve_pending_correction_for_dossier_with_invalid_commune_external_id_task_spec.rb
+++ b/spec/tasks/maintenance/resolve_pending_correction_for_dossier_with_invalid_commune_external_id_task_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe ResolvePendingCorrectionForDossierWithInvalidCommuneExternalIdTask do
+    describe "#process" do
+      subject(:process) { described_class.process }
+      let(:instructeur) { create(:instructeur, email: ENV.fetch('DEFAULT_INSTRUCTEUR_EMAIL') { CONTACT_EMAIL }) }
+      let(:commentaire) { create(:commentaire, instructeur:) }
+      let(:dossier_correction) { create(:dossier_correction, commentaire:, dossier:, resolved_at: nil) }
+
+      before { dossier_correction }
+
+      context 'when dossier did transitioned to en_construction from en_instruction' do
+        let(:dossier) { create(:dossier, :en_instruction) }
+        before { dossier.repasser_en_construction!(instructeur:) }
+        it 'goes back to en_instruction (my mistake, sorry dear colleague, users etc...)' do
+          expect { subject }.to change { dossier.reload.state }.from('en_construction').to('en_instruction')
+        end
+      end
+
+      context 'when dossier didnt transitioned' do
+        let(:dossier) { create(:dossier, :en_construction) }
+
+        it 'noop' do
+          expect { subject }.not_to change { dossier.reload.state }
+        end
+      end
+    end
+  end
+end

--- a/spec/tasks/maintenance/resolve_pending_correction_for_dossier_with_invalid_commune_external_id_task_spec.rb
+++ b/spec/tasks/maintenance/resolve_pending_correction_for_dossier_with_invalid_commune_external_id_task_spec.rb
@@ -6,7 +6,7 @@ module Maintenance
   RSpec.describe ResolvePendingCorrectionForDossierWithInvalidCommuneExternalIdTask do
     describe "#process" do
       subject(:process) { described_class.process }
-      let(:instructeur) { create(:instructeur, email: ENV.fetch('DEFAULT_INSTRUCTEUR_EMAIL') { CONTACT_EMAIL }) }
+      let!(:instructeur) { create(:instructeur, email: ENV.fetch('DEFAULT_INSTRUCTEUR_EMAIL') { CONTACT_EMAIL }) }
       let(:commentaire) { create(:commentaire, instructeur:) }
       let(:dossier_correction) { create(:dossier_correction, commentaire:, dossier:, resolved_at: nil) }
 
@@ -22,7 +22,7 @@ module Maintenance
 
       context 'when dossier didnt transitioned' do
         let(:dossier) { create(:dossier, :en_construction) }
-
+        before { create(:traitement, dossier:) }
         it 'noop' do
           expect { subject }.not_to change { dossier.reload.state }
         end


### PR DESCRIPTION
mattermost: https://mattermost.incubateur.net/betagouv/pl/arjqtrwjabrp5rnzt7tcybn4dc
hs: https://secure.helpscout.net/conversation/2710119750/2095113?viewId=1653799

une boulette de ma part mais a la vue des données, ca se rattrape bien car : 
- ca impacte ±2k dossiers
- parmis eux certains on rebase
- cependant ils sont tous dans un status valid? (ouffff)

Bref, le prob est que ca met la pression sur les admins/instructeurs pour des dossiers qui etaient en instruction depuis... 4ans .