### PR TITLE
ETQ admin, explique mieux que l'attestation v1 reste fonctionnelle alors que j'ai accès à la v2

### DIFF
--- a/app/views/administrateurs/attestation_template_v2s/edit.html.haml
+++ b/app/views/administrateurs/attestation_template_v2s/edit.html.haml
@@ -13,19 +13,16 @@
     attestation_logo_attachment_free_label_value: AttestationTemplate.human_attribute_name(:logo) } do |f|
 
   #attestation-edit.fr-container.fr-my-4w{ data: { controller: 'tiptap', tiptap_insert_after_tag_value: ' ' } }
-    .fr-mb-6w
-      = render Dsfr::AlertComponent.new(state: :info, title: "Nouvel éditeur d’attestation", heading_level: 'h3') do |c|
-        - c.with_body do
-          Cette page permet la mise en forme de l’attestation avec un nouvel éditeur plus flexible
-          tout en respectant la charte de l’état. Essayez-la et donnez-nous votre avis
-          en nous envoyant un email à #{mail_to(Current.contact_email, subject: "Feedback attestation v2")}.
-          %br
-          - if !@procedure.feature_enabled?(:attestation_v2) || @procedure.attestation_templates.v1.published.any?
-            %strong Les attestations délivrées suivent encore l’ancien format :
-            l’activation des attestations basées sur ce format sera bientôt disponible.
-            %br
+    - if @procedure.attestation_templates.v1.published.any?
+      .fr-mb-6w
+        = render Dsfr::AlertComponent.new(state: :info, title: "Nouvel éditeur d’attestation", heading_level: 'h3') do |c|
+          - c.with_body do
+            %p Cette page présente un nouvel éditeur d'attestations, plus flexible et conforme à la charte de l'État.
+            %p
+              %strong Pour modifier l’attestation existante (actuellement délivrée aux usagers),
+              = link_to("cliquez ici", edit_admin_procedure_attestation_template_path(@procedure)) + "."
+            %p Pour générer une attestation à la charte de l‘État, créez-la ci-dessous puis publiez-la: elle remplacera alors l’attestation actuelle.
 
-            = link_to("Suivez ce lien pour revenir aux attestations actuellement délivrées", edit_admin_procedure_attestation_template_path(@procedure))
 
     .fr-grid-row.fr-grid-row--gutters
       .fr-col-12.fr-col-lg-7

--- a/spec/system/administrateurs/procedure_attestation_template_spec.rb
+++ b/spec/system/administrateurs/procedure_attestation_template_spec.rb
@@ -92,9 +92,6 @@ describe 'As an administrateur, I want to manage the procedure’s attestation',
       find_attestation_card(with_nested_selector: ".fr-badge")
 
       find_attestation_card.click
-      within(".fr-alert", text: /Nouvel éditeur/) do
-        find("a").click
-      end
 
       expect(procedure.reload.attestation_templates.v2).to be_empty
 


### PR DESCRIPTION
<img width="1265" alt="Capture d’écran 2024-09-24 à 10 05 46" src="https://github.com/user-attachments/assets/f2bdef5f-e286-45a2-b8d6-34347dabb988">
