### PR TITLE
ETQ instructeur, les en-têtes de tableau de dossiers peuvent passer sur plusieurs lignes

### DIFF
--- a/app/components/instructeurs/column_table_header_component/column_table_header_component.html.haml
+++ b/app/components/instructeurs/column_table_header_component/column_table_header_component.html.haml
@@ -1,3 +1,3 @@
 - @columns.each do |column|
-  %th{ aria_sort(column), scope: "col", class: classname(column) }
+  %th.fr-cell--multiline{ aria_sort(column), scope: "col", class: classname(column) }
     = column_header(column)

--- a/app/views/experts/avis/procedure.html.haml
+++ b/app/views/experts/avis/procedure.html.haml
@@ -46,7 +46,7 @@
                       = link_to(expert_avis_path(avis.procedure, avis), class: "fr-link") do
                         = avis.dossier.id
                     %td= link_to(avis.dossier.user_email_for(:display), expert_avis_path(avis.procedure, avis))
-                    %td= link_to(avis.procedure.libelle, expert_avis_path(avis.procedure, avis))
+                    %td.fr-cell--multiline= link_to(avis.procedure.libelle, expert_avis_path(avis.procedure, avis))
       .fr-table__footer
         .fr-table__footer--start
         .fr-table__footer--middle

--- a/app/views/recherche/index.html.haml
+++ b/app/views/recherche/index.html.haml
@@ -41,7 +41,7 @@
                         = p.dossier_id
                         - if @notifications_dossier_ids.include?(p.dossier_id)
                           %span.notifications{ 'aria-label': 'notifications' }
-                    %td= procedure_libelle
+                    %td.fr-cell--multiline= procedure_libelle
                     %td= user_email
                     %td.flex.column= status_badge(p.state)
 


### PR DESCRIPTION
![Capture d’écran 2024-11-25 à 14 39 03](https://github.com/user-attachments/assets/f275905a-65b2-4f95-a525-f6706de4a3a5)

Ainsi que la colonne "démarche" de la recherche ou de la vue expert
![Capture d’écran 2024-11-25 à 14 43 48](https://github.com/user-attachments/assets/4d447da3-24d5-4057-9e7b-9d93b17fdcaf)

