### PR TITLE
Améliorer le mail si un usager sans compte DS reçoit un transfert de dossier

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -405,10 +405,6 @@ module Users
       @transfer = DossierTransfer.new(dossiers: [dossier])
     end
 
-    def transferer_all
-      @transfer = DossierTransfer.new(dossiers: current_user.dossiers)
-    end
-
     def restore
       dossier.restore(current_user)
       flash.notice = t('users.dossiers.restore')

--- a/app/mailers/dossier_mailer.rb
+++ b/app/mailers/dossier_mailer.rb
@@ -206,6 +206,8 @@ class DossierMailer < ApplicationMailer
   def notify_transfer
     @transfer = params[:dossier_transfer]
 
+    @user = User.find_by(email: @transfer.email)
+
     configure_defaults_for_email(@transfer.email)
 
     I18n.with_locale(@transfer.user_locale) do

--- a/app/views/dossier_mailer/notify_transfer.html.haml
+++ b/app/views/dossier_mailer/notify_transfer.html.haml
@@ -11,7 +11,7 @@
 
 %p
   - if @user.present?
-    = t('.transfer_text')
+    = t('.transfer_text', app_name: Current.application_name)
     %br
     = link_to t('.transfer_link'), dossiers_url(statut: 'dossiers-transferes')
   - else

--- a/app/views/dossier_mailer/notify_transfer.html.haml
+++ b/app/views/dossier_mailer/notify_transfer.html.haml
@@ -10,7 +10,13 @@
       = dossier.procedure.libelle
 
 %p
-  = t('.transfer_text')
-  = link_to t('.transfer_link'), dossiers_url(statut: 'dossiers-transferes')
+  - if @user.present?
+    = t('.transfer_text')
+    %br
+    = link_to t('.transfer_link'), dossiers_url(statut: 'dossiers-transferes')
+  - else
+    = t('.no_user_transfer_text')
+    %br
+    = link_to t('.no_user_transfer_link', app_name: Current.application_name), new_user_registration_url
 
 = render partial: "layouts/mailers/signature"

--- a/app/views/users/dossiers/transferer_all.html.haml
+++ b/app/views/users/dossiers/transferer_all.html.haml
@@ -1,7 +1,0 @@
-.container.mt-4
-  Transferer les #{@transfer.dossiers.size} dossiers de votre compte vers le compte d’un autre usager :
-
-  = form_for @transfer, url: transfers_path, html: { class: 'form mt-2' } do |f|
-    = f.label :email, 'Email du compte destinataire'
-    = f.email_field :email, required: true
-    = f.submit "Envoyer la demande de transfert", class: 'button primary'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -315,7 +315,7 @@ en:
       new:
         title: 'Confirm your email address'
         image_alt: "Email sent"
-        email_cta_html: "Before filling your file, we have to validate your email address <strong>%{email}</strong>."
+        email_cta_html: "Before proceeding, we have to validate your email address <strong>%{email}</strong>."
         email_guidelines_html: "Open your mailbox and <strong>click on the activation link</strong> within the mail we just sent you."
         email_missing: "If you have not received our email (have you checked your spam ?), we can resend it."
         resent: 'Resend the confirmation email'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -307,7 +307,7 @@ fr:
       new:
         title: 'Confirmez votre adresse email'
         image_alt: "Email envoyé"
-        email_cta_html: "Avant d’effectuer votre démarche, nous avons besoin de vérifier votre adresse électronique <strong>%{email}</strong>."
+        email_cta_html: "Avant de pouvoir continuer, nous avons besoin de vérifier votre adresse électronique <strong>%{email}</strong>."
         email_guidelines_html: "Ouvrez votre boîte email, et <strong>cliquez sur le lien d’activation</strong> dans le message que vous avez reçu."
         email_missing: "Si vous n’avez pas reçu notre message (avez-vous vérifié les indésirables ?), nous pouvons vous le renvoyer."
         resent: 'Renvoyer un email de confirmation'

--- a/config/locales/views/dossier_mailer/notify_transfer/en.yml
+++ b/config/locales/views/dossier_mailer/notify_transfer/en.yml
@@ -4,5 +4,7 @@ en:
       subject: You have a pending transfer request.
       transfer_text: "Access the transfer request by clicking on the following link:"
       transfer_link: transfer request
+      no_user_transfer_text: "In order to accept or refuse the request you must have an account:"
+      no_user_transfer_link: Create an account on %{app_name}
       transfert_multiple: "%{sender} sends you a transfer request for %{count} files."
       transfert_simple: "%{sender} sends you a transfer request for file no. %{dossier_id} on the procedure"

--- a/config/locales/views/dossier_mailer/notify_transfer/en.yml
+++ b/config/locales/views/dossier_mailer/notify_transfer/en.yml
@@ -2,8 +2,8 @@ en:
   dossier_mailer:
     notify_transfer:
       subject: You have a pending transfer request.
-      transfer_text: "Access the transfer request by clicking on the following link:"
-      transfer_link: transfer request
+      transfer_text: "In order to accept or refuse the request you must log in on %{app_name}:"
+      transfer_link: Acces transfer request
       no_user_transfer_text: "In order to accept or refuse the request you must have an account:"
       no_user_transfer_link: Create an account on %{app_name}
       transfert_multiple: "%{sender} sends you a transfer request for %{count} files."

--- a/config/locales/views/dossier_mailer/notify_transfer/fr.yml
+++ b/config/locales/views/dossier_mailer/notify_transfer/fr.yml
@@ -4,5 +4,7 @@ fr:
       subject: Vous avez une demande de transfert en attente.
       transfer_text: "Accéder à la demande de transfert en cliquant sur le lien suivant :"
       transfer_link: demande de transfert
