### PR TITLE
Restitution des bandeau de statut (erreur ou succès)

### DIFF
--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -151,10 +151,8 @@
   .dropdown-button {
     white-space: nowrap;
 
-    &::after {
+    [aria-hidden="true"].fr-ml-2v::after {
       content: "▾";
-      margin-left: $default-spacer;
-      font-weight: bold;
     }
 
     &.icon-only {

--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -1,11 +1,9 @@
-@import "colors";
-
 span.notifications {
   position: absolute;
   width: 8px;
   height: 8px;
   border-radius: 4px;
-  background-color: $orange;
+  background-color: var(--background-flat-warning);
 }
 
 .fr-tabs__list span.notifications {

--- a/app/components/dossiers/batch_operation_component/batch_operation_component.html.haml
+++ b/app/components/dossiers/batch_operation_component/batch_operation_component.html.haml
@@ -13,6 +13,7 @@
         -# Dropdown button title
         %button#batch_operation_others.fr-btn.fr-btn--sm.fr-btn--secondary.fr-ml-1w.dropdown-button{ disabled: true, data: { menu_button_target: 'button', batch_operation_target: 'dropdown' } }
           = t('.operations.other')
+          %span.fr-ml-2v{ 'aria-hidden': 'true' }
 
         #state-menu.dropdown-content.fade-in-down{ data: { menu_button_target: 'menu' }, "aria-labelledby" => "batch_operation_others" }
           %ul.dropdown-items

--- a/app/components/dropdown/menu_component/menu_component.html.haml
+++ b/app/components/dropdown/menu_component/menu_component.html.haml
@@ -1,6 +1,7 @@
 = content_tag(@wrapper, wrapper_options) do
   %button{ class: button_class_names, id: button_id, disabled: disabled?, data: data, "aria-expanded": "false", 'aria-haspopup': 'true', 'aria-controls': menu_id }
     = button_inner_html
+    %span.fr-ml-2v{ 'aria-hidden': 'true' }
 
   %div{ data: { menu_button_target: 'menu' }, id: menu_id, 'aria-labelledby': button_id, role: menu_role, 'tabindex': -1, class: menu_class_names }
     = menu_header_html

--- a/app/components/dropdown/menu_component/menu_component.html.haml
+++ b/app/components/dropdown/menu_component/menu_component.html.haml
@@ -2,7 +2,7 @@
   %button{ class: button_class_names, id: button_id, disabled: disabled?, data: data, "aria-expanded": "false", 'aria-haspopup': 'true', 'aria-controls': menu_id }
     = button_inner_html
 
-  %div{ data: { menu_button_target: 'menu' }, id: menu_id, 'aria-labelledby': button_id, role: menu_role, 'tab-index': -1, class: menu_class_names }
+  %div{ data: { menu_button_target: 'menu' }, id: menu_id, 'aria-labelledby': button_id, role: menu_role, 'tabindex': -1, class: menu_class_names }
     = menu_header_html
 
     -# the dropdown can be a menu with a list of item

--- a/app/components/dsfr/input_status_message_component/input_status_message_component.html.haml
+++ b/app/components/dsfr/input_status_message_component/input_status_message_component.html.haml
@@ -1,4 +1,4 @@
-.fr-messages-group{ id: @describedby_id, aria: { live: :assertive } }
+.fr-messages-group{ id: @describedby_id }
   - if @error_full_messages.size > 0
     %p{ class: class_names('fr-message' => true, "fr-message--#{@errors_on_attribute ? 'error' : 'valid'}" => true) }
       = "« #{@champ.libelle} » "

--- a/app/components/editable_champ/champ_label_content_component/champ_label_content_component.html.haml
+++ b/app/components/editable_champ/champ_label_content_component/champ_label_content_component.html.haml
@@ -21,7 +21,7 @@
   %span.fr-hint-text{ data: { controller: 'date-input-hint' } }= hint
 
 - if @champ.description.present?
-  %span.fr-hint-text{ id: @champ.describedby_id }= render SimpleFormatComponent.new(@champ.description, allow_a: true)
+  %span.fr-hint-text= render SimpleFormatComponent.new(@champ.description, allow_a: true)
 
 - if @champ.textarea?
   %span.sr-only= t('.recommended_size', size: @champ.character_limit_base)

--- a/app/components/editable_champ/champ_label_content_component/champ_label_content_component.html.haml
+++ b/app/components/editable_champ/champ_label_content_component/champ_label_content_component.html.haml
@@ -2,8 +2,6 @@
 - if @champ.public?
   - if @champ.mandatory?
     = render EditableChamp::AsteriskMandatoryComponent.new
-  - else
-    %span.sr-only= t('.optional_champ')
 
 - if @champ.forked_with_changes?
   %span.updated-at.highlighted

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,15 +36,8 @@ module ApplicationHelper
     end
   end
 
-  def flash_class(level, sticky: false, fixed: false)
+  def flash_class(sticky: false, fixed: false)
     class_names = []
-
-    case level
-    when 'notice'
-      class_names << 'alert-success'
-    when 'alert', 'error'
-      class_names << 'alert-danger'
-    end
 
     if sticky
       class_names << 'sticky'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,9 +36,15 @@ module ApplicationHelper
     end
   end
 
-  def flash_class(sticky: false, fixed: false)
+  def flash_class(level, sticky: false, fixed: false)
     class_names = []
 
+    case level
+    when 'notice'
+      class_names << 'alert-success'
+    when 'alert', 'error'
+      class_names << 'alert-danger'
+    end
     if sticky
       class_names << 'sticky'
     end

--- a/app/views/invites/_dropdown.html.haml
+++ b/app/views/invites/_dropdown.html.haml
@@ -1,5 +1,6 @@
 - invites = dossier.invites.load
-= render Dropdown::MenuComponent.new(wrapper: :span, wrapper_options: {class: 'invite-user-action'}, button_options: { class: ['fr-btn--secondary'] }, menu_options: { id: 'invite-content' }) do |menu|
+= render Dropdown::MenuComponent.new(wrapper: :div, wrapper_options: {class: 'invite-user-action'}, button_options: { class: ['fr-btn--secondary'] }, menu_options: { id: 'invite-content' }) do |menu|
+  = 'lab'
   - menu.with_button_inner_html do
     = dsfr_icon('fr-icon-user-add-fill', :sm, :mr)
     - if invites.present?

--- a/app/views/invites/_form.html.haml
+++ b/app/views/invites/_form.html.haml
@@ -4,13 +4,13 @@
 
   %h5.fr-h6= t('views.invites.form.edit_dossier', count: invites.size)
   - if invites.present?
-    #invite-list{ morphing ? { tabindex: "-1" } : {} }
+    #invite-list
       %ul
-        - invites.each do |invite|
+        - invites.each_with_index do |invite, index|
           %li
-            = invite.email
+            %span{ :id => "invite_#{index}" }= invite.email
             %small{ 'data-turbo': 'true' }
-              = link_to t('views.invites.form.withdraw_permission'), invite_path(invite), data: { turbo_method: :delete, turbo_confirm: t('views.invites.form.want_to_withdraw_permission', email: invite.email) }, class: "fr-btn fr-btn--sm fr-btn--tertiary-no-outline"
+              = link_to t('views.invites.form.withdraw_permission'), invite_path(invite), data: { turbo_method: :delete, turbo_confirm: t('views.invites.form.want_to_withdraw_permission', email: invite.email) }, class: "fr-btn fr-btn--sm fr-btn--tertiary-no-outline", id: "link_#{index}", "aria-labelledby": "link_#{index} invite_#{index}"
 
     - if dossier.brouillon?
       %p= t('views.invites.form.submit_dossier_yourself')

--- a/app/views/layouts/_flash_messages.html.haml
+++ b/app/views/layouts/_flash_messages.html.haml
@@ -1,22 +1,13 @@
-#flash_messages{ tabindex: '-1' }
+#flash_messages{ tabindex: '-1', data: { turbo_force: :server } }
   #flash_message.center{ class: defined?(unique_classname) ? unique_classname : '' }
     - if flash.any?
       - flash.each do |key, value|
         - sticky = defined?(sticky) ? sticky : false
         - fixed = defined?(fixed) ? fixed : false
-        - if flash_role(key) == 'status'
-          .alert.alert-success{ role: 'status', class: flash_class(sticky: sticky, fixed: fixed), tabindex: '-1', data: { controller: 'autofocus' } }
-            - if value.class == Array
-              - value.each do |message|
-                = sanitize_with_link(message)
-                %br
-            - elsif value.present?
-              = sanitize_with_link(value)
-        - elsif flash_role(key) == 'alert'
-          .alert.alert-danger{ role: 'alert', class: flash_class(sticky: sticky, fixed: fixed), tabindex: '-1', data: { controller: 'autofocus' } }
-            - if value.class == Array
-              - value.each do |message|
-                = sanitize_with_link(message)
-                %br
-            - elsif value.present?
-              = sanitize_with_link(value)
+        .alert{ role: flash_role(key), class: flash_class(key, sticky: sticky, fixed: fixed) }
+          - if value.class == Array
+            - value.each do |message|
+              = sanitize_with_link(message)
+              %br
+          - elsif value.present?
+            = sanitize_with_link(value)

--- a/app/views/layouts/_flash_messages.html.haml
+++ b/app/views/layouts/_flash_messages.html.haml
@@ -1,14 +1,22 @@
-#flash_messages{ aria: { live: 'assertive' } }
-  - if flash.any?
-    #flash_message.center
+#flash_messages
+  #flash_message.center
+    - if flash.any?
       - flash.each do |key, value|
         - sticky = defined?(sticky) ? sticky : false
         - fixed = defined?(fixed) ? fixed : false
-        - if value.class == Array
-          .alert{ class: flash_class(key, sticky: sticky, fixed: fixed), role: flash_role(key) }
-            - value.each do |message|
-              = sanitize_with_link(message)
-              %br
-        - elsif value.present?
-          .alert{ class: flash_class(key, sticky: sticky, fixed: fixed), role: flash_role(key) }
-            = sanitize_with_link(value)
+        - if flash_role(key) == 'status'
+          .alert.alert-success{ role: 'status', class: flash_class(sticky: sticky, fixed: fixed), tabindex: '-1', data: { controller: 'autofocus' } }
+            - if value.class == Array
+              - value.each do |message|
+                = sanitize_with_link(message)
+                %br
+            - elsif value.present?
+              = sanitize_with_link(value)
+        - elsif flash_role(key) == 'alert'
+          .alert.alert-danger{ role: 'alert', class: flash_class(sticky: sticky, fixed: fixed), tabindex: '-1', data: { controller: 'autofocus' } }
+            - if value.class == Array
+              - value.each do |message|
+                = sanitize_with_link(message)
+                %br
+            - elsif value.present?
+              = sanitize_with_link(value)

--- a/app/views/layouts/_flash_messages.html.haml
+++ b/app/views/layouts/_flash_messages.html.haml
@@ -1,5 +1,5 @@
-#flash_messages
-  #flash_message.center
+#flash_messages{ tabindex: '-1' }
+  #flash_message.center{ class: defined?(unique_classname) ? unique_classname : '' }
     - if flash.any?
       - flash.each do |key, value|
         - sticky = defined?(sticky) ? sticky : false

--- a/app/views/layouts/_header.haml
+++ b/app/views/layouts/_header.haml
@@ -53,7 +53,7 @@
                     = render partial: 'shared/help/help_dropdown_instructeur'
                   - else
                     -# NB: on mobile in order to have links correctly aligned, we need a left icon #
-                    = link_to t('help'), t("links.common.faq.url"), class: 'fr-btn dropdown-button'
+                    = link_to t('help'), t("links.common.faq.url"), class: 'fr-btn'
 
 
 

--- a/app/views/layouts/application.turbo_stream.haml
+++ b/app/views/layouts/application.turbo_stream.haml
@@ -1,7 +1,9 @@
 - if flash.any?
-  = turbo_stream.replace 'flash_messages', partial: 'layouts/flash_messages'
+  - unique_classname= "u#{SecureRandom.hex}"
+  = turbo_stream.replace 'flash_messages', partial: 'layouts/flash_messages', locals: { unique_classname: }
+  = turbo_stream.focus 'flash_messages'
   = turbo_stream.show 'flash_messages'
-  = turbo_stream.hide 'flash_messages', delay: 30000
+  = turbo_stream.hide_all ".#{unique_classname}", delay: 15000
   - flash.clear
 
 = yield

--- a/config/locales/metas.en.yml
+++ b/config/locales/metas.en.yml
@@ -12,13 +12,13 @@ en:
         identite:
           title: "New file (%{procedure_label}) - Step 1: Identity"
         show:
-          title: "Summary · File nº %{number} (%{procedure_label})"
+          title: "Summary · File %{number} (%{procedure_label})"
         demande:
-          title: "Application · File nº %{number} (%{procedure_label})"
+          title: "Application · File %{number} (%{procedure_label})"
         messagerie:
-          title: "Mailbox · File nº %{number} (%{procedure_label})"
+          title: "Mailbox · File %{number} (%{procedure_label})"
         brouillon:
-          title: "Modification of draft nº %{number} (%{procedure_label})"
+          title: "File %{number} in draft (%{procedure_label}) - Step 2: Form"
         merci:
           title: "File submitted (%{procedure_label})"
       activate:

--- a/config/locales/metas.fr.yml
+++ b/config/locales/metas.fr.yml
@@ -12,13 +12,13 @@ fr:
         identite:
           title: "Nouveau dossier (%{procedure_label}) - Étape 1 : Identité"
         show:
-          title: "Résumé · Dossier nº %{number} (%{procedure_label})"
+          title: "Résumé · Dossier %{number} (%{procedure_label})"
         demande:
-          title: "Demande · Dossier nº %{number} (%{procedure_label})"
+          title: "Demande · Dossier %{number} (%{procedure_label})"
         messagerie:
-          title: "Messagerie · Dossier nº %{number} (%{procedure_label})"
+          title: "Messagerie · Dossier %{number} (%{procedure_label})"
         brouillon:
-          title: "Modification du brouillon nº %{number} (%{procedure_label})"
+          title: "Dossier %{number} en brouillon (%{procedure_label}) - Étape 2 : Formulaire"
         merci:
           title: "Dossier envoyé (%{procedure_label})"
       activate:

--- a/public/500.html
+++ b/public/500.html
@@ -2109,7 +2109,7 @@
                   <li>
                     <!-- / NB: on mobile in order to have links correctly aligned, we need a left icon -->
                     <a
-                      class="fr-btn dropdown-button"
+                      class="fr-btn"
                       href="/faq"
                       >Aide</a
                     >

--- a/public/502.html
+++ b/public/502.html
@@ -2108,7 +2108,7 @@
                   <li>
                     <!-- / NB: on mobile in order to have links correctly aligned, we need a left icon -->
                     <a
-                      class="fr-btn dropdown-button"
+                      class="fr-btn"
                       href="/faq"
                       >Aide</a
                     >

--- a/public/503.html
+++ b/public/503.html
@@ -2108,7 +2108,7 @@
                   <li>
                     <!-- / NB: on mobile in order to have links correctly aligned, we need a left icon -->
                     <a
-                      class="fr-btn dropdown-button"
+                      class="fr-btn"
                       href="/faq"
                       >Aide</a
                     >

--- a/public/504.html
+++ b/public/504.html
@@ -2108,7 +2108,7 @@
                   <li>
                     <!-- / NB: on mobile in order to have links correctly aligned, we need a left icon -->
                     <a
-                      class="fr-btn dropdown-button"
+                      class="fr-btn"
                       href="/faq"
                       >Aide</a
                     >

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -71,8 +71,10 @@ describe ApplicationHelper do
   end
 
   describe "#flash_class" do
-    it { expect(flash_class(sticky: true)).to eq 'sticky' }
-    it { expect(flash_class(fixed: true)).to eq 'alert-fixed' }
+    it { expect(flash_class('notice')).to eq 'alert-success' }
+    it { expect(flash_class('alert', sticky: true, fixed: true)).to eq 'alert-danger sticky alert-fixed' }
+    it { expect(flash_class('error')).to eq 'alert-danger' }
+    it { expect(flash_class('unknown-level')).to eq '' }
   end
 
   describe "#try_format_date" do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -71,10 +71,8 @@ describe ApplicationHelper do
   end
 
   describe "#flash_class" do
-    it { expect(flash_class('notice')).to eq 'alert-success' }
-    it { expect(flash_class('alert', sticky: true, fixed: true)).to eq 'alert-danger sticky alert-fixed' }
-    it { expect(flash_class('error')).to eq 'alert-danger' }
-    it { expect(flash_class('unknown-level')).to eq '' }
+    it { expect(flash_class(sticky: true)).to eq 'sticky' }
+    it { expect(flash_class(fixed: true)).to eq 'alert-fixed' }
   end
 
   describe "#try_format_date" do

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -76,13 +76,6 @@ module SystemHelpers
     click_on 'Ajouter un champ'
   end
 
-  def remove_flash_message
-    expect(page).to have_button('Ajouter un champ', disabled: false)
-    expect(page).to have_content('Formulaire enregistré')
-    execute_script("document.querySelector('#flash_message').remove();")
-    execute_script("document.querySelector('#autosave-notice').remove();")
-  end
-
   def hide_autonotice_message
     expect(page).to have_text('Formulaire enregistré')
     execute_script("document.querySelector('#autosave-notice').classList.add('hidden');")

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -428,7 +428,7 @@ describe 'The user', js: true do
       let(:procedure) do
         create(:procedure, :published, :for_individual,
           types_de_champ_public: [
-            { type: :integer_number, libelle: 'age', mandatory: false, stable_id: },
+            { type: :integer_number, libelle: 'UNIQ_LABEL', mandatory: false, stable_id: },
             {
               type: :repetition, libelle: 'repetition', condition:, children: [
                 { type: :text, libelle: 'nom', mandatory: true }
@@ -441,8 +441,7 @@ describe 'The user', js: true do
         log_in(user, procedure)
 
         fill_individual
-
-        fill_in('age', with: 10)
+        fill_in('UNIQ_LABEL', with: 10)
         click_on 'Déposer le dossier'
         expect(page).to have_current_path(merci_dossier_path(user_dossier))
       end
@@ -494,7 +493,7 @@ describe 'The user', js: true do
       let(:procedure) do
         create(:procedure, :published, :for_individual,
           types_de_champ_public: [
-            { type: :integer_number, libelle: 'age', mandatory: false, stable_id: },
+            { type: :integer_number, libelle: 'UNIQ_LABEL', mandatory: false, stable_id: },
             { type: :text, libelle: 'nom', mandatory: true, condition: }
           ])
       end
@@ -513,7 +512,7 @@ describe 'The user', js: true do
 
         fill_individual
 
-        fill_in('age', with: '18')
+        fill_in('UNIQ_LABEL', with: '18')
         expect(page).to have_css('label', text: 'nom', visible: :visible)
         expect(page).to have_css('.icon.mandatory')
         click_on 'Déposer le dossier'

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -442,7 +442,7 @@ describe 'The user', js: true do
 
         fill_individual
 
-        fill_in('age (facultatif)', with: 10)
+        fill_in('age', with: 10)
         click_on 'Déposer le dossier'
         expect(page).to have_current_path(merci_dossier_path(user_dossier))
       end
@@ -513,7 +513,7 @@ describe 'The user', js: true do
 
         fill_individual
 
-        fill_in('age (facultatif)', with: '18')
+        fill_in('age', with: '18')
         expect(page).to have_css('label', text: 'nom', visible: :visible)
         expect(page).to have_css('.icon.mandatory')
         click_on 'Déposer le dossier'
@@ -550,7 +550,7 @@ describe 'The user', js: true do
         expect(page).to have_no_css('legend', text: 'info voiture', visible: true)
         expect(page).to have_no_css('label', text: 'tonnage', visible: true)
 
-        fill_in('age du candidat (facultatif)', with: '18')
+        fill_in('age du candidat', with: '18')
         expect(page).to have_css('legend', text: 'permis de conduire', visible: true)
         expect(page).to have_css('legend', text: 'info voiture', visible: true)
         expect(page).to have_no_css('label', text: 'tonnage', visible: true)
@@ -563,10 +563,10 @@ describe 'The user', js: true do
         expect(page).to have_css('label', text: 'parking', visible: true)
 
         # try to fill with invalid data
-        fill_in('tonnage (facultatif)', with: 'a')
+        fill_in('tonnage', with: 'a')
         expect(page).to have_no_css('label', text: 'parking', visible: true)
 
-        fill_in('age du candidat (facultatif)', with: '2')
+        fill_in('age du candidat', with: '2')
         expect(page).to have_no_css('legend', text: 'permis de conduire', visible: true)
         expect(page).to have_no_css('label', text: 'tonnage', visible: true)
 
@@ -578,7 +578,7 @@ describe 'The user', js: true do
         expect(page).to have_no_css('legend', text: 'permis de conduire', visible: true)
         expect(page).to have_no_css('label', text: 'tonnage', visible: true)
 
-        fill_in('age du candidat (facultatif)', with: '18')
+        fill_in('age du candidat', with: '18')
         wait_for_autosave
 
         # the champ keeps their previous value so they are all displayed


### PR DESCRIPTION
# Permet la restitution des bandeaux de status par les technologies d'assistance
__Après__

https://github.com/user-attachments/assets/fe21018d-8276-40dc-9b09-f0b01f053589

__Avant__

https://github.com/user-attachments/assets/1846a1b8-51ca-4f49-ad5e-c1d76023e863

# Rétabli la lecture du message d'erreur lié à un champ
__Après__
![Capture d’écran 2024-10-18 à 17 19 54](https://github.com/user-attachments/assets/728c23bb-432c-4888-9d0d-c91adf8119d1)

https://github.com/user-attachments/assets/e54c390c-3e99-48dc-b1a4-334778926bb3

__Avant__
![Capture d’écran 2024-10-18 à 17 19 19](https://github.com/user-attachments/assets/c6abc4e6-b214-461c-9778-a0fe3bb5f6ca)

https://github.com/user-attachments/assets/42ce6860-cb95-4c63-a88b-6db6af074843

# Explicite le contexte des liens de révocation pour les technologies d'assistance
__Après__

https://github.com/user-attachments/assets/d1077ad9-fe82-4d2c-b074-70718a4b4a2f

__Avant__

https://github.com/user-attachments/assets/08f3db9a-5485-47e1-b8cb-99796bebb341

# Augmente le contraste des pastilles de notification
__Après__
![Capture d’écran 2024-10-15 à 16 22 23](https://github.com/user-attachments/assets/1b9a494f-13b0-499c-9705-9ed5962e5e37)

__Avant__
![Capture d’écran 2024-10-15 à 16 24 11](https://github.com/user-attachments/assets/7ce81a89-2c72-4843-994c-4956f96f57df)

# Corrige des erreurs syntaxique
__Après__
![Capture d’écran 2024-10-18 à 17 16 32](https://github.com/user-attachments/assets/4f20b993-2bba-4df5-beb1-37ff3f1be0ac)

__Avant__
![Capture d’écran 2024-10-18 à 17 17 06](https://github.com/user-attachments/assets/529b0d32-b04c-472e-b056-2cf17ce992b4)

# Divers
- Ajoute l'étape courante au titre de page
- Évite que le pictogramme ajouté en CSS via la propriété `content`ne soit restituée par les technologies d'assistance
- Supprime une classe inutile
- Supprime les attributs `aria-live="assertive"` inutiles
- Supprime le mention doublon _(facultatif)_ à destination des technologies d'asistance