### PR TITLE
amelioration : ETQ instructeur, je peux naviguer entre l'onglet de ma demarche et mes dossiers sans perdre le context (onglet et page) en utilisant un bouton retour

### DIFF
--- a/app/components/dossiers/batch_alert_component.rb
+++ b/app/components/dossiers/batch_alert_component.rb
@@ -13,4 +13,8 @@ class Dossiers::BatchAlertComponent < ApplicationComponent
     @batch.seen_at = Time.zone.now
     @batch.save
   end
+
+  def procedure_path
+    instructeur_procedure_path(@procedure, statut: params[:statut])
+  end
 end

--- a/app/components/dossiers/batch_alert_component/batch_alert_component.html.haml
+++ b/app/components/dossiers/batch_alert_component/batch_alert_component.html.haml
@@ -12,7 +12,7 @@
         %p= t(".#{batch.operation}.in_progress.text_success", count: @batch.total_count, success_count: @batch.success_count)
 
         %p
-          = link_to t('.link_text'), instructeur_procedure_path(@procedure, statut: params["statut"]), data: { action: 'turbo-poll#refresh' }
+          = link_to t('.link_text'), procedure_path, data: { action: 'turbo-poll#refresh' }
           = t('.after_link_text')
 
         %p.fr-mt-2w

--- a/app/components/dossiers/message_component.rb
+++ b/app/components/dossiers/message_component.rb
@@ -80,7 +80,7 @@ class Dossiers::MessageComponent < ApplicationComponent
   end
 
   def delete_url
-    groupe_gestionnaire ? gestionnaire_groupe_gestionnaire_commentaire_path(groupe_gestionnaire, commentaire) : instructeur_commentaire_path(commentaire.dossier.procedure, commentaire.dossier, commentaire)
+    groupe_gestionnaire ? gestionnaire_groupe_gestionnaire_commentaire_path(groupe_gestionnaire, commentaire, statut: params[:statut]) : instructeur_commentaire_path(commentaire.dossier.procedure, commentaire.dossier, commentaire, statut: params[:statut])
   end
 
   def highlight?

--- a/app/components/instructeurs/back_button_component.rb
+++ b/app/components/instructeurs/back_button_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Instructeurs::BackButtonComponent < ApplicationComponent
+  def initialize(to:)
+    @to = to
+  end
+
+  def call
+    link_to "", @to, class: 'back-btn fr-btn fr-btn--secondary fr-btn--sm fr-mr-2w fr-icon-arrow-left-line', title: t('.back')
+  end
+end

--- a/app/components/instructeurs/back_button_component/back_button_component.en.yml
+++ b/app/components/instructeurs/back_button_component/back_button_component.en.yml
@@ -1,0 +1,3 @@
+en:
+  back: Back to list of files
+

--- a/app/components/instructeurs/back_button_component/back_button_component.fr.yml
+++ b/app/components/instructeurs/back_button_component/back_button_component.fr.yml
@@ -1,0 +1,3 @@
+fr:
+  back: Retour à la liste des dossiers
+

--- a/app/components/instructeurs/en_construction_menu_component/en_construction_menu_component.html.haml
+++ b/app/components/instructeurs/en_construction_menu_component/en_construction_menu_component.html.haml
@@ -4,7 +4,7 @@
 
   - if dossier.may_repasser_en_construction?
     = menu.with_item do
-      = link_to(repasser_en_construction_instructeur_dossier_path(dossier.procedure.id, dossier.id), method: :post, role: 'menuitem') do
+      = link_to(repasser_en_construction_instructeur_dossier_path(dossier.procedure.id, dossier.id, statut: params[:statut]), method: :post, role: 'menuitem') do
         %span.fr-icon.fr-icon-draft-line.fr-text-default--info.fr-mt-1v{ "aria-hidden": "true" }
         .dropdown-description
           %h4= t('.revert_en_construction')
