### PR TITLE
 Corrige les défaut d'accessibilité de l'étape 1 d'une démarche

### DIFF
--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -283,7 +283,7 @@ ul.dropdown-items {
   }
 
   dd {
-    word-break: break-all;
+    word-break: break-word;
   }
 }
 

--- a/app/components/dossiers/individual_form_component/individual_form_component.html.haml
+++ b/app/components/dossiers/individual_form_component/individual_form_component.html.haml
@@ -48,9 +48,15 @@
       .fr-fieldset__element.fr-mb-0
         .fr-fieldset.width-100
           .fr-fieldset__element.fr-fieldset__element--short-text
-            = render Dsfr::InputComponent.new(form: individual, attribute: :prenom, opts: { autocomplete: (for_tiers? ? false : 'given-name') })
+            - if for_tiers?
+              = render Dsfr::InputComponent.new(form: individual, attribute: :prenom)
+            - else
+              = render Dsfr::InputComponent.new(form: individual, attribute: :prenom, opts: { autocomplete: 'given-name' })
           .fr-fieldset__element.fr-fieldset__element--short-text
-            = render Dsfr::InputComponent.new(form: individual, attribute: :nom, opts: { autocomplete: (for_tiers? ? false : 'family-name') })
+            - if for_tiers?
+              = render Dsfr::InputComponent.new(form: individual, attribute: :nom)
+            - else
+              = render Dsfr::InputComponent.new(form: individual, attribute: :nom, opts: { autocomplete: 'family-name' })
 
           - if @dossier.procedure.ask_birthday?
             .fr-fieldset__element

--- a/app/components/dossiers/individual_form_component/individual_form_component.html.haml
+++ b/app/components/dossiers/individual_form_component/individual_form_component.html.haml
@@ -46,7 +46,7 @@
               %label.fr-label{ for: "identite_champ_radio_#{Individual::GENDER_MALE}" }
                 = Individual.human_attribute_name('gender.male')
       .fr-fieldset__element.fr-mb-0
-        %fieldset.fr-fieldset.width-100
+        .fr-fieldset.width-100
           .fr-fieldset__element.fr-fieldset__element--short-text
             = render Dsfr::InputComponent.new(form: individual, attribute: :prenom, opts: { autocomplete: (for_tiers? ? false : 'given-name') })
           .fr-fieldset__element.fr-fieldset__element--short-text

--- a/app/components/dossiers/user_procedure_filter_component/user_procedure_filter_component.html.haml
+++ b/app/components/dossiers/user_procedure_filter_component/user_procedure_filter_component.html.haml
@@ -1,4 +1,4 @@
-= form_with(url: dossiers_path, method: :get ) do |f|
+= form_with(url: dossiers_path, method: :get, class: "fr-mb-5w") do |f|
   = f.hidden_field :q, value: params[:q], id: nil
   = f.label :procedure_id, t('.procedures.label'), class: 'fr-label fr-mb-1w', for: 'procedure_select'
   .flex

--- a/app/views/layouts/_header.haml
+++ b/app/views/layouts/_header.haml
@@ -6,7 +6,7 @@
 - is_administrateur_context = nav_bar_profile == :administrateur && administrateur_signed_in?
 - is_expert_context = nav_bar_profile == :expert && expert_signed_in?
 - is_user_context = nav_bar_profile == :user
-- is_search_enabled = [params[:controller] == 'recherche', is_instructeur_context, is_expert_context, is_user_context && current_user.dossiers.count].any?
+- is_search_enabled = [params[:controller] == 'recherche', is_instructeur_context, is_expert_context].any?
 %header{ class: ["fr-header", content_for?(:notice_info) && "fr-header__with-notice-info"], role: "banner", "data-controller": "dsfr-header" }
   %nav{ :role => "navigation", "aria-label" => t('layouts.header.main_menu') }
     .fr-header__body

--- a/app/views/layouts/commencer/_no_procedure.html.haml
+++ b/app/views/layouts/commencer/_no_procedure.html.haml
@@ -1,5 +1,5 @@
 .center
