### PR TITLE
ETQ usager, je veux que les erreurs et les descriptions soient reliées aux champs concernés 

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -221,21 +221,32 @@
   .fr-label + .fr-hint-text > *,
   .fr-fieldset__legend + .fr-hint-text > * {
     // la description d'un champ peut contenir du markup (markdown->html),
-    // on herite donc la fontsize/margin/padding du fr-hint-text
+    // on herite donc la taille de police, la couleur et l'interlignage de fr-hint-text
+    // on réinitialise les marges des éléments
     font-size: inherit;
     line-height: inherit;
-    margin: inherit;
-    padding: inherit;
+    color: inherit;
+    margin: 0;
+    padding: 0;
   }
 
-  .fr-label + .fr-hint-text {
-    // les messages d'aide se trouvant juste après un label prennent le même style que ceux se trouvant dans un label
-    margin-top: .25rem;
+  .fr-fieldset .fr-hint-text ul {
+    margin-left: 0.75rem;
   }
+
+  .fr-fieldset .fr-hint-text ol {
+    margin-left: 1.25rem;
+  }
+
 
   .fr-hint-text + .fr-input {
-    // les champs se trouvant juste après un message d'aide prennent le même syle que ceux se trouvant juste après un label
-    margin-top: .5rem;
+    // les champs se trouvant juste après un message d'aide ont le même espacement que ceux se trouvant juste après un label
+    margin-top: 0.5rem;
+  }
+
+  .fr-fieldset__legend .fr-hint-text {
+    // les messages d'aide se trouvant dans une légende ont le même espacement que ceux se trouvant dans un label
+    margin-top: 0.25rem;
   }
 
   input[type='password'],
@@ -398,10 +409,6 @@
       .utils-repetition-required-destroy-button {
       display: none;
     }
-  }
-
-  .editable-champ-titre_identite {
-    margin-bottom: 2 * $default-padding;
   }
 
   .cnaf-inputs,

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -238,7 +238,6 @@
     margin-left: 1.25rem;
   }
 
-
   .fr-hint-text + .fr-input {
     // les champs se trouvant juste après un message d'aide ont le même espacement que ceux se trouvant juste après un label
     margin-top: 0.5rem;

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -218,13 +218,24 @@
     }
   }
 
-  .fr-label .fr-hint-text > *,
-  .fr-fieldset__legend .fr-hint-text > * {
+  .fr-label + .fr-hint-text > *,
+  .fr-fieldset__legend + .fr-hint-text > * {
     // la description d'un champ peut contenir du markup (markdown->html),
-    // on herite donc la fontsize/mrgin/padding du fr-hint-text
+    // on herite donc la fontsize/margin/padding du fr-hint-text
     font-size: inherit;
+    line-height: inherit;
     margin: inherit;
     padding: inherit;
+  }
+
+  .fr-label + .fr-hint-text {
+    // les messages d'aide se trouvant juste après un label prennent le même style que ceux se trouvant dans un label
+    margin-top: .25rem;
+  }
+
+  .fr-hint-text + .fr-input {
+    // les champs se trouvant juste après un message d'aide prennent le même syle que ceux se trouvant juste après un label
+    margin-top: .5rem;
   }
 
   input[type='password'],

--- a/app/components/attachment/edit_component.rb
+++ b/app/components/attachment/edit_component.rb
@@ -68,6 +68,10 @@ class Attachment::EditComponent < ApplicationComponent
     "attachment-input-#{attachment_id}"
   end
 
+  def show_hint?
+    first? && !persisted?
+  end
+
   def file_field_options
     track_issue_with_missing_validators if missing_validators?
 
@@ -75,12 +79,16 @@ class Attachment::EditComponent < ApplicationComponent
       class: class_names("fr-upload attachment-input": true, "#{attachment_input_class}": true),
       direct_upload: @direct_upload,
       id: input_id,
-      aria: { describedby: champ&.describedby_id },
       data: {
         auto_attach_url:,
         turbo_force: :server
       }.merge(has_file_size_validator? ? { max_file_size: max_file_size } : {})
     }
+
+    describedby = []
+    describedby << champ.describedby_id if champ&.description.present?
+    describedby << describedby_hint_id if show_hint?
+    options[:aria] = { describedby: describedby.join(' ') }
 
     options.merge!(has_content_type_validator? ? { accept: accept_content_type } : {})
     options[:multiple] = true if as_multiple?
@@ -168,6 +176,10 @@ class Attachment::EditComponent < ApplicationComponent
   end
 
   private
+
+  def describedby_hint_id
+    "#{input_id}-pj-hint"
+  end
 
   def input_id
     if champ.present?

--- a/app/components/attachment/edit_component.rb
+++ b/app/components/attachment/edit_component.rb
@@ -88,6 +88,8 @@ class Attachment::EditComponent < ApplicationComponent
     describedby = []
     describedby << champ.describedby_id if champ&.description.present?
     describedby << describedby_hint_id if show_hint?
+    describedby << champ.error_id if champ&.errors&.has_key?(:value)
+
     options[:aria] = { describedby: describedby.join(' ') }
 
     options.merge!(has_content_type_validator? ? { accept: accept_content_type } : {})

--- a/app/components/attachment/edit_component/edit_component.html.haml
+++ b/app/components/attachment/edit_component/edit_component.html.haml
@@ -37,8 +37,8 @@
         - if error?(attachment)
           %p.fr-error-text= error_message(attachment)
 
-  - if first? && !persisted?
-    %p.fr-hint-text.fr-mb-1w
+  - if show_hint?
+    %p.fr-hint-text.fr-mb-1w{ id: describedby_hint_id }
       - if max_file_size.present?
         = t('.max_file_size', max_file_size: number_to_human_size(max_file_size))
       - if allowed_formats.present?

--- a/app/components/dsfr/input_errorable.rb
+++ b/app/components/dsfr/input_errorable.rb
@@ -79,11 +79,18 @@ module Dsfr
                                              'fr-input': !react,
                                              'fr-mb-0': true
                                       }.merge(input_error_class_names)))
-        if errors_on_attribute?
-          @opts.deep_merge!('aria-describedby': describedby_id)
+
+        aria_describedby = []
+
+        if object.respond_to?(:description) && object.description.present?
+          aria_describedby << describedby_id
         elsif hintable?
-          @opts.deep_merge!('aria-describedby': hint_id)
+          aria_describedby << hint_id
         end
+
+        aria_describedby << object.error_id if errors_on_attribute? && object.respond_to?(:error_id)
+
+        @opts.deep_merge!('aria-describedby': aria_describedby.join(' ')) if aria_describedby.present?
 
         if @required
           @opts[react ? :is_required : :required] = true

--- a/app/components/dsfr/input_errorable.rb
+++ b/app/components/dsfr/input_errorable.rb
@@ -67,14 +67,6 @@ module Dsfr
         }
       end
 
-      def input_error_opts
-        {
-          aria: {
-            describedby: describedby_id
-          }
-        }
-      end
-
       def react_input_opts(other_opts = {})
         input_opts(other_opts, true)
       end

