### PR TITLE
tech: ETQ instructeur, ma page pour visualiser un dossier se charge plus vite

### DIFF
--- a/app/models/dossier_preloader.rb
+++ b/app/models/dossier_preloader.rb
@@ -39,7 +39,7 @@ class DossierPreloader
 
   def revisions(pj_template: false)
     @revisions ||= ProcedureRevision.where(id: @dossiers.pluck(:revision_id).uniq)
-      .includes(types_de_champ_public: [], types_de_champ_private: [], types_de_champ: pj_template ? { piece_justificative_template_attachment: :blob } : [])
+      .includes(revision_types_de_champ: { parent: :type_de_champ }, types_de_champ_public: [], types_de_champ_private: [], types_de_champ: pj_template ? { piece_justificative_template_attachment: :blob } : [])
       .index_by(&:id)
   end
 

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -526,7 +526,8 @@ class TypeDeChamp < ApplicationRecord
   end
 
   def level_for_revision(revision)
-    rtdc = revision.revision_types_de_champ.includes(:type_de_champ, parent: :type_de_champ).find { |rtdc| rtdc.stable_id == stable_id }
+    rtdc = revision.revision_types_de_champ.find { |rtdc| rtdc.stable_id == stable_id }
+
     if rtdc.child?
       header_section_level_value.to_i + rtdc.parent.type_de_champ.current_section_level(revision)
     elsif header_section_level_value


### PR DESCRIPTION
En bossant sur la navigation instructeur je suis tombé sur une n+1 aux abords des types de champ/champs.
Ça impacter le Instructeurs/Dossiers#show, Users/Dossiers#show Users/Dossiers#edit... la base devrait être contente

apres :
<img width="951" alt="Capture d’écran 2024-10-08 à 11 09 46 AM" src="https://github.com/user-attachments/assets/5f9d2fd7-c25f-4fad-bb77-2abbd3839ab9">

avant :
<img width="948" alt="Capture d’écran 2024-10-08 à 11 09 26 AM" src="https://github.com/user-attachments/assets/7dcc4ca7-88d7-4186-a034-2fe031b835ee">
