### PR TITLE
ETQ Instructeur avec un compte en beta.gouv.fr ou modernisation.gouv.fr je suis automatiquement redirigé vers une connexion ProConnect

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -7,6 +7,7 @@ class Users::SessionsController < Devise::SessionsController
 
   layout 'login', only: [:new, :create]
 
+  before_action :redirect_to_agent_connect_if_mandatory, only: [:create]
   before_action :restore_procedure_context, only: [:new, :create]
   skip_before_action :redirect_if_untrusted, only: [:reset_link_sent]
   # POST /resource/sign_in
@@ -116,5 +117,14 @@ class Users::SessionsController < Devise::SessionsController
     end
 
     redirect_to root_path, notice: I18n.t('devise.sessions.signed_out')
+  end
+
+  def redirect_to_agent_connect_if_mandatory
+    return if !AgentConnectService.enabled?
+
+    return if !AgentConnectService.email_domain_is_in_mandatory_list?(params[:user][:email])
+
+    flash[:alert] = "La connexion des agents passe à présent systématiquement par AgentConnect"
+    redirect_to agent_connect_path(force_agent_connect: true)
   end
 end

--- a/app/services/agent_connect_service.rb
+++ b/app/services/agent_connect_service.rb
@@ -3,6 +3,8 @@
 class AgentConnectService
   include OpenIDConnect
 
+  MANDATORY_EMAIL_DOMAINS = ['beta.gouv.fr', 'modernisation.gouv.fr']
+
   def self.enabled?
     ENV['AGENT_CONNECT_BASE_URL'].present?
   end
@@ -43,6 +45,10 @@ class AgentConnectService
     app_logout = Rails.application.routes.url_helpers.logout_url(host: host_with_port)
     h = { id_token_hint: id_token, post_logout_redirect_uri: app_logout }
     "#{AGENT_CONNECT[:end_session_endpoint]}?#{h.to_query}"
+  end
+
+  def self.email_domain_is_in_mandatory_list?(email)
+    email.strip.split('@').last.in?(MANDATORY_EMAIL_DOMAINS)
   end
 
   private

--- a/app/views/agent_connect/agent/index.html.haml
+++ b/app/views/agent_connect/agent/index.html.haml
@@ -26,36 +26,36 @@
                   %p
                     = link_to t('.whats_agentconnect'), 'https://agentconnect.gouv.fr/', target: '_blank', rel: "noopener"
 
+            - if !params[:force_agent_connect]
+              %p.fr-hr-or= t('views.shared.france_connect_login.separator')
 
-            %p.fr-hr-or= t('views.shared.france_connect_login.separator')
+              %fieldset.fr-mb-0.fr-fieldset{ aria: { labelledby: 'new-account-legend' } }
+                %legend.fr-fieldset__legend#new-account-legend
+                  %h2.fr-h6= I18n.t('views.users.sessions.new.subtitle')
 
-            %fieldset.fr-mb-0.fr-fieldset{ aria: { labelledby: 'new-account-legend' } }
-              %legend.fr-fieldset__legend#new-account-legend
-                %h2.fr-h6= I18n.t('views.users.sessions.new.subtitle')
+                = render Dsfr::AlertComponent.new(state: :info, size: :sm, extra_class_names: 'fr-mb-2w') do |c|
+                  - c.with_body do
+                    = t('views.users.sessions.new.for_tiers_alert')
 
-              = render Dsfr::AlertComponent.new(state: :info, size: :sm, extra_class_names: 'fr-mb-2w') do |c|
-                - c.with_body do
-                  = t('views.users.sessions.new.for_tiers_alert')
+                .fr-fieldset__element
+                  %p.fr-text--sm= t('utils.asterisk_html')
 
-              .fr-fieldset__element
-                %p.fr-text--sm= t('utils.asterisk_html')
+                .fr-fieldset__element
+                  = render Dsfr::InputComponent.new(form: f, attribute: :email, input_type: :email_field, opts: { autocomplete: 'email' }) do |c|
+                    - c.with_label { t('.pro_email') }
 
-              .fr-fieldset__element
-                = render Dsfr::InputComponent.new(form: f, attribute: :email, input_type: :email_field, opts: { autocomplete: 'email' }) do |c|
-                  - c.with_label { t('.pro_email') }
+                .fr-fieldset__element
+                  = render Dsfr::InputComponent.new(form: f, attribute: :password, input_type: :password_field, opts: { autocomplete: 'current-password' })
 