--- a/app/components/dsfr/input_errorable.rb
+++ b/app/components/dsfr/input_errorable.rb
@@ -38,7 +38,13 @@ module Dsfr
 
       def fieldset_error_opts
         if dsfr_champ_container == :fieldset && errors_on_attribute?
-          { aria: { labelledby: "#{describedby_id} #{object.labelledby_id}" } }
+          labelledby = [@champ.labelledby_id]
+          labelledby << describedby_id if @champ.description.present?
+          labelledby << @champ.error_id
+
+          {
+            aria: { labelledby: labelledby.join(' ') }
+          }
         else
           {}
         end

--- a/app/components/dsfr/input_status_message_component.rb
+++ b/app/components/dsfr/input_status_message_component.rb
@@ -2,10 +2,10 @@
 
 module Dsfr
   class InputStatusMessageComponent < ApplicationComponent
-    def initialize(errors_on_attribute:, error_full_messages:, describedby_id:, champ:)
+    def initialize(errors_on_attribute:, error_full_messages:, champ:)
       @errors_on_attribute = errors_on_attribute
       @error_full_messages = error_full_messages
-      @describedby_id = describedby_id
+      @error_id = champ.error_id
       @champ = champ
     end
   end

--- a/app/components/dsfr/input_status_message_component/input_status_message_component.html.haml
+++ b/app/components/dsfr/input_status_message_component/input_status_message_component.html.haml
@@ -1,4 +1,4 @@
-.fr-messages-group{ id: @describedby_id }
+.fr-messages-group{ id: @error_id, aria: { live: :assertive } }
   - if @error_full_messages.size > 0
     %p{ class: class_names('fr-message' => true, "fr-message--#{@errors_on_attribute ? 'error' : 'valid'}" => true) }
       = "« #{@champ.libelle} » "

--- a/app/components/editable_champ/champ_label_component/champ_label_component.html.haml
+++ b/app/components/editable_champ/champ_label_component/champ_label_component.html.haml
@@ -8,4 +8,4 @@
 - elsif @champ.legend_label?
   %legend.fr-fieldset__legend.fr-text--regular.fr-pb-1w{ id: @champ.labelledby_id }= render EditableChamp::ChampLabelContentComponent.new form: @form, champ: @champ, seen_at: @seen_at
   - if @champ.description.present?
-    .fr-hint-text{ id: @champ.describedby_id }= render SimpleFormatComponent.new(@champ.description, allow_a: true)
+    .fr-hint-text.fr-mt-n1w.fr-mb-1w.fr-pl-1w.width-100{ id: @champ.describedby_id }= render SimpleFormatComponent.new(@champ.description, allow_a: true)

--- a/app/components/editable_champ/champ_label_component/champ_label_component.html.haml
+++ b/app/components/editable_champ/champ_label_component/champ_label_component.html.haml
@@ -3,5 +3,9 @@
 - if @champ.html_label?
   = @form.label @champ.main_value_name, id: @champ.labelledby_id, for: @champ.input_id, class: 'fr-label' do
     - render EditableChamp::ChampLabelContentComponent.new form: @form, champ: @champ, seen_at: @seen_at
+  - if @champ.description.present?
+    .fr-hint-text= render SimpleFormatComponent.new(@champ.description, allow_a: true)
 - elsif @champ.legend_label?
-  %legend.fr-fieldset__legend.fr-text--regular{ id: @champ.labelledby_id }= render EditableChamp::ChampLabelContentComponent.new form: @form, champ: @champ, seen_at: @seen_at
+  %legend.fr-fieldset__legend.fr-text--regular.fr-pb-1w{ id: @champ.labelledby_id }= render EditableChamp::ChampLabelContentComponent.new form: @form, champ: @champ, seen_at: @seen_at
+  - if @champ.description.present?
+    .fr-hint-text{ id: @champ.describedby_id }= render SimpleFormatComponent.new(@champ.description, allow_a: true)

--- a/app/components/editable_champ/champ_label_component/champ_label_component.html.haml
+++ b/app/components/editable_champ/champ_label_component/champ_label_component.html.haml
@@ -4,7 +4,7 @@
   = @form.label @champ.main_value_name, id: @champ.labelledby_id, for: @champ.input_id, class: 'fr-label' do
     - render EditableChamp::ChampLabelContentComponent.new form: @form, champ: @champ, seen_at: @seen_at
   - if @champ.description.present?
-    .fr-hint-text= render SimpleFormatComponent.new(@champ.description, allow_a: true)
+    .fr-hint-text{ id: @champ.describedby_id }= render SimpleFormatComponent.new(@champ.description, allow_a: true)
 - elsif @champ.legend_label?
   %legend.fr-fieldset__legend.fr-text--regular.fr-pb-1w{ id: @champ.labelledby_id }= render EditableChamp::ChampLabelContentComponent.new form: @form, champ: @champ, seen_at: @seen_at
   - if @champ.description.present?

--- a/app/components/editable_champ/champ_label_content_component/champ_label_content_component.html.haml
+++ b/app/components/editable_champ/champ_label_content_component/champ_label_content_component.html.haml
@@ -17,8 +17,5 @@
 - if hint?
   %span.fr-hint-text{ data: { controller: 'date-input-hint' } }= hint
 
-- if @champ.description.present?
-  %span.fr-hint-text= render SimpleFormatComponent.new(@champ.description, allow_a: true)
-
 - if @champ.textarea? && @champ.character_limit_base&.positive?
   %span.fr-hint-text= t('.recommended_size', size: @champ.character_limit_base)

--- a/app/components/editable_champ/checkbox_component/checkbox_component.html.haml
+++ b/app/components/editable_champ/checkbox_component/checkbox_component.html.haml
@@ -1,6 +1,6 @@
 .fr-checkbox-group
   = @form.check_box :value,
-    { required: @champ.required?, id: @champ.input_id, checked: @champ.true?, aria: { describedby: @champ.describedby_id }, class: class_names('required' => @champ.required?)},
+    { required: @champ.required?, id: @champ.input_id, checked: @champ.true?, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, class: class_names('required' => @champ.required?)},
     'true',
     'false'
   %label.fr-label{ for: @champ.input_id, id: @champ.labelledby_id }

--- a/app/components/editable_champ/checkbox_component/checkbox_component.html.haml
+++ b/app/components/editable_champ/checkbox_component/checkbox_component.html.haml
@@ -1,8 +1,10 @@
-.fr-checkbox-group
+.fr-checkbox-group.fr-mb-2w
   = @form.check_box :value,
