### PR TITLE
Tech: bump charlock_holmes 0.7.7 => 0.7.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,7 +171,7 @@ GEM
       marcel (~> 1.0)
       nokogiri (~> 1.10, >= 1.10.4)
       rubyzip (>= 1.3.0, < 3)
-    charlock_holmes (0.7.7)
+    charlock_holmes (0.7.9)
     chartkick (5.0.6)
     choice (0.2.0)
     chunky_png (1.4.0)


### PR DESCRIPTION
solves installation on latest linux kernels