### PR TITLE
ETQ usager, pas d'erreur inutile lors d'un double callback FranceConnect

### DIFF
--- a/app/models/france_connect_information.rb
+++ b/app/models/france_connect_information.rb
@@ -15,6 +15,8 @@ class FranceConnectInformation < ApplicationRecord
         password: Devise.friendly_token[0, 20],
         confirmed_at: Time.zone.now
       )
+
+      update_attribute('user_id', user.id)
     rescue ActiveRecord::RecordNotUnique
       # ignore this exception because we check before if user is nil.
       # exception can be raised in race conditions, when FranceConnect calls callback 2 times.
@@ -23,7 +25,6 @@ class FranceConnectInformation < ApplicationRecord
     end
 
     clean_tokens_and_requested_email
-    update_attribute('user_id', user.id)
     save!
   end
 

--- a/spec/models/france_connect_information_spec.rb
+++ b/spec/models/france_connect_information_spec.rb
@@ -50,25 +50,19 @@ describe FranceConnectInformation, type: :model do
         allow(fci).to receive(:send_custom_confirmation_instructions)
       end
 
-      it 'raises an error' do
-        expect { fci.safely_associate_user!(email) }.to raise_error(NoMethodError)
+      it 'is noop' do
+        expect(fci.safely_associate_user!(email)).to eq(true)
       end
 
       it 'does not create a new user' do
         expect {
-          begin
-            fci.safely_associate_user!(email)
-          rescue NoMethodError
-          end
+          fci.safely_associate_user!(email)
         }.to_not change(User, :count)
       end
 
       it 'does not associate with any user' do
         expect(fci.user).to be_nil
-        begin
-          fci.safely_associate_user!(email)
-        rescue NoMethodError
-        end
+        fci.safely_associate_user!(email)
         expect(fci.reload.user).to be_nil
       end
     end


### PR DESCRIPTION
https://demarches-simplifiees.sentry.io/issues/6122564316/
ça évite probablement une erreur côté utilisateur et devrait permettre le flow de signin de continuer