### PR TITLE
ETQ admin, corrige l'intitulé de la direction de l'attestation pour s'aligner à droite quand il y a plusieurs lignes

### DIFF
--- a/app/assets/stylesheets/attestation.scss
+++ b/app/assets/stylesheets/attestation.scss
@@ -109,6 +109,7 @@
     margin: 5.25mm 0 23.3mm;
     line-height: 14pt;
     font-weight: bold;
+    text-align: right;
   }
 
   .body-start {


### PR DESCRIPTION
Remontée sur Crisp
Charte graphique des docs de l'état : https://www.info.gouv.fr/marque-de-letat/ministeres-secretariats-d-etat-services-deconcentres-ou-a-l

Je ne suis pas parvenu à du pixel perfect (ça dépend de weasyprint)
 
## APRES
![Capture d’écran 2024-12-04 à 10 22 25](https://github.com/user-attachments/assets/97f4c415-6218-478c-8fe7-0898f3183334)

## AVANT

![Capture d’écran 2024-12-04 à 10 22 34](https://github.com/user-attachments/assets/be58ad21-78a2-4d06-becb-f513d96104c8)
