### PR TITLE
ETQ dev, je ne veux plus de méthode `champs_for_revision`

### DIFF
--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -3,24 +3,6 @@
 module DossierChampsConcern
   extend ActiveSupport::Concern
 
-  def champs_for_revision(scope: nil)
-    champs_index = champs.group_by(&:stable_id)
-    revision.types_de_champ_for(scope:)
-      .flat_map { champs_index[_1.stable_id] || [] }
-  end
-
-  # Get all the champs values for the types de champ in the final list.
-  # Dossier might not have corresponding champ – display nil.
-  # To do so, we build a virtual champ when there is no value so we can call for_export with all indexes
-  def champs_for_export(types_de_champ, row_id = nil)
-    types_de_champ.flat_map do |type_de_champ|
-      champ = champ_for_export(type_de_champ, row_id)
-      type_de_champ.libelles_for_export.map do |(libelle, path)|
-        [libelle, TypeDeChamp.champ_value_for_export(type_de_champ.type_champ, champ, path)]
-      end
-    end
-  end
-
   def project_champ(type_de_champ, row_id)
     check_valid_row_id?(type_de_champ, row_id)
     champ = champs_by_public_id[type_de_champ.public_id(row_id)]
@@ -95,6 +77,15 @@ module DossierChampsConcern
       .filter { _1.stable_id.in?(stable_ids) }
       .filter { !_1.child?(revision) }
       .map { _1.repetition? ? project_champ(_1, nil) : champ_for_update(_1, nil, updated_by: nil) }
+  end
+
+  def champs_for_export(types_de_champ, row_id = nil)
+    types_de_champ.flat_map do |type_de_champ|
+      champ = champ_for_export(type_de_champ, row_id)
+      type_de_champ.libelles_for_export.map do |(libelle, path)|
+        [libelle, TypeDeChamp.champ_value_for_export(type_de_champ.type_champ, champ, path)]
+      end
+    end
   end
 
   def champ_for_update(type_de_champ, row_id, updated_by:)

--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -39,6 +39,34 @@ module DossierChampsConcern
     revision.types_de_champ_private.map { project_champ(_1, nil) }
   end
 
+  def filled_champs_public
+    project_champs_public.flat_map do |champ|
+      if champ.repetition?
+        champ.rows.flatten.filter { _1.persisted? && _1.fillable? }
+      elsif champ.persisted? && champ.fillable?
+        champ
+      else
+        []
+      end
+    end
+  end
+
+  def filled_champs_private
+    project_champs_private.flat_map do |champ|
+      if champ.repetition?
+        champ.rows.flatten.filter { _1.persisted? && _1.fillable? }
+      elsif champ.persisted? && champ.fillable?
+        champ
+      else
+        []
+      end
+    end
+  end
+
+  def filled_champs
+    filled_champs_public + filled_champs_private
+  end
+
   def project_rows_for(type_de_champ)
     return [] if !type_de_champ.repetition?
 

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -517,7 +517,7 @@ class Dossier < ApplicationRecord
   def can_passer_en_construction?
     return true if !revision.ineligibilite_enabled || !revision.ineligibilite_rules
 
-    !revision.ineligibilite_rules.compute(champs_for_revision(scope: :public))
+    !revision.ineligibilite_rules.compute(filled_champs_public)
   end
 
   def can_passer_en_instruction?
@@ -567,7 +567,7 @@ class Dossier < ApplicationRecord
 
   def any_etablissement_as_degraded_mode?
     return true if etablissement&.as_degraded_mode?
-    return true if champs_for_revision(scope: :public).any? { _1.etablissement&.as_degraded_mode? }
+    return true if filled_champs_public.any? { _1.etablissement&.as_degraded_mode? }
 
     false
   end
@@ -1031,7 +1031,7 @@ class Dossier < ApplicationRecord
   end
 
   def linked_dossiers_for(instructeur_or_expert)
