### PR TITLE
refactor(dossier): cleanup user controller

### DIFF
--- a/app/components/attachment/edit_component.rb
+++ b/app/components/attachment/edit_component.rb
@@ -12,14 +12,13 @@ class Attachment::EditComponent < ApplicationComponent
 
   EXTENSIONS_ORDER = ['jpeg', 'png', 'pdf', 'zip'].freeze
 
-  def initialize(champ: nil, auto_attach_url: nil, attached_file:, direct_upload: true, index: 0, as_multiple: false, view_as: :link, user_can_destroy: true, user_can_replace: false, attachments: [], max: nil, **kwargs)
+  def initialize(champ: nil, auto_attach_url: nil, attached_file:, direct_upload: true, index: 0, as_multiple: false, view_as: :link, user_can_destroy: true, attachments: [], max: nil, **kwargs)
     @champ = champ
     @attached_file = attached_file
     @direct_upload = direct_upload
     @index = index
     @view_as = view_as
     @user_can_destroy = user_can_destroy
-    @user_can_replace = user_can_replace
     @as_multiple = as_multiple
     @auto_attach_url = auto_attach_url
 

--- a/app/components/attachment/multiple_component.rb
+++ b/app/components/attachment/multiple_component.rb
@@ -17,7 +17,7 @@ class Attachment::MultipleComponent < ApplicationComponent
 
   delegate :count, :empty?, to: :attachments, prefix: true
 
-  def initialize(champ: nil, attached_file:, form_object_name: nil, view_as: :link, user_can_destroy: true, user_can_replace: false, max: nil)
+  def initialize(champ: nil, attached_file:, form_object_name: nil, view_as: :link, user_can_destroy: true, max: nil)
     @champ = champ
     @attached_file = attached_file
     @form_object_name = form_object_name

--- a/app/components/dossiers/edit_footer_component.rb
+++ b/app/components/dossiers/edit_footer_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Dossiers::EditFooterComponent < ApplicationComponent
-  delegate :can_passer_en_construction?, to: :@dossier
+  delegate :can_passer_en_construction?, :can_transition_to_en_construction?, :forked_with_changes?, to: :@dossier
 
   def initialize(dossier:, annotation:)
     @dossier = dossier
@@ -18,7 +18,43 @@ class Dossiers::EditFooterComponent < ApplicationComponent
     @annotation.present?
   end
 