@@ -27,7 +27,7 @@
   - menu.with_item(class: "inactive form-inside fr-pt-1v") do
     = render partial: 'instructeurs/dossiers/instruction_button_motivation', locals: { dossier:,
         visible: true,
-        form_path: pending_correction_instructeur_dossier_path(dossier.procedure, dossier),
+        form_path: pending_correction_instructeur_dossier_path(dossier.procedure, dossier, statut: params[:statut]),
         placeholder: 'Expliquez au demandeur quelle(s) correction(s) sont attendues',
         popup_class: 'pending_correction',
         button_justificatif_label: "Ajouter une pièce jointe (facultatif)",

--- a/app/controllers/instructeurs/archives_controller.rb
+++ b/app/controllers/instructeurs/archives_controller.rb
@@ -22,7 +22,7 @@ module Instructeurs
       else
         flash[:notice] = "Cette archive a déjà été générée."
       end
-      redirect_to instructeur_archives_path(@procedure)
+      redirect_to list_instructeur_archives_path(@procedure)
     end
 
     private

--- a/app/controllers/instructeurs/avis_controller.rb
+++ b/app/controllers/instructeurs/avis_controller.rb
@@ -12,7 +12,7 @@ module Instructeurs
       avis = Avis.find(params[:id])
       if avis.revoke_by!(current_instructeur)
         flash.notice = "#{avis.expert.email} ne peut plus donner son avis sur ce dossier."
-        redirect_back(fallback_location: avis_instructeur_dossier_path(avis.procedure, avis.dossier))
+        redirect_back(fallback_location: avis_instructeur_dossier_path(avis.procedure, params[:statut], avis.dossier))
       end
     end
 
@@ -25,7 +25,7 @@ module Instructeurs
           AvisMailer.avis_invitation(avis).deliver_later
         end
         flash.notice = "Un mail de relance a été envoyé à #{avis.expert.email}"
-        redirect_back(fallback_location: avis_instructeur_dossier_path(avis.procedure, avis.dossier))
+        redirect_back(fallback_location: avis_instructeur_dossier_path(avis.procedure, params[:statut], avis.dossier))
       end
     end
   end

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -278,7 +278,7 @@ module Instructeurs
         @commentaire.dossier.touch(:last_commentaire_updated_at)
         current_instructeur.follow(dossier)
         flash.notice = "Message envoyé"
-        redirect_to messagerie_instructeur_dossier_path(procedure, dossier)
+        redirect_to messagerie_instructeur_dossier_path(procedure, dossier, statut: statut)
       else
         @commentaire.piece_jointe.purge.reload
         flash.alert = @commentaire.errors.full_messages
@@ -290,7 +290,7 @@ module Instructeurs
       @avis = create_avis_from_params(dossier, current_instructeur)
 
       if @avis.nil?
-        redirect_to avis_instructeur_dossier_path(procedure, dossier)
+        redirect_to avis_instructeur_dossier_path(procedure, dossier, statut: statut)
       else
         @avis_seen_at = current_instructeur.follows.find_by(dossier: dossier)&.avis_seen_at
         render :avis

--- a/app/views/instructeurs/avis/_sidemenu.html.haml
+++ b/app/views/instructeurs/avis/_sidemenu.html.haml
@@ -1,2 +1,2 @@
 = render(Dsfr::SidemenuComponent.new) do |component|
-  - component.with_links([{ name: t('helpers.sidemenu.see_avis'), url: avis_instructeur_dossier_path(@dossier.procedure, @dossier) }, { name: t('helpers.sidemenu.ask_avis'), url: avis_new_instructeur_dossier_path(@dossier.procedure, @dossier) }])
+  - component.with_links([{ name: t('helpers.sidemenu.see_avis'), url: avis_instructeur_dossier_path(procedure_id: @dossier.procedure.id, statut: params[:statut], dossier_id: @dossier.id) }, { name: t('helpers.sidemenu.ask_avis'), url: avis_new_instructeur_dossier_path(@dossier.procedure, params[:statut], @dossier) }])

--- a/app/views/instructeurs/dossiers/_header_bottom.html.haml
+++ b/app/views/instructeurs/dossiers/_header_bottom.html.haml
@@ -4,30 +4,30 @@
       - notifications_summary = current_instructeur.notifications_for_dossier(dossier)
 
       = dynamic_tab_item(t('views.instructeurs.dossiers.tab_steps.request'),
-        instructeur_dossier_path(dossier.procedure, dossier),
+        instructeur_dossier_path(dossier.procedure, params[:statut], dossier),
         notification: notifications_summary[:demande])
 
       - if gallery_attachments.present?
         = dynamic_tab_item(t('views.instructeurs.dossiers.tab_steps.attachments'),
-          pieces_jointes_instructeur_dossier_path(dossier.procedure, dossier),
+          pieces_jointes_instructeur_dossier_path(dossier.procedure, dossier, statut: params[:statut]),
           notification: notifications_summary[:pieces_jointes])
 
       = dynamic_tab_item(t('views.instructeurs.dossiers.tab_steps.private_annotations'),
-        annotations_privees_instructeur_dossier_path(dossier.procedure, dossier),
+        annotations_privees_instructeur_dossier_path(dossier.procedure, dossier, statut: params[:statut]),
         notification: notifications_summary[:annotations_privees])
 
       = dynamic_tab_item(t('views.instructeurs.dossiers.tab_steps.external_opinion'),
-        [avis_instructeur_dossier_path(dossier.procedure, dossier),
-        avis_new_instructeur_dossier_path(dossier.procedure, dossier)],
+        [avis_instructeur_dossier_path(dossier.procedure, dossier, statut: params[:statut]),
+        avis_new_instructeur_dossier_path(dossier.procedure, dossier, statut: params[:statut])],
         notification: notifications_summary[:avis])
 
       = dynamic_tab_item(t('views.instructeurs.dossiers.tab_steps.messaging'),
-        messagerie_instructeur_dossier_path(dossier.procedure, dossier),
+        messagerie_instructeur_dossier_path(dossier.procedure, dossier, statut: params[:statut]),
         notification: notifications_summary[:messagerie])
 
       = dynamic_tab_item(t('views.instructeurs.dossiers.tab_steps.involved_persons'),
-        personnes_impliquees_instructeur_dossier_path(dossier.procedure, dossier))
+        personnes_impliquees_instructeur_dossier_path(dossier.procedure, dossier, statut: params[:statut]))
 
       - if dossier.procedure.routing_enabled?
         = dynamic_tab_item(t('views.instructeurs.dossiers.tab_steps.reaffectation'),
-          reaffectation_instructeur_dossier_path(dossier.procedure, dossier))
+          reaffectation_instructeur_dossier_path(dossier.procedure, dossier, statut: params[:statut]))

--- a/app/views/instructeurs/dossiers/_header_top.html.haml
+++ b/app/views/instructeurs/dossiers/_header_top.html.haml
@@ -1,8 +1,11 @@
 #header-top.fr-container
   .flex
     %div
-      %h1.fr-h3.fr-mb-1w
-        = t('show_dossier', scope: [:layouts, :breadcrumb], dossier_id: dossier.id, owner_name: dossier.owner_name)
+      .flex.fr-mb-1w
+        = render Instructeurs::BackButtonComponent.new(to: instructeur_procedure_path(dossier.procedure, statut: params[:statut]))
+        %h1.fr-h3.fr-mb-1w
+          = t('show_dossier', scope: [:layouts, :breadcrumb], dossier_id: dossier.id, owner_name: dossier.owner_name)
+
 
       = link_to dossier.procedure.libelle.truncate_words(10), instructeur_procedure_path(dossier.procedure), title: dossier.procedure.libelle, class: "fr-link"
       .fr-mt-2w.fr-badge-group

--- a/app/views/instructeurs/dossiers/_instruction_button_motivation.html.haml
+++ b/app/views/instructeurs/dossiers/_instruction_button_motivation.html.haml
@@ -1,5 +1,5 @@
 .motivation{ class: class_names(popup_class => true, hidden: !defined?(visible) || !visible, "fr-pb-2w fr-px-2w": true) }
-  = form_tag(defined?(form_path) ? form_path : terminer_instructeur_dossier_path(dossier.procedure, dossier), data: { turbo: true, turbo_confirm: confirm }, method: :post, multipart: true) do
+  = form_tag(defined?(form_path) ? form_path : terminer_instructeur_dossier_path(dossier.procedure, dossier, statut: params[:statut]), data: { turbo: true, turbo_confirm: confirm }, method: :post, multipart: true) do
     - if title == 'Accepter'
       = text_area :dossier, :motivation, class: 'fr-input', placeholder: placeholder, required: false
       - if dossier.attestation_template&.activated?

--- a/app/views/instructeurs/dossiers/_print_and_export_actions.html.haml
+++ b/app/views/instructeurs/dossiers/_print_and_export_actions.html.haml
@@ -12,7 +12,7 @@
         Uniquement cet onglet
 
     - menu.with_item do
