### PR TITLE
Technique : gestion des cas d'erreurs de ImageProcessorJob

### DIFF
--- a/app/models/concerns/attachment_image_processor_concern.rb
+++ b/app/models/concerns/attachment_image_processor_concern.rb
@@ -18,7 +18,7 @@ module AttachmentImageProcessorConcern
 
   def process_image
     return if blob.nil?
-    return if blob.attachments.size > 1
+    return if blob.attachments.size != 1
     return if blob.attachments.last.record_type == "Export"
 
     ImageProcessorJob.perform_later(blob)

--- a/app/models/concerns/attachment_image_processor_concern.rb
+++ b/app/models/concerns/attachment_image_processor_concern.rb
@@ -20,6 +20,7 @@ module AttachmentImageProcessorConcern
     return if blob.nil?
     return if blob.attachments.size != 1
     return if blob.attachments.last.record_type == "Export"
+    return if !blob.content_type.in?(PROCESSABLE_TYPES)
 
     ImageProcessorJob.perform_later(blob)
   end

--- a/app/services/uninterlace_service.rb
+++ b/app/services/uninterlace_service.rb
@@ -17,6 +17,7 @@ class UninterlaceService
   end
 
   def interlaced?(png_path)
+    return false if png_path.blank?
     png = MiniMagick::Image.open(png_path)
     png.data["interlace"] != "None"
   end

--- a/config/initializers/authorized_content_types.rb
+++ b/config/initializers/authorized_content_types.rb
@@ -21,7 +21,9 @@ RARE_IMAGE_TYPES = [
   'image/tiff' # multimedia x 3985
 ]
 
-AUTHORIZED_CONTENT_TYPES = AUTHORIZED_IMAGE_TYPES + AUTHORIZED_PDF_TYPES + [
+PROCESSABLE_TYPES = AUTHORIZED_IMAGE_TYPES + AUTHORIZED_PDF_TYPES
+
+AUTHORIZED_CONTENT_TYPES = PROCESSABLE_TYPES + [
   # multimedia
   'video/mp4', # multimedia x 2075
   'video/quicktime', # multimedia x 486


### PR DESCRIPTION
- le 1er commit gère les blobs sans attachments ->  https://demarches-simplifiees.sentry.io/issues/5414355843
- le 2e commit une partie des fichiers non pris en charge par ImageMagick (notamment les .HEIC) -> https://demarches-simplifiees.sentry.io/issues/5413990217/
- le 3e commit gère une erreur liée au désentrelaçage des fichiers png -> https://demarches-simplifiees.sentry.io/issues/5873082562/