### PR TITLE
refactor(champ): move champ value format methods from TypeDeChamp class to instance

### DIFF
--- a/app/graphql/types/champ_type.rb
+++ b/app/graphql/types/champ_type.rb
@@ -7,9 +7,13 @@ module Types
     global_id_field :id
     field :champ_descriptor_id, String, "L'identifiant du champDescriptor de ce champ", null: false
     field :label, String, "Libellé du champ.", null: false, method: :libelle
-    field :string_value, String, "La valeur du champ sous forme texte.", null: true, method: :for_api_v2
+    field :string_value, String, "La valeur du champ sous forme texte.", null: true
     field :updated_at, GraphQL::Types::ISO8601DateTime, "Date de dernière modification du champ.", null: false
     field :prefilled, Boolean, null: false, method: :prefilled?
+
+    def string_value
+      object.type_de_champ.champ_value_for_api(object)
+    end
 
     definition_methods do
       def resolve_type(object, context)

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -111,23 +111,11 @@ class Champ < ApplicationRecord
   end
 
   def to_s
-    TypeDeChamp.champ_value(type_champ, self)
+    type_de_champ.champ_value(self)
   end
 
-  def for_api
-    TypeDeChamp.champ_value_for_api(type_champ, self, 1)
-  end
-
-  def for_api_v2
-    TypeDeChamp.champ_value_for_api(type_champ, self, 2)
-  end
-
-  def for_export(path = :value)
-    TypeDeChamp.champ_value_for_export(type_champ, self, path)
-  end
-
-  def for_tag(path = :value)
-    TypeDeChamp.champ_value_for_tag(type_champ, self, path)
+  def last_write_type_champ
+    TypeDeChamp::CHAMP_TYPE_TO_TYPE_CHAMP.fetch(type)
   end
 
   def main_value_name

--- a/app/models/champs/iban_champ.rb
+++ b/app/models/champs/iban_champ.rb
@@ -4,14 +4,6 @@ class Champs::IbanChamp < Champ
   validates_with IbanValidator, if: :validate_champ_value_or_prefill?
   after_validation :format_iban
 
-  def for_api
-    to_s.gsub(/\s+/, '')
-  end
-
-  def for_api_v2
-    for_api
-  end
-
   private
 
   def format_iban

--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -81,11 +81,16 @@ module DossierChampsConcern
 
   def champs_for_export(types_de_champ, row_id = nil)
     types_de_champ.flat_map do |type_de_champ|
-      champ = champ_for_export(type_de_champ, row_id)
+      champ = filled_champ(type_de_champ, row_id)
       type_de_champ.libelles_for_export.map do |(libelle, path)|
-        [libelle, TypeDeChamp.champ_value_for_export(type_de_champ.type_champ, champ, path)]
+        [libelle, type_de_champ.champ_value_for_export(champ, path)]
       end
     end
+  end
+
+  def champ_value_for_tag(type_de_champ, path = :value)
+    champ = filled_champ(type_de_champ, nil)
+    type_de_champ.champ_value_for_tag(champ, path)
   end
 
   def champ_for_update(type_de_champ, row_id, updated_by:)
@@ -143,7 +148,7 @@ module DossierChampsConcern
     @champs_by_public_id ||= champs.sort_by(&:id).index_by(&:public_id)
   end
 
-  def champ_for_export(type_de_champ, row_id)
+  def filled_champ(type_de_champ, row_id)
     champ = champs_by_public_id[type_de_champ.public_id(row_id)]
     if champ.blank? || !champ.visible?
       nil

--- a/app/models/logic/champ_value.rb
+++ b/app/models/logic/champ_value.rb
@@ -50,7 +50,8 @@ class Logic::ChampValue < Logic::Term
       "Champs::CheckboxChamp"
       targeted_champ.true?
     when "Champs::IntegerNumberChamp", "Champs::DecimalNumberChamp"
-      targeted_champ.for_api
+      # TODO expose raw typed value of champs
+      targeted_champ.type_de_champ.champ_value_for_api(targeted_champ, version: 1)
     when "Champs::DropDownListChamp"
       targeted_champ.selected
     when "Champs::MultipleDropDownListChamp"

--- a/app/models/types_de_champ/address_type_de_champ.rb
+++ b/app/models/types_de_champ/address_type_de_champ.rb
@@ -6,35 +6,33 @@ class TypesDeChamp::AddressTypeDeChamp < TypesDeChamp::TextTypeDeChamp
     [[path[:libelle], path[:path]]]
   end
 
-  class << self
-    def champ_value(champ)
-      champ.address_label.presence || ''
-    end
+  def champ_value(champ)
+    champ.address_label.presence || ''
+  end
 
-    def champ_value_for_api(champ, version = 2)
+  def champ_value_for_api(champ, version: 2)
+    champ_value(champ)
+  end
+
+  def champ_value_for_tag(champ, path = :value)
+    case path
+    when :value
       champ_value(champ)
+    when :departement
+      champ.departement_code_and_name || ''
+    when :commune
+      champ.commune_name || ''
     end
+  end
 
-    def champ_value_for_tag(champ, path = :value)
-      case path
-      when :value
-        champ_value(champ)
-      when :departement
-        champ.departement_code_and_name || ''
-      when :commune
-        champ.commune_name || ''
-      end
-    end
-
-    def champ_value_for_export(champ, path = :value)
-      case path
-      when :value
-        champ_value(champ)
-      when :departement
-        champ.departement_code_and_name
-      when :commune
-        champ.commune_name
-      end
+  def champ_value_for_export(champ, path = :value)
+    case path
+    when :value
+      champ_value(champ)
+    when :departement
+      champ.departement_code_and_name
+    when :commune
+      champ.commune_name
     end
   end
 

--- a/app/models/types_de_champ/carte_type_de_champ.rb
+++ b/app/models/types_de_champ/carte_type_de_champ.rb
@@ -20,13 +20,11 @@ class TypesDeChamp::CarteTypeDeChamp < TypesDeChamp::TypeDeChampBase
 
   def tags_for_template = [].freeze
 
