### PR TITLE
Correctif : met à jour des follows avec un `attribut pieces_jointes_seen_at` nul

### DIFF
--- a/app/tasks/maintenance/t20241018fix_follows_with_nil_pieces_jointes_seen_at_task.rb
+++ b/app/tasks/maintenance/t20241018fix_follows_with_nil_pieces_jointes_seen_at_task.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20241018fixFollowsWithNilPiecesJointesSeenAtTask < MaintenanceTasks::Task
+    # Normalement tous les follows auraient du être mis à jour lors de la migration db/migrate/20240911064340_backfill_follows_with_pieces_jointes_seen_at.rb
+    # Mais, sur l'instance de DS, 57 follows créés lorsque la migration a tourné ont gardé une valeur nulle pour pieces_jointes_seen_at. On les met à jour ici.
+
+    include RunnableOnDeployConcern
+    include StatementsHelpersConcern
+
+    # Uncomment only if this task MUST run imperatively on its first deployment.
+    # If possible, leave commented for manual execution later.
+    # run_on_first_deploy
+
+    def collection
+      # Collection to be iterated over
+      # Must be Active Record Relation or Array
+      Follow.where(pieces_jointes_seen_at: nil)
+    end
+
+    def process(element)
+      # The work to be done in a single iteration of the task.
+      # This should be idempotent, as the same element may be processed more
+      # than once if the task is interrupted and resumed.
+      element.update_columns(pieces_jointes_seen_at: Time.zone.now)
+    end
+  end
+end

--- a/spec/tasks/maintenance/t20241018fix_follows_with_nil_pieces_jointes_seen_at_task_spec.rb
+++ b/spec/tasks/maintenance/t20241018fix_follows_with_nil_pieces_jointes_seen_at_task_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe T20241018fixFollowsWithNilPiecesJointesSeenAtTask do
+    describe "#process" do
+      subject { described_class.process(follow) }
+
+      let(:follow) { create(:follow) }
+
+      before { follow.update_columns(pieces_jointes_seen_at: nil) }
+
+      it "updates the pieces_jointes_seen_at attribute" do
+        expect { subject }.to change { follow.pieces_jointes_seen_at }.from(nil).to be_within(1.second).of(Time.zone.now)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Sur les quelque 11 millions de follows, une cinquantaine créés au moment de la mep du 15 octobre n'ont pas été mis à jour. La maintenance task dans cette PR corrige les données

cf https://demarches-simplifiees.sentry.io/issues/5998081306/