-    dossier_ids = champs_for_revision.filter(&:dossier_link?).filter_map(&:value)
+    dossier_ids = filled_champs.filter(&:dossier_link?).filter_map(&:value)
     instructeur_or_expert.dossiers.where(id: dossier_ids)
   end
 
@@ -1040,7 +1040,7 @@ class Dossier < ApplicationRecord
   end
 
   def geo_data?
-    GeoArea.exists?(champ_id: champs_for_revision)
+    GeoArea.exists?(champ_id: filled_champs)
   end
 
   def to_feature_collection
@@ -1195,7 +1195,7 @@ class Dossier < ApplicationRecord
   end
 
   def geo_areas
-    champs_for_revision.flat_map(&:geo_areas)
+    filled_champs.flat_map(&:geo_areas)
   end
 
   def bounding_box

--- a/spec/models/concerns/dossier_champs_concern_spec.rb
+++ b/spec/models/concerns/dossier_champs_concern_spec.rb
@@ -110,10 +110,41 @@ RSpec.describe DossierChampsConcern do
     subject { dossier.project_champs_public }
 
     it { expect(subject.size).to eq(4) }
+    it { expect(subject.find { _1.libelle == 'Nom' }).to be_falsey }
   end
 
   describe '#project_champs_private' do
     subject { dossier.project_champs_private }
+
+    it { expect(subject.size).to eq(1) }
+  end
+
+  describe '#filled_champs_public' do
+    let(:types_de_champ_public) do
+      [
+        { type: :header_section },
+        { type: :text, libelle: "Un champ text" },
+        { type: :text, libelle: "Un autre champ text" },
+        { type: :yes_no, libelle: "Un champ yes no" },
+        { type: :repetition, libelle: "Un champ répétable", mandatory: true, children: [{ type: :text, libelle: 'Nom' }] },
+        { type: :explication }
+      ]
+    end
+    subject { dossier.filled_champs_public }
+
+    it { expect(subject.size).to eq(4) }
+    it { expect(subject.find { _1.libelle == 'Nom' }).to be_truthy }
+  end
+
+  describe '#filled_champs_private' do
+    let(:types_de_champ_private) do
+      [
+        { type: :header_section },
+        { type: :text, libelle: "Une annotation" },
+        { type: :explication }
+      ]
+    end
+    subject { dossier.filled_champs_private }
 
     it { expect(subject.size).to eq(1) }
   end

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1852,7 +1852,7 @@ describe Dossier, type: :model do
       let(:types_de_champ_public) { [{ type: :carte }, { type: :carte }, { type: :carte }] }
 
       it do
-        dossier.champs_for_revision
+        dossier.filled_champs
 
         count = 0
 

--- a/spec/tasks/maintenance/remove_piece_justificative_file_not_visible_task_spec.rb
+++ b/spec/tasks/maintenance/remove_piece_justificative_file_not_visible_task_spec.rb
@@ -13,7 +13,7 @@ module Maintenance
       before { expect(champ).to receive(:visible?).and_return(visible) }
 
       context 'when piece_justificative' do
-        let(:champ) { dossier.champs_for_revision(scope: :public).find(&:piece_justificative?) }
+        let(:champ) { dossier.filled_champs_public.find(&:piece_justificative?) }
 
         context 'when not visible' do
           let(:visible) { false }


### PR DESCRIPTION
Un peu d'explication sur l'objectif de ce refactoring :

- On expose des méthodes avec des noms plus explicites pour travailler avec les champs qui ont été remplis `filled_champs`
-  La méthode `make_diff`, opère maintenant sur les champs projetés et la méthode `apply_diff` n'applique les changements que sur les champs matérialisés. Ça veut dire qu'on pourra faire un diff/merge même sur un dossier où certains champs ne sont pas matérialisés. Ce cas n'existe pas actuellement, mais va apparaître avec le prochain refactoring sur les répétitions

- [x] depends on https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/10873
