### PR TITLE
ETQ admin je peux voir les pages d'aides disponibles dans crisp

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -40,6 +40,7 @@ Rails.application.config.content_security_policy do |policy|
   frame_whitelist << URI(MATOMO_IFRAME_URL).host if Rails.application.secrets.matomo[:enabled]
   # allow pdf iframes in the PJ gallery
   frame_whitelist << URI(DS_PROXY_URL).host if DS_PROXY_URL.present?
+  frame_whitelist << "*.crisp.help" if Rails.application.secrets.crisp[:enabled]
   policy.frame_src(:self, *frame_whitelist)
 
   # Everything else: allow us


### PR DESCRIPTION
Fix erreurs de type

`Refused to load https://demarches-simplifiees.crisp.help/fr/article/je-ne-trouve-pas-ma-demarche-dans-le-catalogue-de-demarches-creer-une-nouvelle-demarche-a-partir-dune-demarche-existante-1x1bp4y/reader/compact/  because it does not appear in the frame-src directive of the Content Security Policy.`

quand on veut afficher les pages d'aides depuis crisp
Merci @BenoitSerrano !