### PR TITLE
Ajoute la vocalisation du composant d'analyse de complexicité du mot de passe pour les technologies d'assistance

### DIFF
--- a/app/components/instructeurs/activate_account_form_component/activate_account_form_component.html.haml
+++ b/app/components/instructeurs/activate_account_form_component/activate_account_form_component.html.haml
@@ -16,7 +16,7 @@
 
       .fr-fieldset__element
         = render Dsfr::InputComponent.new(form: f, attribute: :password, input_type: :password_field,
-          opts: { autofocus: 'true', autocomplete: 'new-password', data: { controller: 'turbo-input', turbo_input_url_value: show_password_complexity_path }})
+          opts: { autofocus: 'true', autocomplete: 'new-password', data: { controller: 'turbo-input', turbo_input_url_value: show_password_complexity_path }, aria: {describedby: 'password_hint'}})
 
         #password_complexity
           = render PasswordComplexityComponent.new

--- a/app/components/password_complexity_component/password_complexity_component.html.haml
+++ b/app/components/password_complexity_component/password_complexity_component.html.haml
@@ -1,6 +1,7 @@
-%div{ class: complexity_classes }
+%div{ "aria-hidden":"true", class: complexity_classes }
 
-%div{ class: alert_classes }
-  %h3.fr-alert__title= title
+#password_hint{ class: alert_classes }
+  %h3.fr-alert__title{ "aria-live": "polite", "aria-atomic": "true" }
+    = title
   - if !success?
     = t(".hint_html")

--- a/app/views/administrateurs/activate/new.html.haml
+++ b/app/views/administrateurs/activate/new.html.haml
@@ -18,7 +18,7 @@
 
           .fr-fieldset__element
             = render Dsfr::InputComponent.new(form: f, attribute: :password, input_type: :password_field,
-              opts: { autofocus: 'true', autocomplete: 'new-password', data: { controller: 'turbo-input', turbo_input_url_value: show_password_complexity_path }})
+              opts: { autofocus: 'true', autocomplete: 'new-password', data: { controller: 'turbo-input', turbo_input_url_value: show_password_complexity_path }, aria: {describedby: 'password_hint'}})
 
             #password_complexity
               = render PasswordComplexityComponent.new

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -18,11 +18,10 @@
 
           .fr-fieldset__element
             = render Dsfr::InputComponent.new(form: f, attribute: :password, input_type: :password_field,
-              opts: { autofocus: 'true', autocomplete: 'new-password', minlength: PASSWORD_MIN_LENGTH, data: { controller: 'turbo-input', turbo_input_url_value: show_password_complexity_path }}) do |c|
-              - c.with_describedby do
-                %div{ id: c.describedby_id }
-                  #password_complexity
-                    = render PasswordComplexityComponent.new
+              opts: { autofocus: 'true', autocomplete: 'new-password', data: { controller: 'turbo-input', turbo_input_url_value: show_password_complexity_path }, aria: {describedby: 'password_hint'}})
+
+            #password_complexity
+              = render PasswordComplexityComponent.new
 
           .fr-fieldset__element
             = render Dsfr::InputComponent.new(form: f, attribute: :password_confirmation, input_type: :password_field, opts: { autocomplete: 'new-password' })

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -12,8 +12,8 @@
         = f.hidden_field :reset_password_token
 
 
-        %fieldset.fr-mb-0.fr-fieldset{ aria: { labelledby: 'edit-password-legend' } }
-          %legend.fr-fieldset__legend#edit-password-legend
+        %fieldset.fr-mb-0.fr-fieldset
+          %legend.fr-fieldset__legend
             %h1.fr-h2= I18n.t('views.users.passwords.edit.subtitle')
 
           .fr-fieldset__element

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -17,6 +17,9 @@
             %h1.fr-h2= I18n.t('views.users.passwords.edit.subtitle')
 
           .fr-fieldset__element