-  = image_tag "landing/hero/dematerialiser.svg", class: "fr-responsive-img fr-mb-1v", alt: ""
+  = image_tag "landing/hero/dematerialiser.svg", class: "fr-responsive-img fr-mb-1v", alt: "", "aria-hidden": "true"
   %p.fr-m-4w= t('.text')
   %hr
   %p= t('.are_you_new', app_name: Current.application_name)

--- a/app/views/root/landing.html.haml
+++ b/app/views/root/landing.html.haml
@@ -11,7 +11,7 @@
             = t(".promise")
 
         .hero-illustration
-          %img{ :src => image_url("landing/hero/dematerialiser.svg"), alt: '', width: 499, height: 280, loading: 'lazy' }
+          %img{ :src => image_url("landing/hero/dematerialiser.svg"), alt: '', width: 499, height: 280, loading: 'lazy', 'aria-hidden': 'true' }
 
   .fr-background-alt--blue-france.fr-py-6w
     .container

--- a/app/views/users/_main_navigation.html.haml
+++ b/app/views/users/_main_navigation.html.haml
@@ -2,11 +2,11 @@
   %ul.fr-nav__list
     - if params[:controller] == 'users/commencer'
       %li.fr-nav__item
-        = link_to t('back', scope: [:layouts, :header]), url_for(:back), title: t('back_title', scope: [:layouts, :header]), class: 'fr-nav__link', "aria-controls" => "modal-header__menu"
+        = link_to t('back', scope: [:layouts, :header]), url_for(:back), title: t('back_title', scope: [:layouts, :header]), class: 'fr-nav__link'
 
     %li.fr-nav__item
-      = link_to t('files', scope: [:layouts, :header]), dossiers_path, class: 'fr-nav__link', aria: { current: (controller_name == 'dossiers' && action_name != 'deleted_dossiers') ? 'true' : nil, controls: "modal-header__menu" }
+      = link_to t('files', scope: [:layouts, :header]), dossiers_path, class: 'fr-nav__link', aria: { current: (controller_name == 'dossiers' && action_name != 'deleted_dossiers') ? 'true' : nil }
 
     - if current_user.deleted_dossiers.present?
       %li.fr-nav__item
-        = link_to 'Historique des dossiers supprimés', deleted_dossiers_path(), class: 'fr-nav__link', aria: { current: action_name == 'deleted_dossiers' ? 'true' : nil, controls: "modal-header__menu" }
+        = link_to 'Historique des dossiers supprimés', deleted_dossiers_path(), class: 'fr-nav__link', aria: { current: action_name == 'deleted_dossiers' ? 'true' : nil }

--- a/app/views/users/dossiers/identite.html.haml
+++ b/app/views/users/dossiers/identite.html.haml
@@ -27,6 +27,6 @@
             .fr-radio-rich__img
               %span.fr-icon-parent-fill
 
-        = f.submit t('views.users.dossiers.identite.continue'), class: 'visually-hidden'
+        = f.submit t('views.users.dossiers.identite.continue'), class: 'hidden'
 
   = render Dossiers::IndividualFormComponent.new(dossier: @dossier)

--- a/app/views/users/dossiers/identite.html.haml
+++ b/app/views/users/dossiers/identite.html.haml
@@ -8,8 +8,8 @@
 
       %p.fr-text--sm= t('utils.asterisk_html')
 
-      %fieldset#radio-rich-hint.fr-fieldset{ "aria-labelledby" => "radio-rich-hint-legend radio-rich-hint-messages" }
-        %legend#radio-rich-hint-legend.fr-fieldset__legend--regular.fr-fieldset__legend
+      %fieldset#radio-rich-hint.fr-fieldset
+        %legend.fr-fieldset__legend--regular.fr-fieldset__legend
           = t('views.users.dossiers.identite.legend')
 
         .fr-fieldset__element