-    { required: @champ.required?, id: @champ.input_id, checked: @champ.true?, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, class: class_names('required' => @champ.required?)},
+    { required: @champ.required?, id: @champ.input_id, checked: @champ.true?, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" } },
     'true',
     'false'
   %label.fr-label{ for: @champ.input_id, id: @champ.labelledby_id }
-    %span
+    %span.width-100
       = render EditableChamp::ChampLabelContentComponent.new form: @form, champ: @champ, seen_at: @seen_at
+  - if @champ.description.present?
+    .fr-hint-text.fr-mt-1v.fr-ml-4w{ id: @champ.describedby_id }= render SimpleFormatComponent.new(@champ.description, allow_a: true)

--- a/app/components/editable_champ/cnaf_component/cnaf_component.html.haml
+++ b/app/components/editable_champ/cnaf_component/cnaf_component.html.haml
@@ -4,7 +4,7 @@
     %p.notice= t('.numero_allocataire_notice')
     = @form.text_field :numero_allocataire,
       required: @champ.required?,
-      aria: { describedby: @champ.describedby_id },
+      aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" },
       class: "width-33-desktop", id: @champ.numero_allocataire_input_id
 
   %div
@@ -12,6 +12,6 @@
     %p.notice= t('.code_postal_notice')
     = @form.text_field :code_postal,
       required: @champ.required?,
-      aria: { describedby: @champ.describedby_id },
+      aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" },
       class: "width-33-desktop",
       id: @champ.code_postal_input_id

--- a/app/components/editable_champ/communes_component.rb
+++ b/app/components/editable_champ/communes_component.rb
@@ -3,6 +3,12 @@
 class EditableChamp::CommunesComponent < EditableChamp::EditableChampBaseComponent
   include ApplicationHelper
 
+  def call
+    tag.react_fragment do
+      render(ReactComponent.new("ComboBox/RemoteComboBox", **react_props))
+    end
+  end
+
   def dsfr_input_classname
     'fr-select'
   end

--- a/app/components/editable_champ/communes_component/communes_component.html.haml
+++ b/app/components/editable_champ/communes_component/communes_component.html.haml
@@ -1,2 +1,0 @@
-%react-fragment
-  = render ReactComponent.new "ComboBox/RemoteComboBox", **react_props

--- a/app/components/editable_champ/date_component/date_component.html.haml
+++ b/app/components/editable_champ/date_component/date_component.html.haml
@@ -1,6 +1,6 @@
 = @form.date_field :value,
   input_opts(id: @champ.input_id,
-  aria: { describedby: @champ.describedby_id },
+  aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" },
   value: @champ.value,
   required: @champ.required?,
   class: "width-33-desktop")

--- a/app/components/editable_champ/datetime_component/datetime_component.html.haml
+++ b/app/components/editable_champ/datetime_component/datetime_component.html.haml
@@ -1,1 +1,1 @@
-= @form.datetime_field(:value, input_opts(value: formatted_value_for_datetime_locale, id: @champ.input_id, aria: { describedby: @champ.describedby_id }, data: { controller: 'datetime' }))
+= @form.datetime_field(:value, input_opts(value: formatted_value_for_datetime_locale, id: @champ.input_id, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, data: { controller: 'datetime' }))

--- a/app/components/editable_champ/decimal_number_component/decimal_number_component.html.haml
+++ b/app/components/editable_champ/decimal_number_component/decimal_number_component.html.haml
@@ -1,1 +1,1 @@
-= @form.text_field(:value, input_opts(id: @champ.input_id, aria: { describedby: @champ.describedby_id }, required: @champ.required?, pattern: "-?[0-9]+([\.,][0-9]{1,3})?", inputmode: :decimal, data: { controller: 'format', format: :decimal }))
+= @form.text_field(:value, input_opts(id: @champ.input_id, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, required: @champ.required?, pattern: "-?[0-9]+([\.,][0-9]{1,3})?", inputmode: :decimal, data: { controller: 'format', format: :decimal }))

--- a/app/components/editable_champ/departements_component/departements_component.html.haml
+++ b/app/components/editable_champ/departements_component/departements_component.html.haml
@@ -1,1 +1,1 @@
-= @form.select :value, options, select_options, required: @champ.required?, id: @champ.input_id, aria: { describedby: @champ.describedby_id }, class: "fr-select"
+= @form.select :value, options, select_options, required: @champ.required?, id: @champ.input_id, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, class: "fr-select"

--- a/app/components/editable_champ/dgfip_component/dgfip_component.html.haml
+++ b/app/components/editable_champ/dgfip_component/dgfip_component.html.haml
@@ -4,7 +4,7 @@
     %p.notice= t('.numero_fiscal_notice')
     = @form.text_field :numero_fiscal,
       required: @champ.required?,
-      aria: { describedby: @champ.describedby_id },
+      aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" },
       class: "width-33-desktop", id: @champ.numero_fiscal_input_id
 
   %div
@@ -12,5 +12,5 @@
     %p.notice= t('.reference_avis_notice')
     = @form.text_field :reference_avis,
       required: @champ.required?,
-      aria: { describedby: @champ.describedby_id },
+      aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" },
       class: "width-33-desktop", id: @champ.reference_avis_input_id

--- a/app/components/editable_champ/dossier_link_component/dossier_link_component.html.haml
+++ b/app/components/editable_champ/dossier_link_component/dossier_link_component.html.haml
@@ -1,4 +1,4 @@
-= @form.text_field(:value, input_opts(id: @champ.input_id, aria: { describedby: @champ.describedby_id }, inputmode: :numeric, min: 1, pattern: "[0-9]{1,12}", autocomplete: 'off', required: @champ.required?, class: "width-33-desktop #{@champ.blank? ? '' : 'small-margin'}"))
+= @form.text_field(:value, input_opts(id: @champ.input_id, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, inputmode: :numeric, min: 1, pattern: "[0-9]{1,12}", autocomplete: 'off', required: @champ.required?, class: "width-33-desktop #{@champ.blank? ? '' : 'small-margin'}"))
 
 - if !@champ.blank? && !dossier.blank?
   .fr-info-text.fr-mb-4w= sanitize(dossier.text_summary)

--- a/app/components/editable_champ/drop_down_list_component.rb
+++ b/app/components/editable_champ/drop_down_list_component.rb
@@ -27,13 +27,13 @@ class EditableChamp::DropDownListComponent < EditableChamp::EditableChampBaseCom
   end
 
   def react_props
-    react_input_opts(id: @champ.input_id,
+    react_input_opts(
+      id: @champ.input_id,
       class: 'fr-mt-1w',
       name: @form.field_name(:value),
       selected_key: @champ.selected,
       items: @champ.drop_down_options_with_other.map { _1.is_a?(Array) ? _1 : [_1, _1] },
-      empty_filter_key: @champ.drop_down_other? ? Champs::DropDownListChamp::OTHER : nil,
-      'aria-describedby': @champ.describedby_id,
-      'aria-labelledby': @champ.labelledby_id)
+      empty_filter_key: @champ.drop_down_other? ? Champs::DropDownListChamp::OTHER : nil
+    )
   end
 end

--- a/app/components/editable_champ/drop_down_list_component.rb
+++ b/app/components/editable_champ/drop_down_list_component.rb
@@ -26,6 +26,13 @@ class EditableChamp::DropDownListComponent < EditableChamp::EditableChampBaseCom
     @champ.drop_down_options.any? { _1.size > max_length }
   end
 
+  def select_aria_describedby
+    describedby = []
+    describedby << @champ.describedby_id if @champ.description.present?
+    describedby << @champ.error_id if errors_on_attribute?
+    describedby.present? ? describedby.join(' ') : nil
+  end
+
   def react_props
     react_input_opts(
       id: @champ.input_id,

--- a/app/components/editable_champ/drop_down_list_component/drop_down_list_component.html.haml
+++ b/app/components/editable_champ/drop_down_list_component/drop_down_list_component.html.haml
@@ -24,10 +24,10 @@
   = @form.select :value,
     @champ.drop_down_options_with_other,
     { selected: @champ.selected, include_blank: true },
-    required: @champ.required?,
+    { required: @champ.required?,
     id: @champ.input_id,
     class: select_class_names,
-    aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }
+    aria: { describedby: select_aria_describedby } }
 
 - if @champ.drop_down_other?
   %div{ class: other_element_class_names }

--- a/app/components/editable_champ/drop_down_list_component/drop_down_list_component.html.haml
+++ b/app/components/editable_champ/drop_down_list_component/drop_down_list_component.html.haml
@@ -27,7 +27,7 @@
     required: @champ.required?,
     id: @champ.input_id,
     class: select_class_names,
-    aria: { describedby: @champ.describedby_id }
+    aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }
 
 - if @champ.drop_down_other?
   %div{ class: other_element_class_names }