-      = link_to instructeur_dossier_path(dossier.procedure, dossier, format: :pdf), target: "_blank", rel: "noopener", class: "menu-item menu-link", role: 'menuitem' do
+      = link_to instructeur_dossier_path(dossier.procedure, dossier, statut: params[:statut], format: :pdf), target: "_blank", rel: "noopener", class: "menu-item menu-link", role: 'menuitem' do
         Export PDF
 
     - if dossier.geo_data?

--- a/app/views/instructeurs/dossiers/avis_new.html.haml
+++ b/app/views/instructeurs/dossiers/avis_new.html.haml
@@ -9,7 +9,7 @@
     .fr-col
       - if !@dossier.termine?
         - if @dossier.procedure.allow_expert_review
-          = render partial: "shared/avis/form", locals: { url: avis_instructeur_dossier_path(@dossier.procedure, @dossier), linked_dossiers: @dossier.linked_dossiers_for(current_instructeur), must_be_confidentiel: false, avis: @avis }
+          = render partial: "shared/avis/form", locals: { url: avis_instructeur_dossier_path(@dossier.procedure, params[:statut], @dossier), linked_dossiers: @dossier.linked_dossiers_for(current_instructeur), must_be_confidentiel: false, avis: @avis }
         - else
           %h2.empty-text
             = t('helpers.information_text.unauthorized_avis_text')

--- a/app/views/instructeurs/dossiers/messagerie.html.haml
+++ b/app/views/instructeurs/dossiers/messagerie.html.haml
@@ -2,4 +2,4 @@
 
 = render partial: "header", locals: { dossier: @dossier, gallery_attachments: @gallery_attachments }
 
-= render partial: "shared/dossiers/messagerie", locals: { dossier: @dossier, connected_user: current_instructeur, messagerie_seen_at: @messagerie_seen_at , new_commentaire: @commentaire, form_url: commentaire_instructeur_dossier_path(@dossier.procedure, @dossier) }
+= render partial: "shared/dossiers/messagerie", locals: { dossier: @dossier, connected_user: current_instructeur, messagerie_seen_at: @messagerie_seen_at , new_commentaire: @commentaire, form_url: commentaire_instructeur_dossier_path(@dossier.procedure, @dossier, statut: params[:statut]) }

--- a/app/views/instructeurs/procedures/_dossier_actions.html.haml
+++ b/app/views/instructeurs/procedures/_dossier_actions.html.haml
@@ -25,23 +25,23 @@
         = ""
 
     - else
-      = button_to repasser_en_instruction_instructeur_dossier_path(procedure_id, dossier_id), method: :post, class: 'fr-btn fr-btn--secondary fr-icon-edit-line', form: { data: { turbo: turbo ? 'true' : 'false' } } do
+      = button_to repasser_en_instruction_instructeur_dossier_path(procedure_id, dossier_id, statut: params[:statut]), method: :post, class: 'fr-btn fr-btn--secondary fr-icon-edit-line', form: { data: { turbo: turbo ? 'true' : 'false' } } do
         Repasser en instruction
 
-      = button_to archive_instructeur_dossier_path(procedure_id, dossier_id), method: :patch, class: 'fr-btn fr-icon-folder-2-line' do
+      = button_to archive_instructeur_dossier_path(procedure_id, dossier_id, statut: params[:statut]), method: :patch, class: 'fr-btn fr-icon-folder-2-line' do
         Archiver le dossier
 
-      = button_to instructeur_dossier_path(procedure_id, dossier_id), method: :delete, class: 'fr-btn fr-btn--secondary fr-icon-delete-line icon-only danger', title: t('views.instructeurs.dossiers.delete_dossier') do
+      = button_to instructeur_dossier_path(procedure_id, dossier_id, statut: params[:statut]), method: :delete, class: 'fr-btn fr-btn--secondary fr-icon-delete-line icon-only danger', title: t('views.instructeurs.dossiers.delete_dossier') do
         = ""
 
 - elsif Dossier::EN_CONSTRUCTION_OU_INSTRUCTION.include?(state)
   - if dossier_is_followed
     %li
-      = button_to unfollow_instructeur_dossier_path(procedure_id, dossier_id), method: :patch, class: 'fr-btn fr-btn--secondary fr-icon-star-fill' do
+      = button_to unfollow_instructeur_dossier_path(procedure_id, statut: params[:statut], dossier_id:), method: :patch, class: 'fr-btn fr-btn--secondary fr-icon-star-fill' do
         = t('views.instructeurs.dossiers.stop_follow')
   - else
     %li
-      = button_to follow_instructeur_dossier_path(procedure_id, dossier_id), method: :patch, class: 'fr-btn fr-btn--secondary fr-icon-star-line' do
+      = button_to follow_instructeur_dossier_path(procedure_id, statut: params[:statut], dossier_id:), method: :patch, class: 'fr-btn fr-btn--secondary fr-icon-star-line' do
         = t('views.instructeurs.dossiers.follow_file')
 
   - if with_menu
@@ -50,7 +50,7 @@
 
   - if Dossier.states[:en_construction] == state
     %li{ 'data-turbo': turbo ? 'true' : 'false' }
-      = button_to passer_en_instruction_instructeur_dossier_path(procedure_id, dossier_id), method: :post, class: 'fr-btn fr-icon-edit-line',
+      = button_to passer_en_instruction_instructeur_dossier_path(procedure_id, statut: params[:statut], dossier_id:), method: :post, class: 'fr-btn fr-icon-edit-line',
         disabled: has_blocking_pending_correction, "aria-describedby" => has_blocking_pending_correction ? "tooltip-passer-en-instruction" : nil do
         = t('views.instructeurs.dossiers.passer_en_instruction')
 
@@ -60,5 +60,5 @@
 
   - elsif Dossier.states[:en_instruction] == state && !with_menu && !sva_svr
     %li{ 'data-turbo': turbo ? 'true' : 'false' }
-      = button_to repasser_en_construction_instructeur_dossier_path(procedure_id, dossier_id), method: :post, class: 'fr-btn fr-btn--secondary fr-icon-draft-line' do
+      = button_to repasser_en_construction_instructeur_dossier_path(procedure_id, statut: params[:statut], dossier_id:), method: :post, class: 'fr-btn fr-btn--secondary fr-icon-draft-line' do
         = t('views.instructeurs.dossiers.repasser_en_construction')

