### PR TITLE
ETQ usager je ne peux pas soumettre le form de contact si la PJ n'est pas un fichier

### DIFF
--- a/config/locales/views/contact/en.yml
+++ b/config/locales/views/contact/en.yml
@@ -71,3 +71,4 @@ en:
     create:
       direct_message_sent: Your message has been sent to the mailbox in your file.
       message_sent: Your message has been sent.
+      invalid_piece_jointe: 'The attachment must be a file'

--- a/config/locales/views/contact/fr.yml
+++ b/config/locales/views/contact/fr.yml
@@ -72,3 +72,4 @@ fr:
     create:
       direct_message_sent: Votre message a été envoyé sur la messagerie de votre dossier.
       message_sent: Votre message a été envoyé.
+      invalid_piece_jointe: 'La pièce jointe doit être un fichier'

--- a/spec/controllers/contact_controller_spec.rb
+++ b/spec/controllers/contact_controller_spec.rb
@@ -198,6 +198,16 @@ describe ContactController, question_type: :controller do
           expect(response.body).to include("un message")
         end
       end
+
+      context "with an invalid attachment type" do
+        let(:params) { super().merge(piece_jointe: "not_a_file") }
+
+        it "returns unprocessable entity status" do
+          subject
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.body).to include("La pièce jointe doit être un fichier")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Contexte : 

On a beaucoup de cas / robots / … qui envoient un string et ça génère beaucoup d'erreurs InvalidSignature plus tard.