-  class << self
-    def champ_value_for_api(champ, version = 2)
-      nil
-    end
+  def champ_value_for_api(champ, version: 2)
+    nil
+  end
 
-    def champ_value_for_export(champ, path = :value)
-      champ.geo_areas.map(&:label).join("\n")
-    end
+  def champ_value_for_export(champ, path = :value)
+    champ.geo_areas.map(&:label).join("\n")
   end
 end

--- a/app/models/types_de_champ/checkbox_type_de_champ.rb
+++ b/app/models/types_de_champ/checkbox_type_de_champ.rb
@@ -11,43 +11,41 @@ class TypesDeChamp::CheckboxTypeDeChamp < TypesDeChamp::TypeDeChampBase
     end
   end
 
-  class << self
-    def champ_value(champ)
-      champ.true? ? 'Oui' : 'Non'
-    end
+  def champ_value(champ)
+    champ.true? ? 'Oui' : 'Non'
+  end
 
-    def champ_value_for_tag(champ, path = :value)
-      champ_value(champ)
-    end
+  def champ_value_for_tag(champ, path = :value)
+    champ_value(champ)
+  end
 
-    def champ_value_for_export(champ, path = :value)
-      champ.true? ? 'on' : 'off'
-    end
+  def champ_value_for_export(champ, path = :value)
+    champ.true? ? 'on' : 'off'
+  end
 
-    def champ_value_for_api(champ, version = 2)
-      case version
-      when 2
-        champ.true? ? 'true' : 'false'
-      else
-        super
-      end
+  def champ_value_for_api(champ, version: 2)
+    case version
+    when 2
+      champ.true? ? 'true' : 'false'
+    else
+      super
     end
+  end
 
-    def champ_default_value
-      'Non'
-    end
+  def champ_default_value
+    'Non'
+  end
 
-    def champ_default_export_value(path = :value)
-      'off'
-    end
+  def champ_default_export_value(path = :value)
+    'off'
+  end
 
-    def champ_default_api_value(version = 2)
-      case version
-      when 2
-        'false'
-      else
-        nil
-      end
+  def champ_default_api_value(version = 2)
+    case version
+    when 2
+      'false'
+    else
+      nil
     end
   end
 end

--- a/app/models/types_de_champ/cojo_type_de_champ.rb
+++ b/app/models/types_de_champ/cojo_type_de_champ.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::COJOTypeDeChamp < TypesDeChamp::TextTypeDeChamp
-  class << self
-    def champ_value(champ)
-      "#{champ.accreditation_number} – #{champ.accreditation_birthdate}"
-    end
+  def champ_value(champ)
+    "#{champ.accreditation_number} – #{champ.accreditation_birthdate}"
   end
 end

--- a/app/models/types_de_champ/commune_type_de_champ.rb
+++ b/app/models/types_de_champ/commune_type_de_champ.rb
@@ -1,32 +1,30 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::CommuneTypeDeChamp < TypesDeChamp::TypeDeChampBase
-  class << self
-    def champ_value_for_export(champ, path = :value)
-      case path
-      when :value
-        champ_value(champ)
-      when :departement
-        champ.departement_code_and_name || ''
-      when :code
-        champ.code || ''
-      end
+  def champ_value_for_export(champ, path = :value)
+    case path
+    when :value
+      champ_value(champ)
+    when :departement
+      champ.departement_code_and_name || ''
+    when :code
+      champ.code || ''
     end
+  end
 
-    def champ_value_for_tag(champ, path = :value)
-      case path
-      when :value
-        champ_value(champ)
-      when :departement
-        champ.departement_code_and_name || ''
-      when :code
-        champ.code || ''
-      end
+  def champ_value_for_tag(champ, path = :value)
+    case path
+    when :value
+      champ_value(champ)
+    when :departement
+      champ.departement_code_and_name || ''
+    when :code
+      champ.code || ''
     end
+  end
 
-    def champ_value(champ)
-      champ.code_postal? ? "#{champ.name} (#{champ.code_postal})" : champ.name
-    end
+  def champ_value(champ)
+    champ.code_postal? ? "#{champ.name} (#{champ.code_postal})" : champ.name
   end
 
   private

--- a/app/models/types_de_champ/date_type_de_champ.rb
+++ b/app/models/types_de_champ/date_type_de_champ.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::DateTypeDeChamp < TypesDeChamp::TypeDeChampBase
-  class << self
-    def champ_value(champ)
-      I18n.l(Time.zone.parse(champ.value), format: '%d %B %Y')
-    rescue ArgumentError
-      champ.value.presence || "" # old dossiers can have not parseable dates
-    end
+  def champ_value(champ)
+    I18n.l(Time.zone.parse(champ.value), format: '%d %B %Y')
+  rescue ArgumentError
+    champ.value.presence || "" # old dossiers can have not parseable dates
   end
 end

--- a/app/models/types_de_champ/datetime_type_de_champ.rb
+++ b/app/models/types_de_champ/datetime_type_de_champ.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::DatetimeTypeDeChamp < TypesDeChamp::TypeDeChampBase
-  class << self
-    def champ_value(champ)
-      I18n.l(Time.zone.parse(champ.value))
-    end
+  def champ_value(champ)
+    I18n.l(Time.zone.parse(champ.value))
   end
 end

--- a/app/models/types_de_champ/decimal_number_type_de_champ.rb
+++ b/app/models/types_de_champ/decimal_number_type_de_champ.rb
@@ -1,28 +1,26 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::DecimalNumberTypeDeChamp < TypesDeChamp::TypeDeChampBase
-  class << self
-    def champ_value_for_export(champ, path = :value)
+  def champ_value_for_export(champ, path = :value)
+    champ_formatted_value(champ)
+  end
+
+  def champ_value_for_api(champ, version: 2)
+    case version
+    when 1
       champ_formatted_value(champ)
+    else
+      super
     end
+  end
 
-    def champ_value_for_api(champ, version = 2)
-      case version
-      when 1
-        champ_formatted_value(champ)
-      else
-        super
-      end
-    end
+  def champ_default_export_value(path = :value)
+    0
+  end
 
