### PR TITLE
Instructeur: corrige les pb d'affichage des listes de dossiers dans le cas de fitre vide

### DIFF
--- a/app/components/instructeurs/column_filter_component/column_filter_component.html.haml
+++ b/app/components/instructeurs/column_filter_component/column_filter_component.html.haml
@@ -6,13 +6,30 @@
     %react-fragment
       = render ReactComponent.new "ComboBox/SingleComboBox", **filter_react_props
 
-    %input.hidden{ type: 'submit', formaction: update_filter_instructeur_procedure_path(procedure), data: { autosubmit_target: 'submitter' } }
+    %input.hidden{
+      type: 'submit',
+      formaction: update_filter_instructeur_procedure_path(procedure),
+      formnovalidate: 'true',
+      data: { autosubmit_target: 'submitter' }
+    }
 
   = label_tag :value, t('.value'), for: 'value', class: 'fr-label'
   - if column_type == :enum || column_type == :enums
-    = select_tag :filter, options_for_select(options_for_select_of_column), id: 'value', name: "#{prefix}[filter]", class: 'fr-select', data: { no_autosubmit: true }
+    = select_tag :filter,
+      options_for_select(options_for_select_of_column),
+      id: 'value',
+      name: "#{prefix}[filter]",
+      class: 'fr-select',
+      data: { no_autosubmit: true }
   - else
-    %input#value.fr-input{ type: column_type, name: "#{prefix}[filter]", maxlength: FilteredColumn::FILTERS_VALUE_MAX_LENGTH, disabled: column.nil? ? true : false, data: { no_autosubmit: true } }
+    %input#value.fr-input{
+      type: column_type,
+      name: "#{prefix}[filter]",
+      maxlength: FilteredColumn::FILTERS_VALUE_MAX_LENGTH,
+      disabled: column.nil? ? true : false,
+      data: { no_autosubmit: true },
+      required: true
+    }
 
   = hidden_field_tag :statut, statut
   = submit_tag t('.add_filter'), class: 'fr-btn fr-btn--secondary fr-mt-2w'

--- a/app/models/filtered_column.rb
+++ b/app/models/filtered_column.rb
@@ -13,6 +13,9 @@ class FilteredColumn
 
   validate :check_filter_max_length
   validate :check_filter_max_integer
+  validates :filter, presence: {
+    message: -> (object, _data) { "Le filtre « #{object.label} » ne peut pas être vide" }
+  }
 
   def initialize(column:, filter:)
     @column = column
@@ -33,14 +36,14 @@ class FilteredColumn
     if @filter.present? && @filter.length.to_i > FILTERS_VALUE_MAX_LENGTH
       errors.add(
         :base,
-        "Le filtre #{label} est trop long (maximum: #{FILTERS_VALUE_MAX_LENGTH} caractères)"
+        "Le filtre « #{label} » est trop long (maximum: #{FILTERS_VALUE_MAX_LENGTH} caractères)"
       )
     end
   end
 
   def check_filter_max_integer
     if @column.column == 'id' && @filter.to_i > PG_INTEGER_MAX_VALUE
-      errors.add(:base, "Le filtre #{label} n'est pas un numéro de dossier possible")
+      errors.add(:base, "Le filtre « #{label} » n'est pas un numéro de dossier possible")
     end
   end
 end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -103,6 +103,7 @@ ignore_unused:
 - 'activerecord.attributes.*'
 - 'activemodel.attributes.map_filter.*'
 - 'activemodel.attributes.helpscout/form.*'
+- 'activemodel.errors.models.*'
 - 'activerecord.errors.*'
 - 'errors.messages.blank'
 - 'errors.messages.content_type_invalid'

--- a/config/locales/models/filtered_column/en.yml
+++ b/config/locales/models/filtered_column/en.yml
@@ -1,0 +1,7 @@
+en:
+ activemodel:
+    errors:
+      models:
+        filtered_column:
+          format: "%{message}"
+

--- a/config/locales/models/filtered_column/fr.yml
+++ b/config/locales/models/filtered_column/fr.yml
@@ -1,0 +1,7 @@
+fr:
+ activemodel:
+    errors:
+      models:
+        filtered_column:
+          format: "%{message}"
+

--- a/spec/controllers/instructeurs/procedures_controller_spec.rb
+++ b/spec/controllers/instructeurs/procedures_controller_spec.rb
@@ -911,7 +911,7 @@ describe Instructeurs::ProceduresController, type: :controller do
 
     it 'should render the error' do
       subject
-      expect(flash.alert[0]).to include("Le filtre Nom est trop long (maximum: 4048 caractères)")
+      expect(flash.alert[0]).to include("Le filtre « Nom » est trop long (maximum: 4048 caractères)")
     end
   end
 end

--- a/spec/models/filtered_column_spec.rb
+++ b/spec/models/filtered_column_spec.rb
@@ -11,20 +11,12 @@ describe FilteredColumn do
       let(:filter) { 'a' * (FilteredColumn::FILTERS_VALUE_MAX_LENGTH + 1) }
 
       it 'adds an error' do
-        expect(filtered_column.errors.map(&:message)).to include(/Le filtre label est trop long/)
+        expect(filtered_column.errors.map(&:message)).to include(/Le filtre « label » est trop long/)
       end
     end
 
     context 'when then filter is not too long' do
       let(:filter) { 'a' * FilteredColumn::FILTERS_VALUE_MAX_LENGTH }
-
-      it 'does not add an error' do
-        expect(filtered_column.errors).to be_empty
-      end
-    end
-
-    context 'when the filter is empty' do
-      let(:filter) { nil }
 
       it 'does not add an error' do
         expect(filtered_column.errors).to be_empty
@@ -43,7 +35,7 @@ describe FilteredColumn do
         let(:filter) { (FilteredColumn::PG_INTEGER_MAX_VALUE + 1).to_s }
 
         it 'adds an error' do
-          expect(filtered_column.errors.map(&:message)).to include(/Le filtre label n'est pas un numéro de dossier possible/)
+          expect(filtered_column.errors.map(&:message)).to include(/Le filtre « label » n'est pas un numéro de dossier possible/)
         end
       end
 
@@ -53,6 +45,29 @@ describe FilteredColumn do
         it 'does not add an error' do
           expect(filtered_column.errors).to be_empty
         end
+      end
+    end
+  end
+
+  describe '#check_filter_is_not_blank' do
+    let(:column) { Column.new(procedure_id: 1, table: 'table', column: 'column', label: 'label') }
+    let(:filtered_column) { described_class.new(column:, filter:) }
+
+    before { filtered_column.valid? }
+
+    context 'when the filter is blank' do
+      let(:filter) { '' }
+
+      it 'adds an error' do
+        expect(filtered_column.errors.map(&:message)).to include(/Le filtre « label » ne peut pas être vide/)
+      end
+    end
+
+    context 'when the filter is not blank' do
+      let(:filter) { 'a' }
+
+      it 'does not add an error' do
+        expect(filtered_column.errors).to be_empty
       end
     end
   end


### PR DESCRIPTION
- empêche l'envoie de filtre vide avec un `required` sur l'input html
- ajoute une validation sur la classe `FilteredColumn`
- le mécanisme `procedure_presentation_or_default_and_errors` doit à présent automatiquement réinitialiser les procedure_presentation en error maintenant qu'un filtre vide est considéré anormal

Sentry: https://demarches-simplifiees.sentry.io/issues/5998030314/?project=1429550