### PR TITLE
ETQ Instructeur: cache la colonne de filtrage décision avant du SVA/SVR

### DIFF
--- a/app/models/procedure_presentation.rb
+++ b/app/models/procedure_presentation.rb
@@ -37,7 +37,7 @@ class ProcedurePresentation < ApplicationRecord
       *displayed_columns,
       procedure.dossier_state_column
     ]
-    columns.concat(procedure.sva_svr_columns) if procedure.sva_svr_enabled?
+    columns.concat(procedure.sva_svr_columns.filter(&:displayable)) if procedure.sva_svr_enabled?
     columns
   end
 end


### PR DESCRIPTION
Avant
![Screenshot 2024-11-13 at 10-38-17 Démarche de demo pour la page patron · demarches-simplifiees fr](https://github.com/user-attachments/assets/78349f4f-7bf3-40cc-8127-40b18ced091b)

Apres
![Screenshot 2024-11-13 at 10-44-16 Démarche de demo pour la page patron · demarches-simplifiees fr](https://github.com/user-attachments/assets/e049eb7b-89f3-43ec-a5e4-071c12bf73a5)
