### PR TITLE
(2/X) ETQ administrateur, je veux pouvoir modifier le lien URL de ma démarche sans avoir à la cloturer

### DIFF
--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -292,7 +292,7 @@ module Administrateurs
     end
 
     def check_path
-      path = params.permit(:path)[:path]
+      path = params[:path]
       @path_available = @procedure.path_available?(path)
       @other_procedure = @procedure.other_procedure_with_path(path)
 
@@ -307,12 +307,12 @@ module Administrateurs
     end
 
     def update_path
-      new_path = params.permit(:path)[:path]
+      new_path = params[:path]
       other_procedure = @procedure.other_procedure_with_path(new_path)
 
       if other_procedure.present? && !current_administrateur.owns?(other_procedure)
         flash.alert = "Cette URL de démarche n'est pas disponible"
-        return redirect_to admin_procedure_path_path(@procedure)
+        return redirect_to [:admin, @procedure, :path]
       end
 
       @procedure.claim_path(current_administrateur, new_path)

--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -285,7 +285,6 @@ module Administrateurs
         flash.alert = "La date limite de dépôt des dossiers doit être postérieure à la date du jour pour réactiver la procédure. #{view_context.link_to('Veuillez la modifier', edit_admin_procedure_path(@procedure))}"
         redirect_to admin_procedure_path(@procedure)
       else
-        @procedure.claim_path(current_administrateur, @procedure.suggested_path)
         @current_administrateur = current_administrateur
         @closed_procedures = current_administrateur.procedures.with_discarded.closes.map { |p| ["#{p.libelle} (#{p.id})", p.id] }.to_h
       end
@@ -315,7 +314,7 @@ module Administrateurs
         return redirect_to [:admin, @procedure, :path]
       end
 
-      @procedure.claim_path(current_administrateur, new_path)
+      @procedure.claim_path!(current_administrateur, new_path)
 
       if @procedure.save
         flash.notice = "L'URL de la démarche a bien été mise à jour"

--- a/app/controllers/api/public/v1/json_description_procedures_controller.rb
+++ b/app/controllers/api/public/v1/json_description_procedures_controller.rb
@@ -11,7 +11,7 @@ class API::Public::V1::JSONDescriptionProceduresController < API::Public::V1::Ba
   private
 
   def retrieve_procedure
-    @procedure = Procedure.publiees_ou_brouillons.opendata.find_by(path: params[:path])
+    @procedure = Procedure.publiees_ou_brouillons.opendata.find_with_path(params[:path]).first
     render_not_found("procedure", params[:path]) if @procedure.blank?
   end
 

--- a/app/controllers/concerns/procedure_context_concern.rb
+++ b/app/controllers/concerns/procedure_context_concern.rb
@@ -28,7 +28,7 @@ module ProcedureContextConcern
     uri = URI(get_stored_location_for(:user))
     path_components = uri.path.split('/')
 
-    Procedure.publiees_ou_brouillons.find_by(path: path_components[2])
+    Procedure.publiees_ou_brouillons.find_with_path(path_components[2]).first
   end
 
   def find_prefill_token_in_context

--- a/app/controllers/manager/procedure_paths_controller.rb
+++ b/app/controllers/manager/procedure_paths_controller.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Manager
+  class ProcedurePathsController < Manager::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes(action_name)).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-demo.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/prefill_descriptions_controller.rb
+++ b/app/controllers/prefill_descriptions_controller.rb
@@ -19,7 +19,7 @@ class PrefillDescriptionsController < ApplicationController
   private
 
   def retrieve_procedure
-    @procedure = Procedure.publiees_ou_brouillons.opendata.find_by!(path: params[:path])
+    @procedure = Procedure.publiees_ou_brouillons.opendata.find_with_path(params[:path]).first!
   end
 
   def set_prefill_description

--- a/app/controllers/prefill_type_de_champs_controller.rb
+++ b/app/controllers/prefill_type_de_champs_controller.rb
@@ -10,7 +10,7 @@ class PrefillTypeDeChampsController < ApplicationController
   private
 
   def retrieve_procedure
-    @procedure = Procedure.publiees_ou_brouillons.opendata.find_by!(path: params[:path])
+    @procedure = Procedure.publiees_ou_brouillons.opendata.find_with_path(params[:path]).first!
   end
 
   def set_prefill_type_de_champ

--- a/app/controllers/users/commencer_controller.rb
+++ b/app/controllers/users/commencer_controller.rb
@@ -20,6 +20,8 @@ module Users
 
       return procedure_not_found if @procedure.blank?
 
+      return redirect_to commencer_path(@procedure.path, **extra_query_params), status: :moved_permanently if @procedure.path && @procedure.path != params[:path]
+
       @revision = params[:test] ? @procedure.draft_revision : @procedure.active_revision
 
       if params[:prefill_token].present? || commencer_page_is_reloaded?

--- a/app/controllers/users/commencer_controller.rb
+++ b/app/controllers/users/commencer_controller.rb
@@ -90,7 +90,7 @@ module Users
     def nav_bar_profile = nav_bar_user_or_guest
 
     def closing_details
-      @procedure = Procedure.find_by(path: params[:path])
+      @procedure = Procedure.find_with_path(params[:path]).first
 
       return procedure_not_found if @procedure.blank?
 
@@ -114,11 +114,11 @@ module Users
     end
 
     def retrieve_procedure
-      Procedure.publiees.or(Procedure.brouillons).find_by(path: params[:path])
+      Procedure.publiees.or(Procedure.brouillons).find_with_path(params[:path]).first
     end
 
     def retrieve_procedure_with_closed
-      Procedure.publiees.or(Procedure.brouillons).or(Procedure.closes).order(published_at: :desc).find_by(path: params[:path])
+      Procedure.publiees.or(Procedure.brouillons).or(Procedure.closes).order(published_at: :desc).find_with_path(params[:path]).first
     end
 
     def build_prefilled_dossier
@@ -151,7 +151,7 @@ module Users
     end
 
     def procedure_not_found
-      procedure = Procedure.find_by(path: params[:path])
+      procedure = Procedure.find_with_path(params[:path]).first
 
       if procedure&.replaced_by_procedure
         redirect_to commencer_path(procedure.replaced_by_procedure.path, **extra_query_params)

--- a/app/controllers/users/statistiques_controller.rb
+++ b/app/controllers/users/statistiques_controller.rb
@@ -20,7 +20,7 @@ module Users
     private
 
     def procedure
-      Procedure.publiees_ou_closes.find_by(path: params[:path])
+      Procedure.publiees_ou_closes.find_with_path(params[:path]).first
     end
 
     def procedure_not_found

--- a/app/dashboards/procedure_dashboard.rb
+++ b/app/dashboards/procedure_dashboard.rb
@@ -13,6 +13,7 @@ class ProcedureDashboard < Administrate::BaseDashboard
     published_types_de_champ_public: TypesDeChampCollectionField,
     published_types_de_champ_private: TypesDeChampCollectionField,
     path: ProcedureLinkField,
+    procedure_paths: Field::HasMany,
     aasm_state: ProcedureStateField,
     dossiers: Field::HasMany,
     administrateurs: Field::HasMany,