--- a/app/views/instructeurs/procedures/_header.html.haml
+++ b/app/views/instructeurs/procedures/_header.html.haml
@@ -56,7 +56,7 @@
                 - if @has_export_notification
                   %span.fr-ml-1v.notifications{ 'aria-label': t('instructeurs.dossiers.header.banner.exports_notification_label') }
             %li
-              = link_to t('instructeurs.dossiers.header.banner.archives'), instructeur_archives_path(procedure), class: 'fr-nav__link'
+              = link_to t('instructeurs.dossiers.header.banner.archives'), list_instructeur_archives_path(procedure), class: 'fr-nav__link'
             %li
               = link_to t('instructeurs.dossiers.header.banner.export_templates'), export_templates_instructeur_procedure_path(procedure), class: 'fr-nav__link'
 

--- a/app/views/instructeurs/procedures/_header.html.haml
+++ b/app/views/instructeurs/procedures/_header.html.haml
@@ -1,5 +1,6 @@
 .procedure-header
-  .clipboard-container
+  .clipboard-container.flex
+    = render Instructeurs::BackButtonComponent.new(to: instructeur_procedures_path)
     %h1.fr-h3.fr-mb-0
       = "#{procedure_libelle procedure} (n°#{procedure.id})"
   %nav.fr-nav#navigation{ role: "navigation", "aria-label": t('instructeurs.dossiers.header.banner.procedure_navigation') }

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -111,7 +111,7 @@
 
                     - @projected_dossiers.each do |p|
                       - dossier = p.dossier
-                      - path = instructeur_dossier_path(@procedure, dossier.id)
+                      - path = instructeur_dossier_path(@procedure, dossier.id, statut: params[:statut])
                       %tr{ class: class_names("file-hidden-by-user" => dossier.hidden_by_user_at.present?), id: "table-dossiers-row-#{dossier.id}", "aria-selected" => "false", "data-row-key" => dossier.id }
                         - if batch_operation_component.render?
                           %th.fr-cell--fixed{ scope: 'row' }

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -30,7 +30,7 @@
         = t('views.instructeurs.dossiers.tab_explainations.suivis')
     - if @statut == 'traites'
       %p
-        = t('views.instructeurs.dossiers.tab_explainations.traites_html', archives_path: instructeur_archives_path(@procedure))
+        = t('views.instructeurs.dossiers.tab_explainations.traites_html', archives_path: list_instructeur_archives_path(@procedure))
     - if @statut == 'tous'
       %p
         - if @procedure.routing_enabled?

--- a/app/views/shared/avis/_list.html.haml
+++ b/app/views/shared/avis/_list.html.haml
@@ -42,10 +42,10 @@
               = t('relance_effectuee_le', scope: 'views.shared.avis', date: l(avis.reminded_at, format: '%d/%m/%y à %H:%M'))
           - if expert_or_instructeur.is_a?(Instructeur)
             - if avis.answer.blank?
-              = link_to(t('remind', scope: 'helpers.label'), remind_instructeur_avis_path(avis.procedure, avis), class:'fr-btn fr-btn--sm fr-btn--tertiary-no-outline', data: { confirm: t('remind', scope: 'helpers.confirmation', email: avis.expert.email) })
+              = link_to(t('remind', scope: 'helpers.label'), remind_instructeur_avis_path(avis.procedure, params[:statut], avis), class:'fr-btn fr-btn--sm fr-btn--tertiary-no-outline', data: { confirm: t('remind', scope: 'helpers.confirmation', email: avis.expert.email) })
 
               - if avis.revokable_by?(expert_or_instructeur)
-                = link_to(t('revoke', scope: 'helpers.label'), revoquer_instructeur_avis_path(avis.procedure, avis), class:'fr-btn fr-btn--sm fr-btn--tertiary-no-outline', data: { confirm: t('revoke', scope: 'helpers.confirmation', email: avis.expert.email) }, method: :patch)
+                = link_to(t('revoke', scope: 'helpers.label'), revoquer_instructeur_avis_path(avis.procedure, params[:statut], avis), class:'fr-btn fr-btn--sm fr-btn--tertiary-no-outline', data: { confirm: t('revoke', scope: 'helpers.confirmation', email: avis.expert.email) }, method: :patch)
 
         .border-left
           - if avis.introduction_file.attached?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -532,6 +532,13 @@ Rails.application.routes.draw do
           end
         end
 
+        resources :archives, only: [] do
+          collection do
+            get 'list' => "archives#index"
+            post 'create' => "archives#create"
+          end
+        end
+
         resources :groupes, only: [:index, :show], controller: 'groupe_instructeurs' do
           resource :contact_information
           member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -468,9 +468,69 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :procedures, only: [:index, :show], param: :procedure_id do
+    resources :procedures, only: [:index], param: :procedure_id do
       member do
-        resources :archives, only: [:index, :create]
+        #
+        # nested navigation, all those route are hit during an instructeur instruction navigation context
+        #   must keep track of last view statut page
+        #
+        constraints statut: /a-suivre|suivis|traites|tous|supprimes|expirant|archives/ do
+          get :show, path: "(:statut)", defaults: { statut: 'a-suivre' } # optional because some url may still live on with /procedure/:id
+
+          resources :dossiers, only: [:show, :destroy], param: :dossier_id, path: "(:statut)/dossiers", defaults: { statut: 'a-suivre' } do
+            member do
+              resources :commentaires, only: [:destroy]
+              post 'repousser-expiration' => 'dossiers#extend_conservation'
+              post 'repousser-expiration-and-restore' => 'dossiers#extend_conservation_and_restore'
+              post 'dossier_labels' => 'dossiers#dossier_labels'
+              get 'messagerie'
+              get 'annotations-privees' => 'dossiers#annotations_privees'
+              get 'avis'
+              get 'avis_new'
+              get 'personnes-impliquees' => 'dossiers#personnes_impliquees'
+              patch 'follow'
+              patch 'unfollow'
+              patch 'archive'
+              patch 'unarchive'
+              patch 'restore'
+              post 'commentaire' => 'dossiers#create_commentaire'
+              post 'passer-en-instruction' => 'dossiers#passer_en_instruction'
+              post 'repasser-en-construction' => 'dossiers#repasser_en_construction'
+              post 'repasser-en-instruction' => 'dossiers#repasser_en_instruction'
+              post 'terminer'
+              post 'pending_correction'
+              post 'send-to-instructeurs' => 'dossiers#send_to_instructeurs'
+              post 'avis' => 'dossiers#create_avis'
+              get 'reaffectation'
+              get 'pieces_jointes'
+              post 'reaffecter'
+            end
+          end
+
+          resources :avis, only: [], path: "(:statut)/dossiers", defaults: { statut: 'a-suivre' } do
+            member do
+              patch 'revoquer'
+              get 'remind'
+            end
+          end
+
+          resources :batch_operations, only: [:create], path: "(:statut)/dossiers", defaults: { statut: 'a-suivre' }
+        end
+
+        #
+        # not nested navigation
+        #
+        resources :dossiers, only: [], param: :dossier_id do
+          member do
+            get 'telecharger_pjs' => 'dossiers#telecharger_pjs'
+            get 'print' => 'dossiers#print'
+            patch 'annotations' => 'dossiers#update_annotations'
+            get 'annotations/:stable_id', to: 'dossiers#annotation', as: :annotation
+            get 'geo_data'
+            get 'apercu_attestation'
+            get 'bilans_bdf'
+          end
+        end
 
         resources :groupes, only: [:index, :show], controller: 'groupe_instructeurs' do
           resource :contact_information