+      no_user_transfer_text: "Afin de pouvoir accepter ou refuser la demande vous devez avoir un compte :"
+      no_user_transfer_link: se créer un compte sur %{app_name}
       transfert_multiple: "%{sender} vous adresse une demande de transfert pour %{count} dossiers."
       transfert_simple: "%{sender} vous adresse une demande de transfert pour le dossier n° %{dossier_id} sur la démarche"

--- a/config/locales/views/dossier_mailer/notify_transfer/fr.yml
+++ b/config/locales/views/dossier_mailer/notify_transfer/fr.yml
@@ -2,8 +2,8 @@ fr:
   dossier_mailer:
     notify_transfer:
       subject: Vous avez une demande de transfert en attente.
-      transfer_text: "Accéder à la demande de transfert en cliquant sur le lien suivant :"
-      transfer_link: demande de transfert
+      transfer_text: "Afin de pouvoir accepter ou refuser la demande vous devez vous connectez sur %{app_name} :"
+      transfer_link: accéder à la demande de transfert
       no_user_transfer_text: "Afin de pouvoir accepter ou refuser la demande vous devez avoir un compte :"
       no_user_transfer_link: se créer un compte sur %{app_name}
       transfert_multiple: "%{sender} vous adresse une demande de transfert pour %{count} dossiers."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -390,7 +390,6 @@ Rails.application.routes.draw do
       end
 
       collection do
-        get 'transferer', to: 'dossiers#transferer_all'
         resources :transfers, only: [:create, :update, :destroy]
       end
     end

--- a/spec/mailers/dossier_mailer_spec.rb
+++ b/spec/mailers/dossier_mailer_spec.rb
@@ -313,6 +313,7 @@ RSpec.describe DossierMailer, type: :mailer do
 
   describe 'notify_transfer' do
     let(:user) { create(:user) }
+    let(:user_2) { create(:user) }
     let(:procedure) { create(:procedure) }
     let(:dossier_transfer) { create(:dossier_transfer) }
     let!(:dossier) { create(:dossier, user: user, transfer: dossier_transfer, procedure: procedure) }
@@ -324,6 +325,23 @@ RSpec.describe DossierMailer, type: :mailer do
         expect(subject.subject).to include("Vous avez une demande de transfert en attente.")
         expect(subject.body).to include("#{user.email} vous adresse une demande de transfert pour le dossier n° #{dossier.id} sur la démarche")
         expect(subject.body).to include(procedure.libelle.to_s)
+      end
+    end
+
+    context 'when the user has already an account' do
+      before do
+        dossier_transfer.update!(email: user_2.email)
+      end
+      it 'includes a direct URL to transfers' do
+        expect(subject.body).to include('Accéder à la demande de transfert en cliquant sur le lien suivant :')
+        expect(subject.body).to include(dossiers_url(statut: 'dossiers-transferes', host: ENV.fetch("APP_HOST_LEGACY")))
+      end
+    end
+
+    context 'when the user has no account' do
+      it 'includes a URL to create one' do
+        expect(subject.body).to include('Afin de pouvoir accepter ou refuser la demande vous devez avoir un compte :')
+        expect(subject.body).to include(new_user_registration_url)
       end
     end
 

--- a/spec/mailers/dossier_mailer_spec.rb
+++ b/spec/mailers/dossier_mailer_spec.rb
@@ -333,7 +333,7 @@ RSpec.describe DossierMailer, type: :mailer do
         dossier_transfer.update!(email: user_2.email)
       end
       it 'includes a direct URL to transfers' do
-        expect(subject.body).to include('Accéder à la demande de transfert en cliquant sur le lien suivant :')
+        expect(subject.body).to include('Afin de pouvoir accepter ou refuser la demande vous devez vous connectez sur')
         expect(subject.body).to include(dossiers_url(statut: 'dossiers-transferes', host: ENV.fetch("APP_HOST_LEGACY")))
       end
     end


### PR DESCRIPTION
closes #10846 

- On a vérifié qu'un usager sans compte DS peut bien recevoir un transfert
- On a amélioré le mail afin qu'il y ait un lien vers une création de compte. Une fois la création effectué, il se retrouve sur son tableau de bord et tombe sur l'onglet "demande de transfert" - il peut accepter ou refuser la demande.
- on a profité de cette PR pour supprimer du code inutilisé : faire un transfert de tous les dossiers. Cela pose des questions d'ou on souhaiterait proposer ce bouton et comment on accepte des multiples demandes. La page était masquée et la fonctionnalité pas demandée.  C'est donc plus simple de la retirer.

**Flow d'utilisation avec besoin de création de compte :** 

<img width="1233" alt="Capture d’écran 2024-09-24 à 10 53 54" src="https://github.com/user-attachments/assets/20517257-ed26-4c10-b2cd-9f701bd0f23f">
<img width="968" alt="Capture d’écran 2024-09-24 à 10 54 17" src="https://github.com/user-attachments/assets/0c136a11-63cf-4ac6-9998-f47214b0d413">

<img width="585" alt="Capture d’écran 2024-09-24 à 10 55 03" src="https://github.com/user-attachments/assets/8102b6fd-27d5-42b7-82b7-304f063cc3d9">
<img width="1229" alt="Capture d’écran 2024-09-24 à 10 55 13" src="https://github.com/user-attachments/assets/c4a9b482-38be-4f2a-a0f3-83801845ce62">
<img width="1020" alt="Capture d’écran 2024-09-24 à 10 55 23" src="https://github.com/user-attachments/assets/45b246ba-6725-47cb-b51e-4327c11c40de">
<img width="1280" alt="Capture d’écran 2024-09-24 à 10 55 35" src="https://github.com/user-attachments/assets/17ca8404-0242-46e2-aaf8-895037bd3d87">
