### PR TITLE
ETQ instructeur je vois dans la galerie les pjs issues des avis, annotations privées et justificatifs de décision

### DIFF
--- a/app/components/attachment/gallery_item_component.rb
+++ b/app/components/attachment/gallery_item_component.rb
@@ -23,6 +23,8 @@ class Attachment::GalleryItemComponent < ApplicationComponent
       'Pièce jointe au message'
     elsif from_avis_externe?
       'Pièce jointe à l’avis'
+    elsif from_justificatif_motivation?
+      'Pièce jointe à la décision'
     end
   end
 
@@ -42,6 +44,8 @@ class Attachment::GalleryItemComponent < ApplicationComponent
       'Avis externe (instructeur)'
     when from_avis_externe_expert?
       'Avis externe (expert)'
+    when from_justificatif_motivation?
+      'Justificatif de décision'
     end
   end
 
@@ -120,5 +124,9 @@ class Attachment::GalleryItemComponent < ApplicationComponent
 
   def from_avis_externe_expert?
     from_avis_externe? && attachment.name == 'piece_justificative_file'
+  end
+
+  def from_justificatif_motivation?
+    attachment.name == 'justificatif_motivation'
   end
 end

--- a/app/components/attachment/gallery_item_component.rb
+++ b/app/components/attachment/gallery_item_component.rb
@@ -17,7 +17,13 @@ class Attachment::GalleryItemComponent < ApplicationComponent
   def gallery_demande? = @gallery_demande
 
   def libelle
-    from_dossier? ? attachment.record.libelle : 'Pièce jointe au message'
+    if from_dossier?
+      attachment.record.libelle
+    elsif from_messagerie?
+      'Pièce jointe au message'
+    elsif from_avis_externe?
+      'Pièce jointe à l’avis'
+    end
   end
 
   def origin
@@ -28,6 +34,10 @@ class Attachment::GalleryItemComponent < ApplicationComponent
       'Messagerie (instructeur)'
     when from_messagerie_usager?
       'Messagerie (usager)'
+    when from_avis_externe_instructeur?
+      'Avis externe (instructeur)'
+    when from_avis_externe_expert?
+      'Avis externe (expert)'
     end
   end
 
@@ -82,5 +92,17 @@ class Attachment::GalleryItemComponent < ApplicationComponent
 
   def from_messagerie_usager?
     from_messagerie? && attachment.record.instructeur.nil?
+  end
+
+  def from_avis_externe?
+    attachment.record.is_a?(Avis)
+  end
+
+  def from_avis_externe_instructeur?
+    from_avis_externe? && attachment.name == 'introduction_file'
+  end
+
+  def from_avis_externe_expert?
+    from_avis_externe? && attachment.name == 'piece_justificative_file'
   end
 end

--- a/app/components/attachment/gallery_item_component.rb
+++ b/app/components/attachment/gallery_item_component.rb
@@ -17,7 +17,7 @@ class Attachment::GalleryItemComponent < ApplicationComponent
   def gallery_demande? = @gallery_demande
 
   def libelle
-    if from_dossier?
+    if from_champ?
       attachment.record.libelle
     elsif from_messagerie?
       'Pièce jointe au message'
@@ -28,8 +28,10 @@ class Attachment::GalleryItemComponent < ApplicationComponent
 
   def origin
     case
-    when from_dossier?
+    when from_public_champ?
       'Dossier usager'
+    when from_private_champ?
+      'Annotation privée'
     when from_messagerie_expert?
       'Messagerie (expert)'
     when from_messagerie_instructeur?
@@ -64,7 +66,7 @@ class Attachment::GalleryItemComponent < ApplicationComponent
   end
 
   def updated?
-    from_dossier? && updated_at > attachment.record.dossier.depose_at
+    from_public_champ? && updated_at > attachment.record.dossier.depose_at
   end
 
   def updated_at
@@ -80,8 +82,16 @@ class Attachment::GalleryItemComponent < ApplicationComponent
 
   private
 
-  def from_dossier?
+  def from_champ?
     attachment.record.class.in?([Champs::PieceJustificativeChamp, Champs::TitreIdentiteChamp])
