### PR TITLE
ETQ Usager si je me connecte en Agent-Connect/Pro-Connect je veux être redirigé vers ma page d'origine

### DIFF
--- a/app/controllers/agent_connect/agent_controller.rb
+++ b/app/controllers/agent_connect/agent_controller.rb
@@ -54,7 +54,7 @@ class AgentConnect::AgentController < ApplicationController
 
     sign_in(:user, instructeur.user)
 
-    redirect_to instructeur_procedures_path
+    redirect_to stored_location_for(:user) || instructeur_procedures_path
 
   rescue Rack::OAuth2::Client::Error => e
     Rails.logger.error e.message


### PR DESCRIPTION
Dans le cadre de l'instance Sénat de Démarches Simplifiées, nous utilisons uniquement l'authentification agent-connect qui est remplacée par notre keycloak. Nous avons fait ce choix par simplicité, car la majorité de nos usagers pourront être amenés à instruire des dossiers.


Quand un usager accède à une démarche sans être connecté au préalable, après la connexion Agent Connect, l'usager est redirigé vers la page de ses démarches en instruction.

Avec cette PR, nous proposons de renvoyer après la connexion, l'usager vers la page cible.

Voir aussi : https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/10972#pullrequestreview-2385606258