### PR TITLE
🛠️ Fix | Procedure minimal admins presence

### DIFF
--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -210,6 +210,20 @@ describe Procedure do
       it { is_expected.not_to allow_value([]).for(:administrateurs) }
     end
 
+    context 'before_remove callback for minimal administrator presence' do
+      let(:procedure) { create(:procedure) }
+
+      it 'raises an error when trying to remove the last administrateur' do
+        expect(procedure.administrateurs.count).to eq(1)
+        expect {
+          procedure.administrateurs.destroy(procedure.administrateurs.first)
+        }.to raise_error(
+          ActiveRecord::RecordNotDestroyed,
+          "Cannot remove the last administrateur of procedure #{procedure.libelle} (#{procedure.id})"
+        )
+      end
+    end
+
     context 'juridique' do
       it { is_expected.not_to allow_value(nil).on(:publication).for(:cadre_juridique) }
       it { is_expected.to allow_value('text').on(:publication).for(:cadre_juridique) }


### PR DESCRIPTION
Bonjour à tous !

Sur démarches sociales nous rencontrons un soucis lors de l'utilisation de la feature pour la fusion de deux comptes.

Après qu'un utilisateur accepte la fusion de compte, lors de l’exécution de `Users::ProfilController#accept_merge`, on execute `User#merge` on arrive à la suppression de l'ancien utilisateur.

Lors de cette suppression de l'ancien user, dans le model procédure, le after_remove s'active alors :

```
# models/procedures.rb
 has_many :administrateurs, through: :administrateurs_procedures, after_remove: -> (procedure, _admin) { procedure.validate! }
```

Or cela génère l'erreur suivante pour certains de mes utilisateurs.

```
ActiveRecord::RecordInvalid
La validation a échoué : Le champ « Durée de conservation des dossiers sur demarches-simplifiees.fr (choisi par un usager) » doit être inférieur ou égal à 12 (ActiveRecord::RecordInvalid)
```

D'après l'historique de la ligne, le after_remove s'assure de la présence d'au moins 1 administrateur pour la procédure.

Je propose cette solution pour ne plus avoir le soucis sur la validation de la durée de validité des procédures/