### PR TITLE
ETQ admin, améliore un peu la vitesse de chargement de la liste des démarches

### DIFF
--- a/app/views/administrateurs/procedures/_procedures_list.html.haml
+++ b/app/views/administrateurs/procedures/_procedures_list.html.haml
@@ -45,9 +45,9 @@
             %div
               = dsfr_icon('fr-icon-team-fill')
               - if procedure.routing_enabled?
-                %span.fr-badge= procedure.groupe_instructeurs.count
+                %span.fr-badge= procedure.groupe_instructeurs_count
               - else
-                %span.fr-badge= procedure.instructeurs.count
+                %span.fr-badge= procedure.instructeurs_count
 
               = dsfr_icon('fr-icon-file-text-fill fr-ml-1w')
               %span.fr-badge= procedure.dossiers.state_not_brouillon.visible_by_administration.count


### PR DESCRIPTION
Corrige des N+1 sur `Administrateurs::Procedures#index` : 
- qui comptent le nombre d'instructeurs ou groupe d'instructeurs
- qui récupère le logo (2 requêtes par démarche)

Il en reste d'autres qui dépendent de modèles et/ou conditions intermédiaires, mais qui sont franchement plus complexes et plus coûteux à implémenter.