### PR TITLE
ETQ tech, améliore le détail d'erreurs dans sentry lors de la destruction des ProcedurePresentations

### DIFF
--- a/app/models/assign_to.rb
+++ b/app/models/assign_to.rb
@@ -32,7 +32,7 @@ class AssignTo < ApplicationRecord
     if errors.present?
       Sentry.capture_message(
         "Destroying invalid ProcedurePresentation",
-        extra: { procedure_presentation_id: procedure_presentation.id, errors: }
+        extra: { procedure_presentation_id: procedure_presentation.id, errors: errors.full_messages }
       )
       self.procedure_presentation = nil
     end


### PR DESCRIPTION
Actuellement on récupère quelque chose comme `#<ActiveModel::Errors:0x00007fbcb1d45fd8>`