-  def disabled_submit_buttons_options
+  def can_submit?
+    can_submit_draft? || can_submit_en_construction?
+  end
+
+  def can_submit_draft?
+    !annotation? && can_transition_to_en_construction?
+  end
+
+  def can_submit_en_construction?
+    forked_with_changes?
+  end
+
+  def submit_button_label
+    if can_submit_draft?
+      t('.submit')
+    else
+      t('.submit_changes')
+    end
+  end
+
+  def submit_button_path
+    if can_submit_draft?
+      brouillon_dossier_path(@dossier)
+    else
+      modifier_dossier_path(@dossier.editing_fork_origin)
+    end
+  end
+
+  def submit_button_options
+    if can_submit_draft?
+      submit_draft_button_options
+    else
+      submit_en_construction_button_options
+    end
+  end
+
+  def disabled_submit_button_options
     {
       class: 'fr-text--sm fr-mb-0 fr-mr-2w',
       data: { 'fr-opened': "true" },

--- a/app/components/dossiers/edit_footer_component/edit_footer_component.html.haml
+++ b/app/components/dossiers/edit_footer_component/edit_footer_component.html.haml
@@ -2,24 +2,16 @@
   .send-dossier-actions-bar
     = render Dossiers::AutosaveFooterComponent.new(dossier: @dossier, annotation: annotation?)
 
-    - if !annotation? && @dossier.can_transition_to_en_construction?
+    - if can_submit?
       - if !can_passer_en_construction?
-        = link_to t('.submit_disabled'), "#", disabled_submit_buttons_options
-      = button_to t('.submit'), brouillon_dossier_url(@dossier), submit_draft_button_options
-
-    - if @dossier.forked_with_changes?
-      - if !can_passer_en_construction?
-        = link_to t('.submit_disabled'), "#", disabled_submit_buttons_options
-      = button_to t('.submit_changes'), modifier_dossier_url(@dossier.editing_fork_origin), submit_en_construction_button_options
-
+        = link_to t('.submit_disabled'), "#", disabled_submit_button_options
+      = button_to submit_button_label, submit_button_path, submit_button_options
 
   - if @dossier.brouillon? && !owner?
     .fr-pb-2w.invite-cannot-submit
       = render ::Dsfr::AlertComponent.new(state: :info, title: nil, size: :sm, heading_level: :p, extra_class_names:'') do |c|
         - c.with_body do
           %p.fr-pb-0= t('.invite_notice').html_safe
-
-
 
   - if !annotation?
     = render partial: "shared/dossiers/submit_is_over", locals: { dossier: @dossier }

--- a/app/components/editable_champ/piece_justificative_component.rb
+++ b/app/components/editable_champ/piece_justificative_component.rb
@@ -13,10 +13,6 @@ class EditableChamp::PieceJustificativeComponent < EditableChamp::EditableChampB
     end
   end
 
-  def user_can_destroy?
-    !@champ.mandatory? || @champ.dossier.brouillon?
-  end
-
   def max
     [true, nil].include?(@champ.procedure&.piece_justificative_multiple?) ? Attachment::MultipleComponent::DEFAULT_MAX_ATTACHMENTS : 1
   end

--- a/app/components/editable_champ/piece_justificative_component/piece_justificative_component.html.haml
+++ b/app/components/editable_champ/piece_justificative_component/piece_justificative_component.html.haml
@@ -1,4 +1,4 @@
-= render Attachment::MultipleComponent.new(champ: @champ, attached_file: @champ.piece_justificative_file, form_object_name: @form.object_name, view_as:, user_can_destroy: user_can_destroy?, max:) do |c|
+= render Attachment::MultipleComponent.new(champ: @champ, attached_file: @champ.piece_justificative_file, form_object_name: @form.object_name, view_as:, max:) do |c|
   - if @champ.type_de_champ.piece_justificative_template&.attached?
     - c.with_template do
       = render partial: "shared/piece_justificative_template", locals: { champ: @champ }

--- a/app/components/editable_champ/titre_identite_component.rb
+++ b/app/components/editable_champ/titre_identite_component.rb
@@ -4,8 +4,4 @@ class EditableChamp::TitreIdentiteComponent < EditableChamp::EditableChampBaseCo
   def dsfr_input_classname
     'fr-input'
     end
-
-  def user_can_destroy?
-    !@champ.mandatory? || @champ.dossier.brouillon?
-  end
 end

--- a/app/components/editable_champ/titre_identite_component/titre_identite_component.html.haml
+++ b/app/components/editable_champ/titre_identite_component/titre_identite_component.html.haml
@@ -1,4 +1,3 @@
 - if @champ.type_de_champ.piece_justificative_template&.attached?
   = render partial: "shared/piece_justificative_template", locals: { champ: @champ }
-= render Attachment::EditComponent.new(champ: @form.object, attached_file: @champ.piece_justificative_file, attachment: @champ.piece_justificative_file[0], form_object_name: @form.object_name,
-  user_can_destroy: user_can_destroy?)
+= render Attachment::EditComponent.new(champ: @form.object, attached_file: @champ.piece_justificative_file, attachment: @champ.piece_justificative_file[0], form_object_name: @form.object_name)

--- a/app/controllers/champs/piece_justificative_controller.rb
+++ b/app/controllers/champs/piece_justificative_controller.rb
@@ -30,8 +30,14 @@ class Champs::PieceJustificativeController < Champs::ChampController
       save_succeed = @champ.save
     end
 
-    @champ.dossier.update(last_champ_updated_at: Time.zone.now.utc) if save_succeed
+    if save_succeed && dossier.brouillon?
+      dossier.touch(:last_champ_updated_at, :last_champ_piece_jointe_updated_at)
+    end
 
     save_succeed
+  end
+
+  def dossier
+    @champ.dossier
   end
 end

--- a/app/controllers/concerns/create_avis_concern.rb
+++ b/app/controllers/concerns/create_avis_concern.rb
@@ -57,7 +57,7 @@ module CreateAvisConcern
     persisted, failed = create_results.partition(&:persisted?)
 
     if persisted.any?
-      dossier.update!(last_avis_updated_at: Time.zone.now)
+      dossier.touch(:last_avis_updated_at)
       sent_emails_addresses = []
       persisted.each do |avis|
         avis.dossier.demander_un_avis!(avis)

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -250,7 +250,7 @@ module Instructeurs
 
         if commentaire.valid?
           dossier.flag_as_pending_correction!(commentaire, params[:reason].presence)
-          dossier.update!(last_commentaire_updated_at: Time.zone.now)
+          dossier.touch(:last_commentaire_updated_at)
           current_instructeur.follow(dossier)
 
           flash.notice = "Dossier marqué comme en attente de correction."
@@ -275,7 +275,7 @@ module Instructeurs
       @commentaire = CommentaireService.create(current_instructeur, dossier, commentaire_params)
 
       if @commentaire.errors.empty?
-        @commentaire.dossier.update!(last_commentaire_updated_at: Time.zone.now)
+        @commentaire.dossier.touch(:last_commentaire_updated_at)
         current_instructeur.follow(dossier)
         flash.notice = "Message envoyé"
         redirect_to messagerie_instructeur_dossier_path(procedure, dossier)
@@ -300,7 +300,7 @@ module Instructeurs
     def update_annotations
       dossier_with_champs.update_champs_attributes(champs_private_attributes_params, :private, updated_by: current_user.email)
       if dossier.champs.any?(&:changed_for_autosave?)
-        dossier.last_champ_private_updated_at = Time.zone.now
+        dossier.touch(:last_champ_private_updated_at)
       end
 
       dossier.save(context: :champs_private_value)

--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -237,7 +237,7 @@ module Instructeurs
       dossiers.each do |dossier|
         commentaire = CommentaireService.create(current_instructeur, dossier, bulk_message_params.except(:targets))
         if commentaire.errors.empty?
-          commentaire.dossier.update!(last_commentaire_updated_at: Time.zone.now)
+          commentaire.dossier.touch(:last_commentaire_updated_at)
         else
           errors << dossier.id
         end

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -233,11 +233,6 @@ module Users
 
       if @dossier.errors.blank? && @dossier.can_passer_en_construction?
         @dossier.passer_en_construction!
-        @dossier.process_declarative!
-        @dossier.process_sva_svr!
-        @dossier.groupe_instructeur.instructeurs.with_instant_email_dossier_notifications.each do |instructeur|
-          DossierMailer.notify_new_dossier_depose_to_instructeur(@dossier, instructeur.email).deliver_later
-        end
         redirect_to merci_dossier_path(@dossier)
       else
         respond_to do |format|

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -9,11 +9,11 @@ module Users
     layout 'procedure_context', only: [:identite, :update_identite, :siret, :update_siret]
 
     ACTIONS_ALLOWED_TO_ANY_USER = [:index, :new, :transferer_all, :deleted_dossiers]
-    ACTIONS_ALLOWED_TO_OWNER_OR_INVITE = [:show, :destroy, :demande, :messagerie, :brouillon, :submit_brouillon, :submit_en_construction, :modifier, :modifier_legacy, :update, :create_commentaire, :papertrail, :restore, :champ]
+    ACTIONS_ALLOWED_TO_OWNER_OR_INVITE = [:show, :destroy, :demande, :messagerie, :brouillon, :submit_brouillon, :submit_en_construction, :modifier, :update, :create_commentaire, :papertrail, :restore, :champ]
 
     before_action :ensure_ownership!, except: ACTIONS_ALLOWED_TO_ANY_USER + ACTIONS_ALLOWED_TO_OWNER_OR_INVITE
     before_action :ensure_ownership_or_invitation!, only: ACTIONS_ALLOWED_TO_OWNER_OR_INVITE
-    before_action :ensure_dossier_can_be_updated, only: [:update_identite, :update_siret, :brouillon, :submit_brouillon, :submit_en_construction, :modifier, :modifier_legacy, :update, :champ]
+    before_action :ensure_dossier_can_be_updated, only: [:update_identite, :update_siret, :brouillon, :submit_brouillon, :submit_en_construction, :modifier, :update, :champ]
     before_action :ensure_dossier_can_be_filled, only: [:brouillon, :modifier, :submit_brouillon, :submit_en_construction, :update]
     before_action :ensure_dossier_can_be_viewed, only: [:show]
     before_action :forbid_invite_submission!, only: [:submit_brouillon]
@@ -261,17 +261,6 @@ module Users
 
     def modifier
       @dossier = dossier_with_champs
-    end
-
-    # Transition to en_construction forks,
-    # so users editing en_construction dossiers won't completely break their changes.
-    # TODO: remove me after fork en_construction feature deploy (PR #8790)
-    def modifier_legacy
-      respond_to do |format|
-        format.turbo_stream do
-          flash.alert = "Une mise à jour de cette page est nécessaire pour poursuivre, veuillez la recharger (touche F5). Attention: le dernier champ modifié n’a pas été sauvegardé, vous devrez le ressaisir."
-        end
-      end
     end
 
     def submit_en_construction

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -865,17 +865,6 @@ class Dossier < ApplicationRecord
     procedure.email_template_for(state)
   end
 
-  def submit_en_construction!
-    self.traitements.submit_en_construction
-    save!
-
-    RoutingEngine.compute(self)
-
-    resolve_pending_correction!
-    process_sva_svr!
-    remove_piece_justificative_file_not_visible!
-  end
-
   def process_declarative!
     if procedure.declarative_accepte? && may_accepter_automatiquement?
       accepter_automatiquement!

--- a/app/views/administrateurs/procedures/apercu.html.haml
+++ b/app/views/administrateurs/procedures/apercu.html.haml
@@ -13,6 +13,6 @@
             active: @tab == 'annotations-privees')
 
 - if @tab == 'dossier'
