### PR TITLE
ETQ Instructeur je peux prévisualiser le formulaire d'une démarche

### DIFF
--- a/app/components/editable_champ/champ_label_content_component.rb
+++ b/app/components/editable_champ/champ_label_content_component.rb
@@ -20,4 +20,13 @@ class EditableChamp::ChampLabelContentComponent < ApplicationComponent
   def highlight?
     @champ.updated_at.present? && @seen_at&.<(@champ.updated_at)
   end
+
+  def rebased?
+    return false if @champ.rebased_at.blank?
+    return false if @champ.rebased_at <= (@seen_at || @champ.updated_at)
+    return false if !current_user.owns_or_invite?(@champ.dossier)
+    return false if @champ.dossier.for_procedure_preview?
+
+    true
+  end
 end

--- a/app/components/editable_champ/champ_label_content_component/champ_label_content_component.html.haml
+++ b/app/components/editable_champ/champ_label_content_component/champ_label_content_component.html.haml
@@ -10,7 +10,7 @@
   %span.updated-at{ class: highlight_if_unseen_class }
     = t('.modified_at', datetime: try_format_datetime(@champ.updated_at))
 
-- if @champ.rebased_at.present? && @champ.rebased_at > (@seen_at || @champ.updated_at) && current_user.owns_or_invite?(@champ.dossier)
+- if rebased?
   %span.updated-at.highlighted
     = t('.check_content_rebased')
 

--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -266,6 +266,12 @@ module Instructeurs
       @administrateurs = procedure.administrateurs
     end
 
+    def apercu
+      @procedure = procedure
+      @dossier = procedure.active_revision.dossier_for_preview(current_user)
+      DossierPreloader.load_one(@dossier)
+    end
+
     private
 
     def assign_to_params

--- a/app/views/instructeurs/procedures/_header.html.haml
+++ b/app/views/instructeurs/procedures/_header.html.haml
@@ -37,7 +37,7 @@
             %li
               = link_to t('instructeurs.dossiers.header.banner.contact_users'), email_usagers_instructeur_procedure_path(procedure), class: 'fr-nav__link'
             %li
-              = link_to t('instructeurs.dossiers.header.banner.preview'), apercu_admin_procedure_path(@procedure), target: "_blank", rel: "noopener", class: 'fr-nav__link'
+              = link_to t('instructeurs.dossiers.header.banner.preview'), apercu_instructeur_procedure_path(@procedure), target: "_blank", rel: "noopener", class: 'fr-nav__link'
             %li
               = link_to "#", class: "fr-nav__link fr-link fr-link--md fr-link--icon-left fr-icon-clipboard-line", data: {controller: "clipboard", clipboard_text_value: commencer_url(@procedure.path), action: "click->clipboard#copy" } do
                 = t('instructeurs.dossiers.header.banner.copy_link_button')

--- a/app/views/instructeurs/procedures/apercu.html.haml
+++ b/app/views/instructeurs/procedures/apercu.html.haml
@@ -1,0 +1,15 @@
+- content_for(:title, t('.title_with_libelle', libelle: @dossier.procedure.libelle))
+
+.sub-header
+  .fr-container.flex.column
+    = render partial: 'instructeurs/breadcrumbs',
+      locals: { steps: [[t('show_procedure', scope: [:layouts, :breadcrumb], libelle: @procedure.libelle.truncate(22)), instructeur_procedure_path(@procedure)],
+                        [t('instructeurs.dossiers.header.banner.preview')]] }
+    = render partial: 'instructeurs/procedures/header',
+      locals: { procedure: @procedure }
+
+
+.fr-container
+  %h2.fr-h4= t('.title')
+
+= render partial: "shared/dossiers/edit", locals: { dossier: @dossier }

--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -5,7 +5,7 @@
     = render partial: "shared/dossiers/france_connect_informations_notice", locals: { user_information: dossier.user.france_connect_informations.first }
 
 
-.dossier-edit.container.counter-start-header-section
+.dossier-edit.fr-container.counter-start-header-section
   = render partial: "shared/dossiers/submit_is_over", locals: { dossier: dossier }
   = render NestedForms::FormOwnerComponent.new
   = form_for dossier_for_editing, url: brouillon_dossier_url(dossier), method: :patch, html: { id: 'dossier-edit-form', class: 'form', multipart: true, novalidate: 'novalidate' } do |f|

--- a/app/views/shared/dossiers/_edit_annotations.html.haml
+++ b/app/views/shared/dossiers/_edit_annotations.html.haml
@@ -1,4 +1,4 @@
-.container.dossier-edit
+.fr-container.dossier-edit
   - if dossier.has_annotations?
     %section.counter-start-header-section
       = render NestedForms::FormOwnerComponent.new

--- a/config/locales/views/instructeurs/procedures/email_notifications/en.yml
+++ b/config/locales/views/instructeurs/procedures/email_notifications/en.yml
@@ -26,5 +26,6 @@ en:
         buttons:
           back_to_procedure: Back to procedure
           save: Save
-
-  
+      apercu:
+        title_with_libelle: Preview of « %{libelle} »
+        title: Procedure preview

--- a/config/locales/views/instructeurs/procedures/email_notifications/fr.yml
+++ b/config/locales/views/instructeurs/procedures/email_notifications/fr.yml
@@ -30,3 +30,6 @@ fr:
         buttons:
           back_to_procedure: Revenir à la procédure
           save: Enregistrer
+      apercu:
+        title_with_libelle: Prévisualisation de « %{libelle} »
+        title: Prévisualisation de la démarche

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -490,6 +490,7 @@ Rails.application.routes.draw do
           end
         end
 
+        get 'apercu'
         get 'download_export'
         post 'download_export'
         get 'polling_last_export'

--- a/spec/controllers/instructeurs/procedures_controller_spec.rb
+++ b/spec/controllers/instructeurs/procedures_controller_spec.rb
@@ -926,4 +926,24 @@ describe Instructeurs::ProceduresController, type: :controller do
       it { is_expected.to have_http_status(:forbidden) }
     end
   end
+
+  describe '#preview' do
+    render_views
+
+    let(:instructeur) { create(:instructeur) }
+    let(:procedure) { create(:procedure, types_de_champ_public: [type: :text, libelle: "Premier champ"]) }
+
+    before do
+      sign_in(instructeur.user)
+      create(:groupe_instructeur, procedure:, instructeurs: [instructeur])
+    end
+
+    it 'displays preview' do
+      get :apercu, params: { procedure_id: procedure.id }
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("Premier champ")
+      expect(response.body).not_to include("Déposer")
+    end
+  end
 end


### PR DESCRIPTION
Dans la nouvelle nav, il manquait la route dédiée aux instructeurs.

![Capture d’écran 2024-11-25 à 15 58 32](https://github.com/user-attachments/assets/ee344ebe-bcfb-434a-bbe2-d4c36f7b8e77)


petite curiosité, contrairement aux admins, on affiche le form de la révision active, donc le dossier for preview peut remonter un dossier existant de l'instructeur ayant été rebasé. Il faut donc gérer un cas supplémentaire pour ne pas afficher le msg "Le champ a été modifié par l'administration" qui n'a pas de sens sur cet écran