### PR TITLE
ETQ DS, je veux avoir de la visibilité sur l'usage mémoire des API

### DIFF
--- a/app/controllers/api/v2/graphql_controller.rb
+++ b/app/controllers/api/v2/graphql_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class API::V2::GraphqlController < API::V2::BaseController
+  include GcTrackingConcern
+
   def execute
     result = API::V2::Schema.execute(query:, variables:, context:, operation_name:)
     @query_info = result.context.query_info

--- a/app/controllers/concerns/gc_tracking_concern.rb
+++ b/app/controllers/concerns/gc_tracking_concern.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module GcTrackingConcern
+  extend ActiveSupport::Concern
+
+  included do
+    around_action :track_gc_stat, if: :track_gc?
+
+    def track_gc_stat
+      before = GC.stat
+      yield
+      after = GC.stat
+
+      begin
+        @query_info ||= {}
+        @query_info[:gc_stat_count] = after[:count] - before[:count] # number of gc
+        @query_info[:gc_stat_heap_available_slots] = after[:heap_available_slots] - before[:heap_available_slots]
+      rescue => e
+        Sentry.capture_exception(e)
+      end
+    end
+
+    def track_gc?
+      ENV['TRACK_GC_ENABLED'] == 'enabled'
+    end
+  end
+end


### PR DESCRIPTION
On a tjr les APIs qui sont patraques. 
La piste actuelle : on est pas étanche 🤣 (sous entendu, memory leak). cf: https://mattermost.incubateur.net/betagouv/pl/hpteodxgpif578ckix9pjka5dr

Je propose de suivre la methode proposée par : https://dev.37signals.com/adventures-hunting-down-ruby-memory-leak/ 

TLDR ;

On log déjà les graphql_query/graphql_variable, reste à aggrémenter ça avec : 
* le nombre de fois ou le gc est passé sur l'appel de l'API
* un indicateur de progression de la memoire sur l'appel de l'API

La suite : 
* on trouve les graphql_query/graphql_variable qui font que le gc passe.
* on trouve les graphql_query/graphql_variable qui font le plus progresser la memoire

Apres : 
* on suit la methode proposée...