### PR TITLE
ETQ DS, je souhaite ne pas envoyer plus de mail que prévu quand une demarche se clos a une date prévue

### DIFF
--- a/app/jobs/auto_archive_procedure_dossiers_job.rb
+++ b/app/jobs/auto_archive_procedure_dossiers_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AutoArchiveProcedureDossiersJob < ApplicationJob
+  def perform(procedure)
+    procedure
+      .dossiers
+      .state_en_construction
+      .find_each do |d|
+        begin
+          d.passer_automatiquement_en_instruction!
+        rescue StandardError => e
+          Sentry.capture_exception(e, extra: { procedure_id: procedure.id })
+        end
+      end
+  end
+end

--- a/spec/jobs/auto_archive_procedure_dossiers_job_spec.rb
+++ b/spec/jobs/auto_archive_procedure_dossiers_job_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.describe AutoArchiveProcedureDossiersJob, type: :job do
+  let!(:procedure) { create(:procedure, :published, :with_instructeur) }
+  let!(:job) { AutoArchiveProcedureDossiersJob.new }
+  before do
+    procedure.auto_archive_on = 1.day.ago.to_date
+    procedure.save(validate: false)
+  end
+  subject { job.perform(procedure) }
+
+  context "when procedures have auto_archive_on set on yesterday or today" do
+    let!(:dossier1) { create(:dossier, procedure: procedure) }
+    let!(:dossier2) { create(:dossier, :en_construction, procedure: procedure) }
+    let!(:dossier3) { create(:dossier, :en_construction, procedure: procedure) }
+    let!(:dossier4) { create(:dossier, :en_construction, procedure: procedure) }
+    let!(:dossier5) { create(:dossier, :en_instruction, procedure: procedure) }
+    let!(:dossier6) { create(:dossier, :accepte, procedure: procedure) }
+    let!(:dossier7) { create(:dossier, :refuse, procedure: procedure) }
+    let!(:dossier8) { create(:dossier, :sans_suite, procedure: procedure) }
+    let(:last_operation) { dossier2.dossier_operation_logs.last }
+
+    before do
+      subject
+
+      [dossier1, dossier2, dossier3, dossier4, dossier5, dossier6, dossier7, dossier8].each(&:reload)
+
+      procedure.reload
+    end
+
+    it {
+      expect(dossier1.state).to eq Dossier.states.fetch(:brouillon)
+      expect(dossier2.state).to eq Dossier.states.fetch(:en_instruction)
+      expect(last_operation.operation).to eq('passer_en_instruction')
+      expect(last_operation.automatic_operation?).to be_truthy
+      expect(dossier3.state).to eq Dossier.states.fetch(:en_instruction)
+      expect(dossier4.state).to eq Dossier.states.fetch(:en_instruction)
+      expect(dossier5.state).to eq Dossier.states.fetch(:en_instruction)
+      expect(dossier6.state).to eq Dossier.states.fetch(:accepte)
+      expect(dossier7.state).to eq Dossier.states.fetch(:refuse)
+      expect(dossier8.state).to eq Dossier.states.fetch(:sans_suite)
+    }
+  end
+end

--- a/spec/jobs/cron/auto_archive_procedure_job_spec.rb
+++ b/spec/jobs/cron/auto_archive_procedure_job_spec.rb
@@ -47,20 +47,6 @@ RSpec.describe Cron::AutoArchiveProcedureJob, type: :job do
     end
 
     it {
-      expect(dossier1.state).to eq Dossier.states.fetch(:brouillon)
-      expect(dossier2.state).to eq Dossier.states.fetch(:en_instruction)
-      expect(last_operation.operation).to eq('passer_en_instruction')
-      expect(last_operation.automatic_operation?).to be_truthy
-      expect(dossier3.state).to eq Dossier.states.fetch(:en_instruction)
-      expect(dossier4.state).to eq Dossier.states.fetch(:en_instruction)
-      expect(dossier5.state).to eq Dossier.states.fetch(:en_instruction)
-      expect(dossier6.state).to eq Dossier.states.fetch(:accepte)
-      expect(dossier7.state).to eq Dossier.states.fetch(:refuse)
-      expect(dossier8.state).to eq Dossier.states.fetch(:sans_suite)
-      expect(dossier9.state).to eq Dossier.states.fetch(:en_instruction)
-    }
-
-    it {
       expect(procedure_hier.close?).to eq true
       expect(procedure_aujourdhui.close?).to eq true
     }


### PR DESCRIPTION
mattermost: https://mattermost.incubateur.net/betagouv/pl/uaa5bdt8aiyzxq7c4uhq6qh9io

# probleme 

Le `Cron::AutoArchiveProcedureJob` est executé toutes les minutes. Sauf que :
1. si nos fils d'attentes sont chargées, on va en empiler plusieurs... qui si ils s'executent rentrent dans des "problèmes" de "concurrence".
2. si il prend plus de temps que son delais de re-enqueue (ici 1min), on le ré-execute pendant qu'un autre tourne. encore problème de "concurrence".

Resultat : on envoie plus de mail que necessaire. En l'occurence : 
1. on a envoyé ±20x le même mail a cet usager : https://www.demarches-simplifiees.fr/manager/users/3970392/emails
2. on a executé le job ±20x a ce moment http://localhost:9002/goto/dbd1c880-a59a-11ef-8720-d333a58bae90.

# solution

on ferme les procedure sans plus attendre (`queue_as :critical`). on envoie les mails de fermeture automatique dans un job dediée