-  = render partial: "shared/dossiers/edit", locals: { dossier: @dossier }
+  = render partial: "shared/dossiers/edit", locals: { dossier: @dossier, dossier_for_editing: @dossier }
 - else
   = render partial: "shared/dossiers/edit_annotations", locals: { dossier: @dossier, seen_at: nil }

--- a/app/views/instructeurs/procedures/apercu.html.haml
+++ b/app/views/instructeurs/procedures/apercu.html.haml
@@ -12,4 +12,4 @@
 .fr-container
   %h2.fr-h4= t('.title')
 
-= render partial: "shared/dossiers/edit", locals: { dossier: @dossier }
+= render partial: "shared/dossiers/edit", locals: { dossier: @dossier, dossier_for_editing: @dossier }

--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -1,5 +1,3 @@
-- dossier_for_editing = dossier.en_construction? ? dossier.owner_editing_fork : dossier
-
 - if dossier.france_connected_with_one_identity?  && current_user.instructeur? && !current_user.owns_or_invite?(dossier)
   - content_for(:notice_info) do
     = render partial: "shared/dossiers/france_connect_informations_notice", locals: { user_information: dossier.user.france_connect_informations.first }
@@ -10,7 +8,7 @@
   = render NestedForms::FormOwnerComponent.new
   = form_for dossier_for_editing, url: brouillon_dossier_url(dossier), method: :patch, html: { id: 'dossier-edit-form', class: 'form', multipart: true, novalidate: 'novalidate' } do |f|
 
