### PR TITLE
ETQ superadmin je peux générer les exports adaptés pour la newsletter 

### DIFF
--- a/app/controllers/manager/administrateurs_controller.rb
+++ b/app/controllers/manager/administrateurs_controller.rb
@@ -42,24 +42,16 @@ module Manager
 
     def export_last_half_year
       administrateurs = Administrateur.joins(:user).where(created_at: 6.months.ago..).where.not(users: { email_verified_at: nil })
-      csv = CSV.generate(headers: true) do |csv|
-        csv << ['ID', 'Email', 'Date de création']
-        administrateurs.each do |administrateur|
-          csv << [administrateur.id, administrateur.email, administrateur.created_at]
-        end
-      end
+
+      csv = generate_csv(administrateurs)
 
       send_data csv, filename: "administrateurs_recents_#{Date.today.strftime('%d-%m-%Y')}.csv"
     end
 
     def export_with_publiee_procedure
       administrateurs = Administrateur.joins(:user).where.not(users: { email_verified_at: nil }).joins(:procedures).where(procedures: { aasm_state: [:publiee] })
-      csv = CSV.generate(headers: true) do |csv|
-        csv << ['ID', 'Email', 'Date de création']
-        administrateurs.each do |administrateur|
-          csv << [administrateur.id, administrateur.email, administrateur.created_at]
-        end
-      end
+
+      csv = generate_csv(administrateurs)
 
       send_data csv, filename: "administrateurs_actifs_#{Date.today.strftime('%d-%m-%Y')}.csv"
     end

--- a/app/controllers/manager/administrateurs_controller.rb
+++ b/app/controllers/manager/administrateurs_controller.rb
@@ -40,7 +40,7 @@ module Manager
     def data_exports
     end
 
-    def export_last_month
+    def export_last_half_year
       administrateurs = Administrateur.joins(:user).where(created_at: 6.months.ago..).where.not(users: { email_verified_at: nil })
       csv = CSV.generate(headers: true) do |csv|
         csv << ['ID', 'Email', 'Date de création']

--- a/app/controllers/manager/administrateurs_controller.rb
+++ b/app/controllers/manager/administrateurs_controller.rb
@@ -49,7 +49,19 @@ module Manager
         end
       end
 
-      send_data csv, filename: "administrateurs_#{Date.today.strftime('%d-%m-%Y')}.csv"
+      send_data csv, filename: "administrateurs_recents_#{Date.today.strftime('%d-%m-%Y')}.csv"
+    end
+
+    def export_with_publiee_procedure
+      administrateurs = Administrateur.joins(:user).where.not(users: { email_verified_at: nil }).joins(:procedures).where(procedures: { aasm_state: [:publiee] })
+      csv = CSV.generate(headers: true) do |csv|
+        csv << ['ID', 'Email', 'Date de création']
+        administrateurs.each do |administrateur|
+          csv << [administrateur.id, administrateur.email, administrateur.created_at]
+        end
+      end
+
+      send_data csv, filename: "administrateurs_actifs_#{Date.today.strftime('%d-%m-%Y')}.csv"
     end
 
     private

--- a/app/controllers/manager/application_controller.rb
+++ b/app/controllers/manager/application_controller.rb
@@ -56,5 +56,14 @@ module Manager
 
       payload[:to_log] = to_log
     end
+
+    def generate_csv(users)
+      CSV.generate(headers: true) do |csv|
+        csv << ['ID', 'Email', 'Date de création']
+        users.each do |user|
+          csv << [user.id, user.email, user.created_at]
+        end
+      end
+    end
   end
 end

--- a/app/controllers/manager/instructeurs_controller.rb
+++ b/app/controllers/manager/instructeurs_controller.rb
@@ -32,7 +32,19 @@ module Manager
         end
       end
 
-      send_data csv, filename: "instructeurs_#{Date.today.strftime('%d-%m-%Y')}.csv"
+      send_data csv, filename: "instructeurs_recents_#{Date.today.strftime('%d-%m-%Y')}.csv"
+    end
+
+    def export_currently_active
+      instructeurs = Instructeur.joins(:user).where(users: { current_sign_in_at: 6.months.ago.. }).where.not(users: { email_verified_at: nil })
+      csv = CSV.generate(headers: true) do |csv|
+        csv << ['ID', 'Email', 'Date de création']
+        instructeurs.each do |instructeur|
+          csv << [instructeur.id, instructeur.email, instructeur.created_at]
+        end
+      end
+
+      send_data csv, filename: "instructeurs_actifs_#{Date.today.strftime('%d-%m-%Y')}.csv"
     end
   end
 end

--- a/app/controllers/manager/instructeurs_controller.rb
+++ b/app/controllers/manager/instructeurs_controller.rb
@@ -23,7 +23,7 @@ module Manager
       redirect_to manager_instructeurs_path
     end
 
