### PR TITLE
Tech: ajoute index sur `users#unconfirmed_email`

### DIFF
--- a/db/migrate/20241112090128_add_unconfirmed_email_index_to_users.rb
+++ b/db/migrate/20241112090128_add_unconfirmed_email_index_to_users.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddUnconfirmedEmailIndexToUsers < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :users, :unconfirmed_email, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_10_14_084333) do
+ActiveRecord::Schema[7.0].define(version: 2024_11_12_090128) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_stat_statements"
@@ -1236,6 +1236,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_14_084333) do
     t.index ["last_sign_in_at"], name: "index_users_on_last_sign_in_at"
     t.index ["requested_merge_into_id"], name: "index_users_on_requested_merge_into_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["unconfirmed_email"], name: "index_users_on_unconfirmed_email"
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 


### PR DESCRIPTION
Sert avant tout à éviter de trop charger la base quand du traffic illégitime essaye en masse de post sur `/users/confirmation`