-    = render Dossiers::ErrorsFullMessagesComponent.new(dossier: dossier)
+    = render Dossiers::ErrorsFullMessagesComponent.new(dossier: dossier_for_editing)
     %header.mb-6
       .fr-highlight
         %p.fr-text--sm

--- a/app/views/users/dossiers/brouillon.html.haml
+++ b/app/views/users/dossiers/brouillon.html.haml
@@ -9,4 +9,4 @@
     .fr-container
       = render partial: "shared/dossiers/header", locals: { dossier: @dossier }
 
-  = render partial: "shared/dossiers/edit", locals: { dossier: @dossier }
+  = render partial: "shared/dossiers/edit", locals: { dossier: @dossier, dossier_for_editing: @dossier }

--- a/app/views/users/dossiers/modifier.html.haml
+++ b/app/views/users/dossiers/modifier.html.haml
@@ -7,4 +7,4 @@
   = render partial: 'users/dossiers/show/header', locals: { dossier: @dossier }
 
   .container
-    = render partial: "shared/dossiers/edit", locals: { dossier: @dossier }
+    = render partial: "shared/dossiers/edit", locals: { dossier: @dossier, dossier_for_editing: @dossier_for_editing }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -380,7 +380,6 @@ Rails.application.routes.draw do
         post 'brouillon', to: 'dossiers#submit_brouillon'
         get 'modifier', to: 'dossiers#modifier'
         post 'modifier', to: 'dossiers#submit_en_construction'
