### PR TITLE
ETQ super-admin, corrige l'affichage de certains boutons d'actions dans le manager

### DIFF
--- a/app/views/manager/instructeurs/show.html.erb
+++ b/app/views/manager/instructeurs/show.html.erb
@@ -29,7 +29,7 @@ as well as a link to its edit page.
       'Modifier',
       [:edit, namespace, page.resource],
       class: "button",
-    ) if accessible_action?(:edit, page.resource) && show_action?(:edit, page.resource) %>
+    ) if accessible_action?(page.resource, :edit) %>
 
     <%= link_to 'Réinviter', reinvite_manager_instructeur_path(instructeur), method: :post, class: 'button' %>
 

--- a/app/views/manager/outdated_procedures/_collection.html.erb
+++ b/app/views/manager/outdated_procedures/_collection.html.erb
@@ -78,7 +78,7 @@ to display a collection of resources in an HTML table.
 
           <% collection_presenter.attributes_for(resource).each do |attribute| %>
             <td class="cell-data cell-data--<%= attribute.html_class %>">
-              <% if show_action? :show, resource -%>
+              <% if accessible_action?(resource, :show) -%>
                 <a href="<%= polymorphic_path([namespace, resource]) -%>"
                    tabindex="-1"
                    class="action-show"

--- a/app/views/manager/outdated_procedures/index.html.erb
+++ b/app/views/manager/outdated_procedures/index.html.erb
@@ -48,7 +48,7 @@ It renders the `_table` partial to display details about the resources.
       ),
       [:new, namespace, page.resource_path.to_sym],
       class: "button",
-    ) if accessible_action?(:new, page.resource) && show_action?(:new, new_resource) %>
+    ) if accessible_action?(page.resource_name, :new) %>
   </div>
 </header>
 

--- a/app/views/manager/procedures/show.html.erb
+++ b/app/views/manager/procedures/show.html.erb
@@ -31,7 +31,7 @@ as well as a link to its edit page.
       t("administrate.actions.edit_resource", name: page.page_title),
       [:edit, namespace, page.resource],
       class: "button",
-    ) if accessible_action?(:edit, page.resource) %>
+    ) if accessible_action?(page.resource, :edit) %>
 
     <%= link_to 'Aperçu', apercu_admin_procedure_path(procedure), class: 'button' %>
 

--- a/app/views/manager/published_procedures/index.html.erb
+++ b/app/views/manager/published_procedures/index.html.erb
@@ -48,7 +48,7 @@ It renders the `_table` partial to display details about the resources.
       ),
       [:new, namespace, page.resource_path.to_sym],
       class: "button",
-    ) if accessible_action?(:new, page.resource) && show_action?(:new, new_resource) %>
+    ) if accessible_action?(page.resource_name, :new) %>
   </div>
 </header>
 


### PR DESCRIPTION
Fix régression introduite dans https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/10874 (l'ordre des paramètre était inversé)