### PR TITLE
[bug] Le bouton "suivre le dossier" sur l'onglet total ne s'applique pas individuellement 

### DIFF
--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -159,7 +159,7 @@
                                   dossier_id: p.dossier_id,
                                   state: p.state,
                                   archived: p.archived,
-                                  dossier_is_followed: @followed_dossiers_id.include?(p.dossier_id),
+                                  dossier_is_followed: current_instructeur&.follow?(Dossier.find_by_id(p.dossier_id)),
                                   close_to_expiration: @statut == 'expirant',
                                   hidden_by_administration: @statut == 'supprimes',
                                   hidden_by_expired: p.hidden_by_reason == 'expired',

--- a/app/views/recherche/index.html.haml
+++ b/app/views/recherche/index.html.haml
@@ -99,7 +99,7 @@
                                                                       dossier_id: p.dossier_id,
                                                                       state: p.state,
                                                                       archived: p.archived,
-                                                                      dossier_is_followed: @followed_dossiers_id.include?(p.dossier_id),
+                                                                      dossier_is_followed: current_instructeur&.follow?(Dossier.find_by_id(p.dossier_id)),
                                                                       close_to_expiration: nil,
                                                                       hidden_by_administration: nil,
                                                                       hidden_by_expired: nil,


### PR DESCRIPTION
Il y avait un bug sur le bouton "suivre le dossier" - il était actif si le dossier était suivi par un instructeur du groupe et pas le current_instructeur. 
Ça posait 2 pb :
-  on pouvait retirer le follow à un instructeur sans le vouloir
- on ne pouvait pas suivre soit même le dossier (pour avoir un double suivi)