@@ -479,13 +539,6 @@ Rails.application.routes.draw do
             delete 'remove_instructeur'
             post 'add_signature'
             get 'preview_attestation'
-          end
-        end
-
-        resources :avis, only: [] do
-          member do
-            patch 'revoquer'
-            get 'remind'
           end
         end
 
@@ -502,45 +555,6 @@ Rails.application.routes.draw do
         get 'deleted_dossiers'
         get 'email_usagers'
         post 'create_multiple_commentaire'
-
-        resources :dossiers, only: [:show, :destroy], param: :dossier_id do
-          member do
-            resources :commentaires, only: [:destroy]
-            post 'repousser-expiration' => 'dossiers#extend_conservation'
-            post 'repousser-expiration-and-restore' => 'dossiers#extend_conservation_and_restore'
-            post 'dossier_labels' => 'dossiers#dossier_labels'
-            get 'geo_data'
-            get 'apercu_attestation'
-            get 'bilans_bdf'
-            get 'messagerie'
-            get 'annotations-privees' => 'dossiers#annotations_privees'
-            get 'avis'
-            get 'avis_new'
-            get 'personnes-impliquees' => 'dossiers#personnes_impliquees'
-            get 'annotations/:stable_id', to: 'dossiers#annotation', as: :annotation
-            patch 'follow'
-            patch 'unfollow'
-            patch 'archive'
-            patch 'unarchive'
-            patch 'restore'
-            patch 'annotations' => 'dossiers#update_annotations'
-            post 'commentaire' => 'dossiers#create_commentaire'
-            post 'passer-en-instruction' => 'dossiers#passer_en_instruction'
-            post 'repasser-en-construction' => 'dossiers#repasser_en_construction'
-            post 'repasser-en-instruction' => 'dossiers#repasser_en_instruction'
-            post 'terminer'
-            post 'pending_correction'
-            post 'send-to-instructeurs' => 'dossiers#send_to_instructeurs'
-            post 'avis' => 'dossiers#create_avis'
-            get 'print' => 'dossiers#print'
-            get 'telecharger_pjs' => 'dossiers#telecharger_pjs'
-            get 'reaffectation'
-            get 'pieces_jointes'
-            post 'reaffecter'
-          end
-        end
-
-        resources :batch_operations, only: [:create]
       end
     end
   end

--- a/spec/components/dossiers/batch_alert_component_spec.rb
+++ b/spec/components/dossiers/batch_alert_component_spec.rb
@@ -5,6 +5,15 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
   let(:procedure) { create(:procedure) }
 
   subject { render_inline(component).to_html }
+  let(:component) do
+    described_class.new(
+      batch: batch_operation,
+      procedure:
+    )
+  end
+  before do
+    allow(component).to receive(:procedure_path).and_return(Rails.application.routes.url_helpers.instructeur_procedure_path(procedure, statut: 'a-suivre'))
+  end
 
   describe 'archiver' do
     let(:component) do
@@ -54,7 +63,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       it { expect(batch_operation.seen_at).to eq(nil) }
 
       it 'on next render "seen_at" is set to avoid rendering alert' do
-        render_inline(component).to_html
+        render_inline(described_class.new(batch: batch_operation, procedure:)).to_html
         expect(batch_operation.seen_at).not_to eq(nil)
       end
     end
@@ -108,7 +117,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       it { expect(batch_operation.seen_at).to eq(nil) }
 
       it 'on next render "seen_at" is set to avoid rendering alert' do
-        render_inline(component).to_html
+        render_inline(described_class.new(batch: batch_operation, procedure:)).to_html
         expect(batch_operation.seen_at).not_to eq(nil)
       end
     end
@@ -162,7 +171,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       it { expect(batch_operation.seen_at).to eq(nil) }
 
       it 'on next render "seen_at" is set to avoid rendering alert' do
-        render_inline(component).to_html
+        render_inline(described_class.new(batch: batch_operation, procedure:)).to_html
         expect(batch_operation.seen_at).not_to eq(nil)
       end
     end
@@ -216,7 +225,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       it { expect(batch_operation.seen_at).to eq(nil) }
 
       it 'on next render "seen_at" is set to avoid rendering alert' do
-        render_inline(component).to_html
+        render_inline(described_class.new(batch: batch_operation, procedure:)).to_html
         expect(batch_operation.seen_at).not_to eq(nil)
       end
     end
@@ -270,7 +279,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       it { expect(batch_operation.seen_at).to eq(nil) }
 
       it 'on next render "seen_at" is set to avoid rendering alert' do
-        render_inline(component).to_html
+        render_inline(described_class.new(batch: batch_operation, procedure:)).to_html
         expect(batch_operation.seen_at).not_to eq(nil)
       end
     end
@@ -396,7 +405,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       it { expect(batch_operation.seen_at).to eq(nil) }
 
       it 'on next render "seen_at" is set to avoid rendering alert' do
-        render_inline(component).to_html
+        render_inline(described_class.new(batch: batch_operation, procedure:)).to_html
         expect(batch_operation.seen_at).not_to eq(nil)
       end
     end
@@ -450,7 +459,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       it { expect(batch_operation.seen_at).to eq(nil) }
 
       it 'on next render "seen_at" is set to avoid rendering alert' do
-        render_inline(component).to_html
+        render_inline(described_class.new(batch: batch_operation, procedure:)).to_html
         expect(batch_operation.seen_at).not_to eq(nil)
       end
     end
