### PR TITLE
ETQ usager, utilisant un lecteur d'écran je veux être informé du nombre de caractères restants ou en trop dans un textarea

### DIFF
--- a/app/components/editable_champ/champ_label_content_component/champ_label_content_component.html.haml
+++ b/app/components/editable_champ/champ_label_content_component/champ_label_content_component.html.haml
@@ -20,5 +20,5 @@
 - if @champ.description.present?
   %span.fr-hint-text= render SimpleFormatComponent.new(@champ.description, allow_a: true)
 
-- if @champ.textarea?
-  %span.sr-only= t('.recommended_size', size: @champ.character_limit_base)
+- if @champ.textarea? && @champ.character_limit_base&.positive?
+  %span.fr-hint-text= t('.recommended_size', size: @champ.character_limit_base)

--- a/app/components/editable_champ/textarea_component/textarea_component.en.yml
+++ b/app/components/editable_champ/textarea_component/textarea_component.en.yml
@@ -1,3 +1,3 @@
 en:
   remaining_characters: You have %{remaining_words} characters remaining.
-  excess_characters: You have %{excess_words} characters too many.
+  excess_characters: You have exceeded the recommended size of %{excess_words} characters. Please reduce the number of characters.

--- a/app/components/editable_champ/textarea_component/textarea_component.fr.yml
+++ b/app/components/editable_champ/textarea_component/textarea_component.fr.yml
@@ -1,3 +1,3 @@
 fr:
   remaining_characters: Il vous reste %{remaining_words} caractères.
-  excess_characters: Vous avez dépassé la taille conseillée de %{excess_words} caractères. Réduire le nombre de caractères.
+  excess_characters: Vous avez dépassé la taille conseillée de %{excess_words} caractères. Veuillez réduire le nombre de caractères.

--- a/app/components/editable_champ/textarea_component/textarea_component.html.haml
+++ b/app/components/editable_champ/textarea_component/textarea_component.html.haml
@@ -1,9 +1,10 @@
 ~ @form.text_area(:value, input_opts(id: @champ.input_id, aria: { describedby: @champ.describedby_id }, rows: 6, required: @champ.required?, value: html_to_string(@champ.value), data: { controller: 'autoresize' }))
 
-- if @champ.character_limit_info?
-  %p.fr-info-text
-    = t('.remaining_characters', remaining_words: @champ.remaining_characters)
+%div{ role: 'status' }
+  - if @champ.character_limit_info?
+    %p.fr-info-text
+      = t('.remaining_characters', remaining_words: @champ.remaining_characters)
 
-- if @champ.character_limit_warning?
-  %p.fr-icon--sm.fr-mt-4v.fr-mb-0.fr-hint-text.fr-icon-warning-fill.fr-text-default--warning.characters-count
-    = t('.excess_characters', excess_words: @champ.excess_characters)
+  - if @champ.character_limit_warning?
+    %p.fr-icon--sm.fr-mt-4v.fr-mb-0.fr-hint-text.fr-icon-warning-fill.fr-text-default--warning
+      = t('.excess_characters', excess_words: @champ.excess_characters)

--- a/config/locales/models/champs/decimal_number_champ/en.yml
+++ b/config/locales/models/champs/decimal_number_champ/en.yml
@@ -3,4 +3,4 @@ en:
     attributes:
       champs/decimal_number_champ:
         hints:
-          value: "You can enter up to 3 decimal places after the decimal point. Example: 3.141"
+          value_html: "You can enter up to 3 decimal places after the decimal point. Example: 3.141"

--- a/config/locales/models/champs/decimal_number_champ/fr.yml
+++ b/config/locales/models/champs/decimal_number_champ/fr.yml
@@ -3,4 +3,4 @@ fr:
     attributes:
       champs/decimal_number_champ:
         hints:
-          value: "Vous pouvez saisir jusqu’à 3 décimales après le point. Exemple: 3.141"
+          value_html: "Vous pouvez saisir jusqu’à 3 décimales après le point. Exemple: <span aria-hidden='true'>3.141</span><span class='sr-only'>3 point 141</span>"


### PR DESCRIPTION
# Affiche de la limite de caractères 
__Après__
![Capture d’écran 2024-10-30 à 18 03 02](https://github.com/user-attachments/assets/85175add-49d8-4960-bfc9-43c4696cbe71)

__Avant__
![Capture d’écran 2024-10-30 à 18 03 18](https://github.com/user-attachments/assets/ed8ace62-ff24-4ca1-91b1-f36a885f2555)

# Restitue le `.` dans l'aide du champ décimal
__Après__

https://github.com/user-attachments/assets/6323e422-a6a7-4a41-a90e-f00514fc9440

__Avant__

https://github.com/user-attachments/assets/af5c249c-1f46-4fe4-878f-a33d5368698a

# Restitue le nombre de caractères restants ou en trop
__Après__

https://github.com/user-attachments/assets/f8ce9343-8540-4553-8db9-4da1c041d870

__Avant__

https://github.com/user-attachments/assets/c3dfca4d-58a6-4256-8218-d66863bc53a6