### PR TITLE
amelioration : ETQ operateur j'aimerais simplifier/optimiser la gestion des tâches asynchrones

### DIFF
--- a/app/jobs/batch_operation_enqueue_all_job.rb
+++ b/app/jobs/batch_operation_enqueue_all_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class BatchOperationEnqueueAllJob < ApplicationJob
-  queue_as :mailers # hotfix
+  queue_as :critical
 
   def perform(batch_operation)
     batch_operation.enqueue_all

--- a/app/jobs/batch_operation_process_one_job.rb
+++ b/app/jobs/batch_operation_process_one_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class BatchOperationProcessOneJob < ApplicationJob
-  queue_as :mailers # hotfix
+  queue_as :critical
   retry_on StandardError, attempts: 1 # default 5, for now no retryable behavior
 
   def perform(batch_operation, dossier)

--- a/app/jobs/champ_fetch_external_data_job.rb
+++ b/app/jobs/champ_fetch_external_data_job.rb
@@ -2,6 +2,7 @@
 
 class ChampFetchExternalDataJob < ApplicationJob
   discard_on ActiveJob::DeserializationError
+  queue_as :critical # ui feedback, asap
 
   include Dry::Monads[:result]
 

--- a/app/jobs/cron/cron_job.rb
+++ b/app/jobs/cron/cron_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Cron::CronJob < ApplicationJob
-  queue_as :cron
+  queue_as :default
   class_attribute :schedule_expression
 
   class << self

--- a/app/jobs/destroy_record_later_job.rb
+++ b/app/jobs/destroy_record_later_job.rb
@@ -2,6 +2,7 @@
 
 class DestroyRecordLaterJob < ApplicationJob
   discard_on ActiveRecord::RecordNotFound
+  queue_as :low # destroy later, will be done when possible
 
   def perform(record)
     record.destroy

--- a/app/jobs/dolist_report_job.rb
+++ b/app/jobs/dolist_report_job.rb
@@ -3,6 +3,7 @@
 class DolistReportJob < ApplicationJob
   # Consolidate random recent emails dispatched to Dolist with their statuses
   # and send a report by email.
+  queue_as :low # reporting will be done asap
   def perform(report_to, sample_size = 1000)
     events = EmailEvent.dolist.dispatched.where(processed_at: 2.weeks.ago..).order("RANDOM()").limit(sample_size)
 

--- a/app/jobs/dossier_index_search_terms_job.rb
+++ b/app/jobs/dossier_index_search_terms_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DossierIndexSearchTermsJob < ApplicationJob
-  queue_as :low_priority
+  queue_as :low
 
   discard_on ActiveRecord::RecordNotFound
 

--- a/app/jobs/dossier_operation_log_move_to_cold_storage_batch_job.rb
+++ b/app/jobs/dossier_operation_log_move_to_cold_storage_batch_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DossierOperationLogMoveToColdStorageBatchJob < ApplicationJob
-  queue_as :low_priority
+  queue_as :low
 
   def perform(ids)
     DossierOperationLog.where(id: ids)

--- a/app/jobs/dossier_rebase_job.rb
+++ b/app/jobs/dossier_rebase_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DossierRebaseJob < ApplicationJob
-  queue_as :low_priority # they are massively enqueued, so don't interfere with others especially antivirus
+  queue_as :low # they are massively enqueued, so don't interfere with others especially antivirus
 
   # If by the time the job runs the Dossier has been deleted, ignore the rebase
   discard_on ActiveRecord::RecordNotFound

--- a/app/jobs/etablissement_update_job.rb
+++ b/app/jobs/etablissement_update_job.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class EtablissementUpdateJob < ApplicationJob
+  queue_as :critical # reporting will be done asap, but no occurence found. maube dead?
   def perform(dossier, siret)
     begin
       etablissement_attributes = APIEntrepriseService.get_etablissement_params_for_siret(siret, dossier.procedure.id)

--- a/app/jobs/helpscout_create_conversation_job.rb
+++ b/app/jobs/helpscout_create_conversation_job.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class HelpscoutCreateConversationJob < ApplicationJob
-  queue_as :default
-
   class FileNotScannedYetError < StandardError
   end
 

--- a/app/jobs/helpscout_create_conversation_job.rb
+++ b/app/jobs/helpscout_create_conversation_job.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class HelpscoutCreateConversationJob < ApplicationJob
+  queue_as :critical # user feedback is critical
   class FileNotScannedYetError < StandardError
   end
 

--- a/app/jobs/priorized_mail_delivery_job.rb
+++ b/app/jobs/priorized_mail_delivery_job.rb
@@ -12,7 +12,7 @@ class PriorizedMailDeliveryJob < ActionMailer::MailDeliveryJob
     end
   end
 
