### PR TITLE
ETQ usager utilisant un lecteur d'écran, je veux être informé du résultat retourné par la recherche d'un numéro RNF

### DIFF
--- a/app/components/editable_champ/rnf_component/rnf_component.en.yml
+++ b/app/components/editable_champ/rnf_component/rnf_component.en.yml
@@ -2,4 +2,4 @@
 en:
   rnf_info_error: No foundation found
   rnf_info_pending: RNF verification pending
-  rnf_info_success: "This RNF matches %{title}, %{address}"
+  rnf_info_success: "This RNF matches: %{title}, %{address}"

--- a/app/components/editable_champ/rnf_component/rnf_component.fr.yml
+++ b/app/components/editable_champ/rnf_component/rnf_component.fr.yml
@@ -2,4 +2,4 @@
 fr:
   rnf_info_error: Aucune fondation trouvée
   rnf_info_pending: Vérification du RNF en cours
-  rnf_info_success: "Ce RNF correspond à %{title}, %{address}"
+  rnf_info_success: "Ce RNF correspond à : %{title}, %{address}"

--- a/app/components/editable_champ/rnf_component/rnf_component.html.haml
+++ b/app/components/editable_champ/rnf_component/rnf_component.html.haml
@@ -1,6 +1,6 @@
 = @form.text_field :external_id, input_opts(id: @champ.input_id, required: @champ.required?, class: "width-33-desktop fr-input small-margin", aria: { describedby: @champ.describedby_id })
 
-.rnf-info{ id: dom_id(@champ, :rnf_info) }
+.rnf-info{ id: dom_id(@champ, :rnf_info), role: 'status' }
   - if @champ.fetch_external_data_error?
     %p.fr-error-text= t('.rnf_info_error')
   - elsif @champ.fetch_external_data_pending?

--- a/app/components/editable_champ/rnf_component/rnf_component.html.haml
+++ b/app/components/editable_champ/rnf_component/rnf_component.html.haml
@@ -1,4 +1,4 @@
-= @form.text_field :external_id, input_opts(id: @champ.input_id, required: @champ.required?, class: "width-33-desktop fr-input small-margin", aria: { describedby: @champ.describedby_id })
+= @form.text_field :external_id, input_opts(id: @champ.input_id, required: @champ.required?, class: "width-33-desktop fr-input", aria: { describedby: @champ.describedby_id })
 
 .rnf-info{ id: dom_id(@champ, :rnf_info), role: 'status' }
   - if @champ.fetch_external_data_error?

--- a/app/views/shared/champs/rna/_association.html.haml
+++ b/app/views/shared/champs/rna/_association.html.haml
@@ -1,7 +1,6 @@
 - case error
 - when :invalid
-  %p.fr-error-text
-    Le numéro RNA doit commencer par un W majuscule suivi de 9 chiffres ou lettres
+  %p.fr-error-text= t('.invalid_number')
 - when :not_found
   %p.fr-error-text= t('.not_found')
 - when :network_error

--- a/config/locales/models/champs/rnf_champ/en.yml
+++ b/config/locales/models/champs/rnf_champ/en.yml
@@ -18,4 +18,4 @@ en:
     attributes:
       champs/rnf_champ:
           hints:
-            value: "Expected format : 075-FDD-00003-01"
+            value_html: "Expected format: <span aria-hidden='true'>075-FDD-00003-01</span> <span class='sr-only'>075 hyphen FDD hyphen 00003 hyphen 01</span>"

--- a/config/locales/models/champs/rnf_champ/fr.yml
+++ b/config/locales/models/champs/rnf_champ/fr.yml
@@ -18,4 +18,4 @@ fr:
     attributes:
       champs/rnf_champ:
           hints:
-            value: "Format attendu : 075-FDD-00003-01"
+            value_html: "Format attendu : <span aria-hidden='true'>075-FDD-00003-01</span> <span class='sr-only'>075 tiret FDD tiret 00003 tiret 01</span>"

--- a/config/locales/shared.en.yml
+++ b/config/locales/shared.en.yml
@@ -28,9 +28,10 @@ en:
           not_filled: not filled
           not_found: "RNA number %{rna} (no association found)"
         association:
-          data_fetched: "This RNA number is linked to %{title}, %{address}"
+          data_fetched: "This RNA number is linked to: %{title}, %{address}"
           not_found: "No association found"
           network_error: "A network error has prevented the association associated with this RNA to be fetched"
+          invalid_number: "The RNA number must begin with a capital W followed by 9 digits or letters"
       rnf:
         show:
           not_found: "RNF %{rnf} (no foundation found)"

--- a/config/locales/shared.fr.yml
+++ b/config/locales/shared.fr.yml
@@ -30,9 +30,10 @@ fr:
           not_filled: non renseigné
           not_found: "RNA %{rna} (aucun établissement trouvé)"
         association:
-          data_fetched: "Ce RNA correspond à %{title}, %{address}"
+          data_fetched: "Ce RNA correspond à : %{title}, %{address}"
           not_found: "Aucun établissement trouvé"
           network_error: "Une erreur réseau a empêché l’association liée à ce RNA d’être trouvée"
+          invalid_number: "Le numéro RNA doit commencer par un W majuscule suivi de 9 chiffres ou lettres"
       rnf:
         show:
           not_found: "RNF %{rnf} (aucune fondation trouvée)"


### PR DESCRIPTION
# Simplification de l'utilisation du champ pour les utilisateurs de lecteurs d'écran
- Restitue les `-` dans l'aide du champ RNF
- Restitue le résultat associé au numéro RNF saisi
__Après__

https://github.com/user-attachments/assets/967e67ee-807a-493f-b930-5139564561f2

__Avant__

https://github.com/user-attachments/assets/82d16403-5388-437b-ba28-5ff4b30450e5


# Ajoute la traduction du message d'erreur d'un champ RNA
__Après__
![Capture d’écran 2024-11-04 à 16 44 55](https://github.com/user-attachments/assets/d11e8a8d-70ee-4bf0-8e00-6655b2a15886)

__Avant__
![Capture d’écran 2024-11-04 à 16 45 35](https://github.com/user-attachments/assets/1e60a782-12c4-4156-b9fb-0d89bc7a4c5a)
