### PR TITLE
ETQ tech, réduit le bruit Helpscout sur Sentry 

### DIFF
--- a/app/jobs/helpscout_create_conversation_job.rb
+++ b/app/jobs/helpscout_create_conversation_job.rb
@@ -2,6 +2,9 @@
 
 class HelpscoutCreateConversationJob < ApplicationJob
   queue_as :critical # user feedback is critical
+
+  def max_attempts = 15 # ~10h
+
   class FileNotScannedYetError < StandardError
   end
 

--- a/app/jobs/helpscout_create_conversation_job.rb
+++ b/app/jobs/helpscout_create_conversation_job.rb
@@ -49,6 +49,7 @@ class HelpscoutCreateConversationJob < ApplicationJob
 
   def safe_blob
     return if !contact_form.piece_jointe.virus_scanner&.safe?
+    return if contact_form.piece_jointe.byte_size.zero? # HS don't support empty attachment
 
     contact_form.piece_jointe
   end

--- a/app/jobs/helpscout_create_conversation_job.rb
+++ b/app/jobs/helpscout_create_conversation_job.rb
@@ -25,6 +25,10 @@ class HelpscoutCreateConversationJob < ApplicationJob
     create_conversation
 
     contact_form.delete
+  rescue StandardError
+    contact_form.delete if executions >= max_attempts
+
+    raise
   end
 
   private

--- a/spec/jobs/helpscout_create_conversation_job_spec.rb
+++ b/spec/jobs/helpscout_create_conversation_job_spec.rb
@@ -110,5 +110,21 @@ RSpec.describe HelpscoutCreateConversationJob, type: :job do
         end
       end
     end
+
+    context 'when max attempts are reached' do
+      before do
+        allow(api).to receive(:create_conversation).and_raise(StandardError)
+        allow_any_instance_of(described_class).to receive(:executions).and_return(described_class.new.max_attempts)
+      end
+
+      it 'deletes the contact form' do
+        expect { subject }.to raise_error(StandardError)
+        expect(contact_form).to be_destroyed
+      end
+
+      it 'does not enqueue the job again' do
+        expect { subject rescue nil }.not_to have_enqueued_job(described_class)
+      end
+    end
   end
 end


### PR DESCRIPTION
- HS ne supporte pas les attachments "vides", qui sont parfois nombreux avec les robots, …
- limit les retries
- on en profite pour delete les contact forms qui n'ont jamais été push