### PR TITLE
correctif: ETQ instructeur, je peux exporter mes dossiers même si une répétition a été ajouté a une autre version du formulaire

### DIFF
--- a/app/models/concerns/champs_validate_concern.rb
+++ b/app/models/concerns/champs_validate_concern.rb
@@ -29,7 +29,7 @@ module ChampsValidateConcern
     end
 
     def in_dossier_revision?
-      dossier.revision.types_de_champ.any? { _1.stable_id == stable_id } && is_type?(type_de_champ.type_champ)
+      dossier.revision.in_revision?(stable_id) && is_type?(type_de_champ.type_champ)
     end
   end
 end

--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -109,6 +109,7 @@ module DossierChampsConcern
 
   def repetition_row_ids(type_de_champ)
     return [] if !type_de_champ.repetition?
+    return [] if !revision.in_revision?(type_de_champ.stable_id)
 
     stable_ids = revision.children_of(type_de_champ).map(&:stable_id)
     champs.filter { _1.stable_id.in?(stable_ids) && _1.row_id.present? }

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -203,6 +203,10 @@ class ProcedureRevision < ApplicationRecord
     coordinate_for(tdc).parent_type_de_champ
   end
 
+  def in_revision?(stable_id)
+    types_de_champ.any? { _1.stable_id == stable_id }
+  end
+
   def dependent_conditions(tdc)
     stable_id = tdc.stable_id
 

--- a/spec/models/concerns/dossier_champs_concern_spec.rb
+++ b/spec/models/concerns/dossier_champs_concern_spec.rb
@@ -154,6 +154,21 @@ RSpec.describe DossierChampsConcern do
     subject { dossier.repetition_row_ids(type_de_champ_repetition) }
 
     it { expect(subject.size).to eq(1) }
+
+    context 'given a type de champ repetition in another revision' do
+      let(:procedure) { create(:procedure, :published, types_de_champ_public:, types_de_champ_private:) }
+      let(:draft) { procedure.draft_revision }
+      let(:errored_stable_id) { 666 }
+      let(:type_de_champ_repetition) { procedure.active_revision.types_de_champ.find { _1.stable_id == errored_stable_id } }
+      before do
+        dossier
+        tdc_repetition = draft.add_type_de_champ(type_champ: :repetition, libelle: "repetition", stable_id: errored_stable_id)
+        draft.add_type_de_champ(type_champ: :text, libelle: "t1", parent_stable_id: tdc_repetition.stable_id)
+        procedure.publish_revision!
+      end
+
+      it { expect { subject }.not_to raise_error }
+    end
   end
 
   describe '#project_rows_for' do


### PR DESCRIPTION
sentry: https://demarches-simplifiees.sentry.io/issues/6088812113/?project=1429550&query=&referrer=issue-stream&sort=date&statsPeriod=14d&stream_index=0
crisp: https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_dc7c319b-e1ac-419a-a623-b61f44b87a44/ 