### PR TITLE
correctif: ETQ instructeur, j'aimerais pouvoir modifier mes modèles d'export, meme sur des démarches avec beaucoup de champs

### DIFF
--- a/app/views/instructeurs/export_templates/_form.html.haml
+++ b/app/views/instructeurs/export_templates/_form.html.haml
@@ -11,7 +11,7 @@
 
   .fr-grid-row.fr-grid-row--gutters
     .fr-col-12.fr-col-md-8.fr-pr-4w
-      = form_with model: [:instructeur, procedure, export_template], data: { turbo: 'true', controller: 'autosubmit' } do |f|
+      = form_with model: [:instructeur, procedure, export_template], data: { turbo: 'true', controller: 'autosubmit', method: :put } do |f|
         %input.hidden{ type: 'submit', formaction: preview_instructeur_procedure_export_templates_path, data: { autosubmit_target: 'submitter' }, formnovalidate: 'true', formmethod: 'get' }
 
         = f.hidden_field :kind, value: 'zip'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -455,7 +455,7 @@ Rails.application.routes.draw do
     resources :procedures, only: [] do
       resources :export_templates, only: [:new, :create, :edit, :update, :destroy] do
         collection do
-          get 'preview'
+          put 'preview'
         end
       end
     end

--- a/spec/controllers/instructeurs/export_templates_controller_spec.rb
+++ b/spec/controllers/instructeurs/export_templates_controller_spec.rb
@@ -166,13 +166,15 @@ describe Instructeurs::ExportTemplatesController, type: :controller do
 
     let(:export_template) { create(:export_template, groupe_instructeur:) }
 
-    subject { get :preview, params: { procedure_id: procedure.id, id: export_template.id, export_template: export_template_params }, format: :turbo_stream }
+    context 'with put request' do
+      subject { put :preview, params: { procedure_id: procedure.id, id: export_template.id, export_template: export_template_params }, format: :turbo_stream }
 
-    it '' do
-      dossier = create(:dossier, procedure: procedure, for_procedure_preview: true)
-      subject
-      expect(response.body).to include "DOSSIER_#{dossier.id}"
-      expect(response.body).to include "mon_export_#{dossier.id}.pdf"
+      it 'works with bigbig procedure' do
+        dossier = create(:dossier, procedure: procedure, for_procedure_preview: true)
+        subject
+        expect(response.body).to include "DOSSIER_#{dossier.id}"
+        expect(response.body).to include "mon_export_#{dossier.id}.pdf"
+      end
     end
   end
 


### PR DESCRIPTION
hs: https://secure.helpscout.net/conversation/2711019264/2095236/

# problème
on envoie des requetes GET ac des URI trop longues, cf: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/414


# solution
on envoie des requetes PUT, pas de problème d'URI 😎 (le mec est brillant ! 🤣)
