### PR TITLE
Addressable address

### DIFF
--- a/app/models/champs/address_champ.rb
+++ b/app/models/champs/address_champ.rb
@@ -6,18 +6,22 @@ class Champs::AddressChamp < Champs::TextChamp
   end
 
   def feature=(value)
-    if value.blank?
-      self.data = nil
+    h = if value.blank?
+      nil
     else
       feature = JSON.parse(value)
       if feature.key?('properties')
-        self.data = APIGeoService.parse_ban_address(feature)
+        APIGeoService.parse_ban_address(feature)
       else
-        self.data = feature
+        feature
       end
     end
+
+    self.data = h
+    self.value_json = h
   rescue JSON::ParserError
     self.data = nil
+    self.value_json = nil
   end
 
   def selected_items

--- a/app/models/concerns/addressable_column_concern.rb
+++ b/app/models/concerns/addressable_column_concern.rb
@@ -8,7 +8,7 @@ module AddressableColumnConcern
       [
         ["Code postal (5 chiffres)", '$.postal_code', :text, []],
         ["Commune", '$.city_name', :text, []],
-        ["Département", '$.departement_code', :enum, APIGeoService.departement_options],
+        ["Département", '$.department_code', :enum, APIGeoService.departement_options],
         ["Région", '$.region_name', :enum, APIGeoService.region_options]
       ].map do |(label, jsonpath, type, options_for_select)|
         Columns::JSONPathColumn.new(

--- a/app/models/concerns/columns_concern.rb
+++ b/app/models/concerns/columns_concern.rb
@@ -15,6 +15,7 @@ module ColumnsConcern
       # TODO: to remove after linked_drop_down column column_id migration
       if column.nil? && h_id.is_a?(Hash) && h_id[:column_id].present?
         h_id[:column_id].gsub!('->', '.')
+        h_id[:column_id].gsub!('departement_code', 'department_code')
 
         column = columns.find { _1.h_id == h_id }
       end

--- a/app/models/types_de_champ/address_type_de_champ.rb
+++ b/app/models/types_de_champ/address_type_de_champ.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::AddressTypeDeChamp < TypesDeChamp::TextTypeDeChamp
+  include AddressableColumnConcern
+
   def libelles_for_export
     path = paths.first
     [[path[:libelle], path[:path]]]
@@ -34,6 +36,11 @@ class TypesDeChamp::AddressTypeDeChamp < TypesDeChamp::TextTypeDeChamp
     when :commune
       champ.commune_name
     end
+  end
+
+  def columns(procedure:, displayable: true, prefix: nil)
+    super
+      .concat(addressable_columns(procedure:, displayable:, prefix:))
   end
 
   private

--- a/app/tasks/maintenance/backfill_address_value_json_task.rb
+++ b/app/tasks/maintenance/backfill_address_value_json_task.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class BackfillAddressValueJSONTask < MaintenanceTasks::Task
+    # task run on 15/01/2025, needed for address columns
+    include RunnableOnDeployConcern
+    include StatementsHelpersConcern
+
+    no_collection
+
+    def process
+      sql = "UPDATE champs SET value_json = data WHERE type = 'Champs::AddressChamp' AND data IS NOT NULL;"
+
+      with_statement_timeout("15min") do
+        Champ.connection.execute(sql)
+      end
+    end
+  end
+end

--- a/app/tasks/maintenance/migrate_export_address_and_linked_columns_task.rb
+++ b/app/tasks/maintenance/migrate_export_address_and_linked_columns_task.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class MigrateExportAddressAndLinkedColumnsTask < MaintenanceTasks::Task
+    include RunnableOnDeployConcern
+
+    def collection
+      Export.all
+    end
+
+    def process(export)
+      # by using the `will_change!` method, we ensure that the column will be saved
+      # and thus the address and linked columns id will be migrated to the new format
+      export.filtered_columns_will_change!
+      export.sorted_column_will_change!
+
+      export.save(validate: false)
+    end
+  end
+end

--- a/app/tasks/maintenance/migrate_export_template_address_and_linked_columns_task.rb
+++ b/app/tasks/maintenance/migrate_export_template_address_and_linked_columns_task.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class MigrateExportTemplateAddressAndLinkedColumnsTask < MaintenanceTasks::Task
+    include RunnableOnDeployConcern
+
+    def collection
+      ExportTemplate.all
+    end
+
+    def process(export_template)
+      # by using the `will_change!` method, we ensure that the column will be saved
+      # and thus the address and linked columns id will be migrated to the new format
+      export_template.exported_columns_will_change!
+
+      export_template.save(validate: false)
+    end
+  end
+end

--- a/app/tasks/maintenance/migrate_procedure_presentation_address_and_linked_columns_task.rb
+++ b/app/tasks/maintenance/migrate_procedure_presentation_address_and_linked_columns_task.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class MigrateProcedurePresentationAddressAndLinkedColumnsTask < MaintenanceTasks::Task
+    include RunnableOnDeployConcern
+
+    def collection
+      ProcedurePresentation.all
+    end
+
+    def process(procedure_presentation)
+      # by using the `will_change!` method, we ensure that the column will be saved
+      # and thus the address and linked columns id will be migrated to the new format
+      procedure_presentation.displayed_columns_will_change!
+      procedure_presentation.sorted_column_will_change!
+      procedure_presentation.a_suivre_filters_will_change!
+      procedure_presentation.suivis_filters_will_change!
+      procedure_presentation.traites_filters_will_change!
+      procedure_presentation.tous_filters_will_change!
+      procedure_presentation.supprimes_filters_will_change!
+      procedure_presentation.supprimes_recemment_filters_will_change!
+      procedure_presentation.expirant_filters_will_change!
+      procedure_presentation.archives_filters_will_change!
+
+      procedure_presentation.save(validate: false)
+    end
+  end
+end

--- a/spec/factories/champ.rb
+++ b/spec/factories/champ.rb
@@ -163,7 +163,7 @@ FactoryBot.define do
 
     factory :champ_do_not_use_rna, class: 'Champs::RNAChamp' do
       value { 'W173847273' }
-      value_json { AddressProxy::ADDRESS_PARTS.index_by(&:itself).merge(title: "LA PRÉVENTION ROUTIERE") }
+      value_json { AddressProxy::ADDRESS_PARTS.index_by(&:itself).merge(title: "LA PRÉVENTION ROUTIERE", department_code: 'department_code') }
     end
 
     factory :champ_do_not_use_engagement_juridique, class: 'Champs::EngagementJuridiqueChamp' do
@@ -176,7 +176,7 @@ FactoryBot.define do
     factory :champ_do_not_use_rnf, class: 'Champs::RNFChamp' do
       value { '075-FDD-00003-01' }
       external_id { '075-FDD-00003-01' }
-      value_json { AddressProxy::ADDRESS_PARTS.index_by(&:itself).merge(title: "Fondation SFR") }
+      value_json { AddressProxy::ADDRESS_PARTS.index_by(&:itself).merge(title: "Fondation SFR", department_code: 'department_code') }
     end
 
     factory :champ_do_not_use_expression_reguliere, class: 'Champs::ExpressionReguliereChamp' do

--- a/spec/factories/champ.rb
+++ b/spec/factories/champ.rb
@@ -51,6 +51,7 @@ FactoryBot.define do
 
     factory :champ_do_not_use_address, class: 'Champs::AddressChamp' do
       value { '2 rue des Démarches' }
+      value_json { { postal_code: '38000', city_name: 'grenoble', department_code: '38', region_name: 'Auvergne-Rhones-Alpes' } }
     end
 
     factory :champ_do_not_use_yes_no, class: 'Champs::YesNoChamp' do

--- a/spec/models/columns/champ_column_spec.rb
+++ b/spec/models/columns/champ_column_spec.rb
@@ -12,7 +12,7 @@ describe Columns::ChampColumn do
         expect_type_de_champ_values('civilite', eq(["M."]))
         expect_type_de_champ_values('email', eq(['yoda@beta.gouv.fr']))
         expect_type_de_champ_values('phone', eq(['0666666666']))
-        expect_type_de_champ_values('address', eq(["2 rue des Démarches"]))
+        expect_type_de_champ_values('address', eq(["2 rue des Démarches", "38000", "grenoble", "38", "Auvergne-Rhones-Alpes"]))
         expect_type_de_champ_values('communes', eq(["Coye-la-Forêt", "60580", "60"]))
         expect_type_de_champ_values('departements', eq(['01']))
         expect_type_de_champ_values('regions', eq(['01']))

--- a/spec/models/columns/champ_column_spec.rb
+++ b/spec/models/columns/champ_column_spec.rb
@@ -55,8 +55,8 @@ describe Columns::ChampColumn do
         expect_type_de_champ_values('mesri', eq([nil]))
         expect_type_de_champ_values('cojo', eq([nil]))
         expect_type_de_champ_values('expression_reguliere', eq([nil]))
-        expect_type_de_champ_values('rna', eq(["W173847273", "postal_code", "city_name", "departement_code", "region_name", "LA PRÉVENTION ROUTIERE"]))
-        expect_type_de_champ_values('rnf', eq(["075-FDD-00003-01", "postal_code", "city_name", "departement_code", "region_name", "Fondation SFR"]))
+        expect_type_de_champ_values('rna', eq(["W173847273", "postal_code", "city_name", "department_code", "region_name", "LA PRÉVENTION ROUTIERE"]))
+        expect_type_de_champ_values('rnf', eq(["075-FDD-00003-01", "postal_code", "city_name", "department_code", "region_name", "Fondation SFR"]))
       end
     end
 

--- a/spec/models/concerns/columns_concern_spec.rb
+++ b/spec/models/concerns/columns_concern_spec.rb
@@ -4,7 +4,12 @@ describe ColumnsConcern do
   let(:procedure_id) { procedure.id }
 
   describe '#find_column' do
-    let(:types_de_champ_public) { [{ type: :linked_drop_down_list, libelle: 'linked' }] }
+    let(:types_de_champ_public) do
+      [
+        { type: :linked_drop_down_list, libelle: 'linked' },
+        { type: :address, libelle: 'address' }
+      ]
+    end
     let(:procedure) { create(:procedure, types_de_champ_public:) }
     let(:notifications_column) { procedure.notifications_column }
 
@@ -28,6 +33,14 @@ describe ColumnsConcern do
 
       h_id = { procedure_id:, column_id: }
       expect(procedure.find_column(h_id:)).to eq(value_column)
+
+      address_tdc = procedure.active_revision.types_de_champ
+        .find { _1.type_champ == 'address' }
+
+      adresse_department_column = procedure.find_column(label: "address – Département")
+      column_id = "type_de_champ/#{address_tdc.stable_id}-$.departement_code"
+      h_id = { procedure_id:, column_id: }
+      expect(procedure.find_column(h_id:)).to eq(adresse_department_column)
     end
   end
 

--- a/spec/models/types_de_champ/address_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/address_type_de_champ_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe TypesDeChamp::AddressTypeDeChamp do
+  describe '#columns' do
+    let(:procedure) { create(:procedure, types_de_champ_public: [libelle: 'addr', type: 'address']) }
+    let(:address_tdc) { procedure.active_revision.types_de_champ.first }
+    let(:columns) { address_tdc.columns(procedure:) }
+
+    it '' do
+      expected_columns = [
+        "addr",
+        "addr – Code postal (5 chiffres)",
+        "addr – Commune",
+        "addr – Département",
+        "addr – Région"
+      ]
+
+      expect(columns.map(&:label)).to match_array(expected_columns)
+    end
+  end
+end

--- a/spec/services/dossier_filter_service_spec.rb
+++ b/spec/services/dossier_filter_service_spec.rb
@@ -602,8 +602,8 @@ describe DossierFilterService do
         let(:filter) { ["rna – Département", value] }
 
         before do
-          kept_dossier.project_champs_public.find { _1.stable_id == 1 }.update(value_json: { "departement_code" => value })
-          create(:dossier, procedure:).project_champs_public.find { _1.stable_id == 1 }.update(value_json: { "departement_code" => "unknown" })
+          kept_dossier.project_champs_public.find { _1.stable_id == 1 }.update(value_json: { "department_code" => value })
+          create(:dossier, procedure:).project_champs_public.find { _1.stable_id == 1 }.update(value_json: { "department_code" => "unknown" })
         end
 
         it { is_expected.to contain_exactly(kept_dossier.id) }

--- a/spec/services/dossier_projection_service_spec.rb
+++ b/spec/services/dossier_projection_service_spec.rb
@@ -244,7 +244,7 @@ describe DossierProjectionService do
         let(:label) { "SIRET – Département" }
 
         before do
-          dossier.project_champs_public.first.update(value_json: { 'departement_code': '38' })
+          dossier.project_champs_public.first.update(value_json: { 'department_code': '38' })
         end
 
         it { is_expected.to eq('38') }

--- a/spec/system/instructeurs/procedure_filters_spec.rb
+++ b/spec/system/instructeurs/procedure_filters_spec.rb
@@ -147,8 +147,8 @@ describe "procedure filters" do
             "street_name" => "fake",
             "street_number" => "fake",
             "street_address" => "fake",
-            "departement_code" => "37",
-            "departement_name" => "Indre-et-Loire"
+            "department_code" => "37",
+            "department_name" => "Indre-et-Loire"
           }
         )
         rna_champ.reload