-    def champ_default_export_value(path = :value)
-      0
-    end
+  private
 
-    private
-
-    def champ_formatted_value(champ)
-      champ.value&.to_f
-    end
+  def champ_formatted_value(champ)
+    champ.value&.to_f
   end
 end

--- a/app/models/types_de_champ/departement_type_de_champ.rb
+++ b/app/models/types_de_champ/departement_type_de_champ.rb
@@ -5,36 +5,34 @@ class TypesDeChamp::DepartementTypeDeChamp < TypesDeChamp::TextTypeDeChamp
     APIGeoService.departement_name(filter_value).presence || filter_value
   end
 
-  class << self
-    def champ_value(champ)
-      "#{champ.code} – #{champ.name}"
-    end
+  def champ_value(champ)
+    "#{champ.code} – #{champ.name}"
+  end
 
-    def champ_value_for_export(champ, path = :value)
-      case path
-      when :code
-        champ.code
-      when :value
-        champ.name
-      end
+  def champ_value_for_export(champ, path = :value)
+    case path
+    when :code
+      champ.code
+    when :value
+      champ.name
     end
+  end
 
-    def champ_value_for_tag(champ, path = :value)
-      case path
-      when :code
-        champ.code
-      when :value
-        champ_value(champ)
-      end
+  def champ_value_for_tag(champ, path = :value)
+    case path
+    when :code
+      champ.code
+    when :value
+      champ_value(champ)
     end
+  end
 
-    def champ_value_for_api(champ, version = 2)
-      case version
-      when 2
-        champ_value(champ).tr('–', '-')
-      else
-        champ_value(champ)
-      end
+  def champ_value_for_api(champ, version: 2)
+    case version
+    when 2
+      champ_value(champ).tr('–', '-')
+    else
+      champ_value(champ)
     end
   end
 

--- a/app/models/types_de_champ/epci_type_de_champ.rb
+++ b/app/models/types_de_champ/epci_type_de_champ.rb
@@ -1,27 +1,25 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::EpciTypeDeChamp < TypesDeChamp::TextTypeDeChamp
-  class << self
-    def champ_value_for_export(champ, path = :value)
-      case path
-      when :value
-        champ_value(champ)
-      when :code
-        champ.code
-      when :departement
-        champ.departement_code_and_name
-      end
+  def champ_value_for_export(champ, path = :value)
+    case path
+    when :value
+      champ_value(champ)
+    when :code
+      champ.code
+    when :departement
+      champ.departement_code_and_name
     end
+  end
 
-    def champ_value_for_tag(champ, path = :value)
-      case path
-      when :value
-        champ_value(champ)
-      when :code
-        champ.code
-      when :departement
-        champ.departement_code_and_name
-      end
+  def champ_value_for_tag(champ, path = :value)
+    case path
+    when :value
+      champ_value(champ)
+    when :code
+      champ.code
+    when :departement
+      champ.departement_code_and_name
     end
   end
 

--- a/app/models/types_de_champ/iban_type_de_champ.rb
+++ b/app/models/types_de_champ/iban_type_de_champ.rb
@@ -4,4 +4,8 @@ class TypesDeChamp::IbanTypeDeChamp < TypesDeChamp::TypeDeChampBase
   def estimated_fill_duration(revision)
     FILL_DURATION_MEDIUM
   end
+
+  def champ_value_for_api(champ, version: 2)
+    champ_value(champ).gsub(/\s+/, '')
+  end
 end

--- a/app/models/types_de_champ/integer_number_type_de_champ.rb
+++ b/app/models/types_de_champ/integer_number_type_de_champ.rb
@@ -1,28 +1,26 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::IntegerNumberTypeDeChamp < TypesDeChamp::TypeDeChampBase
-  class << self
-    def champ_value_for_export(champ, path = :value)
+  def champ_value_for_export(champ, path = :value)
+    champ_formatted_value(champ)
+  end
+
+  def champ_value_for_api(champ, version: 2)
+    case version
+    when 1
       champ_formatted_value(champ)
+    else
+      super
     end
+  end
 
-    def champ_value_for_api(champ, version = 2)
-      case version
-      when 1
-        champ_formatted_value(champ)
-      else
-        super
-      end
-    end
+  def champ_default_export_value(path = :value)
+    0
+  end
 
-    def champ_default_export_value(path = :value)
-      0
-    end
+  private
 
-    private
-
-    def champ_formatted_value(champ)
-      champ.value&.to_i
-    end
+  def champ_formatted_value(champ)
+    champ.value&.to_i
   end
 end

--- a/app/models/types_de_champ/linked_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/linked_drop_down_list_type_de_champ.rb
@@ -32,40 +32,38 @@ class TypesDeChamp::LinkedDropDownListTypeDeChamp < TypesDeChamp::TypeDeChampBas
     secondary_options
   end
 
-  class << self
-    def champ_value(champ)
-      [champ.primary_value, champ.secondary_value].filter(&:present?).join(' / ')
-    end
+  def champ_value(champ)
+    [champ.primary_value, champ.secondary_value].filter(&:present?).join(' / ')
+  end
 
-    def champ_value_for_tag(champ, path = :value)
-      case path
-      when :primary
-        champ.primary_value
-      when :secondary
-        champ.secondary_value
-      when :value
-        champ_value(champ)
-      end
+  def champ_value_for_tag(champ, path = :value)
+    case path
+    when :primary
+      champ.primary_value
+    when :secondary
+      champ.secondary_value
+    when :value
+      champ_value(champ)
     end
+  end
 
-    def champ_value_for_export(champ, path = :value)
-      case path
-      when :primary
-        champ.primary_value
-      when :secondary
-        champ.secondary_value
-      when :value
-        "#{champ.primary_value || ''};#{champ.secondary_value || ''}"
-      end
+  def champ_value_for_export(champ, path = :value)
+    case path
+    when :primary
+      champ.primary_value
+    when :secondary
+      champ.secondary_value
+    when :value
+      "#{champ.primary_value || ''};#{champ.secondary_value || ''}"
     end
