### PR TITLE
Tech: ajoute un scope pour détecter les brouillons vides

### DIFF
--- a/app/models/concerns/dossier_empty_concern.rb
+++ b/app/models/concerns/dossier_empty_concern.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module DossierEmptyConcern
+  extend ActiveSupport::Concern
+
+  included do
+    scope :empty_brouillon, -> (created_at) do
+      dossiers_ids = Dossier.brouillon.where(created_at:).ids
+
+      dossiers_with_value = Dossier.select('id').includes(:champs)
+        .where.not(champs: { value: nil })
+        .where(id: dossiers_ids)
+
+      dossier_with_geo_areas = Dossier.select('id').includes(champs: :geo_areas)
+        .where.not(geo_areas: { id: nil })
+        .where(id: dossiers_ids)
+
+      dossier_with_pj = Dossier.select('id')
+        .joins(champs: :piece_justificative_file_attachments)
+        .where(id: dossiers_ids)
+
+      brouillon
+        .where.not(id: dossiers_with_value)
+        .where.not(id: dossier_with_geo_areas)
+        .where.not(id: dossier_with_pj)
+        .where(id: dossiers_ids)
+    end
+  end
+end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -12,6 +12,7 @@ class Dossier < ApplicationRecord
   include DossierSectionsConcern
   include DossierStateConcern
   include DossierChampsConcern
+  include DossierEmptyConcern
 
   enum state: {
     brouillon:       'brouillon',

--- a/spec/models/concerns/dossier_empty_concern_spec.rb
+++ b/spec/models/concerns/dossier_empty_concern_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe DossierEmptyConcern do
+  describe 'empty_brouillon' do
+    let(:types) { [{ type: :text }, { type: :carte }, { type: :piece_justificative }] }
+    let(:procedure) { create(:procedure, types_de_champ_public: types) }
+    let!(:empty_brouillon) { create(:dossier, procedure:) }
+    let!(:empty_en_construction) { create(:dossier, :en_construction, procedure:) }
+    let!(:value_filled_dossier) { create(:dossier, procedure:) }
+    let!(:carte_filled_dossier) { create(:dossier, procedure:) }
+    let!(:pj_filled_dossier) { create(:dossier, procedure:) }
+    let(:geo_area) { build(:geo_area, :selection_utilisateur, :polygon) }
+    let(:attachment) { { io: StringIO.new("toto"), filename: "toto.png", content_type: "image/png" } }
+
+    subject { Dossier.empty_brouillon(2.days.ago..) }
+
+    before do
+      value_filled_dossier.champs.first.update(value: 'filled')
+      carte_filled_dossier.champs.second.update(geo_areas: [geo_area])
+      pj_filled_dossier.champs.third.piece_justificative_file.attach(attachment)
+    end
+
+    it do
+      is_expected.to eq([empty_brouillon])
+    end
+  end
+end


### PR DESCRIPTION
Pour l'instant on introduit juste le scope pour le tester en production.

Ce scope trouve les dossiers créés une période donnée qui n'ont
- pas de champ avec une `value`
- ni de points géographique
- ni de pj attachées

le sql produit donne : 

- une premiere requete pour chopper les id des champs en brouillon créé dans la période mentionnée
`dossiers_ids = Dossier.brouillon.where(created_at:).ids`

- puis un filtre sur ces dossiers pour isoler les vides

```
SELECT "dossiers"."id" FROM "dossiers"
WHERE "dossiers"."state" = $1
  AND "dossiers"."id" NOT IN
    (SELECT "dossiers"."id" FROM "dossiers"
     LEFT OUTER JOIN "champs" ON "champs"."dossier_id" = "dossiers"."id"
     WHERE "champs"."value" IS NOT NULL AND "dossiers"."id" IN ($2, $3, $4, $5, $6))
  AND "dossiers"."id" NOT IN
    (SELECT "dossiers"."id" FROM "dossiers"
     LEFT OUTER JOIN "champs" ON "champs"."dossier_id" = "dossiers"."id"
     LEFT OUTER JOIN "geo_areas" ON "geo_areas"."champ_id" = "champs"."id"
     WHERE "geo_areas"."id" IS NOT NULL AND "dossiers"."id" IN ($7, $8, $9, $10, $11))
  AND "dossiers"."id" NOT IN
    (SELECT "dossiers"."id" FROM "dossiers"
     INNER JOIN "champs" ON "champs"."dossier_id" = "dossiers"."id"
     INNER JOIN "active_storage_attachments" ON "active_storage_attachments"."record_type" = $12
     AND "active_storage_attachments"."name" = $13
     AND "active_storage_attachments"."record_id" = "champs"."id"
     WHERE "dossiers"."id" IN ($14, $15, $16, $17, $18)) AND "dossiers"."id" IN ($19, $20, $21, $22, $23)
```