+  end
+
+  def from_public_champ?
+    from_champ? && !attachment.record.private?
+  end
+
+  def from_private_champ?
+    from_champ? && attachment.record.private?
   end
 
   def from_messagerie?

--- a/app/components/attachment/gallery_item_component.rb
+++ b/app/components/attachment/gallery_item_component.rb
@@ -30,6 +30,8 @@ class Attachment::GalleryItemComponent < ApplicationComponent
     case
     when from_dossier?
       'Dossier usager'
+    when from_messagerie_expert?
+      'Messagerie (expert)'
     when from_messagerie_instructeur?
       'Messagerie (instructeur)'
     when from_messagerie_usager?
@@ -90,8 +92,12 @@ class Attachment::GalleryItemComponent < ApplicationComponent
     from_messagerie? && attachment.record.instructeur.present?
   end
 
+  def from_messagerie_expert?
+    from_messagerie? && attachment.record.expert.present?
+  end
+
   def from_messagerie_usager?
-    from_messagerie? && attachment.record.instructeur.nil?
+    from_messagerie? && attachment.record.instructeur.nil? && attachment.record.expert.nil?
   end
 
   def from_avis_externe?

--- a/app/components/attachment/gallery_item_component/gallery_item_component.html.haml
+++ b/app/components/attachment/gallery_item_component/gallery_item_component.html.haml
@@ -9,7 +9,7 @@
           Visualiser
     - if !gallery_demande?
       .fr-text--sm.fr-mt-2v.fr-mb-1v
-        = libelle.truncate(25)
+        = libelle.truncate(30)
     = render Attachment::ShowComponent.new(attachment:, truncate: true, new_tab: gallery_demande?)
     - if !gallery_demande?
       .fr-mt-2v.fr-mb-2v{ class: badge_updated_class }
@@ -19,7 +19,7 @@
       = image_tag('apercu-indisponible.png')
     - if !gallery_demande?
       .fr-text--sm.fr-mt-2v.fr-mb-1v
-        = libelle.truncate(25)
+        = libelle.truncate(30)
     = render Attachment::ShowComponent.new(attachment:, truncate: true, new_tab: gallery_demande?)
     - if !gallery_demande?
       .fr-mt-2v.fr-mb-2v{ class: badge_updated_class }

--- a/app/controllers/experts/avis_controller.rb
+++ b/app/controllers/experts/avis_controller.rb
@@ -104,7 +104,12 @@ module Experts
       updated_recently = @avis.updated_recently?
       if @avis.update(avis_params)
         flash.notice = 'Votre réponse est enregistrée.'
-        @avis.dossier.update!(last_avis_updated_at: Time.zone.now)
+
+        timestamps = [:last_avis_updated_at, :updated_at]
+        timestamps << :last_avis_piece_jointe_updated_at if @avis.piece_justificative_file.attached?
+
+        @avis.dossier.touch(*timestamps)
+
         if !updated_recently
           @avis.dossier.followers_instructeurs
             .with_instant_expert_avis_email_notifications_enabled

--- a/app/controllers/experts/avis_controller.rb
+++ b/app/controllers/experts/avis_controller.rb
@@ -167,7 +167,11 @@ module Experts
       @commentaire = CommentaireService.create(current_expert, avis.dossier, commentaire_params)
 
       if @commentaire.errors.empty?
-        @commentaire.dossier.update!(last_commentaire_updated_at: Time.zone.now)
+        timestamps = [:last_commentaire_updated_at, :updated_at]
+        timestamps << :last_commentaire_piece_jointe_updated_at if @commentaire.piece_jointe.attached?
+
+        @commentaire.dossier.touch(*timestamps)
+
         flash.notice = "Message envoyé"
         redirect_to messagerie_expert_avis_path(avis.procedure, avis)
       else

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -522,7 +522,12 @@ module Instructeurs
           .compact
           .map(&:id)
 