@@ -78,6 +79,7 @@ class ProcedureDashboard < Administrate::BaseDashboard
   SHOW_PAGE_ATTRIBUTES = [
     :id,
     :path,
+    :procedure_paths,
     :aasm_state,
     :administrateurs,
     :instructeurs,

--- a/app/dashboards/procedure_path_dashboard.rb
+++ b/app/dashboards/procedure_path_dashboard.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "administrate/base_dashboard"
+
+class ProcedurePathDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    path: ProcedureLinkField,
+    procedure: Field::BelongsTo,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = [
+    :path,
+    :created_at
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = [
+    :id,
+    :path,
+    :procedure,
+    :created_at,
+    :updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = [
+    :path,
+    :procedure
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how procedure paths are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(procedure_path)
+  #   "ProcedurePath ##{procedure_path.id}"
+  # end
+end

--- a/app/models/concerns/procedure_path_concern.rb
+++ b/app/models/concerns/procedure_path_concern.rb
@@ -4,7 +4,7 @@ module ProcedurePathConcern
   extend ActiveSupport::Concern
 
   included do
-    has_many :procedure_paths, dependent: :destroy, autosave: true
+    has_many :procedure_paths, inverse_of: :procedure, dependent: :destroy, autosave: true
 
     after_initialize :ensure_path_exists
     before_validation :ensure_path_exists

--- a/app/models/concerns/procedure_path_concern.rb
+++ b/app/models/concerns/procedure_path_concern.rb
@@ -42,17 +42,13 @@ module ProcedurePathConcern
     end
 
     def claim_path!(administrateur, new_path)
-      claim_path(administrateur, new_path)
-      raise ActiveRecord::RecordInvalid if errors.any?
-    end
-
-    def claim_path(administrateur, new_path)
       return if new_path.blank?
 
       procedure_path = procedure_paths.find { _1.path == new_path } || ProcedurePath.find_or_initialize_by(path: new_path)
 
       if procedure_path.procedure.present? && !administrateur.owns?(procedure_path.procedure)
         errors.add(:path, :taken)
+        raise ActiveRecord::RecordInvalid
       end
 
       procedure_path.updated_at = Time.zone.now

--- a/app/models/concerns/procedure_path_concern.rb
+++ b/app/models/concerns/procedure_path_concern.rb
@@ -9,7 +9,10 @@ module ProcedurePathConcern
     # validates :path, presence: true, format: { with: /\A[a-z0-9_\-]{3,200}\z/ }, uniqueness: { scope: [:path, :closed_at, :hidden_at, :unpublished_at], case_sensitive: false }
 
     after_initialize :ensure_path_exists
-    before_save :ensure_path_exists
+    before_validation :ensure_path_exists
+
+    validates :procedure_paths, length: { minimum: 1 }
+
     scope :find_with_path, -> (path) { joins(:procedure_paths).where(procedure_paths: { path: }).limit(1) }
 
     def ensure_path_exists

--- a/app/models/concerns/procedure_path_concern.rb
+++ b/app/models/concerns/procedure_path_concern.rb
@@ -13,7 +13,11 @@ module ProcedurePathConcern
 
     validates :procedure_paths, length: { minimum: 1 }
 
-    scope :find_with_path, -> (path) { joins(:procedure_paths).where(procedure_paths: { path: path.downcase.strip }).limit(1) }
+    scope :find_with_path, -> (path) do
+      normalized_path = path.downcase.strip
+      joins(:procedure_paths).where(procedure_paths: { path: normalized_path }).or(where(path: normalized_path)).limit(1)
+      # TODO: remove the or(where(path: normalized_path)) when the migration is done
+    end
 
     def ensure_path_exists
       uuid = SecureRandom.uuid

--- a/app/models/concerns/procedure_path_concern.rb
+++ b/app/models/concerns/procedure_path_concern.rb
@@ -10,6 +10,7 @@ module ProcedurePathConcern
 
     after_initialize :ensure_path_exists
     before_save :ensure_path_exists
+    scope :find_with_path, -> (path) { joins(:procedure_paths).where(procedure_paths: { path: }).limit(1) }
 
     def ensure_path_exists
       if self.path.blank?
@@ -20,7 +21,7 @@ module ProcedurePathConcern
     def other_procedure_with_path(path)
       Procedure.publiees
         .where.not(id: self.id)
-        .find_by(path: path)
+        .find_with_path(path).first
     end
 
     def path

--- a/app/models/concerns/procedure_path_concern.rb
+++ b/app/models/concerns/procedure_path_concern.rb
@@ -15,7 +15,7 @@ module ProcedurePathConcern
 
     scope :find_with_path, -> (path) do
       normalized_path = path.downcase.strip
-      joins(:procedure_paths).where(procedure_paths: { path: normalized_path }).or(where(path: normalized_path)).limit(1)
+      left_joins(:procedure_paths).where(procedure_paths: { path: normalized_path }).or(where(path: normalized_path)).limit(1)
       # TODO: remove the or(where(path: normalized_path)) when the migration is done
     end
 

--- a/app/models/concerns/procedure_path_concern.rb
+++ b/app/models/concerns/procedure_path_concern.rb
@@ -13,7 +13,7 @@ module ProcedurePathConcern
 
     validates :procedure_paths, length: { minimum: 1 }
 
-    scope :find_with_path, -> (path) { joins(:procedure_paths).where(procedure_paths: { path: }).limit(1) }
+    scope :find_with_path, -> (path) { joins(:procedure_paths).where(procedure_paths: { path: path.downcase.strip }).limit(1) }
 
     def ensure_path_exists
       uuid = SecureRandom.uuid

--- a/app/models/concerns/procedure_path_concern.rb
+++ b/app/models/concerns/procedure_path_concern.rb
@@ -4,7 +4,9 @@ module ProcedurePathConcern
   extend ActiveSupport::Concern
 
   included do
-    validates :path, presence: true, format: { with: /\A[a-z0-9_\-]{3,200}\z/ }, uniqueness: { scope: [:path, :closed_at, :hidden_at, :unpublished_at], case_sensitive: false }
+    has_many :procedure_paths, dependent: :destroy, autosave: true
+
+    # validates :path, presence: true, format: { with: /\A[a-z0-9_\-]{3,200}\z/ }, uniqueness: { scope: [:path, :closed_at, :hidden_at, :unpublished_at], case_sensitive: false }
 
     after_initialize :ensure_path_exists
     before_save :ensure_path_exists

--- a/app/models/concerns/procedure_path_concern.rb
+++ b/app/models/concerns/procedure_path_concern.rb
@@ -60,6 +60,10 @@ module ProcedurePathConcern
       other_procedure_with_path(path).blank?
     end
 
+    def previous_paths
+      procedure_paths.reject { |path| path.path == self.path || path.uuid_path? }
+    end
+
     def path_customized?
       !path.match?(/[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}/)
     end

--- a/app/models/concerns/procedure_path_concern.rb
+++ b/app/models/concerns/procedure_path_concern.rb
@@ -44,12 +44,14 @@ module ProcedurePathConcern
     def claim_path!(administrateur, new_path)
       return if new_path.blank?
 
-      procedure_path = procedure_paths.find { _1.path == new_path } || ProcedurePath.find_or_initialize_by(path: new_path)
+      other_procedure = other_procedure_with_path(new_path)
 
-      if procedure_path.procedure.present? && !administrateur.owns?(procedure_path.procedure)
+      if other_procedure.present? && !administrateur.owns?(other_procedure)
         errors.add(:path, :taken)
         raise ActiveRecord::RecordInvalid
       end
+
+      procedure_path = procedure_paths.find { _1.path == new_path } || ProcedurePath.find_or_initialize_by(path: new_path)
 
       procedure_path.updated_at = Time.zone.now
 

--- a/app/models/concerns/procedure_path_concern.rb
+++ b/app/models/concerns/procedure_path_concern.rb
@@ -23,6 +23,14 @@ module ProcedurePathConcern
         .find_by(path: path)
     end
 
+    def path
+      canonical_path || super
+    end
+
+    def canonical_path
+      procedure_paths.by_updated_at.first&.path
+    end
+
     def path_available?(path)
       other_procedure_with_path(path).blank?
     end

--- a/app/models/concerns/procedure_path_concern.rb
+++ b/app/models/concerns/procedure_path_concern.rb
@@ -16,13 +16,17 @@ module ProcedurePathConcern
     scope :find_with_path, -> (path) { joins(:procedure_paths).where(procedure_paths: { path: }).limit(1) }
 
     def ensure_path_exists
+      uuid = SecureRandom.uuid
       if self.path.blank?
-        self.path = SecureRandom.uuid
+        self.path = uuid
+      end
+      if self.procedure_paths.empty?
+        self.procedure_paths.build(path: uuid)
       end
     end
 
     def other_procedure_with_path(path)
-      Procedure.publiees
+      Procedure
         .where.not(id: self.id)
         .find_with_path(path).first
     end

--- a/app/models/concerns/procedure_path_concern.rb
+++ b/app/models/concerns/procedure_path_concern.rb
@@ -6,8 +6,6 @@ module ProcedurePathConcern
   included do
     has_many :procedure_paths, dependent: :destroy, autosave: true
 
-    # validates :path, presence: true, format: { with: /\A[a-z0-9_\-]{3,200}\z/ }, uniqueness: { scope: [:path, :closed_at, :hidden_at, :unpublished_at], case_sensitive: false }
-
     after_initialize :ensure_path_exists
     before_validation :ensure_path_exists
 

--- a/app/models/concerns/procedure_publish_concern.rb
+++ b/app/models/concerns/procedure_publish_concern.rb
@@ -10,8 +10,10 @@ module ProcedurePublishConcern
       end
 
       other_procedure = other_procedure_with_path(path)
-      if other_procedure.present? && administrateur.owns?(other_procedure)
-        other_procedure.unpublish!
+      claim_path!(administrateur, path)
+      if other_procedure.present?
+        other_procedure.unpublish! if other_procedure.may_unpublish?
+
         publish!(other_procedure.canonical_procedure || other_procedure)
       else
         publish!
@@ -57,6 +59,7 @@ module ProcedurePublishConcern
 
   def after_publish(canonical_procedure = nil)
     self.canonical_procedure = canonical_procedure
+
     touch(:published_at)
     publish_new_revision
   end

--- a/app/models/concerns/procedure_publish_concern.rb
+++ b/app/models/concerns/procedure_publish_concern.rb
@@ -3,7 +3,7 @@
 module ProcedurePublishConcern
   extend ActiveSupport::Concern
 
-  def publish_or_reopen!(administrateur)
+  def publish_or_reopen!(administrateur, path)
     Procedure.transaction do
       if brouillon?
         reset!

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -431,7 +431,7 @@ class Procedure < ApplicationRecord
     procedure = self.deep_clone(include: include_list) do |original, kopy|
       ClonePiecesJustificativesService.clone_attachments(original, kopy)
     end
-    procedure.path = SecureRandom.uuid
+    procedure.claim_path(admin, SecureRandom.uuid)
     procedure.aasm_state = :brouillon
     procedure.closed_at = nil
     procedure.unpublished_at = nil

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -431,7 +431,7 @@ class Procedure < ApplicationRecord
     procedure = self.deep_clone(include: include_list) do |original, kopy|
       ClonePiecesJustificativesService.clone_attachments(original, kopy)
     end
-    procedure.claim_path(admin, SecureRandom.uuid)
+    procedure.claim_path!(admin, SecureRandom.uuid)
     procedure.aasm_state = :brouillon
     procedure.closed_at = nil
     procedure.unpublished_at = nil

--- a/app/models/procedure_path.rb
+++ b/app/models/procedure_path.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class ProcedurePath < ApplicationRecord
+  belongs_to :procedure
+
+  before_destroy :ensure_one_path, :ensure_is_customized
+
+  validates :path, presence: true, format: { with: /\A[a-z0-9_\-]{3,200}\z/ }, uniqueness: { case_sensitive: false }
+
+  scope :by_updated_at, -> { order(updated_at: :desc) }
+
+  def ensure_one_path
+    return if procedure.procedure_paths.count > 1 || destroyed_by_association
+
+    errors.add(:base, :at_least_one_path)
+    throw(:abort)
+  end
+
+  def ensure_is_customized
+    return if !uuid_path? || destroyed_by_association
+
+    errors.add(:base, :cannot_delete_customized_path)
+    throw(:abort)
+  end
+
+  def uuid_path?
+    path.match?(/[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}/)
+  end
+end

--- a/app/tasks/maintenance/migrate_existing_procedure_paths_task.rb
+++ b/app/tasks/maintenance/migrate_existing_procedure_paths_task.rb
@@ -2,6 +2,10 @@
 
 module Maintenance
   class MigrateExistingProcedurePathsTask < MaintenanceTasks::Task
+    include RunnableOnDeployConcern
+
+    run_on_first_deploy
+
     def collection
       Procedure.all
     end

--- a/app/tasks/maintenance/migrate_existing_procedure_paths_task.rb
+++ b/app/tasks/maintenance/migrate_existing_procedure_paths_task.rb
@@ -11,7 +11,7 @@ module Maintenance
     end
 
     def process(element)
-      element.save!
+      element.save!(validate: false)
 
       if element.publiee?
         element.procedure_paths << ProcedurePath.find_or_create_by(path: element[:path])
@@ -20,7 +20,7 @@ module Maintenance
           element.procedure_paths << ProcedurePath.find_or_create_by(path: element[:path])
         end
       end
-      element.save!
+      element.save!(validate: false)
     end
   end
 end

--- a/app/tasks/maintenance/migrate_existing_procedure_paths_task.rb
+++ b/app/tasks/maintenance/migrate_existing_procedure_paths_task.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class MigrateExistingProcedurePathsTask < MaintenanceTasks::Task
+    def collection
+      Procedure.all
+    end
+
+    def process(element)
+      if element.publiee?
+        element.procedure_paths << ProcedurePath.find_or_create_by(path: element[:path])
+      else
+        if Procedure.publiees.exists?(path: element[:path]) # the path is already used by another published procedure
+          element.procedure_paths << ProcedurePath.new(path: SecureRandom.uuid)
+        else # the path is not used by another published procedure
+          element.procedure_paths << ProcedurePath.find_or_create_by(path: element[:path])
+        end
+      end
+      element.save!
+    end
+  end
+end

--- a/app/tasks/maintenance/migrate_existing_procedure_paths_task.rb
+++ b/app/tasks/maintenance/migrate_existing_procedure_paths_task.rb
@@ -7,12 +7,12 @@ module Maintenance
     end
 
     def process(element)
+      element.save!
+
       if element.publiee?
         element.procedure_paths << ProcedurePath.find_or_create_by(path: element[:path])
       else
-        if Procedure.publiees.exists?(path: element[:path]) # the path is already used by another published procedure
-          element.procedure_paths << ProcedurePath.new(path: SecureRandom.uuid)
-        else # the path is not used by another published procedure
+        if !Procedure.publiees.exists?(path: element[:path]) # the path is not used by another published procedure
           element.procedure_paths << ProcedurePath.find_or_create_by(path: element[:path])
         end
       end

--- a/app/views/administrateurs/_breadcrumbs.html.haml
+++ b/app/views/administrateurs/_breadcrumbs.html.haml
@@ -27,6 +27,9 @@
 
         - elsif @procedure.locked?
           = link_to commencer_url(@procedure.path), commencer_url(@procedure.path), class: "fr-link"
+
+          = link_to "", admin_procedure_path_path(@procedure), class: "fr-btn fr-icon-pencil-line fr-btn--sm fr-btn--tertiary-no-outline", "aria-label": t('edit_path', scope: [:layouts, :breadcrumb]), title: t('edit_path', scope: [:layouts, :breadcrumb])
+
           .flex.fr-mt-1w
 
             - if @procedure.api_entreprise_token_expired_or_expires_soon?

--- a/app/views/administrateurs/procedures/_publication_form_inputs.html.haml
+++ b/app/views/administrateurs/procedures/_publication_form_inputs.html.haml
@@ -9,7 +9,7 @@
     .flex
       %span.placeholder
         = commencer_url(path: '')
-      = text_field_tag(:path, procedure.path,
+      = text_field_tag(:path, procedure.suggested_path,
                       id: 'procedure_path',
                       placeholder: t('activerecord.attributes.procedure.procedure_path_placeholder'),
                       required: true,

--- a/app/views/administrateurs/procedures/path.html.haml
+++ b/app/views/administrateurs/procedures/path.html.haml
@@ -1,0 +1,30 @@
+= render partial: 'administrateurs/breadcrumbs',
+  locals: { steps: [['Démarches', admin_procedures_back_path(@procedure)],
+                    [@procedure.libelle.truncate_words(10), admin_procedure_path(@procedure)],
+                    ['Lien de la démarche']] }
+
+.fr-container
+  %h1.fr-h2 Lien de la démarche
+
+= form_with url: admin_procedure_update_path_url(@procedure), method: :patch do |f|
+  .fr-container
+    = render Dsfr::AlertComponent.new(state: :info, size: :sm, extra_class_names: 'fr-mb-2w') do |c|
+      - c.with_body do
+        %p
+          Si vous avez communiqué le lien de votre démarche à des usagers et que vous souhaitez le modifier, pensez à leur communiquer le nouveau lien.
+
+    .fr-input
+      .flex
+        %span.placeholder
+          = commencer_url(path: '')
+        = text_field_tag(:path, @procedure.path,
+                        id: 'procedure_path',
+                        placeholder: t('activerecord.attributes.procedure.procedure_path_placeholder'),
+                        required: true,
+                        class: 'unstyled flex-1',
+                        pattern: '[a-z0-9.\-_]{3,200}',
+                        autocomplete: 'off',
+                        data: { controller: 'turbo-input', turbo_input_url_value: admin_procedure_check_path_path })
+    #check_path
+
+  = render Procedure::FixedFooterComponent.new(procedure: @procedure, form: f)

--- a/app/views/administrateurs/procedures/path.html.haml
+++ b/app/views/administrateurs/procedures/path.html.haml
@@ -33,4 +33,13 @@
                           data: { controller: 'turbo-input', turbo_input_url_value: admin_procedure_check_path_path })
     #check_path
 
+    - if @procedure.previous_paths.any?
+      .fr-mt-2w
+        %p.fr-text--sm.fr-mb-1w
+          Pour information les liens précédents resteront accessibles tant qu'ils ne sont pas utilisés par une autre de vos démarches :
+        %ul
+          - @procedure.previous_paths.each do |path|
+            %li.fr-mb-1w
+              = link_to commencer_url(path: path.path), commencer_url(path: path.path), class: 'fr-link fr-link--sm'
+
   = render Procedure::FixedFooterComponent.new(procedure: @procedure, form: f)

--- a/app/views/administrateurs/procedures/path.html.haml
+++ b/app/views/administrateurs/procedures/path.html.haml
@@ -11,20 +11,26 @@
     = render Dsfr::AlertComponent.new(state: :info, size: :sm, extra_class_names: 'fr-mb-2w') do |c|
       - c.with_body do
         %p
-          Si vous avez communiqué le lien de votre démarche à des usagers et que vous souhaitez le modifier, pensez à leur communiquer le nouveau lien.
+          Si vous avez communiqué le lien de votre démarche à des usagers et que vous souhaitez le modifier, les anciens liens resteront accessibles.
 
-    .fr-input
-      .flex
-        %span.placeholder
-          = commencer_url(path: '')
-        = text_field_tag(:path, @procedure.path,
-                        id: 'procedure_path',
-                        placeholder: t('activerecord.attributes.procedure.procedure_path_placeholder'),
-                        required: true,
-                        class: 'unstyled flex-1',
-                        pattern: '[a-z0-9.\-_]{3,200}',
-                        autocomplete: 'off',
-                        data: { controller: 'turbo-input', turbo_input_url_value: admin_procedure_check_path_path })
+    .fr-input-group
+      = label_tag :procedure_path, class: 'fr-label' do
+        = t('activerecord.attributes.procedure.procedure_path')
+
+        %span.fr-hint-text
+          = t('activerecord.attributes.procedure.hints.procedure_path')
+      .fr-input
+        .flex
+          %span.placeholder
+            = commencer_url(path: '')
+          = text_field_tag(:path, @procedure.path,
+                          id: 'procedure_path',
+                          placeholder: t('activerecord.attributes.procedure.procedure_path_placeholder'),
+                          required: true,
+                          class: 'unstyled flex-1',
+                          pattern: '[a-z0-9.\-_]{3,200}',
+                          autocomplete: 'off',
+                          data: { controller: 'turbo-input', turbo_input_url_value: admin_procedure_check_path_path })
     #check_path
 
   = render Procedure::FixedFooterComponent.new(procedure: @procedure, form: f)

--- a/app/views/fields/procedure_link_field/_index.html.haml
+++ b/app/views/fields/procedure_link_field/_index.html.haml
@@ -1,0 +1,4 @@
+- if field.data.present?
+  = link_to commencer_path(field.resource.path), commencer_path(field.resource.path), target: '_blank', rel: 'noopener'
+- else
+  Plus en ligne

--- a/config/locales/models/procedure/en.yml
+++ b/config/locales/models/procedure/en.yml
@@ -66,6 +66,8 @@ en:
         aasm_state: Status
         admin_count: Administrators count
         template: Is a template
+      procedure/procedure_paths:
+        path: Public link
     errors:
       models:
         procedure:

--- a/config/locales/models/procedure/fr.yml
+++ b/config/locales/models/procedure/fr.yml
@@ -72,6 +72,8 @@ fr:
         aasm_state: 'Statut'
         admin_count: 'Nb administrateurs'
         template: 'Est un modèle'
+      procedure/procedure_paths:
+        path: 'Lien public'
     errors:
       models:
         procedure:

--- a/config/locales/views/administrateurs/procedures/en.yml
+++ b/config/locales/views/administrateurs/procedures/en.yml
@@ -75,7 +75,7 @@ en:
       technical_issues: "Issues are affecting the proper functioning of the process"
       check_path:
         path_not_available:
-          owner: This URL is identical to another of your published procedures. If you publish this procedure, the old one will be unpublished and will no longer be accessible to the public.
+          owner: This URL is identical to another of your published procedures. If you publish this procedure, the URL will no longer point to the old procedure.
           not_owner: This URL is identical to another procedure, you must modify it.
       unpublished_changes_sticky_header:
         intro_html: Changes made will only be visible <strong>after the next publication</strong>

--- a/config/locales/views/administrateurs/procedures/fr.yml
+++ b/config/locales/views/administrateurs/procedures/fr.yml
@@ -75,7 +75,7 @@ fr:
       technical_issues: Des problèmes impactent le bon fonctionnement de la démarche
       check_path:
         path_not_available:
-          owner: Cette url est identique à celle d’une autre de vos démarches publiées. Si vous publiez cette démarche, l’ancienne sera dépubliée et ne sera plus accessible au public.
+          owner: Cette url est identique à celle d’une autre de vos démarches publiées. Si vous publiez cette démarche, le lien ne pointera plus sur l'ancienne démarche.
           not_owner: Cette url est identique à celle d’une autre démarche, vous devez la modifier afin de pouvoir publier votre démarche.
       unpublished_changes_sticky_header:
         intro_html: Les modifications effectuées ne seront visibles <strong>qu'à la prochaine publication</strong>

--- a/config/locales/views/layouts/_breadcrumb.en.yml
+++ b/config/locales/views/layouts/_breadcrumb.en.yml
@@ -1,20 +1,21 @@
 en:
   layouts:
     breadcrumb:
-      root: "Home - List of procedures"
-      you_are_here: "You are here"
+      root: 'Home - List of procedures'
+      you_are_here: 'You are here'
       show: Show breadcrumb
-      preview: "Preview the form"
-      preview_annotations: "Preview annotations"
-      continue_annotations: "Validate annotations"
-      since: "since %{date}"
-      closed: "Closed"
-      published: "Published"
-      draft: "Draft"
-      to_modify: "To modify"
-      more_info_on_test: "For more information on test stage"
-      go_to_FAQ: "read FAQ"
-      url_FAQ: "/faq#accordion-administrateur-2"
+      preview: 'Preview the form'
+      preview_annotations: 'Preview annotations'
+      continue_annotations: 'Validate annotations'
+      since: 'since %{date}'
+      closed: 'Closed'
+      published: 'Published'
+      draft: 'Draft'
+      to_modify: 'To modify'
+      more_info_on_test: 'For more information on test stage'
+      go_to_FAQ: 'read FAQ'
+      url_FAQ: '/faq#accordion-administrateur-2'
       faq: Frequently Asked Questions
-      show_dossier: "File nº %{dossier_id} – %{owner_name}"
+      show_dossier: 'File nº %{dossier_id} – %{owner_name}'
       show_procedure: '%{libelle} – Files'
+      edit_path: Edit procedure link

--- a/config/locales/views/layouts/_breadcrumb.fr.yml
+++ b/config/locales/views/layouts/_breadcrumb.fr.yml
@@ -1,20 +1,21 @@
 fr:
   layouts:
     breadcrumb:
-      root: "Accueil - Liste des démarches"
-      you_are_here: "Vous êtes ici"
-      show: "Voir le fil d’Ariane"
-      preview: "Prévisualiser le formulaire"
-      preview_annotations: "Prévisualiser les annotations"
-      continue_annotations: "Valider les annotations"
-      since: "depuis le %{date}"
-      closed: "Close"
-      published: "Publiée"
-      draft: "En test"
-      to_modify: "À modifier"
-      more_info_on_test: "Pour plus d’information sur la phase de test"
-      go_to_FAQ: "consulter la FAQ"
-      url_FAQ: "/faq#accordion-administrateur-2"
+      root: 'Accueil - Liste des démarches'
+      you_are_here: 'Vous êtes ici'
+      show: 'Voir le fil d’Ariane'
+      preview: 'Prévisualiser le formulaire'
+      preview_annotations: 'Prévisualiser les annotations'
+      continue_annotations: 'Valider les annotations'
+      since: 'depuis le %{date}'
+      closed: 'Close'
+      published: 'Publiée'
+      draft: 'En test'
+      to_modify: 'À modifier'
+      more_info_on_test: 'Pour plus d’information sur la phase de test'
+      go_to_FAQ: 'consulter la FAQ'
+      url_FAQ: '/faq#accordion-administrateur-2'
       faq: Foire aux Questions
-      show_dossier: "Dossier nº %{dossier_id} – %{owner_name}"
+      show_dossier: 'Dossier nº %{dossier_id} – %{owner_name}'
       show_procedure: '%{libelle} – Suivi des dossiers'
+      edit_path: Modifier le lien de la démarche

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -675,6 +675,8 @@ Rails.application.routes.draw do
       put 'archive'
       get 'publication' => 'procedures#publication', as: :publication
       get 'check_path' => 'procedures#check_path', as: :check_path
+      get 'path'
+      patch 'path', to: 'procedures#update_path', as: :update_path
       put 'publish' => 'procedures#publish', as: :publish
       put 'reset_draft' => 'procedures#reset_draft', as: :reset_draft
       put 'publish_revision' => 'procedures#publish_revision', as: :publish_revision

--- a/db/migrate/20241003105247_create_procedure_paths.rb
+++ b/db/migrate/20241003105247_create_procedure_paths.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateProcedurePaths < ActiveRecord::Migration[7.0]
+  def change
+    create_table :procedure_paths do |t|
+      t.string :path
+      t.references :procedure, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :procedure_paths, :path, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -908,6 +908,15 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_27_093613) do
     t.index ["from"], name: "index_path_rewrites_on_from", unique: true
   end
 
+  create_table "procedure_paths", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "path"
+    t.bigint "procedure_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["path"], name: "index_procedure_paths_on_path", unique: true
+    t.index ["procedure_id"], name: "index_procedure_paths_on_procedure_id"
+  end
+
   create_table "procedure_presentations", id: :serial, force: :cascade do |t|
     t.jsonb "a_suivre_filters", default: [], null: false, array: true
     t.jsonb "archives_filters", default: [], null: false, array: true
@@ -1369,6 +1378,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_27_093613) do
   add_foreign_key "instructeurs_procedures", "procedures"
   add_foreign_key "labels", "procedures"
   add_foreign_key "merge_logs", "users"
+  add_foreign_key "procedure_paths", "procedures"
   add_foreign_key "procedure_presentations", "assign_tos"
   add_foreign_key "procedure_revision_types_de_champ", "procedure_revision_types_de_champ", column: "parent_id"
   add_foreign_key "procedure_revision_types_de_champ", "procedure_revisions", column: "revision_id"

--- a/spec/controllers/users/commencer_controller_spec.rb
+++ b/spec/controllers/users/commencer_controller_spec.rb
@@ -32,6 +32,23 @@ describe Users::CommencerController, type: :controller do
       end
     end
 
+    context 'when there is an old path' do
+      let!(:old_path) do
+        travel_to(1.day.ago) do
+          create(:procedure_path, procedure: published_procedure, path: 'old_path')
+        end
+      end
+
+      let!(:new_path) { create(:procedure_path, procedure: published_procedure, path: 'new_path') }
+
+      let(:path) { old_path.path }
+
+      it 'redirects to the new path' do
+        expect(subject.status).to eq(301)
+        expect(subject).to redirect_to(commencer_path(path: new_path.path))
+      end
+    end
+
     context 'when the path is for a draft procedure' do
       let(:path) { draft_procedure.path }
 

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -72,7 +72,7 @@ FactoryBot.define do
     end
 
     after(:create) do |procedure, evaluator|
-      procedure.claim_path(evaluator.administrateur, evaluator.path)
+      procedure.claim_path!(evaluator.administrateur, evaluator.path)
       evaluator.instructeurs.each { |i| i.assign_to_procedure(procedure) }
 
       if evaluator.updated_at

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -14,7 +14,6 @@ FactoryBot.define do
     estimated_duration_visible { true }
     ask_birthday { false }
     lien_site_web { "https://mon-site.gouv" }
-    path { SecureRandom.uuid }
     declarative_with_state { nil }
     sva_svr { {} }
 
@@ -32,9 +31,12 @@ FactoryBot.define do
       types_de_champ_private { [] }
       updated_at { nil }
       dossier_submitted_message { nil }
+      path { nil }
     end
 
     after(:build) do |procedure, evaluator|
+      procedure[:path] = SecureRandom.uuid # temporary to avoid errors (to be removed)
+
       procedure.defaut_groupe_instructeur = procedure.groupe_instructeurs.first
       initial_revision = build(:procedure_revision, procedure: procedure, dossier_submitted_message: evaluator.dossier_submitted_message)
 
@@ -70,6 +72,7 @@ FactoryBot.define do
     end
 
     after(:create) do |procedure, evaluator|
+      procedure.claim_path(evaluator.administrateur, evaluator.path)
       evaluator.instructeurs.each { |i| i.assign_to_procedure(procedure) }
 
       if evaluator.updated_at

--- a/spec/factories/procedure_path.rb
+++ b/spec/factories/procedure_path.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  sequence(:procedure_path) { |n| "fake_path#{n}" }
+
+  factory :procedure_path do
+    path { generate(:procedure_path) }
+  end
+end

--- a/spec/models/concerns/procedure_path_concern_spec.rb
+++ b/spec/models/concerns/procedure_path_concern_spec.rb
@@ -146,4 +146,19 @@ describe ProcedurePathConcern do
 
     # test if the procedure path is owned by another administrateur
   end
+
+  describe '#previous_paths' do
+    let(:procedure) { create(:procedure) }
+
+    context 'when the path has been changed twice' do
+      before do
+        procedure.claim_path!(procedure.administrateurs.first, 'custom_path')
+        procedure.claim_path!(procedure.administrateurs.first, 'custom_path_2')
+      end
+
+      it "should only contain the paths that are not the current one nor the uuid" do
+        expect(procedure.previous_paths.map(&:path)).to eq(['custom_path'])
+      end
+    end
+  end
 end

--- a/spec/models/concerns/procedure_path_concern_spec.rb
+++ b/spec/models/concerns/procedure_path_concern_spec.rb
@@ -47,6 +47,20 @@ describe ProcedurePathConcern do
         expect(result).to be_nil
       end
     end
+
+    context "when the migration is pending" do
+      context "a procedure with the given path exists (but the path is not in the procedure_paths table)" do
+        let!(:procedure) { create(:procedure) }
+
+        before do
+          procedure.update_column("path", "path-not-in-procedure-paths")
+        end
+
+        it "returns the procedure" do
+          expect(Procedure.find_with_path("path-not-in-procedure-paths").first).to eq(procedure)
+        end
+      end
+    end
   end
 
   describe 'path_customized?' do

--- a/spec/models/concerns/procedure_path_concern_spec.rb
+++ b/spec/models/concerns/procedure_path_concern_spec.rb
@@ -1,6 +1,45 @@
 # frozen_string_literal: true
 
 describe ProcedurePathConcern do
+  describe ".find_with_path" do
+    let!(:procedure1) { create(:procedure) }
+
+    let!(:procedure_path1) { procedure1.procedure_paths.create(path: "test-path-1") }
+
+    context "when a procedure with the given path exists" do
+      it "returns the procedure with the matching path" do
+        result = Procedure.find_with_path("test-path-1").first
+
+        expect(result).to eq(procedure1)
+      end
+    end
+
+    context "when no procedure with the given path exists" do
+      it "returns an empty result" do
+        result = Procedure.find_with_path("unknown-path").first
+
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  describe 'path_customized?' do
+    let(:procedure) { create :procedure }
+
+    subject { procedure.path_customized? }
+
+    context 'when the path is still the default' do
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when the path has been changed' do
+      before { procedure.claim_path!(procedure.administrateurs.first, 'custom_path') }
+
+      it { expect(procedure.path).to eq('custom_path') }
+      it { is_expected.to be_truthy }
+    end
+  end
+
   describe '#canonical_path' do
     let!(:procedure) do
       travel_to(3.days.ago) do

--- a/spec/models/concerns/procedure_path_concern_spec.rb
+++ b/spec/models/concerns/procedure_path_concern_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+describe ProcedurePathConcern do
+  describe '#canonical_path' do
+    let!(:procedure) do
+      travel_to(3.days.ago) do
+        create(:procedure)
+      end
+    end
+
+    before do
+      travel_to(2.days.ago) do
+        create(:procedure_path,
+          procedure: procedure,
+          path: 'older-path')
+      end
+
+      travel_to(1.day.ago) do
+        create(:procedure_path,
+          procedure: procedure,
+          path: 'newer-path')
+      end
+
+      travel_to(10.days.ago) do
+        create(:procedure_path,
+          procedure: procedure,
+          path: 'other-path')
+      end
+    end
+
+    it 'returns the path of the most recently updated procedure_path' do
+      expect(procedure.canonical_path).to eq('newer-path')
+    end
+  end
+end

--- a/spec/models/concerns/procedure_path_concern_spec.rb
+++ b/spec/models/concerns/procedure_path_concern_spec.rb
@@ -89,4 +89,21 @@ describe ProcedurePathConcern do
       expect(procedure.canonical_path).to eq('newer-path')
     end
   end
+
+  describe "#claim_path" do
+    let!(:procedure) { create(:procedure) }
+    let!(:procedure_2) { create(:procedure) }
+    let!(:procedure_path) { create(:procedure_path, procedure: procedure, path: "test-path") }
+    let!(:procedure_path_2) { create(:procedure_path, procedure: procedure_2, path: "test-path-2") }
+    let(:administrateur) { procedure.administrateurs.first }
+
+    subject do
+      procedure.claim_path(administrateur, procedure_path_2.path)
+      procedure.save!
+    end
+
+    it "assigns the procedure to the procedure_path" do
+      expect { subject }.to change { procedure_path_2.reload.procedure }.from(procedure_2).to(procedure)
+    end
+  end
 end

--- a/spec/models/concerns/procedure_path_concern_spec.rb
+++ b/spec/models/concerns/procedure_path_concern_spec.rb
@@ -54,9 +54,11 @@ describe ProcedurePathConcern do
 
         before do
           procedure.update_column("path", "path-not-in-procedure-paths")
+          procedure.procedure_paths.delete_all
         end
 
         it "returns the procedure" do
+          expect(procedure.procedure_paths.count).to eq(0)
           expect(Procedure.find_with_path("path-not-in-procedure-paths").first).to eq(procedure)
         end
       end

--- a/spec/models/concerns/procedure_path_concern_spec.rb
+++ b/spec/models/concerns/procedure_path_concern_spec.rb
@@ -30,6 +30,14 @@ describe ProcedurePathConcern do
 
         expect(result).to eq(procedure1)
       end
+
+      context "when the path is in uppercase or has trailing spaces" do
+        it "returns the procedure with the matching path" do
+          result = Procedure.find_with_path("TEST-PATH-1 ").first
+
+          expect(result).to eq(procedure1)
+        end
+      end
     end
 
     context "when no procedure with the given path exists" do

--- a/spec/models/concerns/procedure_path_concern_spec.rb
+++ b/spec/models/concerns/procedure_path_concern_spec.rb
@@ -1,6 +1,24 @@
 # frozen_string_literal: true
 
 describe ProcedurePathConcern do
+  describe "#destroy" do
+    let!(:procedure) { create(:procedure) }
+
+    context "when there is only one procedure_path (the uuid)" do
+      it do
+        procedure_path = procedure.procedure_paths.first
+        expect { procedure_path.destroy }.not_to change { procedure.procedure_paths.count }
+        expect { procedure_path.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
+      end
+    end
+
+    context "when there is more than one procedure_path" do
+      let!(:procedure_path1) { procedure.procedure_paths.create(path: "path1") }
+
+      it { expect { procedure_path1.destroy }.to change { procedure.procedure_paths.count }.from(2).to(1) }
+    end
+  end
+
   describe ".find_with_path" do
     let!(:procedure1) { create(:procedure) }
 

--- a/spec/models/procedure_path_spec.rb
+++ b/spec/models/procedure_path_spec.rb
@@ -17,4 +17,40 @@ RSpec.describe ProcedurePath, type: :model do
       end
     end
   end
+
+  describe '#destroy' do
+    let(:procedure) { create(:procedure) }
+
+    context 'when it is the only path' do
+      it 'prevents destruction' do
+        expect { procedure.procedure_paths.first.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
+        expect { procedure.procedure_paths.first.destroy }.not_to change(ProcedurePath, :count).from(1)
+      end
+    end
+
+    context 'when there are multiple paths' do
+      let!(:procedure_path1) { create(:procedure_path, procedure: procedure) }
+
+      it 'allows destruction' do
+        expect { procedure_path1.destroy }.to change(ProcedurePath, :count).from(2).to(1)
+      end
+    end
+
+    context 'when path is a UUID' do
+      let(:procedure_path) { create(:procedure_path, procedure: procedure, path: '123e4567-e89b-12d3-a456-426614174000') }
+
+      it 'prevents destruction' do
+        expect { procedure_path.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
+        expect { procedure_path.destroy }.not_to change(ProcedurePath, :count)
+      end
+    end
+
+    context 'when destroyed by association' do
+      let!(:procedure_path) { create(:procedure_path, procedure: procedure, path: '123e4567-e89b-12d3-a456-426614174000') }
+
+      it 'allows destruction' do
+        expect { procedure.destroy }.to change(ProcedurePath, :count).from(2).to(0)
+      end
+    end
+  end
 end

--- a/spec/models/procedure_path_spec.rb
+++ b/spec/models/procedure_path_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe ProcedurePath, type: :model do
+  describe '#uuid_path?' do
+    it 'returns true for valid UUID format paths' do
+      procedure_path = build(:procedure_path, path: '123e4567-e89b-12d3-a456-426614174000')
+      expect(procedure_path.uuid_path?).to be true
+    end
+
+    it 'returns false for non-UUID format paths' do
+      [
+        'ma-super-demarche',
+        'demarch-2024'
+      ].each do |path|
+        procedure_path = build(:procedure_path, path: path)
+        expect(procedure_path.uuid_path?).to be false
+      end
+    end
+  end
+end

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -1341,7 +1341,7 @@ describe Procedure do
     end
 
     context 'when the path has been changed' do
-      before { procedure.path = 'custom_path' }
+      before { procedure.claim_path(procedure.administrateurs.first, 'custom_path') }
 
       it { is_expected.to be_truthy }
     end
@@ -1367,7 +1367,7 @@ describe Procedure do
     subject { procedure.suggested_path }
 
     context 'when the path has been customized' do
-      before { procedure.path = 'custom_path' }
+      let(:path) { 'custom_path' }
 
       it { is_expected.to eq 'custom_path' }
     end

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -1002,8 +1002,8 @@ describe Procedure do
       it 'changes the procedure state to published' do
         expect(procedure.closed_at).to be_nil
         expect(procedure.published_at).to eq(now)
-        expect(Procedure.find_by(path: "example-path")).to eq(procedure)
-        expect(Procedure.find_by(path: "example-path").administrateurs).to eq(procedure.administrateurs)
+        expect(Procedure.find_with_path("example-path").first).to eq(procedure)
+        expect(Procedure.find_with_path("example-path").first.administrateurs).to eq(procedure.administrateurs)
       end
 
       it 'creates a new draft revision' do

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -1079,7 +1079,7 @@ describe Procedure do
 
       before do
         parent_procedure.update!(canonical_procedure: canonical_procedure)
-        parent_procedure.claim_path(administrateur, canonical_path)
+        parent_procedure.claim_path!(administrateur, canonical_path)
         Timecop.freeze(now) do
           procedure.publish_or_reopen!(administrateur, canonical_path)
         end
@@ -1337,22 +1337,6 @@ describe Procedure do
       expect(procedure.draft_revision).not_to be_nil
       expect(procedure.revisions.count).to eq(2)
       expect(procedure.revisions).to eq([procedure.published_revision, procedure.draft_revision])
-    end
-  end
-
-  describe 'path_customized?' do
-    let(:procedure) { create :procedure }
-
-    subject { procedure.path_customized? }
-
-    context 'when the path is still the default' do
-      it { is_expected.to be_falsey }
-    end
-
-    context 'when the path has been changed' do
-      before { procedure.claim_path(procedure.administrateurs.first, 'custom_path') }
-
-      it { is_expected.to be_truthy }
     end
   end
 

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -1133,6 +1133,20 @@ describe Procedure do
       it 'raises an error' do
         expect { procedure.publish_or_reopen!(administrateur, other_procedure.path) }.to raise_error(ActiveRecord::RecordInvalid)
       end
+
+      context "before maintenance task" do
+        let(:other_procedure) do
+          p = create(:procedure, :published, administrateurs: [create(:administrateur)])
+          p.update_column(:path, 'other-path')
+          p.procedure_paths.delete_all
+          p
+        end
+
+        it 'raises an error' do
+          expect { procedure.publish_or_reopen!(administrateur, other_procedure.path) }.to raise_error(ActiveRecord::RecordInvalid)
+          expect(procedure.canonical_path).not_to eq(other_procedure.path)
+        end
+      end
     end
   end
 

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -1125,6 +1125,15 @@ describe Procedure do
         expect(procedure.revisions).to eq([procedure.published_revision, procedure.draft_revision])
       end
     end
+
+    context 'when publishing a procedure with the same path as another procedure from another admin' do
+      let(:procedure) { create(:procedure, path: 'example-path', administrateurs: [administrateur]) }
+      let(:other_procedure) { create(:procedure, path: 'example-path', administrateurs: [create(:administrateur)]) }
+
+      it 'raises an error' do
+        expect { procedure.publish_or_reopen!(administrateur, other_procedure.path) }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
   end
 
   describe "#publish_revision!" do

--- a/spec/perf/heavy_dossier_spec.rb
+++ b/spec/perf/heavy_dossier_spec.rb
@@ -80,7 +80,7 @@ describe Users::DossiersController, type: :controller do
           post :submit_en_construction, params: { id: dossier.id }
         end
 
-        expect(query_count).to be_between(60, 70)
+        expect(query_count).to be_between(70, 80)
       end
     end
   end

--- a/spec/services/procedure_export_service_zip_spec.rb
+++ b/spec/services/procedure_export_service_zip_spec.rb
@@ -43,7 +43,7 @@ describe ProcedureExportService do
             ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
               subject
             end
-            expect(sql_count).to be <= 63
+            expect(sql_count).to be <= 73
 
             dossier = dossiers.first
 

--- a/spec/system/administrateurs/procedure_cloning_spec.rb
+++ b/spec/system/administrateurs/procedure_cloning_spec.rb
@@ -56,7 +56,7 @@ describe 'As an administrateur I wanna clone a procedure', js: true do
       find('#publish-procedure-link').click
       expect(find_field('procedure_path').value).to eq 'libelle-de-la-procedure-2'
       fill_in 'procedure_path', with: 'libelle-de-la-procedure'
-      expect(page).to have_content 'Si vous publiez cette démarche, l’ancienne sera dépubliée et ne sera plus accessible au public.'
+      expect(page).to have_content "Si vous publiez cette démarche, le lien ne pointera plus sur l'ancienne démarche."
 
       fill_in 'lien_site_web', with: 'http://some.website'
       click_on 'publish'
@@ -94,7 +94,7 @@ describe 'As an administrateur I wanna clone a procedure', js: true do
       find('#publish-procedure-link').click
       expect(find_field('procedure_path').value).to eq 'libelle-de-la-procedure-2'
       fill_in 'procedure_path', with: 'libelle-de-la-procedure'
-      expect(page).to have_content 'Si vous publiez cette démarche, l’ancienne sera dépubliée et ne sera plus accessible au public.'
+      expect(page).to have_content "Si vous publiez cette démarche, le lien ne pointera plus sur l'ancienne démarche."
       fill_in 'lien_site_web', with: 'http://some.website'
       click_on 'publish'
 

--- a/spec/tasks/maintenance/migrate_existing_procedure_paths_task_spec.rb
+++ b/spec/tasks/maintenance/migrate_existing_procedure_paths_task_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 module Maintenance
   RSpec.describe MigrateExistingProcedurePathsTask do
     describe "#process" do
-      subject(:process) { described_class.process(element) }
+      subject(:process) { described_class.process(element.reload) }
 
       context "when procedure is published" do
         let(:element) { create(:procedure, :published) }
@@ -16,7 +16,7 @@ module Maintenance
         end
 
         it "should use the same generated path as procedure_path" do
-          expect { process }.to change { element.procedure_paths.count }.from(0).to(1)
+          expect { process }.to change { element.procedure_paths.count }.from(0).to(2)
           expect(element.procedure_paths.last.path).to eq("path-not-in-procedure-paths")
         end
 
@@ -65,8 +65,9 @@ module Maintenance
 
         context "when path is not used by another published procedure" do
           it "should use the same path" do
-            expect { process }.to change { element.procedure_paths.count }.from(0).to(1)
+            expect { process }.to change { element.procedure_paths.count }.from(0).to(2)
             expect(element.procedure_paths.last.path).to eq("some-path")
+            expect(element.path).to eq("some-path")
           end
         end
       end

--- a/spec/tasks/maintenance/migrate_existing_procedure_paths_task_spec.rb
+++ b/spec/tasks/maintenance/migrate_existing_procedure_paths_task_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe MigrateExistingProcedurePathsTask do
+    describe "#process" do
+      subject(:process) { described_class.process(element) }
+
+      context "when procedure is published" do
+        let(:element) { create(:procedure, :published) }
+
+        before do
+          element.update_column("path", "path-not-in-procedure-paths")
+          element.procedure_paths.delete_all
+        end
+
+        it "should use the same generated path as procedure_path" do
+          expect { process }.to change { element.procedure_paths.count }.from(0).to(1)
+          expect(element.procedure_paths.last.path).to eq("path-not-in-procedure-paths")
+        end
+
+        context "when procedure is already migrated" do
+          before do
+            create(:procedure_path, procedure: element, path: "path-not-in-procedure-paths")
+          end
+
+          it "should not generate any new ProcedurePath" do
+            expect { process }.not_to change { ProcedurePath.count }
+          end
+        end
+      end
+
+      context "when procedure is not published" do
+        let(:element) { create(:procedure, :closed) }
+
+        before do
+          element.update_column("path", "some-path")
+          element.procedure_paths.delete_all
+        end
+
+        context "when path is already used by another published procedure" do
+          let(:other_procedure) { create(:procedure, :published) }
+
+          before do
+            other_procedure.update_column("path", "some-path")
+          end
+
+          it "should generate a new UUID path" do
+            expect { process }.to change { element.procedure_paths.count }.from(0).to(1)
+            expect(element.procedure_paths.last.path).to match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
+          end
+
+          context "when other_procedure is already migrated" do
+            before do
+              create(:procedure_path, procedure: other_procedure, path: "some-path")
+            end
+
+            it "should generate a new UUID path" do
+              expect { process }.to change { element.procedure_paths.count }.from(0).to(1)
+              expect(element.procedure_paths.last.path).to match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
+            end
+          end
+        end
+
+        context "when path is not used by another published procedure" do
+          it "should use the same path" do
+            expect { process }.to change { element.procedure_paths.count }.from(0).to(1)
+            expect(element.procedure_paths.last.path).to eq("some-path")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
<img width="1220" alt="image" src="https://github.com/user-attachments/assets/54d18874-d35c-4da6-ae7b-e8c0f67b7d62">

Cette PR permet à l'administrateur de modifier le lien de la démarche.
Il est toujours possible pour un administrateur de récupérer un ancien lien qui était associé à une autre de ses démarches. Pas possible de récupérer le lien d'une démarche qui n'appartient pas à l'administrateur.
On garde un historique des anciens liens associés à une démarche, ceux ci redirigent vers le dernier lien en cours (sauf si un ancien lien a été associé à une autre démarche).

Il y a une tâche de migration de données associée à cette PR, en attendant que la tâche ait tourné, l'ancien attribut `path` pointe toujours sur la démarche.

Il faudra ensuite une autre PR pour gérer les `PathRewrite`, et supprimer les références à l'ancien attribut `path`