--- a/spec/tasks/maintenance/backfill_address_value_json_task_spec.rb
+++ b/spec/tasks/maintenance/backfill_address_value_json_task_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe BackfillAddressValueJSONTask do
+    describe "#process" do
+      subject(:process) { described_class.process }
+
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :address, libelle: 'address' }]) }
+      let(:dossier) { create(:dossier, procedure:) }
+      let(:address_champ) { dossier.project_champs_public.first }
+      let(:address_data) { { 'address' => 'address' } }
+
+      before { address_champ.update(data: address_data) }
+
+      it do
+        expect(address_champ.value_json).to be_nil
+
+        process
+        address_champ.reload
+
+        expect(address_champ.value_json).to eq(address_data)
+      end
+    end
+  end
+end

--- a/spec/tasks/maintenance/migrate_procedure_presentation_address_and_linked_columns_task_spec.rb
+++ b/spec/tasks/maintenance/migrate_procedure_presentation_address_and_linked_columns_task_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe MigrateProcedurePresentationAddressAndLinkedColumnsTask do
+    def displayed_column_ids
+      raw = ProcedurePresentation
+        .connection
+        .select_value('SELECT array_to_json(displayed_columns) from procedure_presentations')
+
+      JSON.parse(raw).map { _1['column_id'] }
+    end
+
+    def a_suivre_column_id
+      raw = ProcedurePresentation
+        .connection
+        .select_value('SELECT array_to_json(a_suivre_filters) from procedure_presentations')
+        .then { JSON.parse(_1).first }
+
+      raw['id']['column_id']
+    end
+
+    describe "#process" do
+      subject(:process) { described_class.process(ProcedurePresentation.find(procedure_presentation.id)) }
+
+      let(:instructeur) { create(:instructeur) }
+      let(:procedure_presentation) do
+        groupe_instructeur = procedure.defaut_groupe_instructeur
+        assign_to = create(:assign_to, instructeur:, groupe_instructeur:)
+        assign_to.procedure_presentation_or_default_and_errors.first
+      end
+
+      describe "#old_linked_drop_down?" do
+        let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :linked_drop_down_list, libelle: 'linked' }]) }
+
+        let(:old_syntaxed_columns) do
+          procedure.columns.filter { _1.label =~ /linked/ }.map do |column|
+            def column.h_id
+              original_h_id = super()
+              original_h_id[:column_id] = original_h_id[:column_id].gsub('.', '->')
+              original_h_id
+            end
+
+            column
+          end
+        end
+
+        before do
+          procedure_presentation.update(displayed_columns: old_syntaxed_columns)
+          procedure_presentation.update(a_suivre_filters: [FilteredColumn.new(column: old_syntaxed_columns.first, filter: 'filter')])
+
+          # destroy the columns cache
+          Current.procedure_columns = nil
+        end
+
+        it do
+          # ensure old syntax is present in db
+          expect(displayed_column_ids.any? { _1.include?('->') }).to be(true)
+          expect(a_suivre_column_id).to include('->')
+
+          process
+
+          expect(displayed_column_ids.any? { _1.include?('->') }).to be(false)
+          expect(a_suivre_column_id).not_to include('->')
+        end
+      end
+
+      describe "#department_columns" do
+        let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :address, libelle: 'address' }]) }
+        let(:old_department) do
+          department_column = procedure.columns.filter { _1.id =~ /\$.department/ }.first
+
+          def department_column.h_id
+            original_h_id = super()
+            original_h_id[:column_id] = original_h_id[:column_id].gsub('department', 'departement')
+            original_h_id
+          end
+
+          department_column
+        end
+
+        before do
+          procedure_presentation.update(displayed_columns: [old_department])
+
+          # destroy the columns cache
+          Current.procedure_columns = nil
+        end
+
+        it do
+          # ensure old syntax is present in db
+          expect(displayed_column_ids.any? { _1.include?('departement') }).to be(true)
+
+          process
+
+          expect(displayed_column_ids.any? { _1.include?('departement') }).to be(false)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- on rajoute le concerne `AddressableColumnConcern` au champ `address` -> il expose maintenant les colonnes code postal / commune / département / région
- pour que ces colonnes soient remplis, il faut que la donnée address soit sauvegardée dans la colonne `value_json`, elle stockée dans `data` en ce moment
- dans le champ address, le departement est stocké est sous forme `department_code`
- `AddressableColumnConcern` est maintenant utilisé dans les champs `rna` / `rnf` / `siret` et `address`

pour les champs siret / rna /  rnf / le departement est sauvé sous format `departement_code` et `department_code` grace au commit 366c02dbb7eaad4e1a67e6a1ae2ddfa6e06e8683 et la donnée a été backfillée avec les taches populate_rnf_json_value / rna / siret

Du coup, on peut modifier le json_path du departement de `$.departement_code` -> `$.department_code` pour faire marcher la colonne partout.

puis

- [x] backfill des champs adresse pour remplir `value_json`

a discuter :
- faisabilité de l'update direct des address value_json va passer
- technique de maj des colonnes dans les pp a répéter pour les exports et les export_templates
- AddressProxy se base encore sur `departement_name`, `departement_code`