### PR TITLE
ETQ support je vois dans HS lorsqu'un instructeur a désactivé ses notifications

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -41,6 +41,18 @@ class WebhookController < ActionController::Base
       if instructeur
         url = manager_instructeur_url(instructeur)
         html << link_to_manager(instructeur, url)
+
+        disabled_notifications = instructeur.assign_to.filter do |assign_to|
+          !assign_to.instant_email_dossier_notifications_enabled ||
+          !assign_to.instant_email_message_notifications_enabled ||
+          !assign_to.instant_expert_avis_email_notifications_enabled
+        end
+
+        html << "Notifications activées" if disabled_notifications.empty?
+        disabled_notifications.each do |assign_to|
+          html << "Notifs désactivées Procedure##{assign_to.groupe_instructeur.procedure_id}"
+        end
+
       end
 
       if administrateur

--- a/spec/controllers/webhook_controller_spec.rb
+++ b/spec/controllers/webhook_controller_spec.rb
@@ -63,6 +63,20 @@ describe WebhookController, type: :controller do
         it 'returns a link to the Administrateur profile in the Manager' do
           expect(payload).to have_key('html')
           expect(payload['html']).to have_selector("a[href='#{manager_administrateur_url(admin)}']")
+          expect(payload['html']).to have_text("Notifications activées")
+        end
+      end
+
+      context "when notifications are disabled" do
+        let(:instructeur) { create(:instructeur, user:) }
+        let(:procedure) { create(:procedure) }
+        before do
+          create(:assign_to, instructeur:, procedure:,
+            instant_email_dossier_notifications_enabled: false)
+        end
+
+        it 'returns a summary of disabled notifications' do
+          expect(payload['html']).to have_text("Notifs désactivées Procedure##{procedure.id}")
         end
       end
     end


### PR DESCRIPTION
remontée par les bizdev, ça fait gagner du temps pour comprendre pourquoi un instructeur ne reçoit pas certains emails (car actuellement ça demande plein de clics pour voir cette info, et c'est le premier truc qu'ils checkent dans un pb de mail)