### PR TITLE
ETQ usager: corrige la date prévisionnelle SVA lorsqu'il y a un mélange de demandes de corrections résolues et en attente

### DIFF
--- a/app/services/sva_svr_decision_date_calculator_service.rb
+++ b/app/services/sva_svr_decision_date_calculator_service.rb
@@ -59,7 +59,7 @@ class SVASVRDecisionDateCalculatorService
   end
 
   def latest_correction_date
-    correction_date dossier.corrections.max_by(&:resolved_at)
+    correction_date dossier.corrections.max_by { _1.resolved_at || Time.current }
   end
 
   def calculate_correction_delay(start_date)

--- a/spec/services/sva_svr_decision_date_calculator_service_spec.rb
+++ b/spec/services/sva_svr_decision_date_calculator_service_spec.rb
@@ -139,6 +139,20 @@ describe SVASVRDecisionDateCalculatorService do
         it 'calculates the date based on SVA rules from the last resolved date' do
           expect(subject).to eq(Date.new(2023, 7, 26))
         end
+
+        context 'and a pending correction' do
+          before do
+            travel_to Time.zone.local(2023, 5, 30, 18) do
+              dossier.flag_as_pending_correction!(build(:commentaire, dossier:))
+            end
+
+            travel_to Time.zone.local(2023, 6, 5, 8)
+          end
+
+          it 'calculates the date, like if resolution will be today and delay restarted' do
+            expect(subject).to eq(Date.new(2023, 8, 6))
+          end
+        end
       end
 
       context 'there is a pending correction' do


### PR DESCRIPTION
https://demarches-simplifiees.sentry.io/issues/5667063306

L'erreur intervenait : 
- dans un mode SVA de réinitialisation de la date
-  lorsqu'on a une correction avec une `resolved_at` et une sans : la comparaison des 2 valeurs n'était pas possible, 

Note: c'est purement indicatif/de l'affichage et n'avait pas d'autre conséquence car tant que la demande de correction existe, le dossier est bloqué en construction