@@ -504,7 +513,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       it { expect(batch_operation.seen_at).to eq(nil) }
 
       it 'on next render "seen_at" is set to avoid rendering alert' do
-        render_inline(component).to_html
+        render_inline(described_class.new(batch: batch_operation, procedure:)).to_html
         expect(batch_operation.seen_at).not_to eq(nil)
       end
     end
@@ -558,7 +567,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       it { expect(batch_operation.seen_at).to eq(nil) }
 
       it 'on next render "seen_at" is set to avoid rendering alert' do
-        render_inline(component).to_html
+        render_inline(described_class.new(batch: batch_operation, procedure:)).to_html
         expect(batch_operation.seen_at).not_to eq(nil)
       end
     end
@@ -612,7 +621,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       it { expect(batch_operation.seen_at).to eq(nil) }
 
       it 'on next render "seen_at" is set to avoid rendering alert' do
-        render_inline(component).to_html
+        render_inline(described_class.new(batch: batch_operation, procedure:)).to_html
         expect(batch_operation.seen_at).not_to eq(nil)
       end
     end

--- a/spec/components/dossiers/message_component_spec.rb
+++ b/spec/components/dossiers/message_component_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe Dossiers::MessageComponent, type: :component do
       groupe_gestionnaire: groupe_gestionnaire
     )
   end
+  before do
+    allow(component).to receive(:params).and_return({ statut: 'a-suivre' })
+  end
+
   let(:seen_at) { commentaire.created_at + 1.hour }
 
   describe 'for dossier' do
@@ -230,7 +234,7 @@ RSpec.describe Dossiers::MessageComponent, type: :component do
 
       describe 'delete message button for gestionnaire' do
         let(:connected_user) { gestionnaire }
-        let(:form_url) { component.helpers.gestionnaire_groupe_gestionnaire_commentaire_path(groupe_gestionnaire, commentaire) }
+        let(:form_url) { component.helpers.gestionnaire_groupe_gestionnaire_commentaire_path(groupe_gestionnaire, commentaire, statut: 'a-suivre') }
 
         context 'when commentaire had been written by connected gestionnaire' do
           it { is_expected.to have_selector("form[action=\"#{form_url}\"]") }

--- a/spec/components/instructeurs/en_contruction_menu_component_spec.rb
+++ b/spec/components/instructeurs/en_contruction_menu_component_spec.rb
@@ -4,7 +4,9 @@ RSpec.describe Instructeurs::EnConstructionMenuComponent, type: :component do
   include DossierHelper
 
   subject do
-    render_inline(described_class.new(dossier:))
+    component = described_class.new(dossier:)
+    allow(component).to receive(:statut).and_return('a-suivre')
+    render_inline(component)
   end
 
   matcher :have_dropdown_title do |expected_title|

--- a/spec/controllers/instructeurs/avis_controller_spec.rb
+++ b/spec/controllers/instructeurs/avis_controller_spec.rb
@@ -19,7 +19,7 @@ describe Instructeurs::AvisController, type: :controller do
       let!(:avis) { create(:avis, dossier: dossier, claimant: instructeur, experts_procedure: experts_procedure) }
 
       before do
-        patch :revoquer, params: { procedure_id: procedure.id, id: avis.id }
+        patch :revoquer, params: { procedure_id: procedure.id, id: avis.id, statut: 'a-suivre' }
       end
 
       it "revoke the dossier" do
@@ -35,7 +35,7 @@ describe Instructeurs::AvisController, type: :controller do
         let!(:avis) { create(:avis, dossier: dossier, claimant: instructeur, experts_procedure: experts_procedure) }
 
         it 'sends a reminder to the expert' do
-          get :remind, params: { procedure_id: procedure.id, id: avis.id }
+          get :remind, params: { procedure_id: procedure.id, id: avis.id, statut: 'a-suivre' }
           expect(AvisMailer).to have_received(:avis_invitation_and_confirm_email)
           expect(flash.notice).to eq("Un mail de relance a été envoyé à #{avis.expert.email}")
           expect(avis.reload.reminded_at).to be_present
@@ -46,7 +46,7 @@ describe Instructeurs::AvisController, type: :controller do
         let!(:avis) { create(:avis, dossier: dossier, claimant: instructeur, experts_procedure: experts_procedure, question_label: '123') }
 
         it 'sends a reminder to the expert' do
-          get :remind, params: { procedure_id: procedure.id, id: avis.id }
+          get :remind, params: { procedure_id: procedure.id, id: avis.id, statut: 'a-suivre' }
           expect(AvisMailer).to have_received(:avis_invitation_and_confirm_email)
           expect(flash.notice).to eq("Un mail de relance a été envoyé à #{avis.expert.email}")
           expect(avis.reload.reminded_at).to be_present

--- a/spec/controllers/instructeurs/batch_operations_controller_spec.rb
+++ b/spec/controllers/instructeurs/batch_operations_controller_spec.rb
@@ -10,7 +10,8 @@ describe Instructeurs::BatchOperationsController, type: :controller do
       batch_operation: {
         operation: BatchOperation.operations.fetch(:archiver),
         dossier_ids: [dossier.id]
-      }
+      },
+      statut: 'a-suivre'
     }
   end
 
@@ -20,7 +21,10 @@ describe Instructeurs::BatchOperationsController, type: :controller do
 
     context 'ACL' do
       let(:params) do
-        { procedure_id: create(:procedure).id }
+        {
+          procedure_id: create(:procedure).id,
+          statut: 'a-suivre'
+        }
       end
 
       it 'fails when procedure does not belongs to instructeur' do

--- a/spec/controllers/instructeurs/commentaires_controller_spec.rb
+++ b/spec/controllers/instructeurs/commentaires_controller_spec.rb
@@ -13,7 +13,7 @@ describe Instructeurs::CommentairesController, type: :controller do
     describe 'destroy' do
       context 'when it works' do
         let(:commentaire) { create(:commentaire, instructeur: instructeur, dossier: dossier) }
-        subject { delete :destroy, params: { dossier_id: dossier.id, procedure_id: procedure.id, id: commentaire.id }, format: :turbo_stream }
+        subject { delete :destroy, params: { dossier_id: dossier.id, procedure_id: procedure.id, id: commentaire.id, statut: 'a-suivre' }, format: :turbo_stream }
 
         it 'respond with OK and flash' do
           expect(subject).to have_http_status(:ok)
