### PR TITLE
ETQ Instructeur, je veux pouvoir retirer une colonne au libellé très long

### DIFF
--- a/app/assets/stylesheets/dsfr.scss
+++ b/app/assets/stylesheets/dsfr.scss
@@ -234,11 +234,6 @@ input[type='radio'] {
   text-transform: lowercase;
 }
 
-// We don't want badge to split in two lines
-.fr-tag {
-  white-space: nowrap;
-}
-
 // Caption is bold, but all-procedures table use fr-tag in caption
 .fr-table caption .fr-tag {
   font-weight: normal;
@@ -251,4 +246,9 @@ input[type='radio'] {
 
 .fr-cell--numeric {
   font-variant-numeric: tabular-nums;
+}
+
+// We don't want badge to split in two lines
+.fr-tag.no-wrap {
+  white-space: nowrap;
 }

--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -130,7 +130,7 @@ module DossierHelper
   end
 
   def tag_label(name, color)
-    tag.span(name, class: "fr-tag fr-tag--sm fr-tag--#{Label.class_name(color)}")
+    tag.span(name, class: "fr-tag fr-tag--sm fr-tag--#{Label.class_name(color)} no-wrap")
   end
 
   def demandeur_dossier(dossier)


### PR DESCRIPTION
en spécifiant uniquement le no wrap sur les labels du tableau j'ai a nouveau un retour a la ligne sur le selecteur des colonnes


![Screenshot 2024-11-25 at 14-53-49 test filtres sur 2 champs mm nom · demarches-simplifiees fr](https://github.com/user-attachments/assets/acd992d3-67cd-4a73-be9c-18cb3ba70cec)

