### PR TITLE
ETQ tech, réduit l'impact d'images invalides sur sentry

### DIFF
--- a/app/models/concerns/attachment_image_processor_concern.rb
+++ b/app/models/concerns/attachment_image_processor_concern.rb
@@ -21,6 +21,7 @@ module AttachmentImageProcessorConcern
     return if blob.attachments.size != 1
     return if blob.attachments.last.record_type == "Export"
     return if !blob.content_type.in?(PROCESSABLE_TYPES)
+    return if blob.byte_size.zero? # some empty files may be considered as image depending on filename
 
     ImageProcessorJob.perform_later(blob)
   end


### PR DESCRIPTION
Réduit l'impact de certaines erreurs trop présentes sur sentry à cause des retries trop nombreux, souvent dues à YWH: 
- des fichiers bidon se faisant passer pour des images, mais qui échouent tôt au tard du côté d'image magick : 
- n'essaie pas de processer des fichiers vides se faisant passer par des images (~5000 fichiers sur 10 jours)

Cf:
- https://demarches-simplifiees.sentry.io/issues/5873082562
- https://demarches-simplifiees.sentry.io/issues/5413990217