--- a/app/components/editable_champ/editable_champ_base_component.rb
+++ b/app/components/editable_champ/editable_champ_base_component.rb
@@ -21,4 +21,17 @@ class EditableChamp::EditableChampBaseComponent < ApplicationComponent
   def describedby_id
     @champ.describedby_id
   end
+
+  def fieldset_aria_opts
+    if dsfr_champ_container == :fieldset
+      labelledby = [@champ.labelledby_id]
+      labelledby << describedby_id if @champ.description.present?
+
+      {
+        aria: { labelledby: labelledby.join(' ') }
+      }
+    else
+      {}
+    end
+  end
 end

--- a/app/components/editable_champ/editable_champ_base_component.rb
+++ b/app/components/editable_champ/editable_champ_base_component.rb
@@ -28,7 +28,8 @@ class EditableChamp::EditableChampBaseComponent < ApplicationComponent
       labelledby << describedby_id if @champ.description.present?
 
       {
-        aria: { labelledby: labelledby.join(' ') }
+        aria: { labelledby: labelledby.join(' ') },
+        role: 'group'
       }
     else
       {}

--- a/app/components/editable_champ/editable_champ_component.rb
+++ b/app/components/editable_champ/editable_champ_component.rb
@@ -36,7 +36,9 @@ class EditableChamp::EditableChampComponent < ApplicationComponent
         }.merge(champ_component.input_group_error_class_names)
       ),
       data: { controller: stimulus_controller, **data_dependent_conditions, **stimulus_values }
-    }.deep_merge(champ_component.fieldset_error_opts)
+    }
+      .deep_merge(champ_component.fieldset_aria_opts)
+      .deep_merge(champ_component.fieldset_error_opts)
   end
 
   def fieldset_element_attributes

--- a/app/components/editable_champ/editable_champ_component/editable_champ_component.html.haml
+++ b/app/components/editable_champ/editable_champ_component/editable_champ_component.html.haml
@@ -5,4 +5,4 @@
 
     = render champ_component
 
-    = render Dsfr::InputStatusMessageComponent.new(errors_on_attribute: champ_component.errors_on_attribute?, error_full_messages: champ_component.error_full_messages, describedby_id: @champ.describedby_id, champ: @champ)
+    = render Dsfr::InputStatusMessageComponent.new(errors_on_attribute: champ_component.errors_on_attribute?, error_full_messages: champ_component.error_full_messages, champ: @champ)

--- a/app/components/editable_champ/email_component/email_component.html.haml
+++ b/app/components/editable_champ/email_component/email_component.html.haml
@@ -1,1 +1,1 @@
-= @form.email_field(:value, input_opts(id: @champ.input_id, aria: { describedby: @champ.describedby_id }, required: @champ.required?))
+= @form.email_field(:value, input_opts(id: @champ.input_id, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, required: @champ.required?))

--- a/app/components/editable_champ/engagement_juridique_component/engagement_juridique_component.html.haml
+++ b/app/components/editable_champ/engagement_juridique_component/engagement_juridique_component.html.haml
@@ -1,1 +1,1 @@
-= @form.text_field(:value, input_opts(id: @champ.input_id, required: @champ.required?, aria: { describedby: @champ.describedby_id }))
+= @form.text_field(:value, input_opts(id: @champ.input_id, required: @champ.required?, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }))

--- a/app/components/editable_champ/epci_component/epci_component.html.haml
+++ b/app/components/editable_champ/epci_component/epci_component.html.haml
@@ -8,4 +8,4 @@
     .fr-select-group
       = @form.label :value, for: @champ.epci_input_id, class: 'fr-label' do
         - "EPCI"
-      = @form.select :value, epci_options, epci_select_options, required: @champ.required?, id: @champ.epci_input_id, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, class: "width-33-desktop width-100-mobile fr-select"
+      = @form.select :value, epci_options, epci_select_options, required: @champ.required?, id: @champ.epci_input_id, class: "width-33-desktop width-100-mobile fr-select"

--- a/app/components/editable_champ/epci_component/epci_component.html.haml
+++ b/app/components/editable_champ/epci_component/epci_component.html.haml
@@ -8,4 +8,4 @@
     .fr-select-group
       = @form.label :value, for: @champ.epci_input_id, class: 'fr-label' do
         - "EPCI"
-      = @form.select :value, epci_options, epci_select_options, required: @champ.required?, id: @champ.epci_input_id, aria: { describedby: @champ.describedby_id }, class: "width-33-desktop width-100-mobile fr-select"
+      = @form.select :value, epci_options, epci_select_options, required: @champ.required?, id: @champ.epci_input_id, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, class: "width-33-desktop width-100-mobile fr-select"

--- a/app/components/editable_champ/expression_reguliere_component/expression_reguliere_component.html.haml
+++ b/app/components/editable_champ/expression_reguliere_component/expression_reguliere_component.html.haml
@@ -1,1 +1,1 @@
-= @form.text_field(:value, input_opts(id: @champ.input_id, placeholder: @champ.expression_reguliere_exemple_text, required: @champ.required?, aria: { describedby: @champ.describedby_id }))
+= @form.text_field(:value, input_opts(id: @champ.input_id, placeholder: @champ.expression_reguliere_exemple_text, required: @champ.required?, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }))

--- a/app/components/editable_champ/iban_component/iban_component.html.haml
+++ b/app/components/editable_champ/iban_component/iban_component.html.haml
@@ -1,1 +1,1 @@
-= @form.text_field(:value, input_opts(id: @champ.input_id, required: @champ.required?, aria: { describedby: @champ.describedby_id }, data: { controller: 'format', format: 'iban' }, class: "width-66-desktop", maxlength: 34 + 9)) # count space separator of 4 digits-groups
+= @form.text_field(:value, input_opts(id: @champ.input_id, required: @champ.required?, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, data: { controller: 'format', format: 'iban' }, class: "width-66-desktop", maxlength: 34 + 9)) # count space separator of 4 digits-groups

--- a/app/components/editable_champ/integer_number_component/integer_number_component.html.haml
+++ b/app/components/editable_champ/integer_number_component/integer_number_component.html.haml
@@ -1,1 +1,1 @@
-= @form.text_field(:value, input_opts(id: @champ.input_id, aria: { describedby: @champ.describedby_id }, pattern: "-?[0-9]*", inputmode: :numeric, required: @champ.required?, data: { controller: 'format', format: :integer }))
+= @form.text_field(:value, input_opts(id: @champ.input_id, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, pattern: "-?[0-9]*", inputmode: :numeric, required: @champ.required?, data: { controller: 'format', format: :integer }))