--- a/app/views/users/dossiers/identite.html.haml
+++ b/app/views/users/dossiers/identite.html.haml
@@ -6,6 +6,8 @@
   - if @dossier.procedure.for_tiers_enabled?
     = form_for @dossier, url: identite_dossier_path(@dossier), method: :patch, html: { class: "form" }, data: {turbo: true, controller: :autosubmit} do |f|
 
+      %p.fr-text--sm= t('utils.asterisk_html')
+
       %fieldset#radio-rich-hint.fr-fieldset{ "aria-labelledby" => "radio-rich-hint-legend radio-rich-hint-messages" }
         %legend#radio-rich-hint-legend.fr-fieldset__legend--regular.fr-fieldset__legend
           = t('views.users.dossiers.identite.legend')

--- a/app/views/users/dossiers/identite.html.haml
+++ b/app/views/users/dossiers/identite.html.haml
@@ -11,6 +11,7 @@
       %fieldset#radio-rich-hint.fr-fieldset
         %legend.fr-fieldset__legend--regular.fr-fieldset__legend
           = t('views.users.dossiers.identite.legend')
+          = render EditableChamp::AsteriskMandatoryComponent.new
 
         .fr-fieldset__element
           .fr-radio-group.fr-radio-rich

--- a/app/views/users/dossiers/identite.html.haml
+++ b/app/views/users/dossiers/identite.html.haml
@@ -1,4 +1,4 @@
-- content_for(:title, "Nouveau dossier (#{@dossier.procedure.libelle})")
+- content_for(:title, t(".title", scope: :metas, procedure_label: @dossier.procedure.libelle))
 
 = render partial: "shared/dossiers/submit_is_over", locals: { dossier: @dossier }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,7 +82,7 @@ en:
     header:
       close_modal: 'Close'
       back: "Back"
-      back_title: "Revenir sur le site de mon administration"
+      back_title: "Back to my administration's website"
       main_menu: "Main menu"
     locale_dropdown:
       select_locale: "Choose a language"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -73,7 +73,7 @@ fr:
     header:
       close_modal: 'Fermer'
       back: "Revenir en arrière"
-      back_title: "Revenir sur le site de mon administration"
+      back_title: "Revenir en arrière, sur le site de mon administration"
       main_menu: "Menu principal"
     locale_dropdown:
       select_locale: "Sélectionner une langue"

--- a/config/locales/metas.en.yml
+++ b/config/locales/metas.en.yml
@@ -7,6 +7,8 @@ en:
         index:
           title: Files
           title_search: "Search: %{terms}"
+        identite:
+          title: "New file (%{procedure_label}) - Step 1: Identity"
         show:
           title: "Summary · File nº %{number} (%{procedure_label})"
         demande:

--- a/config/locales/metas.fr.yml
+++ b/config/locales/metas.fr.yml
@@ -7,6 +7,8 @@ fr:
         index:
           title: Dossiers
           title_search: "Recherche : %{terms}"
+        identite:
+          title: "Nouveau dossier (%{procedure_label}) - Étape 1 : Identité"
         show:
           title: "Résumé · Dossier nº %{number} (%{procedure_label})"
         demande:


### PR DESCRIPTION
# Met à jour la navigation principale
- Supprime les attributs `aria-controls` inappropriés
- Reprend l'intitulé visible du lien "Revenir en arrière" dans l'attribut `title`