+  end
 
-    def champ_value_for_api(champ, version = 2)
-      case version
-      when 1
-        { primary: champ.primary_value, secondary: champ.secondary_value }
-      else
-        super
-      end
+  def champ_value_for_api(champ, version: 2)
+    case version
+    when 1
+      { primary: champ.primary_value, secondary: champ.secondary_value }
+    else
+      super
     end
   end
 

--- a/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
@@ -1,17 +1,15 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::MultipleDropDownListTypeDeChamp < TypesDeChamp::TypeDeChampBase
-  class << self
-    def champ_value(champ)
-      champ.selected_options.join(', ')
-    end
+  def champ_value(champ)
+    champ.selected_options.join(', ')
+  end
 
-    def champ_value_for_tag(champ, path = :value)
-      ChampPresentations::MultipleDropDownListPresentation.new(champ.selected_options)
-    end
+  def champ_value_for_tag(champ, path = :value)
+    ChampPresentations::MultipleDropDownListPresentation.new(champ.selected_options)
+  end
 
-    def champ_value_for_export(champ, path = :value)
-      champ.selected_options.join(', ')
-    end
+  def champ_value_for_export(champ, path = :value)
+    champ.selected_options.join(', ')
   end
 end

--- a/app/models/types_de_champ/pays_type_de_champ.rb
+++ b/app/models/types_de_champ/pays_type_de_champ.rb
@@ -1,27 +1,25 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::PaysTypeDeChamp < TypesDeChamp::TextTypeDeChamp
-  class << self
-    def champ_value(champ)
-      champ.name
-    end
+  def champ_value(champ)
+    champ.name
+  end
 
-    def champ_value_for_export(champ, path = :value)
-      case path
-      when :value
-        champ_value(champ)
-      when :code
-        champ.code
-      end
+  def champ_value_for_export(champ, path = :value)
+    case path
+    when :value
+      champ_value(champ)
+    when :code
+      champ.code
     end
+  end
 
-    def champ_value_for_tag(champ, path = :value)
-      case path
-      when :value
-        champ_value(champ)
-      when :code
-        champ.code
-      end
+  def champ_value_for_tag(champ, path = :value)
+    case path
+    when :value
+      champ_value(champ)
+    when :code
+      champ.code
     end
   end
 

--- a/app/models/types_de_champ/phone_type_de_champ.rb
+++ b/app/models/types_de_champ/phone_type_de_champ.rb
@@ -22,15 +22,13 @@ class TypesDeChamp::PhoneTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   # See issue #6996.
   DEFAULT_COUNTRY_CODES = [:FR, :GP, :GF, :MQ, :RE, :YT, :NC, :PF].freeze
 
-  class << self
-    def champ_value(champ)
-      if Phonelib.valid_for_countries?(champ.value, DEFAULT_COUNTRY_CODES)
-        Phonelib.parse_for_countries(champ.value, DEFAULT_COUNTRY_CODES).full_national
-      else
-        # When he phone number is possible for the default countries, but not strictly valid,
-        # `full_national` could mess up the formatting. In this case just return the original.
-        champ.value
-      end
+  def champ_value(champ)
+    if Phonelib.valid_for_countries?(champ.value, DEFAULT_COUNTRY_CODES)
+      Phonelib.parse_for_countries(champ.value, DEFAULT_COUNTRY_CODES).full_national
+    else
+      # When he phone number is possible for the default countries, but not strictly valid,
+      # `full_national` could mess up the formatting. In this case just return the original.
+      champ.value
     end
   end
 end

--- a/app/models/types_de_champ/piece_justificative_type_de_champ.rb
+++ b/app/models/types_de_champ/piece_justificative_type_de_champ.rb
@@ -7,21 +7,19 @@ class TypesDeChamp::PieceJustificativeTypeDeChamp < TypesDeChamp::TypeDeChampBas
 
   def tags_for_template = [].freeze
 
-  class << self
-    def champ_value_for_export(champ, path = :value)
-      champ.piece_justificative_file.map { _1.filename.to_s }.join(', ')
-    end
+  def champ_value_for_export(champ, path = :value)
+    champ.piece_justificative_file.map { _1.filename.to_s }.join(', ')
+  end
 
-    def champ_value_for_api(champ, version = 2)
-      return if version == 2
+  def champ_value_for_api(champ, version: 2)
+    return if version == 2
 
-      # API v1 don't support multiple PJ
-      attachment = champ.piece_justificative_file.first
-      return if attachment.nil?
+    # API v1 don't support multiple PJ
+    attachment = champ.piece_justificative_file.first
+    return if attachment.nil?
 
-      if attachment.virus_scanner.safe? || attachment.virus_scanner.pending?
-        attachment.url
-      end
+    if attachment.virus_scanner.safe? || attachment.virus_scanner.pending?
+      attachment.url
     end
   end
 end

--- a/app/models/types_de_champ/region_type_de_champ.rb
+++ b/app/models/types_de_champ/region_type_de_champ.rb
@@ -5,27 +5,25 @@ class TypesDeChamp::RegionTypeDeChamp < TypesDeChamp::TextTypeDeChamp
     APIGeoService.region_name(filter_value).presence || filter_value
   end
 
-  class << self
-    def champ_value(champ)
-      champ.name
-    end
+  def champ_value(champ)
+    champ.name
+  end
 
-    def champ_value_for_export(champ, path = :value)
-      case path
-      when :value
-        champ_value(champ)
-      when :code
-        champ.code
-      end
+  def champ_value_for_export(champ, path = :value)
+    case path
+    when :value
+      champ_value(champ)
+    when :code
+      champ.code
     end
+  end
 
-    def champ_value_for_tag(champ, path = :value)
-      case path
-      when :value
-        champ_value(champ)
-      when :code
-        champ.code
-      end
+  def champ_value_for_tag(champ, path = :value)
+    case path
+    when :value
+      champ_value(champ)
+    when :code
+      champ.code
     end
   end
 

