### PR TITLE
Corrige diverses coquilles

### DIFF
--- a/app/components/attachment/edit_component/edit_component.html.haml
+++ b/app/components/attachment/edit_component/edit_component.html.haml
@@ -6,7 +6,7 @@
           .flex.flex-gap-2{ class: class_names("attachment-error": attachment.virus_scanner_error?) }
             - if user_can_destroy?
               = render NestedForms::OwnedButtonComponent.new(formaction: destroy_attachment_path, http_method: :delete, opt: {class: "fr-btn fr-btn--tertiary fr-btn--sm fr-icon-delete-line", title: t(".delete_file", filename: attachment.filename)}) do
-                = t('.delete')
+                = t('.delete_file', filename: attachment.filename)
 
               - if downloadable?(attachment)
                 = render Dsfr::DownloadComponent.new(attachment: attachment)
@@ -24,7 +24,7 @@
         .flex.flex-gap-2{ class: class_names("attachment-error": attachment.virus_scanner_error?) }
           - if user_can_destroy?
             = render NestedForms::OwnedButtonComponent.new(formaction: destroy_attachment_path, http_method: :delete, opt: {class: "fr-btn fr-btn--tertiary fr-btn--sm fr-icon-delete-line", title: t(".delete_file", filename: attachment.filename)}) do
-              = t('.delete')
+              = t('.delete_file', filename: attachment.filename)
 
           - if downloadable?(attachment)
             = render Dsfr::DownloadComponent.new(attachment:)

--- a/app/components/editable_champ/champ_label_component/champ_label_component.html.haml
+++ b/app/components/editable_champ/champ_label_component/champ_label_component.html.haml
@@ -5,9 +5,3 @@
     - render EditableChamp::ChampLabelContentComponent.new form: @form, champ: @champ, seen_at: @seen_at
 - elsif @champ.legend_label?
   %legend.fr-fieldset__legend.fr-text--regular{ id: @champ.labelledby_id }= render EditableChamp::ChampLabelContentComponent.new form: @form, champ: @champ, seen_at: @seen_at
-- elsif @champ.single_checkbox?
-  -# no label to add
-- else
-  -# champ civilite (and other?)
-  .fr-label.fr-mb-1w{ id: @champ.labelledby_id }
-    = render EditableChamp::ChampLabelContentComponent.new form: @form, champ: @champ, seen_at: @seen_at

--- a/app/components/release_note/form_component/form_component.html.haml
+++ b/app/components/release_note/form_component/form_component.html.haml
@@ -24,7 +24,7 @@
                 = category.humanize
 
         - if categories_error?
-          .fr-messages-group{ id: "checkboxes-error-messages", aria_live: "assertive" }
+          .fr-messages-group{ id: "checkboxes-error-messages", "aria-live": "assertive" }
             - if categories_full_messages_errors.one?
               %p.fr-message.fr-message--error{ id: categories_errors_describedby_id }= categories_full_messages_errors.first
             - else

--- a/config/locales/models/champs/champs.en.yml
+++ b/config/locales/models/champs/champs.en.yml
@@ -1,4 +1,4 @@
-fr:
+en:
   activerecord:
     errors:
       models:


### PR DESCRIPTION
# Ajoute du contexte aux boutons de suppression
__Après__
![Capture d’écran 2024-11-05 à 14 45 05](https://github.com/user-attachments/assets/5eba6deb-8ee0-4963-951d-3e2d3f2aecd6)

__Avant__
![Capture d’écran 2024-11-05 à 14 44 39](https://github.com/user-attachments/assets/0bcd07d2-bd28-4a7a-8c06-6b3beb772e85)


# Supprime une condition inutile 
Le champ civilité est géré par la condition `- elsif @champ.legend_label?`

# Rectifie des erreurs typographiques
Restaure la traduction des messages d'erreur des champs