--- a/app/components/editable_champ/linked_drop_down_list_component/linked_drop_down_list_component.html.haml
+++ b/app/components/editable_champ/linked_drop_down_list_component/linked_drop_down_list_component.html.haml
@@ -2,7 +2,7 @@
   .fr-select-group
     = render EditableChamp::ChampLabelComponent.new form: @form, champ: @champ, seen_at: @seen_at
 
-    = @form.select :primary_value, @champ.primary_options, {}, required: @champ.required?, class: 'fr-select fr-mb-3v', id: @champ.input_id, aria: { describedby: @champ.describedby_id }
+    = @form.select :primary_value, @champ.primary_options, {}, required: @champ.required?, class: 'fr-select fr-mb-3v', id: @champ.input_id, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }
 
 - if @champ.has_secondary_options_for_primary?
   .secondary

--- a/app/components/editable_champ/mesri_component/mesri_component.html.haml
+++ b/app/components/editable_champ/mesri_component/mesri_component.html.haml
@@ -4,5 +4,5 @@
     %p.notice= t('.ine_notice')
     = @form.text_field :ine,
       required: @champ.required?,
-      aria: { describedby: @champ.describedby_id },
+      aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" },
       class: "width-33-desktop", id: @champ.input_id

--- a/app/components/editable_champ/multiple_drop_down_list_component.rb
+++ b/app/components/editable_champ/multiple_drop_down_list_component.rb
@@ -12,14 +12,13 @@ class EditableChamp::MultipleDropDownListComponent < EditableChamp::EditableCham
   end
 
   def react_props
-    react_input_opts(id: @champ.input_id,
+    react_input_opts(
+      id: @champ.input_id,
       class: 'fr-mt-1w',
       name: @form.field_name(:value, multiple: true),
       selected_keys: @champ.selected_options,
       items: @champ.drop_down_options,
-      value_separator: false,
-      'aria-label': @champ.libelle,
-      'aria-describedby': @champ.describedby_id,
-      'aria-labelledby': @champ.labelledby_id)
+      value_separator: false
+    )
   end
 end

--- a/app/components/editable_champ/multiple_drop_down_list_component/multiple_drop_down_list_component.html.haml
+++ b/app/components/editable_champ/multiple_drop_down_list_component/multiple_drop_down_list_component.html.haml
@@ -3,7 +3,7 @@
     - capture do
       .fr-fieldset__element
         .fr-checkbox-group
-          = b.check_box(checked: @champ.selected_options.include?(b.value), aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, id: @champ.checkbox_id(b.value), class: 'fr-checkbox-group__checkbox')
+          = b.check_box(checked: @champ.selected_options.include?(b.value), id: @champ.checkbox_id(b.value), class: 'fr-checkbox-group__checkbox')
           %label.fr-label{ for: @champ.checkbox_id(b.value) }
             = b.text
 

--- a/app/components/editable_champ/multiple_drop_down_list_component/multiple_drop_down_list_component.html.haml
+++ b/app/components/editable_champ/multiple_drop_down_list_component/multiple_drop_down_list_component.html.haml
@@ -3,7 +3,7 @@
     - capture do
       .fr-fieldset__element
         .fr-checkbox-group
-          = b.check_box(checked: @champ.selected_options.include?(b.value), aria: { describedby: @champ.describedby_id }, id: @champ.checkbox_id(b.value), class: 'fr-checkbox-group__checkbox')
+          = b.check_box(checked: @champ.selected_options.include?(b.value), aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, id: @champ.checkbox_id(b.value), class: 'fr-checkbox-group__checkbox')
           %label.fr-label{ for: @champ.checkbox_id(b.value) }
             = b.text
 

--- a/app/components/editable_champ/number_component/number_component.html.haml
+++ b/app/components/editable_champ/number_component/number_component.html.haml
@@ -1,1 +1,1 @@
-= @form.text_field(:value, input_opts(id: @champ.input_id, aria: { describedby: @champ.describedby_id }, required: @champ.required?, pattern: "-?[0-9]*", inputmode: :decimal))
+= @form.text_field(:value, input_opts(id: @champ.input_id, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, required: @champ.required?, pattern: "-?[0-9]*", inputmode: :decimal))

--- a/app/components/editable_champ/pays_component/pays_component.html.haml
+++ b/app/components/editable_champ/pays_component/pays_component.html.haml
@@ -1,1 +1,1 @@
-= @form.select :value, options, select_options, required: @champ.required?, id: @champ.input_id, aria: { describedby: @champ.describedby_id }, class: "width-33-desktop width-100-mobile fr-select"
+= @form.select :value, options, select_options, required: @champ.required?, id: @champ.input_id, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, class: "width-33-desktop width-100-mobile fr-select"

--- a/app/components/editable_champ/phone_component/phone_component.html.haml
+++ b/app/components/editable_champ/phone_component/phone_component.html.haml
@@ -1,4 +1,4 @@
 -# Allowed @formats:
 -# very light validation is made client-side
 -# stronger validation is made server-side
-= @form.phone_field(:value, input_opts(id: @champ.input_id, aria: { describedby: @champ.describedby_id }, required: @champ.required?, pattern: "[^a-z^A-Z]+"))
+= @form.phone_field(:value, input_opts(id: @champ.input_id, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, required: @champ.required?, pattern: "[^a-z^A-Z]+"))

--- a/app/components/editable_champ/pole_emploi_component/pole_emploi_component.html.haml
+++ b/app/components/editable_champ/pole_emploi_component/pole_emploi_component.html.haml
@@ -4,5 +4,5 @@
     %p.notice= t('.identifiant_notice')
     = @form.text_field :identifiant,
       required: @champ.required?,
-      aria: { describedby: @champ.describedby_id },
+      aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" },
       class: "width-33-desktop", id: @champ.input_id

--- a/app/components/editable_champ/regions_component/regions_component.html.haml
+++ b/app/components/editable_champ/regions_component/regions_component.html.haml
@@ -1,1 +1,1 @@
-= @form.select :value, options, select_options, required: @champ.required?, id: @champ.input_id, aria: { describedby: @champ.describedby_id }, class: "width-33-desktop width-100-mobile fr-select"
+= @form.select :value, options, select_options, required: @champ.required?, id: @champ.input_id, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, class: "width-33-desktop width-100-mobile fr-select"

--- a/app/components/editable_champ/repetition_component/repetition_component.html.haml
+++ b/app/components/editable_champ/repetition_component/repetition_component.html.haml
@@ -1,7 +1,7 @@
 %fieldset
   %legend.fr-h5{ legend_params }= @champ.libelle
   - if @champ.description.present?
-    .notice{ notice_params }= render SimpleFormatComponent.new(@champ.description, allow_a: true)
+    .notice.fr-mt-n2w{ notice_params }= render SimpleFormatComponent.new(@champ.description, allow_a: true)
 
 
   .repetition{ id: dom_id(@champ, :rows), class: class_names('utils-repetition-required' => @champ.mandatory?) }