--- a/app/models/types_de_champ/repetition_type_de_champ.rb
+++ b/app/models/types_de_champ/repetition_type_de_champ.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::RepetitionTypeDeChamp < TypesDeChamp::TypeDeChampBase
-  def self.champ_value_for_tag(champ, path = :value)
+  def champ_value_for_tag(champ, path = :value)
     return nil if path != :value
     return champ_default_value if champ.rows.blank?
 

--- a/app/models/types_de_champ/rna_type_de_champ.rb
+++ b/app/models/types_de_champ/rna_type_de_champ.rb
@@ -7,9 +7,7 @@ class TypesDeChamp::RNATypeDeChamp < TypesDeChamp::TypeDeChampBase
     FILL_DURATION_MEDIUM
   end
 
-  class << self
-    def champ_value_for_export(champ, path = :value)
-      champ.identifier
-    end
+  def champ_value_for_export(champ, path = :value)
+    champ.identifier
   end
 end

--- a/app/models/types_de_champ/rnf_type_de_champ.rb
+++ b/app/models/types_de_champ/rnf_type_de_champ.rb
@@ -3,35 +3,33 @@
 class TypesDeChamp::RNFTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   include AddressableColumnConcern
 
-  class << self
-    def champ_value_for_export(champ, path = :value)
-      case path
-      when :value
-        champ.rnf_id
-      when :departement
-        champ.departement_code_and_name
-      when :code_insee
-        champ.commune&.fetch(:code)
-      when :address
-        champ.full_address
-      when :nom
-        champ.title
-      end
+  def champ_value_for_export(champ, path = :value)
+    case path
+    when :value
+      champ.rnf_id
+    when :departement
+      champ.departement_code_and_name
+    when :code_insee
+      champ.commune&.fetch(:code)
+    when :address
+      champ.full_address
+    when :nom
+      champ.title
     end
+  end
 
-    def champ_value_for_tag(champ, path = :value)
-      case path
-      when :value
-        champ.rnf_id
-      when :departement
-        champ.departement_code_and_name || ''
-      when :code_insee
-        champ.commune&.fetch(:code) || ''
-      when :address
-        champ.full_address || ''
-      when :nom
-        champ.title || ''
-      end
+  def champ_value_for_tag(champ, path = :value)
+    case path
+    when :value
+      champ.rnf_id
+    when :departement
+      champ.departement_code_and_name || ''
+    when :code_insee
+      champ.commune&.fetch(:code) || ''
+    when :address
+      champ.full_address || ''
+    when :nom
+      champ.title || ''
     end
   end
 

--- a/app/models/types_de_champ/textarea_type_de_champ.rb
+++ b/app/models/types_de_champ/textarea_type_de_champ.rb
@@ -5,9 +5,7 @@ class TypesDeChamp::TextareaTypeDeChamp < TypesDeChamp::TextTypeDeChamp
     FILL_DURATION_MEDIUM
   end
 
-  class << self
-    def champ_value_for_export(champ, path = :value)
-      ActionView::Base.full_sanitizer.sanitize(champ.value)
-    end
+  def champ_value_for_export(champ, path = :value)
+    ActionView::Base.full_sanitizer.sanitize(champ.value)
   end
 end

--- a/app/models/types_de_champ/titre_identite_type_de_champ.rb
+++ b/app/models/types_de_champ/titre_identite_type_de_champ.rb
@@ -10,17 +10,15 @@ class TypesDeChamp::TitreIdentiteTypeDeChamp < TypesDeChamp::TypeDeChampBase
 
   def tags_for_template = [].freeze
 
-  class << self
-    def champ_value_for_export(champ, path = :value)
-      champ.piece_justificative_file.attached? ? "présent" : "absent"
-    end
+  def champ_value_for_export(champ, path = :value)
+    champ.piece_justificative_file.attached? ? "présent" : "absent"
+  end
 
-    def champ_value_for_api(champ, version = 2)
-      nil
-    end
+  def champ_value_for_api(champ, version: 2)
+    nil
+  end
 
-    def champ_default_export_value(path = :value)
-      "absent"
-    end
+  def champ_default_export_value(path = :value)
+    "absent"
   end
 end

--- a/app/models/types_de_champ/type_de_champ_base.rb
+++ b/app/models/types_de_champ/type_de_champ_base.rb
@@ -15,12 +15,12 @@ class TypesDeChamp::TypeDeChampBase
   end
 
   def tags_for_template
-    tdc = @type_de_champ
+    type_de_champ = @type_de_champ
     paths.map do |path|
       path.merge(
         libelle: TagsSubstitutionConcern::TagsParser.normalize(path[:libelle]),
         id: path[:path] == :value ? "tdc#{stable_id}" : "tdc#{stable_id}/#{path[:path]}",
-        lambda: -> (dossier) { dossier.project_champ(tdc, nil).for_tag(path[:path]) }
+        lambda: -> (dossier) { dossier.champ_value_for_tag(type_de_champ, path[:path]) }
       )
     end
   end

--- a/app/models/types_de_champ/type_de_champ_base.rb
+++ b/app/models/types_de_champ/type_de_champ_base.rb
@@ -54,43 +54,41 @@ class TypesDeChamp::TypeDeChampBase
     filter_value
   end
 
-  class << self
-    def champ_value(champ)
-      champ.value.present? ? champ.value.to_s : champ_default_value
-    end
+  def champ_value(champ)
+    champ.value.present? ? champ.value.to_s : champ_default_value
+  end
 
-    def champ_value_for_api(champ, version = 2)
-      case version
-      when 2
-        champ_value(champ)
-      else
-        champ.value.presence || champ_default_api_value(version)
-      end
+  def champ_value_for_api(champ, version: 2)
+    case version
+    when 2
+      champ_value(champ)
+    else
+      champ.value.presence || champ_default_api_value(version)
     end
+  end
 
-    def champ_value_for_export(champ, path = :value)
-      path == :value ? champ.value.presence : champ_default_export_value(path)
-    end
+  def champ_value_for_export(champ, path = :value)
+    path == :value ? champ.value.presence : champ_default_export_value(path)
+  end
 