-              .fr-fieldset__element
-                = render Dsfr::InputComponent.new(form: f, attribute: :password, input_type: :password_field, opts: { autocomplete: 'current-password' })
+                  %p= link_to t('views.users.sessions.new.reset_password'), new_user_password_path, class: "fr-link"
 
-                %p= link_to t('views.users.sessions.new.reset_password'), new_user_password_path, class: "fr-link"
+                .fr-fieldset__element
+                  .auth-options
+                    .flex-no-shrink
+                      = f.check_box :remember_me
+                      = f.label :remember_me, t('views.users.sessions.new.remember_me'), class: 'remember-me'
 
-              .fr-fieldset__element
-                .auth-options
-                  .flex-no-shrink
-                    = f.check_box :remember_me
-                    = f.label :remember_me, t('views.users.sessions.new.remember_me'), class: 'remember-me'
-
-                .fr-btns-group= f.submit t('views.users.sessions.new.connection'), class: "fr-btn"
+                  .fr-btns-group= f.submit t('views.users.sessions.new.connection'), class: "fr-btn"
 
           %hr
 

--- a/app/views/agent_connect/agent/index.html.haml
+++ b/app/views/agent_connect/agent/index.html.haml
@@ -2,7 +2,7 @@
 
 #agentconnect
   .fr-container
-    .fr-grid-row.fr-grid-row--gutters
+    .fr-grid-row.fr-grid-row--gutters.fr-mt-0
 
       .fr-col-lg.fr-p-6w.fr-background-alt--blue-france
 

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -96,6 +96,16 @@ describe Users::SessionsController, type: :controller do
         expect(controller.current_user).to be(nil)
       end
     end
+
+    context 'when email domain is in mandatory list' do
+      let(:email) { 'user@beta.gouv.fr' }
+      it 'redirects to agent connect with force parameter' do
+        expect(AgentConnectService).to receive(:enabled?).and_return(true)
+        subject
+        expect(response).to redirect_to(agent_connect_path(force_agent_connect: true))
+        expect(flash[:alert]).to eq("La connexion des agents passe à présent systématiquement par AgentConnect")
+      end
+    end
   end
 
   describe '#destroy' do

--- a/spec/services/agent_connect_service_spec.rb
+++ b/spec/services/agent_connect_service_spec.rb
@@ -16,4 +16,28 @@ describe AgentConnectService do
       expect(subject).to eq("https://agent-connect.fr/logout?id_token_hint=id_token&post_logout_redirect_uri=http%3A%2F%2Ftest.host%2Flogout")
     end
   end
+
+  describe '.email_domain_is_in_mandatory_list?' do
+    subject { described_class.email_domain_is_in_mandatory_list?(email) }
+
+    context 'when email domain is beta.gouv.fr' do
+      let(:email) { 'user@beta.gouv.fr' }
+      it { is_expected.to be true }
+    end
+
+    context 'when email domain is modernisation.gouv.fr' do
+      let(:email) { 'user@modernisation.gouv.fr' }
+      it { is_expected.to be true }
+    end
+
+    context 'when email domain is not in the mandatory list' do
+      let(:email) { 'user@example.com' }
+      it { is_expected.to be false }
+    end
+
+    context 'when email contains whitespace' do
+      let(:email) { ' user@beta.gouv.fr ' }
+      it { is_expected.to be true }
+    end
+  end
 end


### PR DESCRIPTION
Fixes #10952

Comme vu avec Sim, on ne fait pas de nouvelle page, on réutilise la page actuelle sur AgentConnect, en cachant le formulaire user/password.

J'ai modifié le message d'alerte prévu `La connexion des instructeurs et administrateurs ...`en `La connexion des agents...` puisque des Agents peuvent aussi se connecter en utilisant la connexion par utilisateur.

Je ne me suis pas lancé dans le renommage AgentConnect => ProConnect, mais si c'est prio je peux le faire dans une autre PR.

<img width="1197" alt="image" src="https://github.com/user-attachments/assets/d9c653a2-c3aa-433b-9940-5bb5b435ffc5" />