+            %p.fr-text--sm= t('utils.asterisk_html')
+
+          .fr-fieldset__element
             = render Dsfr::InputComponent.new(form: f, attribute: :password, input_type: :password_field,
               opts: { autofocus: 'true', autocomplete: 'new-password', data: { controller: 'turbo-input', turbo_input_url_value: show_password_complexity_path }, aria: {describedby: 'password_hint'}})
 

--- a/app/views/experts/avis/sign_up.html.haml
+++ b/app/views/experts/avis/sign_up.html.haml
@@ -14,7 +14,7 @@
 
           .fr-fieldset__element
             = render Dsfr::InputComponent.new(form: f, attribute: :password, input_type: :password_field,
-              opts: { autofocus: 'true', autocomplete: 'new-password', data: { controller: 'turbo-input', turbo_input_url_value: show_password_complexity_path }})
+              opts: { autofocus: 'true', autocomplete: 'new-password', data: { controller: 'turbo-input', turbo_input_url_value: show_password_complexity_path }, aria: {describedby: 'password_hint'}})
 
             #password_complexity
               = render PasswordComplexityComponent.new

--- a/app/views/gestionnaires/activate/new.html.haml
+++ b/app/views/gestionnaires/activate/new.html.haml
@@ -18,7 +18,7 @@
 
           .fr-fieldset__element
             = render Dsfr::InputComponent.new(form: f, attribute: :password, input_type: :password_field,
-              opts: { autofocus: 'true', autocomplete: 'new-password', data: { controller: 'turbo-input', turbo_input_url_value: show_password_complexity_path }})
+              opts: { autofocus: 'true', autocomplete: 'new-password', data: { controller: 'turbo-input', turbo_input_url_value: show_password_complexity_path }, aria: {describedby: 'password_hint'}})
 
             #password_complexity
               = render PasswordComplexityComponent.new

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -19,7 +19,7 @@
 
       .fr-fieldset__element
         = render Dsfr::InputComponent.new(form: f, attribute: :password, input_type: :password_field,
-          opts: { autofocus: 'true', autocomplete: 'new-password', data: { controller: 'turbo-input', turbo_input_url_value: show_password_complexity_path }})
+          opts: { autofocus: 'true', autocomplete: 'new-password', data: { controller: 'turbo-input', turbo_input_url_value: show_password_complexity_path }, aria: {describedby: 'password_hint'}})
 
         #password_complexity
           = render PasswordComplexityComponent.new


### PR DESCRIPTION
# Vocalisation du composant 
- L'attribut `aria-describedby` permet de lier le bloc au champs de saisie pour assurer la lecture initiale de son contenu lorsque le champs de saisie reçoit le focus.   
- Les attributs `aria-live="polite"` et `aria-atomic="true"` servent à restituer le changement de titre dès que l'utilisateur  ou l'utilisatrice stoppe sa saisie.

__Après__

https://github.com/user-attachments/assets/90619cbf-0936-46be-9641-899c62d4d532


__Avant__

https://github.com/user-attachments/assets/c7a397c3-1647-4205-85ff-1d476cc6c41f

---

#  Suppression d'un attribut redondant
L'attribut `aria-labelledby` est inutile du fait de la présence de l'élément `legend`.
__Après__
<img width="469" alt="" src="https://github.com/user-attachments/assets/dc5ac8c9-f427-4c90-af07-67f42cd8b0f7">


__Avant__
<img width="754" alt="" src="https://github.com/user-attachments/assets/19e8808c-bce6-4d13-8202-a448ed5ea90a">

---

# Ajout de la mention explicitant les astérisques.
__Après__
<img width="676" alt="" src="https://github.com/user-attachments/assets/fd32f20e-4cca-4964-a2a9-dd0b87207804">


__Avant__
<img width="660" alt="" src="https://github.com/user-attachments/assets/4b2d8513-09cb-485a-936b-ee678818bb6e">