-    def champ_value_for_tag(champ, path = :value)
-      path == :value ? champ_value(champ) : nil
-    end
+  def champ_value_for_tag(champ, path = :value)
+    path == :value ? champ_value(champ) : nil
+  end
 
-    def champ_default_value
+  def champ_default_value
+    ''
+  end
+
+  def champ_default_export_value(path = :value)
+    nil
+  end
+
+  def champ_default_api_value(version = 2)
+    case version
+    when 2
       ''
-    end
-
-    def champ_default_export_value(path = :value)
+    else
       nil
-    end
-
-    def champ_default_api_value(version = 2)
-      case version
-      when 2
-        ''
-      else
-        nil
-      end
     end
   end
 

--- a/app/models/types_de_champ/yes_no_type_de_champ.rb
+++ b/app/models/types_de_champ/yes_no_type_de_champ.rb
@@ -11,49 +11,47 @@ class TypesDeChamp::YesNoTypeDeChamp < TypesDeChamp::CheckboxTypeDeChamp
     end
   end
 
-  class << self
-    def champ_value(champ)
-      champ_formatted_value(champ)
-    end
+  def champ_value(champ)
+    champ_formatted_value(champ)
+  end
 
-    def champ_value_for_tag(champ, path = :value)
-      champ_formatted_value(champ)
-    end
+  def champ_value_for_tag(champ, path = :value)
+    champ_formatted_value(champ)
+  end
 
-    def champ_value_for_export(champ, path = :value)
-      champ_formatted_value(champ)
-    end
+  def champ_value_for_export(champ, path = :value)
+    champ_formatted_value(champ)
+  end
 
-    def champ_value_for_api(champ, version = 2)
-      case version
-      when 2
-        champ.true? ? 'true' : 'false'
-      else
-        super
-      end
+  def champ_value_for_api(champ, version: 2)
+    case version
+    when 2
+      champ.true? ? 'true' : 'false'
+    else
+      super
     end
+  end
 
-    def champ_default_value
-      'Non'
+  def champ_default_value
+    'Non'
+  end
+
+  def champ_default_export_value(path = :value)
+    'Non'
+  end
+
+  def champ_default_api_value(version = 2)
+    case version
+    when 2
+      'false'
+    else
+      nil
     end
+  end
 
-    def champ_default_export_value(path = :value)
-      'Non'
-    end
+  private
 
-    def champ_default_api_value(version = 2)
-      case version
-      when 2
-        'false'
-      else
-        nil
-      end
-    end
-
-    private
-
-    def champ_formatted_value(champ)
-      champ.true? ? 'Oui' : 'Non'
-    end
+  def champ_formatted_value(champ)
+    champ.true? ? 'Oui' : 'Non'
   end
 end

--- a/app/serializers/champ_serializer.rb
+++ b/app/serializers/champ_serializer.rb
@@ -17,7 +17,7 @@ class ChampSerializer < ActiveModel::Serializer
     when GeoArea
       object.geometry
     else
-      object.for_api
+      object.type_de_champ.champ_value_for_api(object, version: 1)
     end
   end
 

--- a/app/serializers/dossier_serializer.rb
+++ b/app/serializers/dossier_serializer.rb
@@ -65,7 +65,7 @@ class DossierSerializer < ActiveModel::Serializer
       {
         created_at: champ.created_at&.in_time_zone('UTC'),
         type_de_piece_justificative_id: champ.type_de_champ.old_pj[:stable_id],
-        content_url: champ.for_api,
+        content_url: champ.type_de_champ.champ_value_for_api(champ, version: 1),
         user: champ.dossier.user
       }
     end.flatten

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -519,7 +519,7 @@ describe API::V2::GraphqlController do
             {
               id: champ.to_typed_id,
               label: champ.libelle,
-              stringValue: champ.for_api_v2
+              stringValue: champ.type_de_champ.champ_value_for_api(champ)
             }
           end
           expect(gql_data[:dossier][:champs]).to match_array(expected_champs)

--- a/spec/models/champ_spec.rb
+++ b/spec/models/champ_spec.rb
@@ -176,10 +176,12 @@ describe Champ do
     let(:champ) { Champs::TextChamp.new(value:, dossier: build(:dossier)) }
     before { allow(champ).to receive(:type_de_champ).and_return(build(:type_de_champ_text)) }
 
+    let(:value_for_export) { champ.type_de_champ.champ_value_for_export(champ) }
+
     context 'when type_de_champ is text' do
       let(:value) { '123' }
 
-      it { expect(champ.for_export).to eq('123') }
+      it { expect(value_for_export).to eq('123') }
     end
 
     context 'when type_de_champ is textarea' do
@@ -188,7 +190,7 @@ describe Champ do
 
       let(:value) { '<b>gras<b>' }
 
-      it { expect(champ.for_export).to eq('gras') }
+      it { expect(value_for_export).to eq('gras') }
     end
 
     context 'when type_de_champ is yes_no' do
@@ -198,19 +200,19 @@ describe Champ do
       context 'if yes' do
         let(:value) { 'true' }
 
-        it { expect(champ.for_export).to eq('Oui') }
+        it { expect(value_for_export).to eq('Oui') }
       end
 
       context 'if no' do
         let(:value) { 'false' }
 
-        it { expect(champ.for_export).to eq('Non') }
+        it { expect(value_for_export).to eq('Non') }
       end
 
       context 'if nil' do
         let(:value) { nil }
 
-        it { expect(champ.for_export).to eq('Non') }
+        it { expect(value_for_export).to eq('Non') }
       end
     end
 
@@ -220,19 +222,21 @@ describe Champ do
 
       let(:value) { '["Crétinier", "Mousserie"]' }
 
-      it { expect(champ.for_export).to eq('Crétinier, Mousserie') }
+      it { expect(value_for_export).to eq('Crétinier, Mousserie') }
     end
 
     context 'when type_de_champ and champ.type mismatch' do
       let(:value) { :noop }
       let(:champ_yes_no) { Champs::YesNoChamp.new(value: 'true') }
       let(:champ_text) { Champs::TextChamp.new(value: 'hello') }
