### PR TITLE
ETQ instructeur je peux ajouter plusieurs instructeurs à la fois

### DIFF
--- a/app/views/instructeurs/groupe_instructeurs/show.html.haml
+++ b/app/views/instructeurs/groupe_instructeurs/show.html.haml
@@ -22,11 +22,16 @@
 
   .card.fr-mt-2w
     = render Procedure::InvitationWithTypoComponent.new(maybe_typos: @maybe_typos, url: add_instructeur_instructeur_groupe_path(@procedure, @groupe_instructeur.id), title: "Avant d'ajouter l'email, veuillez confirmer" )
-    %h2.fr-h3 Gestion des instructeurs
-    = form_for(Instructeur.new(user: User.new), url: { action: :add_instructeur }, html: { class: 'form' }) do |f|
-      %h3.fr-h4 Affecter un nouvel instructeur
-      = render Dsfr::InputComponent.new(form: f, attribute: :email)
-      = f.submit 'Affecter', class: 'fr-btn fr-primary'
+    %h2.fr-h3= t('.title')
+
+    = form_for :instructeur, url: { action: :add_instructeur, id: @groupe_instructeur.id }, html: { class: 'form' } do |f|
+      .instructeur-wrapper
+        %p= t('.instructeur_emails')
+        %p.fr-hint-text= t('.copy_paste_hint')
+        %react-fragment
+          = render ReactComponent.new 'ComboBox/MultiComboBox', id: 'instructeur_emails', name: 'emails[]', allows_custom_value: true, 'aria-label': 'Emails'
+
+        = f.submit t('.assign'), class: 'fr-btn fr-btn--tertiary'
 
     %table.fr-table.fr-mt-2w.width-100
       %thead

--- a/config/locales/views/instructeurs/groupe_instructeurs/fr.yml
+++ b/config/locales/views/instructeurs/groupe_instructeurs/fr.yml
@@ -1,0 +1,16 @@
+fr:
+  instructeurs:
+    groupe_instructeurs:
+      show:
+        title: Affecter un nouvel instructeur
+        instructeur_emails: Adresse électronique des instructeurs que vous souhaitez affecter à cette démarche.
+        copy_paste_hint: "Vous pouvez saisir les adresses individuellement, ou bien copier-coller dans le champ ci-dessous une liste d’adresses séparées par des points-virgules (exemple : adresse1@mail.com; adresse2@mail.com; adresse3@mail.com)."
+        assign: Affecter
+        wrong_adress: "L’adresse électronique saisie n’est pas valide."
+      add_instructeur:
+        wrong_address:
+          one: "%{emails} n’est pas une adresse email valide"
+          other: "%{emails} ne sont pas des adresses emails valides"
+        assignment:
+          one: "L’instructeur %{emails} a été affecté au groupe « %{groupe} »."
+          other: "Les instructeurs %{emails} ont été affectés au groupe « %{groupe} »."

--- a/spec/controllers/instructeurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/instructeurs/groupe_instructeurs_controller_spec.rb
@@ -2,9 +2,9 @@
 
 describe Instructeurs::GroupeInstructeursController, type: :controller do
   render_views
-  let(:administrateurs) { [create(:administrateur, user: instructeur.user)] }
-  let(:instructeur) { create(:instructeur) }
-  let(:procedure) { create(:procedure, :published, administrateurs:) }
+  let(:administrateur) { create(:administrateur) }
+  let(:instructeur) { administrateur.instructeur }
+  let(:procedure) { create(:procedure, :published, administrateurs: [administrateur]) }
   let!(:gi_1_1) { procedure.defaut_groupe_instructeur }
   let!(:gi_1_2) { create(:groupe_instructeur, label: 'groupe instructeur 2', procedure: procedure) }
 

--- a/spec/controllers/instructeurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/instructeurs/groupe_instructeurs_controller_spec.rb
@@ -88,7 +88,7 @@ describe Instructeurs::GroupeInstructeursController, type: :controller do
         params: {
           procedure_id: procedure.id,
           id: gi_1_2.id,
-          instructeur: { email: new_instructeur_email }
+          emails: [new_instructeur_email]
         }
     end
 
@@ -99,7 +99,7 @@ describe Instructeurs::GroupeInstructeursController, type: :controller do
       it "works" do
         expect(gi_1_2.instructeurs.map(&:email)).to include(new_instructeur_email)
         expect(flash.notice).to be_present
-        expect(response).to redirect_to(instructeur_groupe_path(procedure, gi_1_2))
+        expect(response).to have_http_status(:success)
         expect(InstructeurMailer).to have_received(:confirm_and_notify_added_instructeur).with(instance_of(Instructeur), gi_1_2, anything)
         expect(GroupeInstructeurMailer).not_to have_received(:notify_added_instructeurs)
       end
@@ -114,7 +114,7 @@ describe Instructeurs::GroupeInstructeursController, type: :controller do
       it "works" do
         expect(gi_1_2.instructeurs.map(&:email)).to include(new_instructeur_email)
         expect(flash.notice).to be_present
-        expect(response).to redirect_to(instructeur_groupe_path(procedure, gi_1_2))
+        expect(response).to have_http_status(:success)
         expect(InstructeurMailer).not_to have_received(:confirm_and_notify_added_instructeur)
         expect(GroupeInstructeurMailer).to have_received(:notify_added_instructeurs)
       end
@@ -129,7 +129,7 @@ describe Instructeurs::GroupeInstructeursController, type: :controller do
       it "works" do
         expect(gi_1_2.instructeurs.map(&:email)).to include(new_instructeur_email)
         expect(flash.notice).to be_present
-        expect(response).to redirect_to(instructeur_groupe_path(procedure, gi_1_2))
+        expect(response).to have_http_status(:success)
         expect(InstructeurMailer).to have_received(:confirm_and_notify_added_instructeur)
         expect(GroupeInstructeurMailer).not_to have_received(:notify_added_instructeurs)
       end
@@ -137,11 +137,13 @@ describe Instructeurs::GroupeInstructeursController, type: :controller do
 
     context 'of an instructeur already in the group' do
       let(:new_instructeur_email) { instructeur.email }
-      before { subject }
+      before do
+        instructeur.user.update(email_verified_at: 1.day.ago)
+        subject
+      end
 
       it "works" do
-        expect(flash.alert).to be_present
-        expect(response).to redirect_to(instructeur_groupe_path(procedure, gi_1_2))
+        expect(response).to have_http_status(:success)
         expect(InstructeurMailer).not_to have_received(:confirm_and_notify_added_instructeur)
         expect(GroupeInstructeurMailer).not_to have_received(:notify_added_instructeurs)
       end


### PR DESCRIPTION
Voir #10955 

- J'ai ajouté le composant multicombobox afin d'ajouter plusieurs instructeurs à la fois, soit en les entrant manuellement, soit en copiant-collant une liste, comme c'est déjà possible côté admin.
- Je n'ai pas rendu inactif le bouton tant qu'on n'a pas ajouté d'emails d'instructeurs (compliqué de modifier le composant combobox, peut-être à faire dans une autre PR)

AVANT 

<img width="1541" alt="Capture d’écran 2024-10-22 à 16 26 57" src="https://github.com/user-attachments/assets/21b59daf-0623-4cd2-adfd-78722515be72">

APRÈS

<img width="1541" alt="Capture d’écran 2024-10-22 à 16 31 07" src="https://github.com/user-attachments/assets/e46c15b2-0c28-49e2-9702-499212471eef">