-        patch 'modifier', to: 'dossiers#modifier_legacy'
         get 'champs/:stable_id', to: 'dossiers#champ', as: :champ
         get 'merci'
         get 'demande'

--- a/spec/components/attachment/multiple_component_spec.rb
+++ b/spec/components/attachment/multiple_component_spec.rb
@@ -96,14 +96,6 @@ RSpec.describe Attachment::MultipleComponent, type: :component do
     end
   end
 
-  context 'when user can replace' do
-    let(:kwargs) { { user_can_replace: true } }
-
-    before do
-      attach_to_champ(attached_file, champ)
-    end
-  end
-
   def attach_to_champ(attached_file, champ)
     attached_file.attach(
       io: StringIO.new("x" * 2),

--- a/spec/views/shared/dossiers/_edit.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_edit.html.haml_spec.rb
@@ -6,10 +6,11 @@ describe 'shared/dossiers/edit', type: :view do
     allow(view).to receive(:administrateur_signed_in?).and_return(false)
   end
 
-  subject { render 'shared/dossiers/edit', dossier: dossier, apercu: false }
+  subject { render 'shared/dossiers/edit', dossier:, dossier_for_editing:, apercu: false }
 
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
+  let(:dossier_for_editing) { dossier }
 
   context 'when there are some champs' do
     let(:type_de_champ_header_section) { procedure.draft_types_de_champ_public.find(&:header_section?) }
@@ -116,6 +117,7 @@ describe 'shared/dossiers/edit', type: :view do
 
     context 'when dossier is en construction' do
       let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, procedure:) }
+      let(:dossier_for_editing) { dossier.owner_editing_fork }
 
       it 'can delete a piece justificative' do
         expect(subject).to have_selector("[title='Supprimer le fichier #{champ.piece_justificative_file.attachments[0].filename}']")


### PR DESCRIPTION
Ce nettoyage est fait pour préparer le passage vers l'édition par streams :

-  `last_champ_updated_at` est touché seulement sur les brouillons
-  On passe explicitement `@dossier_for_editing` aux views. Ça permet de driver l'usage depuis le controller sans logique  dans les views. Cette variable disparaîtra après le passage complet aux streams
-  Supprimer du code mort