### PR TITLE
Correctif : ETQ admin je peux importer des groupes d'instructeurs

### DIFF
--- a/app/components/procedure/groupes_management_component/groupes_management_component.html.haml
+++ b/app/components/procedure/groupes_management_component/groupes_management_component.html.haml
@@ -1,6 +1,8 @@
 - content_for(:title, 'Groupes')
 %h1 Gestion des groupes
 
+= render Procedure::ImportComponent.new(procedure: @procedure)
+
 = render Procedure::GroupesSearchComponent.new(procedure: @procedure,
   query: @query,
   to_configure_count: @procedure.groupe_instructeurs.filter(&:routing_to_configure?).count,


### PR DESCRIPTION
remet la fonctionnalité d'import de groupes d'instructeurs enlevée lors de la refonte de l'interface