--- a/app/components/editable_champ/rna_component/rna_component.html.haml
+++ b/app/components/editable_champ/rna_component/rna_component.html.haml
@@ -1,4 +1,4 @@
-= @form.text_field(:value, input_opts( id: @champ.input_id, aria: { describedby: @champ.describedby_id }, data: { controller: 'turbo-input format', format: 'deleteSpace', turbo_input_load_on_connect_value: @champ.prefilled? && @champ.value.present? && @champ.data.blank?, turbo_input_url_value: update_path }, required: @champ.required?, pattern: "W[0-9A-Z]{9}", class: "width-33-desktop", maxlength: 10))
+= @form.text_field(:value, input_opts( id: @champ.input_id, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, data: { controller: 'turbo-input format', format: 'deleteSpace', turbo_input_load_on_connect_value: @champ.prefilled? && @champ.value.present? && @champ.data.blank?, turbo_input_url_value: update_path }, required: @champ.required?, pattern: "W[0-9A-Z]{9}", class: "width-33-desktop", maxlength: 10))
 
 .rna-info{ id: dom_id(@champ, :rna_info) }
   = render 'shared/champs/rna/association', champ: @champ, error: nil

--- a/app/components/editable_champ/rnf_component/rnf_component.html.haml
+++ b/app/components/editable_champ/rnf_component/rnf_component.html.haml
@@ -1,4 +1,4 @@
-= @form.text_field :external_id, input_opts(id: @champ.input_id, required: @champ.required?, class: "width-33-desktop fr-input", aria: { describedby: @champ.describedby_id })
+= @form.text_field :external_id, input_opts(id: @champ.input_id, required: @champ.required?, class: "width-33-desktop fr-input", aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" })
 
 .rnf-info{ id: dom_id(@champ, :rnf_info), role: 'status' }
   - if @champ.fetch_external_data_error?

--- a/app/components/editable_champ/siret_component/siret_component.html.haml
+++ b/app/components/editable_champ/siret_component/siret_component.html.haml
@@ -1,4 +1,4 @@
-= @form.text_field(:value, input_opts(id: @champ.input_id, aria: { describedby: @champ.describedby_id }, data: { controller: 'turbo-input format', format: 'siret', turbo_input_load_on_connect_value: @champ.prefilled? && @champ.value.present? && @champ.etablissement.blank?, turbo_input_url_value: update_path }, required: @champ.required?, class: "width-33-desktop"))
+= @form.text_field(:value, input_opts(id: @champ.input_id, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, data: { controller: 'turbo-input format', format: 'siret', turbo_input_load_on_connect_value: @champ.prefilled? && @champ.value.present? && @champ.etablissement.blank?, turbo_input_url_value: update_path }, required: @champ.required?, class: "width-33-desktop"))
 .siret-info{ id: dom_id(@champ, :siret_info) }
   - if @champ.etablissement.present?
     = render EditableChamp::EtablissementTitreComponent.new(etablissement: @champ.etablissement)

--- a/app/components/editable_champ/text_component/text_component.html.haml
+++ b/app/components/editable_champ/text_component/text_component.html.haml
@@ -1,1 +1,1 @@
-= @form.text_field(:value, input_opts(id: @champ.input_id, required: @champ.required?, aria: { describedby: @champ.describedby_id }))
+= @form.text_field(:value, input_opts(id: @champ.input_id, required: @champ.required?, aria: { describedby:"#{@champ.describedby_id} #{@champ.error_id}" }))

--- a/app/components/editable_champ/textarea_component/textarea_component.html.haml
+++ b/app/components/editable_champ/textarea_component/textarea_component.html.haml
@@ -1,4 +1,4 @@
-~ @form.text_area(:value, input_opts(id: @champ.input_id, aria: { describedby: @champ.describedby_id }, rows: 6, required: @champ.required?, value: html_to_string(@champ.value), data: { controller: 'autoresize' }))
+~ @form.text_area(:value, input_opts(id: @champ.input_id, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, rows: 6, required: @champ.required?, value: html_to_string(@champ.value), data: { controller: 'autoresize' }))
 
 %div{ role: 'status' }
   - if @champ.character_limit_info?

--- a/app/javascript/components/ComboBox.tsx
+++ b/app/javascript/components/ComboBox.tsx
@@ -50,11 +50,15 @@ export function ComboBox({
       className={`fr-ds-combobox ${className ?? ''}`}
       shouldFocusWrap={true}
     >
-      {label ? <Label className="fr-label">{label}</Label> : null}
-      {description ? (
-        <Text slot="description" className="fr-hint-text">
-          {description}
-        </Text>
+      {label ? (
+        <Label className="fr-label">
+          {label}
+          {description ? (
+            <Text slot="description" className="fr-hint-text fr-mb-1w">
+              {description}
+            </Text>
+          ) : null}
+        </Label>
       ) : null}
       <div className="fr-ds-combobox__input" style={{ position: 'relative' }}>
         <Input className="fr-select fr-autocomplete" ref={inputRef} />

--- a/app/javascript/components/ComboBox.tsx
+++ b/app/javascript/components/ComboBox.tsx
@@ -18,7 +18,6 @@ import { findOrCreateContainerElement } from '@coldwired/react';
 import * as s from 'superstruct';
 
 import {
-  useLabelledBy,
   useDispatchChangeEvent,
   useMultiList,
   useSingleList,
@@ -94,7 +93,6 @@ export function SingleComboBox({
   ...maybeProps
 }: SingleComboBoxProps) {
   const {
-    'aria-labelledby': ariaLabelledby,
     items: defaultItems,
     selectedKey: defaultSelectedKey,
     emptyFilterKey,
@@ -105,7 +103,6 @@ export function SingleComboBox({
     ...props
   } = useMemo(() => s.create(maybeProps, SingleComboBoxProps), [maybeProps]);
 
-  const labelledby = useLabelledBy(props.id, ariaLabelledby);
   const { ref, dispatch } = useDispatchChangeEvent();
 
   const { selectedItem, onReset, ...comboBoxProps } = useSingleList({
@@ -117,12 +114,7 @@ export function SingleComboBox({
 
   return (
     <>
-      <ComboBox
-        aria-labelledby={labelledby}
-        menuTrigger="focus"
-        {...comboBoxProps}
-        {...props}
-      >
+      <ComboBox menuTrigger="focus" {...comboBoxProps} {...props}>
         {(item) => <ComboBoxItem id={item.value}>{item.label}</ComboBoxItem>}
       </ComboBox>
       {children || name ? (
@@ -147,7 +139,6 @@ export function SingleComboBox({
 
 export function MultiComboBox(maybeProps: MultiComboBoxProps) {
   const {
-    'aria-labelledby': ariaLabelledby,
     items: defaultItems,
     selectedKeys: defaultSelectedKeys,
     name,
@@ -159,7 +150,6 @@ export function MultiComboBox(maybeProps: MultiComboBoxProps) {
     ...props
   } = useMemo(() => s.create(maybeProps, MultiComboBoxProps), [maybeProps]);
 
-  const labelledby = useLabelledBy(props.id, ariaLabelledby);
   const { ref, dispatch } = useDispatchChangeEvent();
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -202,7 +192,6 @@ export function MultiComboBox(maybeProps: MultiComboBoxProps) {
         </TagGroup>
       ) : null}
       <ComboBox
-        aria-labelledby={labelledby}
         allowsCustomValue={allowsCustomValue}
         inputRef={inputRef}
         menuTrigger="focus"
@@ -246,7 +235,6 @@ export function RemoteComboBox({
   ...maybeProps
 }: RemoteComboBoxProps) {
   const {
-    'aria-labelledby': ariaLabelledby,
     items: defaultItems,
     selectedKey: defaultSelectedKey,
     allowsCustomValue,
@@ -261,7 +249,6 @@ export function RemoteComboBox({
     ...props
   } = useMemo(() => s.create(maybeProps, RemoteComboBoxProps), [maybeProps]);
 
-  const labelledby = useLabelledBy(props.id, ariaLabelledby);
   const { ref, dispatch } = useDispatchChangeEvent();
 
   const load = useMemo(
@@ -288,7 +275,6 @@ export function RemoteComboBox({
       <ComboBox
         allowsEmptyCollection={comboBoxProps.inputValue.length > 0}
         allowsCustomValue={allowsCustomValue}
-        aria-labelledby={labelledby}
         {...comboBoxProps}
         {...props}
       >

--- a/app/javascript/components/react-aria/hooks.ts
+++ b/app/javascript/components/react-aria/hooks.ts
@@ -510,24 +510,6 @@ export const createLoader: (
     }
   };
 
-export function useLabelledBy(id?: string, ariaLabelledby?: string) {
-  return useMemo(
-    () => (ariaLabelledby ? ariaLabelledby : findLabelledbyId(id)),
-    [id, ariaLabelledby]
-  );
-}
-
-function findLabelledbyId(id?: string) {
-  if (!id) {
-    return;
-  }
-  const label = document.querySelector(`[for="${id}"]`);
-  if (!label?.id) {
-    return;
-  }
-  return label.id;
-}
-
 export function useOnFormReset(onReset?: () => void) {
   const ref = useRef<HTMLInputElement>(null);
   const onResetListener = useEvent<EventListener>((event) => {

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -179,6 +179,10 @@ class Champ < ApplicationRecord
     "#{html_id}-describedby_id"
   end
 
+  def error_id
+    "#{html_id}-error_id"
+  end
+
   def log_fetch_external_data_exception(exception)
     update_column(:fetch_external_data_exceptions, [exception.inspect])
   end

--- a/spec/components/attachment/edit_component_spec.rb
+++ b/spec/components/attachment/edit_component_spec.rb
@@ -35,6 +35,16 @@ RSpec.describe Attachment::EditComponent, type: :component do
     it 'renders allowed formats' do
       expect(subject).to have_content(/Formats supportés : jpeg, png/)
     end
+
+    it 'sets up its aria describedby' do
+      subject
+
+      hint_element = page.find('.fr-hint-text')
+      expect(hint_element['id']).to eq("#{champ.input_id}-pj-hint")
+
+      input_describedby = page.find('input')['aria-describedby'].split
+      expect(input_describedby).to eq([champ.describedby_id, "#{champ.input_id}-pj-hint"])
+    end
   end
 
   context 'when there is an attachment' do

--- a/spec/components/attachment/edit_component_spec.rb
+++ b/spec/components/attachment/edit_component_spec.rb
@@ -36,14 +36,27 @@ RSpec.describe Attachment::EditComponent, type: :component do
       expect(subject).to have_content(/Formats supportés : jpeg, png/)
     end
 
-    it 'sets up its aria describedby' do
-      subject
+    describe 'aria describedby' do
+      let(:describedby_attribute) { page.find('input')['aria-describedby'].split }
 
-      hint_element = page.find('.fr-hint-text')
-      expect(hint_element['id']).to eq("#{champ.input_id}-pj-hint")
+      it 'targets describedby_id and pj-hint' do
+        subject
 
-      input_describedby = page.find('input')['aria-describedby'].split
-      expect(input_describedby).to eq([champ.describedby_id, "#{champ.input_id}-pj-hint"])
+        hint_element = page.find('.fr-hint-text')
+        expect(hint_element['id']).to eq("#{champ.input_id}-pj-hint")
+
+        expect(describedby_attribute).to eq([champ.describedby_id, "#{champ.input_id}-pj-hint"])
+      end
+
+      context 'when there is an error' do
+        before { champ.errors.add(:value, 'is invalid') }
+
+        it 'targets error_id' do
+          subject
+
+          expect(describedby_attribute).to eq([champ.describedby_id, "#{champ.input_id}-pj-hint", champ.error_id])
+        end
+      end
     end
   end
 

--- a/spec/components/editable_champ/communes_component_spec.rb
+++ b/spec/components/editable_champ/communes_component_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+describe EditableChamp::CommunesComponent, type: :component do
+  let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :communes }]) }
+  let(:dossier) { create(:dossier, procedure:) }
+  let(:tdc) { procedure.active_revision.types_de_champ.first }
+  let(:champ) { dossier.champs.first }
+
+  describe 'aria-describedby' do
+    let(:react_component) { page.find('react-component') }
+    let(:react_props) { JSON.parse(react_component['props']) }
+
+    subject do
+      component = nil
+      ActionView::Base.empty.form_for(champ, url: '/') do |form|
+        component = EditableChamp::EditableChampComponent.new(champ:, form:)
+      end
+
+      render_inline(component)
+      react_props['aria-describedby']&.split
+    end
+
+    context 'when the champ has a description' do
+      it { is_expected.to eq([champ.describedby_id]) }
+
+      context 'and the champ has an error' do
+        before { champ.errors.add(:value, 'error') }
+
+        it { is_expected.to eq([champ.describedby_id, champ.error_id]) }
+      end
+    end
+
+    context 'when the champ has no description' do
+      before { tdc.update(description: nil) }
+
+      it { is_expected.to be_nil }
+
+      context 'and the champ has an error' do
+        before { champ.errors.add(:value, 'error') }
+
+        it { is_expected.to eq([champ.error_id]) }
+      end
+    end
+  end
+end

--- a/spec/components/editable_champ/drop_down_list_component_spec.rb
+++ b/spec/components/editable_champ/drop_down_list_component_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+describe EditableChamp::DropDownListComponent, type: :component do
+  let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :drop_down_list }]) }
+  let(:dossier) { create(:dossier, procedure:) }
+  let(:tdc) { procedure.active_revision.types_de_champ.first }
+  let(:champ) { dossier.champs.first }
+
+  subject(:render) do
+    component = nil
+    ActionView::Base.empty.form_for(champ, url: '/') do |form|
+      component = EditableChamp::EditableChampComponent.new(champ:, form:)
+    end
+
+    render_inline(component)
+  end
+
+  let(:fieldset) { page.find('fieldset') }
+  let(:radios) { fieldset.all('input[type="radio"]') }
+  def aria_labelledby(el) = el['aria-labelledby']&.split
+  def aria_describedby(el) = el['aria-describedby']&.split
+
+  describe 'with radio buttons' do
+    def no_aria_on_radio? = radios.all? { aria_labelledby(_1).nil? && aria_describedby(_1).nil? }
+
+    context 'when the champ has a description' do
+      it do
+        render
+
+        expect(aria_labelledby(fieldset)).to eq([champ.labelledby_id, champ.describedby_id])
+        expect(no_aria_on_radio?).to be true
+      end
+
+      context 'and the champ has an error' do
+        before { champ.errors.add(:value, 'error') }
+
+        it do
+          render
+
+          expect(aria_labelledby(fieldset)).to eq([champ.labelledby_id, champ.describedby_id, champ.error_id])
+          expect(no_aria_on_radio?).to be true
+        end
+      end
+    end
+
+    context 'when the champ has no description' do
+      before { tdc.update!(description: nil) }
+
+      it do
+        render
+
+        expect(aria_labelledby(fieldset)).to eq([champ.labelledby_id])
+        expect(no_aria_on_radio?).to be true
+      end
+
+      context 'and the champ has an error' do
+        before { champ.errors.add(:value, 'error') }
+
+        it do
+          render
+
+          expect(aria_labelledby(fieldset)).to eq([champ.labelledby_id, champ.error_id])
+          expect(no_aria_on_radio?).to be true
+        end
+      end
+    end
+  end
+
+  describe 'with select' do
+    before { tdc.update!(drop_down_options: ('a'..'f').to_a) }
+    let(:select) { page.find('select') }
+
+    it do
+      render
+      expect(page.all('fieldset')).to be_empty
+    end
+
+    describe 'aria-describedby' do
+      subject { render; aria_describedby(select) }
+
+      context 'when the champ has a description' do
+        it { is_expected.to eq([champ.describedby_id]) }
+
+        context 'and the champ has an error' do
+          before { champ.errors.add(:value, 'error') }
+
+          it { is_expected.to eq([champ.describedby_id, champ.error_id]) }
+        end
+      end
+
+      context 'when the champ has no description' do
+        before { tdc.update!(description: nil) }
+
+        it { is_expected.to be_nil }
+
+        context 'and the champ has an error' do
+          before { champ.errors.add(:value, 'error') }
+
+          it { is_expected.to eq([champ.error_id]) }
+        end
+      end
+    end
+  end
+
+  describe 'with a combobox' do
+    before { tdc.update!(drop_down_options: ('a'..'z').to_a) }
+    let(:select) { page.find('select') }
+    let(:react_component) { page.find('react-component') }
+    let(:react_props) { JSON.parse(react_component['props']) }
+
+    it do
+      render
+      expect(page.all('fieldset')).to be_empty
+    end
+
+    describe 'aria-describedby' do
+      subject { render; react_props['aria-describedby']&.split }
+
+      context 'when the champ has a description' do
+        it { is_expected.to eq([champ.describedby_id]) }
+
+        context 'and the champ has an error' do
+          before { champ.errors.add(:value, 'error') }
+
+          it { is_expected.to eq([champ.describedby_id, champ.error_id]) }
+        end
+      end
+
+      context 'when the champ has no description' do
+        before { tdc.update!(description: nil) }
+
+        it { is_expected.to be_nil }
+
+        context 'and the champ has an error' do
+          before { champ.errors.add(:value, 'error') }
+
+          it { is_expected.to eq([champ.error_id]) }
+        end
+      end
+    end
+  end
+end

--- a/spec/components/editable_champ/drop_down_list_component_spec.rb
+++ b/spec/components/editable_champ/drop_down_list_component_spec.rb
@@ -28,6 +28,8 @@ describe EditableChamp::DropDownListComponent, type: :component do
         render
 
         expect(aria_labelledby(fieldset)).to eq([champ.labelledby_id, champ.describedby_id])
+        expect(fieldset['role']).to eq('group')
+
         expect(no_aria_on_radio?).to be true
       end
 


### PR DESCRIPTION
# Déplace les descriptions contribuées à l'extérieur des étiquettes
![Capture d’écran 2024-10-28 à 15 25 55](https://github.com/user-attachments/assets/973f6400-5266-4a26-85f1-ac0250b9a8e4)

__Après__
![Capture d’écran 2024-10-28 à 15 23 13](https://github.com/user-attachments/assets/48f75f73-6cc7-40ff-bfd9-2c132810d7fe)

__Avant__
![Capture d’écran 2024-10-28 à 15 25 46](https://github.com/user-attachments/assets/97cd36d8-ff89-4e3c-a9b4-edea976351b2)

# Précise le contexte du bouton de suppression d'une pièce jointe
![Capture d’écran 2024-10-28 à 15 28 45](https://github.com/user-attachments/assets/4a2f2678-cf74-4cc6-af21-e185b61172f9)

__Après__
![Capture d’écran 2024-10-28 à 15 29 47](https://github.com/user-attachments/assets/3cf75bcd-9538-4880-b422-02e25a8a9573)


__Avant__
![Capture d’écran 2024-10-28 à 15 28 53](https://github.com/user-attachments/assets/ba96da43-1b34-42b5-a570-57f27fad4a07)

# Uniformise le rendu des descriptions utilisant des balises HTML
__Après__
![Capture d’écran 2024-10-28 à 15 44 11](https://github.com/user-attachments/assets/4a1e28a0-f44e-4199-b65d-32cf9596641b)
![Capture d’écran 2024-10-28 à 15 44 28](https://github.com/user-attachments/assets/caccd0a1-dd84-4eaf-90f8-31d78ce84952)

__Avant__
![Capture d’écran 2024-10-28 à 15 43 49](https://github.com/user-attachments/assets/1b0e246b-aca0-462d-a9cf-3af4348accee)
![Capture d’écran 2024-10-28 à 15 43 20](https://github.com/user-attachments/assets/9a0bcb74-f9cf-49dc-8d56-e20788f4d6a5)

# Applique les recommandations du DSFR concernant la liaison des messages d'erreur aux champs et aux regroupements

## En cas de regroupement (balise `fieldset`)
- L'étiquette (le `label`), la description (si elle existe) et l'erreur (si elle est présente) sont liés au `fieldset` via l'attribut [`aria-labelledby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby).
- Les champs en erreur compris dans le regroupement ne sont pas liés à l'erreur ou à la description.
- Référence : [Recommandation DSFR pour les regroupements](https://www.systeme-de-design.gouv.fr/composants-et-modeles/composants/bouton-radio/).
![Capture d’écran 2024-11-28 à 17 00 43](https://github.com/user-attachments/assets/0e834651-f341-4188-b18e-fe9f4d09be32)

## En cas de champ simple (`input`, `select`, `textarea`)
- L'étiquette (le `label`) est lié au champ via le couple d'attribut `for` / `id`.
- La description (si elle existe) et l'erreur (si elle est présente) sont liés au champ via l'attribut [`aria-describedby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby)
- Référence : [Recommandation DSFR pour les champs simples](https://www.systeme-de-design.gouv.fr/composants-et-modeles/composants/champ-de-saisie/).
![Capture d’écran 2024-11-28 à 17 13 29](https://github.com/user-attachments/assets/ada714c9-518a-499a-b041-a1d1dd5ba546)
