### PR TITLE
ETQ admin, corrige l'affichage dans le récap de modifications d'une erreur existant dans l'attestation v2

### DIFF
--- a/app/components/procedure/card/attestation_component.rb
+++ b/app/components/procedure/card/attestation_component.rb
@@ -8,11 +8,7 @@ class Procedure::Card::AttestationComponent < ApplicationComponent
   private
 
   def edit_attestation_path
-    if @procedure.attestation_templates_v2.any? || @procedure.feature_enabled?(:attestation_v2)
-      helpers.edit_admin_procedure_attestation_template_v2_path(@procedure)
-    else
-      helpers.edit_admin_procedure_attestation_template_path(@procedure)
-    end
+    helpers.edit_admin_procedure_attestation_template_v2_path(@procedure)
   end
 
   def error_messages

--- a/app/components/procedure/errors_summary.rb
+++ b/app/components/procedure/errors_summary.rb
@@ -43,7 +43,11 @@ class Procedure::ErrorsSummary < ApplicationComponent
       tdc = error.options[:type_de_champ]
       annotations_admin_procedure_path(@procedure, anchor: dom_id(tdc.stable_self, :editor_error))
     when :attestation_template
-      edit_admin_procedure_attestation_template_path(@procedure)
+      if error.detail[:value].version == 1
+        edit_admin_procedure_attestation_template_path(@procedure)
+      else
+        edit_admin_procedure_attestation_template_v2_path(@procedure)
+      end
     when :initiated_mail, :received_mail, :closed_mail, :refused_mail, :without_continuation_mail, :re_instructed_mail
       klass = "Mails::#{error.attribute.to_s.classify}".constantize
       edit_admin_procedure_mail_template_path(@procedure, klass.const_get(:SLUG))

--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -76,8 +76,7 @@ module Administrateurs
             types_de_champ: [],
             revision_types_de_champ: { type_de_champ: { piece_justificative_template_attachment: :blob } }
           },
-          attestation_template_v1: [],
-          attestation_templates_v2: [],
+          attestation_template: [],
           initiated_mail: [],
           received_mail: [],
           closed_mail: [],

--- a/spec/components/procedures/errors_summary_spec.rb
+++ b/spec/components/procedures/errors_summary_spec.rb
@@ -101,7 +101,7 @@ describe Procedure::ErrorsSummary, type: :component do
 
     it 'render error nicely' do
       expect(page).to have_selector("a", text: "Les règles d’inéligibilité")
-      expect(page).to have_selector("a", text: "Le modèle d’attestation")
+      expect(page).to have_selector("a[href*='v2']", text: "Le modèle d’attestation")
       expect(page).to have_selector("a", text: "L’email de notification de passage de dossier en instruction")
       expect(page).to have_text("n'est pas valide", count: 2)
     end
@@ -118,7 +118,7 @@ describe Procedure::ErrorsSummary, type: :component do
     end
 
     it 'render error nicely' do
-      expect(page).to have_selector("a", text: "Le modèle d’attestation")
+      expect(page).to have_selector("a:not([href*='v2'])", text: "Le modèle d’attestation")
       expect(page).to have_text("n'est pas valide", count: 1)
     end
   end


### PR DESCRIPTION
Avant on avait 2 messages pour la même attestation (la même attestation était validée 2 fois, par 2 relations différentes), et pas vers les bons liens : 

![Capture d’écran 2024-11-27 à 11 57 37](https://github.com/user-attachments/assets/8abad85e-0880-4fbf-b926-999fa377ee16)

On ne met plus qu'un seul lien pour aller vers la v2.
Comme en prod le ff de la v2 est activé globalement, on répercute ça dans les tests et c'est une première étape pour le retirer du code.