-        champs_attachments_ids + commentaires_attachments_ids + avis_attachments_ids
+        justificatif_motivation_id = dossier
+          .justificatif_motivation
+          &.attachment
+          &.id
+
+        champs_attachments_ids + commentaires_attachments_ids + avis_attachments_ids + [justificatif_motivation_id]
       end
       @gallery_attachments = ActiveStorage::Attachment.where(id: gallery_attachments_ids)
     end

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -513,11 +513,16 @@ module Instructeurs
           .commentaires
           .includes(piece_jointe_attachments: :blob)
           .map(&:piece_jointe)
-          .map(&:attachments)
-          .flatten
+          .flat_map(&:attachments)
           .map(&:id)
 
-        champs_attachments_ids + commentaires_attachments_ids
+        avis_attachments_ids = dossier
+          .avis.flat_map { [_1.introduction_file, _1.piece_justificative_file] }
+          .flat_map(&:attachments)
+          .compact
+          .map(&:id)
+
+        champs_attachments_ids + commentaires_attachments_ids + avis_attachments_ids
       end
       @gallery_attachments = ActiveStorage::Attachment.where(id: gallery_attachments_ids)
     end

--- a/app/models/concerns/blob_image_processor_concern.rb
+++ b/app/models/concerns/blob_image_processor_concern.rb
@@ -10,7 +10,7 @@ module BlobImageProcessorConcern
   end
 
   def representation_required?
-    from_champ? || from_messagerie? || logo? || from_action_text?
+    from_champ? || from_messagerie? || logo? || from_action_text? || from_avis?
   end
 
   private
@@ -29,6 +29,10 @@ module BlobImageProcessorConcern
 
   def from_action_text?
     attachments.any? { _1.record.class == ActionText::RichText }
+  end
+
+  def from_avis?
+    attachments.any? { _1.record.class == Avis }
   end
 
   def watermark_required?

--- a/app/models/concerns/blob_image_processor_concern.rb
+++ b/app/models/concerns/blob_image_processor_concern.rb
@@ -10,7 +10,7 @@ module BlobImageProcessorConcern
   end
 
   def representation_required?
-    from_champ? || from_messagerie? || logo? || from_action_text? || from_avis?
+    from_champ? || from_messagerie? || logo? || from_action_text? || from_avis? || from_justificatif_motivation?
   end
 
   private
@@ -37,5 +37,9 @@ module BlobImageProcessorConcern
 
   def watermark_required?
     attachments.any? { _1.record.class == Champs::TitreIdentiteChamp }
+  end
+
+  def from_justificatif_motivation?
+    attachments.any? { _1.name == 'justificatif_motivation' }
   end
 end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -378,7 +378,8 @@ class Dossier < ApplicationRecord
       ' OR last_avis_updated_at > follows.avis_seen_at' \
       ' OR last_commentaire_updated_at > follows.messagerie_seen_at' \
       ' OR last_commentaire_piece_jointe_updated_at > follows.pieces_jointes_seen_at' \
-      ' OR last_champ_piece_jointe_updated_at > follows.pieces_jointes_seen_at')
+      ' OR last_champ_piece_jointe_updated_at > follows.pieces_jointes_seen_at' \
+      ' OR last_avis_piece_jointe_updated_at > follows.pieces_jointes_seen_at')
       .distinct
   end
 

--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -125,7 +125,7 @@ class Instructeur < ApplicationRecord
       annotations_privees = dossier.last_champ_private_updated_at&.>(follow.annotations_privees_seen_at) || false
       avis_notif = dossier.last_avis_updated_at&.>(follow.avis_seen_at) || false
       messagerie = dossier.last_commentaire_updated_at&.>(follow.messagerie_seen_at) || false
-      pieces_jointes = dossier.last_champ_piece_jointe_updated_at&.>(follow.pieces_jointes_seen_at) || dossier.last_commentaire_piece_jointe_updated_at&.>(follow.pieces_jointes_seen_at) || false
+      pieces_jointes = dossier.last_champ_piece_jointe_updated_at&.>(follow.pieces_jointes_seen_at) || dossier.last_commentaire_piece_jointe_updated_at&.>(follow.pieces_jointes_seen_at) || dossier.last_avis_piece_jointe_updated_at&.>(follow.pieces_jointes_seen_at) || false
 
       annotations_hash(demande, annotations_privees, avis_notif, messagerie, pieces_jointes)
     else