-    def export_last_month
+    def export_last_half_year
       instructeurs = Instructeur.joins(:user).where(created_at: 6.months.ago..).where.not(users: { email_verified_at: nil })
       csv = CSV.generate(headers: true) do |csv|
         csv << ['ID', 'Email', 'Date de création']

--- a/app/controllers/manager/instructeurs_controller.rb
+++ b/app/controllers/manager/instructeurs_controller.rb
@@ -25,24 +25,16 @@ module Manager
 
     def export_last_half_year
       instructeurs = Instructeur.joins(:user).where(created_at: 6.months.ago..).where.not(users: { email_verified_at: nil })
-      csv = CSV.generate(headers: true) do |csv|
-        csv << ['ID', 'Email', 'Date de création']
-        instructeurs.each do |instructeur|
-          csv << [instructeur.id, instructeur.email, instructeur.created_at]
-        end
-      end
+
+      csv = generate_csv(instructeurs)
 
       send_data csv, filename: "instructeurs_recents_#{Date.today.strftime('%d-%m-%Y')}.csv"
     end
 
     def export_currently_active
       instructeurs = Instructeur.joins(:user).where(users: { current_sign_in_at: 6.months.ago.. }).where.not(users: { email_verified_at: nil })
-      csv = CSV.generate(headers: true) do |csv|
-        csv << ['ID', 'Email', 'Date de création']
-        instructeurs.each do |instructeur|
-          csv << [instructeur.id, instructeur.email, instructeur.created_at]
-        end
-      end
+
+      csv = generate_csv(instructeurs)
 
       send_data csv, filename: "instructeurs_actifs_#{Date.today.strftime('%d-%m-%Y')}.csv"
     end

--- a/app/views/manager/administrateurs/data_exports.html.erb
+++ b/app/views/manager/administrateurs/data_exports.html.erb
@@ -1,6 +1,6 @@
 <div>
   <ul>
-    <li><a href="/manager/exports/administrateurs/last_month">Export des administrateurs (6 mois)</a></li>
-    <li><a href="/manager/exports/instructeurs/last_month">Export des instructeurs (6 mois)</a></li>
+    <li><a href="/manager/exports/administrateurs/last_half_year">Export des administrateurs créés dans les 6 derniers mois</a></li>
+    <li><a href="/manager/exports/instructeurs/last_half_year">Export des instructeurs créés dans les 6 derniers mois</a></li>
   </ul>
 </div>

--- a/app/views/manager/administrateurs/data_exports.html.erb
+++ b/app/views/manager/administrateurs/data_exports.html.erb
@@ -1,6 +1,19 @@
-<div>
+<header class="main-content__header">
+  <h1 class="main-content__page-title">
+    Export des administrateurs et instructeurs
+  </h1>
+</header>
+
+<section class="main-content__body">
+  <h2>Pour les invitations aux webinaires</h2>
   <ul>
     <li><a href="/manager/exports/administrateurs/last_half_year">Export des administrateurs créés dans les 6 derniers mois</a></li>
     <li><a href="/manager/exports/instructeurs/last_half_year">Export des instructeurs créés dans les 6 derniers mois</a></li>
   </ul>
-</div>
+
+  <h2>Pour les newsletters</h2>
+  <ul>
+    <li><a href="/manager/exports/administrateurs/with_publiee_procedure">Export des administrateurs avec au moins une démarche publiée</a></li>
+    <li><a href="/manager/exports/instructeurs/currently_active">Export des instructeurs qui se sont connectés dans les 6 derniers mois</a></li>
+  </ul>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,6 +117,8 @@ Rails.application.routes.draw do
     get 'data_exports' => 'administrateurs#data_exports'
     get 'exports/administrateurs/last_half_year' => 'administrateurs#export_last_half_year'
     get 'exports/instructeurs/last_half_year' => 'instructeurs#export_last_half_year'
+    get 'exports/administrateurs/with_publiee_procedure' => 'administrateurs#export_with_publiee_procedure'
+    get 'exports/instructeurs/currently_active' => 'instructeurs#export_currently_active'
 
     get 'import_procedure_tags' => 'procedures#import_data'
     post 'import_tags' => 'procedures#import_tags'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,8 +115,8 @@ Rails.application.routes.draw do
     end
 
     get 'data_exports' => 'administrateurs#data_exports'
-    get 'exports/administrateurs/last_month' => 'administrateurs#export_last_month'
-    get 'exports/instructeurs/last_month' => 'instructeurs#export_last_month'
+    get 'exports/administrateurs/last_half_year' => 'administrateurs#export_last_half_year'
+    get 'exports/instructeurs/last_half_year' => 'instructeurs#export_last_half_year'
 
     get 'import_procedure_tags' => 'procedures#import_data'
     post 'import_tags' => 'procedures#import_tags'


### PR DESCRIPTION
On avait déjà deux liens dans le manager pour récupérer la liste des admins et instructeurs créés dans les six derniers mois.
Dans cette PR on ajoute deux nouveaux liens pour récupérer les admins avec démarche publiée et les instructeurs connectés dans les 6 derniers mois.