__Après__
![Capture d’écran 2024-09-30 à 14 53 07](https://github.com/user-attachments/assets/26b2170e-8fee-434c-9f1c-b3459bdb5ee4)

__Avant__
![Capture d’écran 2024-09-30 à 14 53 52](https://github.com/user-attachments/assets/ed23f62c-3f22-4337-8762-9f58e25572a9)

# Sépare le formulaire de la navigation, lorsqu'il y a un seul champ
__Après__
![Capture d’écran 2024-09-30 à 15 04 19](https://github.com/user-attachments/assets/ac71c65b-f6f5-4df0-985e-3e88f13f59de)

__Avant__
![Capture d’écran 2024-09-30 à 15 04 38](https://github.com/user-attachments/assets/25f2e791-4d1e-4c35-ad13-e3f5e4f7ea95)


# Évite la vocalisation d'une image de décoration par Voice Over
__Après__

https://github.com/user-attachments/assets/6ec15472-88d6-4023-9caf-aa098c00cfc5

__Avant__

https://github.com/user-attachments/assets/58eec90f-6efd-45a2-a08f-8d879fba7e3a

# Met à jour l'indication des champs obligatoires
- Ajout de l'explication des astérisques
- Ajout de l'astérisque dans la légende du choix du destinataire de la démarche

__Après__
![Capture d’écran 2024-09-30 à 15 18 40](https://github.com/user-attachments/assets/964487b3-8ba2-4338-bc66-d79e05c18e2e)

__Avant__
![Capture d’écran 2024-09-30 à 15 18 59](https://github.com/user-attachments/assets/903f1dce-af7d-4458-9381-a824876b2699)

# Précise l'étape courante de la démarche dans le titre page
__Après__
![Capture d’écran 2024-09-30 à 15 22 18](https://github.com/user-attachments/assets/9229278c-28f1-4644-bfbe-8800a2ff9100)

__Avant__
![Capture d’écran 2024-09-30 à 15 21 48](https://github.com/user-attachments/assets/f8fd624a-e50b-4e90-b16b-cea40824c797)

# Masque le bouton de soumission intermédiaire aux technologies d'assistance
__Après__
![Capture d’écran 2024-09-30 à 15 25 34](https://github.com/user-attachments/assets/72155964-3ed8-43f3-bd85-194048005b11)

__Avant__
![Capture d’écran 2024-09-30 à 15 26 21](https://github.com/user-attachments/assets/091574ac-275e-47bb-8bcb-6ba7d6d60ddd)

# Supprime les attributs `aria-labelledby` inutiles
__Après__
![Capture d’écran 2024-09-30 à 15 30 30](https://github.com/user-attachments/assets/2360cbca-d359-44c6-89a4-881799d93767)

__Avant__
![Capture d’écran 2024-09-30 à 15 30 07](https://github.com/user-attachments/assets/7b17617e-c474-475d-90a5-e77b54af5e13)

# Supprime les regroupements inutiles
__Après__
![Capture d’écran 2024-09-30 à 15 33 11](https://github.com/user-attachments/assets/8862e67e-a581-4ce1-a647-373097813795)

__Avant__
![Capture d’écran 2024-09-30 à 15 33 44](https://github.com/user-attachments/assets/69e70766-8b3e-46fa-9a01-333d2a97bf93)

# Améliore la césure dans le menu d'aide
__Après__
![Capture d’écran 2024-09-30 à 15 41 34](https://github.com/user-attachments/assets/a4bf955c-7398-41e5-987d-a3a7b4db96bf)

__Avant__
![Capture d’écran 2024-09-30 à 15 41 05](https://github.com/user-attachments/assets/a6af20dc-30dd-4c45-9c83-3f934614c3fb)

# Supprime les attributs `autocomplete="false"` erronés 
__Après__
![Capture d’écran 2024-09-30 à 15 44 46](https://github.com/user-attachments/assets/876e836e-87dd-4b7f-8223-493dcbc4f364)

__Avant__
![Capture d’écran 2024-09-30 à 15 45 33](https://github.com/user-attachments/assets/1a40736d-c6b7-4db0-b66f-948e6cf63903)

# Supprime le bouton de recherche ouvrant la modale en mobile en vue utilisateur
__Après__
![Capture d’écran 2024-09-30 à 15 46 02](https://github.com/user-attachments/assets/bb4ab5df-fb2b-437c-a60f-c7023abe0980)

__Avant__
![Capture d’écran 2024-09-30 à 15 45 49](https://github.com/user-attachments/assets/99f9bb45-d988-47d2-b7f7-9680447f5b82)