--- a/db/migrate/20241009155037_add_last_avis_piece_jointe_updated_at.rb
+++ b/db/migrate/20241009155037_add_last_avis_piece_jointe_updated_at.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLastAvisPieceJointeUpdatedAt < ActiveRecord::Migration[7.0]
+  def change
+    add_column :dossiers, :last_avis_piece_jointe_updated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -495,6 +495,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_14_084333) do
     t.string "hidden_by_reason"
     t.datetime "hidden_by_user_at", precision: nil
     t.datetime "identity_updated_at", precision: nil
+    t.datetime "last_avis_piece_jointe_updated_at"
     t.datetime "last_avis_updated_at", precision: nil
     t.datetime "last_champ_piece_jointe_updated_at"
     t.datetime "last_champ_private_updated_at", precision: nil

--- a/spec/components/attachment/gallery_item_component_spec.rb
+++ b/spec/components/attachment/gallery_item_component_spec.rb
@@ -100,6 +100,14 @@ RSpec.describe Attachment::GalleryItemComponent, type: :component do
         expect(subject).to have_text('Messagerie (instructeur)')
       end
     end
+
+    context 'from an expert' do
+      let(:expert) { create(:expert) }
+      before { commentaire.update!(expert:) }
+      it "displays the right tag" do
+        expect(subject).to have_text('Messagerie (expert)')
+      end
+    end
   end
 
   context "when attachment is from an avis" do

--- a/spec/components/attachment/gallery_item_component_spec.rb
+++ b/spec/components/attachment/gallery_item_component_spec.rb
@@ -101,4 +101,52 @@ RSpec.describe Attachment::GalleryItemComponent, type: :component do
       end
     end
   end
+
+  context "when attachment is from an avis" do
+    context 'from an instructeur' do
+      let(:avis) { create(:avis, :with_introduction, dossier: dossier) }
+      let(:attachment) { avis.introduction_file.attachment }
+
+      it "displays a generic libelle, link, tag and renders title" do
+        expect(subject).to have_text('Pièce jointe à l’avis')
+        expect(subject).to have_link(filename)
+        expect(subject).to have_text('Avis externe (instructeur)')
+        expect(component.title).to eq("Pièce jointe à l’avis -- #{filename}")
+      end
+
+      context "when instructeur has not seen it yet" do
+        let(:seen_at) { now - 1.day }
+
+        before do
+          attachment.blob.update(created_at: now)
+        end
+
+        it 'displays datetime in the right style' do
+          expect(subject).to have_css('.highlighted')
+        end
+      end
+
+      context "when instructeur has already seen it" do
+        let!(:seen_at) { now }
+
+        before do
+          freeze_time
+          attachment.blob.touch(:created_at)
+        end
+
+        it 'displays datetime in the right style' do
+          expect(subject).not_to have_css('.highlighted')
+        end
+      end
+    end
+
+    context 'from an expert' do
+      let(:avis) { create(:avis, :with_piece_justificative, dossier: dossier) }
+      let(:attachment) { avis.piece_justificative_file.attachment }
+
+      it "displays the right tag" do
+        expect(subject).to have_text('Avis externe (expert)')
+      end
+    end
+  end
 end

--- a/spec/components/attachment/gallery_item_component_spec.rb
+++ b/spec/components/attachment/gallery_item_component_spec.rb
@@ -145,6 +145,20 @@ RSpec.describe Attachment::GalleryItemComponent, type: :component do
     end
   end
 
