### PR TITLE
ETQ ds, j'utilise le nouvel endpoint pour les API rnf

### DIFF
--- a/app/services/rnf_service.rb
+++ b/app/services/rnf_service.rb
@@ -26,7 +26,7 @@ class RNFService
   end
 
   def typhoeus_options
-    { ssl_verifyhost: 0 }
+    { ssl_verifypeer: false }
   end
 
   def schema


### PR DESCRIPTION
Désactivé la vérification SSL au lieux de la vérification d'host, Le certificat est un certificat IGC: https://www.interieur.gouv.fr/IGC