+      let(:type_de_champ_yes_no) { build(:type_de_champ_yes_no) }
+      let(:type_de_champ_text) { build(:type_de_champ_text) }
       before do
-        allow(champ_yes_no).to receive(:type_de_champ).and_return(build(:type_de_champ_yes_no))
-        allow(champ_text).to receive(:type_de_champ).and_return(build(:type_de_champ_text))
+        allow(champ_yes_no).to receive(:type_de_champ).and_return(type_de_champ_yes_no)
+        allow(champ_text).to receive(:type_de_champ).and_return(type_de_champ_text)
       end
-      it { expect(TypeDeChamp.champ_value_for_export('text', champ_yes_no)).to eq(nil) }
-      it { expect(TypeDeChamp.champ_value_for_export('yes_no', champ_text)).to eq('Non') }
+      it { expect(type_de_champ_text.champ_value_for_export(champ_yes_no)).to eq(nil) }
+      it { expect(type_de_champ_yes_no.champ_value_for_export(champ_text)).to eq('Non') }
     end
   end
 

--- a/spec/models/champs/carte_champ_spec.rb
+++ b/spec/models/champs/carte_champ_spec.rb
@@ -50,7 +50,7 @@ describe Champs::CarteChamp do
       let(:geo_areas) { [build(:geo_area, :selection_utilisateur, :point)] }
 
       it "returns point label" do
-        expect(champ.for_export).to eq("Un point situé à 46°32'19\"N 2°25'42\"E")
+        expect(champ.type_de_champ.champ_value_for_export(champ)).to eq("Un point situé à 46°32'19\"N 2°25'42\"E")
       end
     end
 
@@ -58,7 +58,7 @@ describe Champs::CarteChamp do
       let(:geo_areas) { [build(:geo_area, :selection_utilisateur, :cadastre)] }
 
       it "returns cadastre parcelle label" do
-        expect(champ.for_export).to match(/Parcelle n° 42/)
+        expect(champ.type_de_champ.champ_value_for_export(champ)).to match(/Parcelle n° 42/)
       end
     end
   end

--- a/spec/models/champs/commune_champ_spec.rb
+++ b/spec/models/champs/commune_champ_spec.rb
@@ -23,9 +23,9 @@ describe Champs::CommuneChamp do
       expect(champ.code).to eq(code_insee)
       expect(champ.code_departement).to eq(code_departement)
       expect(champ.code_postal).to eq(code_postal)
-      expect(champ.for_export(:value)).to eq 'Châteldon (63290)'
-      expect(champ.for_export(:code)).to eq '63102'
-      expect(champ.for_export(:departement)).to eq '63 – Puy-de-Dôme'
+      expect(champ.type_de_champ.champ_value_for_export(champ, :value)).to eq 'Châteldon (63290)'
+      expect(champ.type_de_champ.champ_value_for_export(champ, :code)).to eq '63102'
+      expect(champ.type_de_champ.champ_value_for_export(champ, :departement)).to eq '63 – Puy-de-Dôme'
     end
 
     context 'with tricky bug (should not happen, but it happens)' do
@@ -59,9 +59,9 @@ describe Champs::CommuneChamp do
         expect(champ.code).to eq(code_insee)
         expect(champ.code_departement).to eq(code_departement)
         expect(champ.code_postal).to eq(code_postal)
-        expect(champ.for_export(:value)).to eq 'Châteldon (63290)'
-        expect(champ.for_export(:code)).to eq '63102'
-        expect(champ.for_export(:departement)).to eq '63 – Puy-de-Dôme'
+        expect(champ.type_de_champ.champ_value_for_export(champ, :value)).to eq 'Châteldon (63290)'
+        expect(champ.type_de_champ.champ_value_for_export(champ, :code)).to eq '63102'
+        expect(champ.type_de_champ.champ_value_for_export(champ, :departement)).to eq '63 – Puy-de-Dôme'
       end
     end
   end

--- a/spec/models/champs/decimal_number_champ_spec.rb
+++ b/spec/models/champs/decimal_number_champ_spec.rb
@@ -69,7 +69,7 @@ describe Champs::DecimalNumberChamp do
   describe 'for_export' do
     let(:champ) { Champs::DecimalNumberChamp.new(value:) }
     before { allow(champ).to receive(:type_de_champ).and_return(build(:type_de_champ_decimal_number)) }
-    subject { champ.for_export }
+    subject { champ.type_de_champ.champ_value_for_export(champ) }
     context 'with nil' do
       let(:value) { 0 }
       it { is_expected.to eq(0.0) }

--- a/spec/models/champs/departement_champ_spec.rb
+++ b/spec/models/champs/departement_champ_spec.rb
@@ -80,7 +80,6 @@ describe Champs::DepartementChamp, type: :model do
       expect(champ.value).to eq('Ain')
       expect(champ.selected).to eq('01')
       expect(champ.to_s).to eq('01 – Ain')
-      expect(champ.for_api_v2).to eq('01 - Ain')
     end
 
     it 'with code having 3 chars' do

--- a/spec/models/champs/linked_drop_down_list_champ_spec.rb
+++ b/spec/models/champs/linked_drop_down_list_champ_spec.rb
@@ -55,7 +55,7 @@ describe Champs::LinkedDropDownListChamp do
     let(:secondary_value) { nil }
 
     before { allow(champ).to receive(:type_de_champ).and_return(build(:type_de_champ_linked_drop_down_list)) }
-    subject { champ.for_export }
+    subject { champ.type_de_champ.champ_value_for_export(champ) }
 
     context 'with no value' do
       let(:value) { nil }

--- a/spec/models/champs/multiple_drop_down_list_champ_spec.rb
+++ b/spec/models/champs/multiple_drop_down_list_champ_spec.rb
@@ -90,6 +90,6 @@ describe Champs::MultipleDropDownListChamp do
 
   describe "#for_tag" do
     let(:value) { ["val1", "val2"] }
-    it { expect(champ.for_tag.to_s).to eq("val1, val2") }
+    it { expect(champ.type_de_champ.champ_value_for_tag(champ).to_s).to eq("val1, val2") }
   end
 end