@@ -48,7 +48,7 @@ describe Instructeurs::CommentairesController, type: :controller do
 
       context 'when dossier had been discarded' do
         let(:commentaire) { create(:commentaire, instructeur: instructeur, dossier: dossier, discarded_at: 2.hours.ago) }
-        subject { delete :destroy, params: { dossier_id: dossier.id, procedure_id: procedure.id, id: commentaire.id }, format: :turbo_stream }
+        subject { delete :destroy, params: { dossier_id: dossier.id, procedure_id: procedure.id, id: commentaire.id, statut: 'a-suivre' }, format: :turbo_stream }
 
         it 'respond with OK and flash' do
           expect(subject).to have_http_status(:ok)
@@ -65,7 +65,7 @@ describe Instructeurs::CommentairesController, type: :controller do
     describe 'destroy' do
       context 'when it works' do
         let(:commentaire) { create(:commentaire, expert: expert, dossier: dossier) }
-        subject { delete :destroy, params: { dossier_id: dossier.id, procedure_id: procedure.id, id: commentaire.id }, format: :turbo_stream }
+        subject { delete :destroy, params: { dossier_id: dossier.id, procedure_id: procedure.id, id: commentaire.id, statut: 'a-suivre' }, format: :turbo_stream }
 
         it 'respond with OK and flash' do
           expect(subject).to have_http_status(:ok)

--- a/spec/controllers/instructeurs/procedures_controller_spec.rb
+++ b/spec/controllers/instructeurs/procedures_controller_spec.rb
@@ -263,7 +263,7 @@ describe Instructeurs::ProceduresController, type: :controller do
     let!(:gi_2) { create(:groupe_instructeur, label: '2', procedure: procedure) }
     let!(:gi_3) { create(:groupe_instructeur, label: '3', procedure: procedure) }
 
-    let(:statut) { nil }
+    let(:statut) { 'a-suivre' }
 
     subject do
       get :show, params: { procedure_id: procedure.id, statut: statut }

--- a/spec/system/instructeurs/instruction_spec.rb
+++ b/spec/system/instructeurs/instruction_spec.rb
@@ -199,20 +199,19 @@ describe 'Instructing a dossier:', js: true do
     expect(page).to have_text("Dossier envoyé")
   end
 
-  context 'A instructeur can ask for an Archive' do
-    let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }], instructeurs: [instructeur]) }
-    let(:dossier) { create(:dossier, :accepte, procedure: procedure) }
-    before do
-      log_in(instructeur.email, password)
-      visit instructeur_archives_path(procedure)
-    end
-    scenario 'download' do
-      expect {
-        page.first(".fr-table .fr-btn").click
-      }.to have_enqueued_job(ArchiveCreationJob).with(procedure, an_instance_of(Archive), instructeur)
-      expect(Archive.first.month).not_to be_nil
-    end
+  scenario 'A instructeur can ask for an Archive', chrome: true do
+    archivable_procedure = create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }], instructeurs: [instructeur])
+    create(:dossier, :accepte, procedure: archivable_procedure)
+
+    log_in(instructeur.email, password)
+    visit list_instructeur_archives_path(archivable_procedure)
+
+    expect {
+      page.first(".fr-table .fr-btn").click
+    }.to have_enqueued_job(ArchiveCreationJob).with(archivable_procedure, an_instance_of(Archive), instructeur)
+    expect(Archive.first.month).not_to be_nil
   end
+
   context 'with dossiers having attached files' do
     let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }], instructeurs: [instructeur]) }
     let(:dossier) { create(:dossier, :en_construction, procedure: procedure) }

--- a/spec/system/instructeurs/instruction_spec.rb
+++ b/spec/system/instructeurs/instruction_spec.rb
@@ -38,7 +38,16 @@ describe 'Instructing a dossier:', js: true do
     expect(page).to have_current_path(instructeur_procedure_path(procedure))
 
     click_on dossier.user.email
-    expect(page).to have_current_path(instructeur_dossier_path(procedure, dossier))
+    expect(page).to have_current_path(instructeur_dossier_path(procedure, dossier, statut: 'a-suivre'))
+    page.find('.back-btn').click
+
+    click_on 'Suivre le dossier'
+    click_on 'suivi'
+    expect(page).to have_current_path(instructeur_procedure_path(procedure, statut: 'suivis'))
+
+    click_on dossier.user.email
+    expect(page).to have_current_path(instructeur_dossier_path(procedure, 'suivis', dossier))
+    expect(page).to have_selector(".back-btn[href=\"#{instructeur_procedure_path(procedure, statut: 'suivis')}\"]")
 
     click_on 'Passer en instruction'
 
@@ -70,16 +79,17 @@ describe 'Instructing a dossier:', js: true do
     dossier.reload
     expect(dossier.state).to eq(Dossier.states.fetch(:accepte))
     expect(dossier.motivation).to eq('a good reason')
+    # keep back up to date after most action on dossier
+    expect(page).to have_selector(".back-btn[href=\"#{instructeur_procedure_path(procedure, statut: 'suivis')}\"]")
 
     click_on procedure.libelle
     click_on 'traité'
     expect(page).to have_button('Repasser en instruction')
     click_on 'Supprimer le dossier'
-    click_on 'traité'
     expect(page).not_to have_button('Repasser en instruction')
   end
 
-  scenario 'An instructeur can add anotations' do
+  scenario 'An instructeur can add annotations' do
     log_in(instructeur.email, password)
 
     visit instructeur_dossier_path(procedure, dossier)
@@ -90,15 +100,6 @@ describe 'Instructing a dossier:', js: true do
     expect(page).to have_field 'Nom'
     fill_in 'Nom', with: 'John Doe'
     expect(page).to have_text 'Annotations enregistrées'
-  end
-
-  scenario 'An instructeur can destroy a dossier from view' do
-    log_in(instructeur.email, password)
-
-    dossier.passer_en_instruction(instructeur: instructeur)
-    dossier.accepter!(instructeur: instructeur)
-    visit instructeur_dossier_path(procedure, dossier)
-    click_on 'Supprimer le dossier'
   end
 
   scenario 'A instructeur can follow/unfollow a dossier' do
@@ -152,18 +153,20 @@ describe 'Instructing a dossier:', js: true do
     expect(page).to have_text('Télécharger l’export')
   end
 
-  scenario 'A instructeur can see the personnes impliquées' do
+  scenario 'A instructeur can see the personnes impliquées and statut is maintened over avis/personnes impliquee paths', chrome: true do
     instructeur2 = create(:instructeur, password: password)
 
     log_in(instructeur.email, password)
 
     click_on procedure.libelle
