### PR TITLE
ETQ instructeur: fix position de la pastille de notification d'exports dans le menu

### DIFF
--- a/app/views/instructeurs/procedures/_header.html.haml
+++ b/app/views/instructeurs/procedures/_header.html.haml
@@ -45,6 +45,8 @@
       %li.fr-nav__item.relative
         %button.fr-nav__btn{ 'aria-expanded': 'false', 'aria-controls': 'menu-downloads', 'aria-current': ('page' if current_nav_section == 'downloads') }
           = t('instructeurs.dossiers.header.banner.downloads')
+          - if @has_export_notification
+            %span.notifications{ 'aria-label': t('instructeurs.dossiers.header.banner.exports_notification_label') }
         #menu-downloads.fr-collapse.fr-menu
           %ul.fr-menu__list
             %li
@@ -53,9 +55,6 @@
               = link_to t('instructeurs.dossiers.header.banner.archives'), instructeur_archives_path(procedure), class: 'fr-nav__link'
             %li
               = link_to t('instructeurs.dossiers.header.banner.export_templates'), export_templates_instructeur_procedure_path(procedure), class: 'fr-nav__link'
-
-  - if @has_export_notification
-    %span.notifications{ 'aria-label': t('instructeurs.dossiers.header.banner.exports_notification_label') }
 
   #last-export-alert
     = render partial: "instructeurs/procedures/last_export_alert", locals: { export: @last_export, statut: @statut }


### PR DESCRIPTION
on ajustera légèrement plus tard si nécessaire

![Capture d’écran 2024-11-25 à 13 03 48](https://github.com/user-attachments/assets/f763b0d5-1443-4e4a-8b49-4d12fdc0c535)
