### PR TITLE
ETQ instructeur je peux filtrer un champ "choix simple" avec un long libellé d'option

### DIFF
--- a/app/models/procedure_presentation.rb
+++ b/app/models/procedure_presentation.rb
@@ -8,7 +8,7 @@ class ProcedurePresentation < ApplicationRecord
   SLASH = '/'
   TYPE_DE_CHAMP = 'type_de_champ'
 
-  FILTERS_VALUE_MAX_LENGTH = 100
+  FILTERS_VALUE_MAX_LENGTH = 4048
   # https://www.postgresql.org/docs/current/datatype-numeric.html
   PG_INTEGER_MAX_VALUE = 2147483647
 

--- a/spec/controllers/instructeurs/procedures_controller_spec.rb
+++ b/spec/controllers/instructeurs/procedures_controller_spec.rb
@@ -906,12 +906,12 @@ describe Instructeurs::ProceduresController, type: :controller do
 
     subject do
       column = procedure.find_column(label: "Nom").id
-      post :add_filter, params: { procedure_id: procedure.id, column:, value: "n" * 110, statut: "a-suivre" }
+      post :add_filter, params: { procedure_id: procedure.id, column:, value: "n" * 4100, statut: "a-suivre" }
     end
 
     it 'should render the error' do
       subject
-      expect(flash.alert[0]).to include("Le filtre Nom est trop long (maximum: 100 caractères)")
+      expect(flash.alert[0]).to include("Le filtre Nom est trop long (maximum: 4048 caractères)")
     end
   end
 end

--- a/spec/models/procedure_presentation_spec.rb
+++ b/spec/models/procedure_presentation_spec.rb
@@ -42,12 +42,16 @@ describe ProcedurePresentation do
     end
 
     context 'of filters' do
-      it { expect(build(:procedure_presentation, filters: { "suivis" => [{ table: "user", column: "reset_password_token", "order" => "asc" }] })).to be_invalid }
-      it { expect(build(:procedure_presentation, filters: { "suivis" => [{ table: "user", column: "email", "value" => "exceedingly long filter value" * 10 }] })).to be_invalid }
+      it do
+        expect(build(:procedure_presentation, filters: { "suivis" => [{ table: "user", column: "reset_password_token", "order" => "asc" }] })).to be_invalid
+        expect(build(:procedure_presentation, filters: { "suivis" => [{ table: "user", column: "email", "value" => "exceedingly long filter value" * 1000 }] })).to be_invalid
+      end
 
       describe 'check_filters_max_integer' do
-        it { expect(build(:procedure_presentation, filters: { "suivis" => [{ table: "self", column: "id", "value" => ProcedurePresentation::PG_INTEGER_MAX_VALUE.to_s }] })).to be_invalid }
-        it { expect(build(:procedure_presentation, filters: { "suivis" => [{ table: "self", column: "id", "value" => (ProcedurePresentation::PG_INTEGER_MAX_VALUE - 1).to_s }] })).to be_valid }
+        it do
+          expect(build(:procedure_presentation, filters: { "suivis" => [{ table: "self", column: "id", "value" => ProcedurePresentation::PG_INTEGER_MAX_VALUE.to_s }] })).to be_invalid
+          expect(build(:procedure_presentation, filters: { "suivis" => [{ table: "self", column: "id", "value" => (ProcedurePresentation::PG_INTEGER_MAX_VALUE - 1).to_s }] })).to be_valid
+        end
       end
     end
   end


### PR DESCRIPTION
Notre infra supporte des urls d'au moins 8000 caractères (probablement plus encore), donc on est large et je me demande même de la pertinence de cette limite. (les navigateurs modernes supportent + de 30K caractères)

Régression introduite par https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/10866
Cf https://secure.helpscout.net/conversation/2729750912/2099226?viewId=3192413