### PR TITLE
ETQ usager je peux restorer un brouillon supprimé automatiquement car pas modifié automatiquement

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -505,7 +505,7 @@ module Users
       if action_name == 'update' || action_name == 'champ'
         Dossier.visible_by_user.or(Dossier.for_procedure_preview).or(Dossier.for_editing_fork)
       elsif action_name == 'restore'
-        Dossier.hidden_by_user
+        Dossier.hidden_by_user.or(Dossier.hidden_by_not_modified_for_a_long_time)
       elsif action_name == 'extend_conservation_and_restore' || (action_name == 'show' && request.format.pdf?)
         Dossier.visible_by_user.or(Dossier.hidden_by_expired)
       else

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -1407,6 +1407,19 @@ describe Users::DossiersController, type: :controller do
         expect(dossier.reload.hidden_by_user_at).to be_nil
       end
     end
+
+    context 'when brouillon has been automatically expired' do
+      let(:dossier) { create(:dossier, :brouillon, user:) }
+
+      before {
+        dossier.hide_and_keep_track!(:automatic, :not_modified_for_a_long_time)
+      }
+
+      it 'must restore hidden attributes' do
+        expect { subject }.to change { dossier.reload.hidden_by_expired_at }.from(anything).to(nil)
+        expect(dossier.hidden_by_reason).to eq("not_modified_for_a_long_time")
+      end
+    end
   end
 
   describe '#new' do


### PR DESCRIPTION
Le bouton était déjà disponible dans l'interface. Fix un peu le feu au support