-  def custom_queue
+  def custom_queue # should be low
     ENV.fetch('BULK_EMAIL_QUEUE') { Rails.application.config.action_mailer.deliver_later_queue_name.to_s }
   end
 end

--- a/app/jobs/procedure_sva_svr_process_dossier_job.rb
+++ b/app/jobs/procedure_sva_svr_process_dossier_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ProcedureSVASVRProcessDossierJob < ApplicationJob
-  queue_as :sva
+  queue_as :critical
 
   def perform(dossier)
     dossier.process_sva_svr!

--- a/app/jobs/process_stalled_declarative_dossier_job.rb
+++ b/app/jobs/process_stalled_declarative_dossier_job.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class ProcessStalledDeclarativeDossierJob < ApplicationJob
+  queue_as :low
   def perform(dossier)
     return if dossier.declarative_triggered_at.present?
 

--- a/app/jobs/reset_expiring_dossiers_job.rb
+++ b/app/jobs/reset_expiring_dossiers_job.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class ResetExpiringDossiersJob < ApplicationJob
+  queue_as :low
   def perform(procedure)
     procedure
       .dossiers

--- a/app/jobs/send_closing_notification_job.rb
+++ b/app/jobs/send_closing_notification_job.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class SendClosingNotificationJob < ApplicationJob
+  queue_as :low # no rush on this one
+
   def perform(user_ids, content, procedure)
     User.where(id: user_ids).find_each do |user|
       Expired::MailRateLimiter.new().send_with_delay(UserMailer.notify_after_closing(user, content, @procedure))

--- a/app/jobs/web_hook_job.rb
+++ b/app/jobs/web_hook_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class WebHookJob < ApplicationJob
-  queue_as :webhooks_v1
+  queue_as :default
 
   TIMEOUT = 10
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -53,14 +53,14 @@ module TPS
     config.action_dispatch.ip_spoofing_check = false
 
     # Set the queue name for the mail delivery jobs to 'mailers'
-    config.action_mailer.deliver_later_queue_name = 'mailers'
+    config.action_mailer.deliver_later_queue_name = 'critical' # otherwise, :low
 
     # Allow the error messages format to be customized
     config.active_model.i18n_customize_full_message = true
 
     # Set the queue name for the analysis jobs to 'active_storage_analysis'
-    config.active_storage.queues.analysis = :active_storage_analysis
-    config.active_storage.queues.purge = :purge
+    config.active_storage.queues.analysis = :default
+    config.active_storage.queues.purge = :low
 
     config.active_support.cache_format_version = 7.0
 


### PR DESCRIPTION
crisp : https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_b8907e69-2264-4b84-883e-753f55e4320b/
depends_on: https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/10888

# TODO. 
on migre delayed_job -> sidekiq sur la mm machine avec une file dédiée export
et tous les autres, on fait le systeme a trois file en `strict`
quelles regles de queue ?
* qui va dans critical : ce qui peut pas attendre +2min
* qui va dans default : ce qui peut attendre de 2min a 15min
* qui va dans low : ce qui peut attendre + 15min

# probleme 
trop délais sur nos jobs, retour usager : ça marche pas

# solution
by @colinux 
```
J'ai réfléchi au sujet et bien spyé sidekq, et je crois qu'on doit tout remettre à plat, revenir comme préconisé par mike perham, à 3 files traitées par priorité et non par poids urgent / default / low (et éventuellement une dernière ultra low pour les taches sur plusieurs mois comme le déplacement des PJ). 
Là on perd bcp de capacité à cause de l'aléatoire, (la file default à 8 ne représente que 25% de la proba d'être traité), alors que d'autres files sont tjs vides. Ainsi on répartit mieux notre capacité réelle de 2x50 threads qui serait tout le temps utilisée, on conserve un bon ordre chronologique, et on priorise comme l'ultra critique. 
Les règles pour critique pourraient être : 

ce qui blqoue 'laccès au compte (mail de compte)
ce qui bloque l'instruction de dossier
ce qui ne se met pas par paquet de 1000 ou plus
Et on peut avoir des objectifs type " critique < 2 min", default < 15 min, low < 1h. Si on est dessus on augmente la capa, ou on change un job de prio.

Sur le rate limit de l'api entreprise c'est de toute façon pas au worker de faire ça dans un système distribué, et ça peut se gérer différemment grâce aux headers par exemple 
```
100% aligné la dessus et j'aimerais nous soulager les problèmes du quotidien ac des retours interne, utilisateur etc... donc je propose une belle review de groupe, et on y va :-)

# TODO, **avant de proder**
- [ ] faire en sorte que nos workers actuel poll les queues `critical`, `default`, `low`.

## TODO, **apres la prod**
- [ ] simplifier les workers pour que les backend poll chacun les queues  `critical`, `default`, `low`.
- [ ] gardeer les workers delayed_job sur `archive`/`export`