+    click_on 'Suivre le dossier'
+    click_on 'suivi'
     click_on dossier.user.email
 
     click_on 'Avis externes'
-    expect(page).to have_current_path(avis_instructeur_dossier_path(procedure, dossier))
+    expect(page).to have_current_path(avis_instructeur_dossier_path(procedure, dossier, statut: 'suivis'))
     within('.fr-sidemenu') { click_on 'Demander un avis' }
-    expect(page).to have_current_path(avis_new_instructeur_dossier_path(procedure, dossier))
+    expect(page).to have_current_path(avis_new_instructeur_dossier_path(procedure, dossier, statut: 'suivis'))
 
     expert_email = 'expert@tps.com'
     ask_confidential_avis(expert_email, 'a good introduction')
@@ -171,6 +174,7 @@ describe 'Instructing a dossier:', js: true do
     ask_confidential_avis(instructeur2.email, 'a good introduction')
 
     click_on 'Personnes impliquées'
+    expect(page).to have_current_path(personnes_impliquees_instructeur_dossier_path(procedure, dossier, statut: 'suivis'))
     expect(page).to have_text(expert_email)
     expect(page).to have_text(instructeur2.email)
   end

--- a/spec/system/routing/rules_full_scenario_spec.rb
+++ b/spec/system/routing/rules_full_scenario_spec.rb
@@ -216,7 +216,7 @@ describe 'The routing with rules', js: true do
     ## on the dossier itself
     click_on 'suivi'
     click_on litteraire_user.email
-    expect(page).to have_current_path(instructeur_dossier_path(procedure, litteraire_user.dossiers.first))
+    expect(page).to have_current_path(instructeur_dossier_path(procedure, litteraire_user.dossiers.first, statut: :suivis))
     expect(page).to have_text('Annotations privées')
     expect(find('.fr-tabs')).to have_css('span.notifications')
     log_out
@@ -231,7 +231,7 @@ describe 'The routing with rules', js: true do
 
     # the instructeurs who belong to scientifique AND litteraire groups manage scientifique and litteraire dossiers
     register_instructeur_and_log_in(alain.email)
-    visit instructeur_procedure_path(procedure, params: { statut: 'tous' })
+    visit instructeur_procedure_path(procedure, statut: 'tous')
     expect(page).to have_text(litteraire_user.email)
     expect(page).to have_text(scientifique_user.email)
 
@@ -239,7 +239,7 @@ describe 'The routing with rules', js: true do
     click_on scientifique_user.email
     click_on 'Suivre le dossier'
 
-    visit instructeur_procedure_path(procedure, params: { statut: 'tous' })
+    visit instructeur_procedure_path(procedure, statut: 'tous')
     click_on litteraire_user.email
     click_on 'Suivre le dossier'
     log_out

--- a/spec/views/instructeur/dossiers/_instruction_button_motivation.html.haml_spec.rb
+++ b/spec/views/instructeur/dossiers/_instruction_button_motivation.html.haml_spec.rb
@@ -4,6 +4,7 @@ describe 'instructeurs/dossiers/instruction_button_motivation', type: :view do
   let(:dossier) { create(:dossier, :en_instruction) }
 
   subject do
+    allow(controller).to receive(:params).and_return(statut: 'a-suivre')
     render(
       'instructeurs/dossiers/instruction_button_motivation',
       dossier: dossier,

--- a/spec/views/instructeur/dossiers/annotations_privee.html.haml_spec.rb
+++ b/spec/views/instructeur/dossiers/annotations_privee.html.haml_spec.rb
@@ -7,6 +7,7 @@ describe 'instructeurs/dossiers/annotations_privees', type: :view do
   before do
     sign_in(current_instructeur.user)
     allow(view).to receive(:current_instructeur).and_return(current_instructeur)
+    allow(controller).to receive(:params).and_return({ statut: 'a-suivre' })
     assign(:dossier, dossier)
   end
 

--- a/spec/views/instructeur/dossiers/show.html.haml_spec.rb
+++ b/spec/views/instructeur/dossiers/show.html.haml_spec.rb
@@ -7,6 +7,7 @@ describe 'instructeurs/dossiers/show', type: :view do
   before do
     sign_in(current_instructeur.user)
     allow(view).to receive(:current_instructeur).and_return(current_instructeur)
+    allow(controller).to receive(:params).and_return(statut: 'a-suivre')
     assign(:dossier, dossier)
   end
 

--- a/spec/views/shared/avis/list.html.haml_spec.rb
+++ b/spec/views/shared/avis/list.html.haml_spec.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 describe 'shared/avis/_list', type: :view do
-  before { view.extend DossierHelper }
+  before do
+    view.extend DossierHelper
+    allow(view).to receive(:params).and_return({ statut: 'a-suivre' })
+  end
 
   subject { render 'shared/avis/list', avis: avis, avis_seen_at: seen_at, expert_or_instructeur: instructeur }
 


### PR DESCRIPTION
closes: #[#10784](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/10784)

# probleme 

ETQ instructeur, lorsque je traite un dossier et que je retourne a ma liste de dossier, je perds mon contexte de navigation  

ex, j'etais sur l'onglet a `suivi`, je consulte un dossier, je l'accepte, je retourne a la liste des dossier... je retombe sur la liste des dossiers `a-suivre`. J'aurais aimé retourné sur l'onglet `suivi`

# solution 

J'ai testé plusieurs approches 

1. conserver le dernier statut consulté en cache via la `session`. Sauf que ca vient mettre le bazarre quand je navigue dans avec deux onglet de mon navigateur sur des onglets different (ex: suivis dans un onglet, tous dans l'autre). bah on se marche dessus
2. faire suivre le `param[:statut]` via la method `default_url_options`. Sauf que ca vient mettre le bazarre dans toutes les URLs, ex je fais un back depuis la liste des dossiers vers la liste des demarches, j'ai un statut sur la liste des demarches qui vient mettre le bazarre

Donc ça m'a gavé de bricoler, je propose un nouveau schema d'url qui porte le contexte de navigation
* `procedure/:procedure_id?statut=suivi` -> `procedure/:procedure_id/suivi`
* `procedure/:procedure_id/dossiers/:dossier_id` -> `procedure/:procedure_id/suivi/dossiers/:dossier_id`

Quid des anciennes URL ? bah on les supporte présuppose d'un default : `a-suvire`

Et ca s'applique a toutes les routes sur le chemin de l'instruction