--- a/spec/models/champs/piece_justificative_champ_spec.rb
+++ b/spec/models/champs/piece_justificative_champ_spec.rb
@@ -33,7 +33,7 @@ describe Champs::PieceJustificativeChamp do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative }]) }
     let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
     let(:champ) { dossier.champs.first }
-    subject { champ.for_export }
+    subject { champ.type_de_champ.champ_value_for_export(champ) }
 
     it { is_expected.to eq('toto.txt') }
 
@@ -50,7 +50,7 @@ describe Champs::PieceJustificativeChamp do
 
     before { champ.piece_justificative_file.first.blob.update(virus_scan_result:) }
 
-    subject { champ.for_api }
+    subject { champ.type_de_champ.champ_value_for_api(champ, version: 1) }
 
     context 'when file is safe' do
       let(:virus_scan_result) { ActiveStorage::VirusScanner::SAFE }

--- a/spec/models/champs/repetition_champ_spec.rb
+++ b/spec/models/champs/repetition_champ_spec.rb
@@ -19,7 +19,7 @@ describe Champs::RepetitionChamp do
     end
 
     it "can render as string" do
-      expect(champ.for_tag.to_s).to eq(
+      expect(champ.type_de_champ.champ_value_for_tag(champ).to_s).to eq(
         <<~TXT.strip
           Languages
 
@@ -29,7 +29,7 @@ describe Champs::RepetitionChamp do
     end
 
     it "as tiptap node" do
-      expect(champ.for_tag.to_tiptap_node).to include(type: 'orderedList')
+      expect(champ.type_de_champ.champ_value_for_tag(champ).to_tiptap_node).to include(type: 'orderedList')
     end
   end
 end

--- a/spec/models/champs/rna_champ_spec.rb
+++ b/spec/models/champs/rna_champ_spec.rb
@@ -23,11 +23,11 @@ describe Champs::RNAChamp do
         champ.update(data: { association_titre: "Super asso" })
       end
 
-      it { expect(champ.for_export).to eq("W182736273 (Super asso)") }
+      it { expect(champ.type_de_champ.champ_value_for_export(champ)).to eq("W182736273 (Super asso)") }
     end
 
     context "no association title" do
-      it { expect(champ.for_export).to eq("W182736273") }
+      it { expect(champ.type_de_champ.champ_value_for_export(champ)).to eq("W182736273") }
     end
   end
 end

--- a/spec/models/champs/rnf_champ_spec.rb
+++ b/spec/models/champs/rnf_champ_spec.rb
@@ -125,11 +125,11 @@ describe Champs::RNFChamp, type: :model do
     let(:champ) { described_class.new(external_id:, data: JSON.parse(body)) }
     before { allow(champ).to receive(:type_de_champ).and_return(build(:type_de_champ_rnf)) }
     it do
-      expect(champ.for_export(:value)).to eq '075-FDD-00003-01'
-      expect(champ.for_export(:nom)).to eq 'Fondation SFR'
-      expect(champ.for_export(:address)).to eq '16 Rue du Général de Boissieu 75015 Paris'
-      expect(champ.for_export(:code_insee)).to eq '75115'
-      expect(champ.for_export(:departement)).to eq '75 – Paris'
+      expect(champ.type_de_champ.champ_value_for_export(champ, :value)).to eq '075-FDD-00003-01'
+      expect(champ.type_de_champ.champ_value_for_export(champ, :nom)).to eq 'Fondation SFR'
+      expect(champ.type_de_champ.champ_value_for_export(champ, :address)).to eq '16 Rue du Général de Boissieu 75015 Paris'
+      expect(champ.type_de_champ.champ_value_for_export(champ, :code_insee)).to eq '75115'
+      expect(champ.type_de_champ.champ_value_for_export(champ, :departement)).to eq '75 – Paris'
     end
   end
 end

--- a/spec/models/champs/titre_identite_champ_spec.rb
+++ b/spec/models/champs/titre_identite_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::TitreIdentiteChamp do
   describe "#for_export" do
     let(:champ) { described_class.new }
     before { allow(champ).to receive(:type_de_champ).and_return(build(:type_de_champ_titre_identite)) }
-    subject { champ.for_export }
+    subject { champ.type_de_champ.champ_value_for_export(champ) }
 
     context 'without attached file' do
       let(:piece_justificative_file) { double(attached?: true) }

--- a/spec/system/users/en_construction_spec.rb
+++ b/spec/system/users/en_construction_spec.rb
@@ -19,7 +19,7 @@ describe "Dossier en_construction", js: true do
     expect(page).not_to have_button("Remplacer")
     click_on "Supprimer le fichier toto.txt"
 
-    wait_until { champ.reload.for_export.blank? }
+    wait_until { champ.reload.blank? }
     expect(page).not_to have_text("toto.txt")
   end
 
@@ -38,7 +38,7 @@ describe "Dossier en_construction", js: true do
       expect(page).to have_selector(input_selector)
       find(input_selector).attach_file(Rails.root.join('spec/fixtures/files/file.pdf'))
 
-      wait_until { champ.reload.for_export == 'file.pdf' }
+      wait_until { champ.reload.piece_justificative_file.first&.filename == 'file.pdf' }
       expect(page).to have_text("file.pdf")
     end
   end


### PR DESCRIPTION
Cette PR déplace les méthodes de formatage des valeurs d'un champ de la classe vers l'instance. On passe de `TypeDeChamp.champ_value(type_champ, champ)` à `type_de_champ.champ_value(champ)`. Le fait de mettre les méthodes sur la classe était selon moi une optimisation prématurée pour le `DossierProjectionService`. Mais cela introduisait des limitations (on n'avait pas accès aux options du type de champ, seulement au type). La contrepartie, c'est que pour les colonnes affichées dans le Dashboard, on doit charger le type_de_champ en entier. Vu le faible nombre de colonnes, c'est totalement négligeable.

En bonus dans cette PR, je supprime les indirections sur le champ utilisé uniquement dans les tests.