### PR TITLE
Opendata: fichier de stats sur la répartition des dossiers

### DIFF
--- a/app/jobs/cron/datagouv/file_state_by_month_job.rb
+++ b/app/jobs/cron/datagouv/file_state_by_month_job.rb
@@ -1,0 +1,34 @@
+class Cron::Datagouv::FileStateByMonthJob < Cron::CronJob
+  include DatagouvCronSchedulableConcern
+  self.schedule_expression = "every month at 3:20"
+  FILE_NAME = "nb_dossiers_par_etat_par_mois"
+  HEADERS = ["mois", "procedure_id", "nb_dossiers_crees", "nb_dossiers_deposes", "nb_dossiers_en_instruction", "nb_dossiers_traites"]
+
+  def perform(*args)
+    GenerateOpenDataCsvService.save_csv_to_tmp(FILE_NAME, HEADERS, data) do |file|
+      begin
+        APIDatagouv::API.upload(file, :statistics_dataset)
+      ensure
+        FileUtils.rm(file)
+      end
+    end
+  end
+
+  def data
+    # possible adjustment: procedure with at least 300 folders
+    Procedure.publiee
+      .where(estimated_dossiers_count: 300.., opendata: true)
+      .joins('INNER JOIN procedure_revisions ON procedures.published_revision_id = procedure_revisions.id')
+      .joins('INNER JOIN dossiers ON procedure_revisions.id = dossiers.revision_id')
+      .merge(Dossier.visible_by_user_or_administration)
+      .order('procedures.id')
+      .group('procedures.id')
+      .pluck(
+        'procedures.id',
+        Arel.sql('SUM(CASE WHEN dossiers.state = \'brouillon\' THEN 1 ELSE 0 END)'),
+        Arel.sql('SUM(CASE WHEN dossiers.state = \'en_construction\' THEN 1 ELSE 0 END)'),
+        Arel.sql('SUM(CASE WHEN dossiers.state = \'en_instruction\' THEN 1 ELSE 0 END)'),
+        Arel.sql('SUM(CASE WHEN dossiers.state IN (\'accepte\', \'sans_suite\', \'refuse\') THEN 1 ELSE 0 END)')
+      )
+  end
+end

--- a/app/jobs/cron/datagouv/file_state_by_month_job.rb
+++ b/app/jobs/cron/datagouv/file_state_by_month_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Cron::Datagouv::FileStateByMonthJob < Cron::CronJob
   include DatagouvCronSchedulableConcern
   self.schedule_expression = "every month at 3:20"

--- a/spec/jobs/cron/datagouv/file_by_state_by_month_job_spec.rb
+++ b/spec/jobs/cron/datagouv/file_by_state_by_month_job_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+RSpec.describe Cron::Datagouv::FileStateByMonthJob, type: :job do
+  let(:status) { 200 }
+  let(:body) { "ok" }
+  let(:stub) { stub_request(:post, /https:\/\/www.data.gouv.fr\/api\/.*\/upload\//) }
+
+  describe '#perform' do
+    before do
+      stub
+    end
+
+    subject { Cron::Datagouv::FileStateByMonthJob.perform_now }
+
+    it 'send POST request to datagouv' do
+      subject
+      expect(stub).to have_been_requested
+    end
+  end
+
+  describe '#data' do
+    let!(:procedure) { create(:procedure, :published, estimated_dossiers_count: 300, opendata: true) }
+    let!(:dossier_brouillon) { create(:dossier, state: :brouillon, procedure:) }
+    let!(:dossier_depose) { create(:dossier, state: :en_construction, procedure:) }
+    let!(:dossier_en_instruction) { create(:dossier, state: :en_instruction, procedure:) }
+    let!(:dossier_accepte) { create(:dossier, state: :accepte, procedure:) }
+    let!(:dossier_refuse) { create(:dossier, state: :refuse, procedure:) }
+    let!(:dossier_sans_suite) { create(:dossier, state: :sans_suite, procedure:) }
+
+    subject { Cron::Datagouv::FileStateByMonthJob.new.data }
+
+    context 'when all conditions are met' do
+      it 'returns the correct data and structure' do
+        expect(subject).to match_array(
+          [[procedure.id, 1, 1, 1, 3]]
+        )
+      end
+    end
+
+    context 'when the procedure is not opendata' do
+      before do
+        procedure.update(opendata: false)
+      end
+
+      it 'does not include the procedure' do
+        expect(subject).to be_empty
+      end
+    end
+
+    context 'when the procedure has insufficient number of dossiers' do
+      before do
+        procedure.update(estimated_dossiers_count: 299)
+      end
+
+      it 'does not include the procedure' do
+        expect(subject).to be_empty
+      end
+    end
+
+    context 'when the procedure has several revisions' do
+      before do
+        procedure.publish_revision!
+      end
+
+      it 'only considers the published revision' do
+        expect(subject).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
En lien avec l'issue : https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/10615

Il s'agit là du jdd autour du nb de dossiers.

Ceci viendrait enrichir le jdd data.gouv "utilisation du service", avec donc chaque mois les données suivantes :

id procédure
nb dossiers en brouillon
nb dossiers en construction
nb dossiers en instruction
nb dossiers traités

A définir : l'horaire du job