### PR TITLE
ETQ instructeur, le sous menu de gestion de démarche devrait être homogène

### DIFF
--- a/app/views/instructeurs/procedures/_header.html.haml
+++ b/app/views/instructeurs/procedures/_header.html.haml
@@ -21,7 +21,7 @@
 
             - elsif procedure.administrateurs.exists?(id: current_administrateur&.id)
               %li
-                = link_to t('instructeurs.dossiers.header.banner.instructeurs'), admin_procedure_groupe_instructeurs_path(procedure), class:
+                = link_to t('instructeurs.dossiers.header.banner.instructeurs'), admin_procedure_groupe_instructeurs_path(procedure), class: 'fr-nav__link'
             %li
               = link_to t('instructeurs.dossiers.header.banner.notification_management'), email_notifications_instructeur_procedure_path(procedure), class: 'fr-nav__link'
             %li


### PR DESCRIPTION
apres: 
> <img width="349" alt="Capture d’écran 2024-11-21 à 10 42 48 AM" src="https://github.com/user-attachments/assets/60c8b921-5788-4f0a-8dc1-55adc5ad7d22">

avant:
> <img width="372" alt="Capture d’écran 2024-11-21 à 10 41 07 AM" src="https://github.com/user-attachments/assets/dc8444a1-f3d4-4440-a543-da1d4d1bded9">