+  context "when attachment is from a justificatif motivation" do
+    let(:fake_justificatif) { fixture_file_upload('spec/fixtures/files/piece_justificative_0.pdf', 'application/pdf') }
+    let(:attachment) { dossier.justificatif_motivation.attachment }
+
+    before { dossier.update!(justificatif_motivation: fake_justificatif) }
+
+    it "displays a generic libelle, link, tag and renders title" do
+      expect(subject).to have_text('Justificatif de décision')
+      expect(subject).to have_link(filename)
+      expect(subject).to have_text('Pièce jointe à la décision')
+      expect(component.title).to eq("Pièce jointe à la décision -- #{filename}")
+    end
+  end
+
   context "when attachment is from an avis" do
     context 'from an instructeur' do
       let(:avis) { create(:avis, :with_introduction, dossier: dossier) }

--- a/spec/components/attachment/gallery_item_component_spec.rb
+++ b/spec/components/attachment/gallery_item_component_spec.rb
@@ -4,9 +4,10 @@ require 'rails_helper'
 
 RSpec.describe Attachment::GalleryItemComponent, type: :component do
   let(:instructeur) { create(:instructeur) }
-  let(:procedure) { create(:procedure, :published, types_de_champ_public:) }
+  let(:procedure) { create(:procedure, :published, types_de_champ_public:, types_de_champ_private:) }
   let(:types_de_champ_public) { [{ type: :piece_justificative }] }
-  let(:dossier) { create(:dossier, :with_populated_champs, :en_construction, procedure:) }
+  let(:types_de_champ_private) { [{ type: :piece_justificative }] }
+  let(:dossier) { create(:dossier, :with_populated_champs, :with_populated_annotations, :en_construction, procedure:) }
   let(:filename) { attachment.blob.filename.to_s }
   let(:gallery_demande) { false }
   let(:seen_at) { nil }
@@ -16,8 +17,10 @@ RSpec.describe Attachment::GalleryItemComponent, type: :component do
 
   subject { render_inline(component).to_html }
 
-  context "when attachment is from a piece justificative champ" do
-    let(:champ) { dossier.champs.first }
+  context "when attachment is from a public piece justificative champ" do
+    let(:champ) do
+      dossier.champs.where(private: false).first
+    end
     let(:libelle) { champ.libelle }
     let(:attachment) { champ.piece_justificative_file.attachments.first }
 
@@ -45,6 +48,38 @@ RSpec.describe Attachment::GalleryItemComponent, type: :component do
       it 'displays the right text' do
         expect(subject).to have_text('Modifiée le')
       end
+    end
+
+    context "when gallery item is in page Demande" do
+      let(:gallery_demande) { true }
+
+      it "does not display libelle" do
+        expect(subject).not_to have_text(libelle)
+      end
+    end
+  end
+
+  context "when attachment is from a private piece justificative champ" do
+    let(:annotation) do
+      dossier.champs.where(private: true).first
+    end
+    let(:libelle) { annotation.libelle }
+    let(:attachment) { annotation.piece_justificative_file.attachments.first }
+
+    # Correspond au cas standard où le blob est créé avant le dépôt du dossier
+    before { dossier.touch(:depose_at) }
+
+    it "displays libelle, link, tag and renders title" do
+      expect(subject).to have_text(libelle)
+      expect(subject).to have_link(filename)
+      expect(subject).to have_text('Annotation privée')
+      expect(component.title).to eq("#{libelle} -- #{filename}")
+    end
+
+    it "displays when gallery item has been added" do
+      expect(subject).to have_text('Ajoutée le')
+      expect(subject).not_to have_css('.highlighted')
+      expect(subject).to have_text(component.helpers.try_format_datetime(attachment.record.created_at, format: :veryshort))
     end
 
     context "when gallery item is in page Demande" do


### PR DESCRIPTION
Correspond à une partie de https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/10756 

Dans cette PR on ajoute à la galerie les PJs venant de :
- demande d'avis d'instructeur
- avis d'expert
- message d'expert
- annotation privée
- justificatif de décision

On ajoute une pastille orange à l'onglet Pièces jointes seulement si la PJ vient de l'usager ou d'un expert, mais pas si elle vient d'un instructeur

ex : 

<img width="1296" alt="Capture d’écran 2024-10-11 à 15 15 09" src="https://github.com/user-attachments/assets/394b929f-7d50-407e-99fe-d3a667874743">
