### PR TITLE
fix(dossier): on fork merge, always remove previous champ version

### DIFF
--- a/app/models/concerns/dossier_clone_concern.rb
+++ b/app/models/concerns/dossier_clone_concern.rb
@@ -167,7 +167,7 @@ module DossierCloneConcern
     added_champs.each { _1.update_column(:dossier_id, id) }
 
     if updated_champs.present?
-      champs_index = filled_champs_public.index_by(&:public_id)
+      champs_index = champs.index_by(&:public_id)
       updated_champs.each do |champ|
         champs_index[champ.public_id]&.destroy!
         champ.update_column(:dossier_id, id)

--- a/app/tasks/maintenance/t20241216remove_non_unique_champs_task.rb
+++ b/app/tasks/maintenance/t20241216remove_non_unique_champs_task.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20241216removeNonUniqueChampsTask < MaintenanceTasks::Task
+    # Documentation: cette tâche supprime les champs en double dans un dossier
+
+    include RunnableOnDeployConcern
+    include StatementsHelpersConcern
+
+    def collection
+      Dossier.state_not_brouillon.includes(champs: true)
+    end
+
+    def process(dossier)
+      dossier.champs.filter { _1.row_id.nil? }.group_by(&:public_id).each do |_, champs|
+        if champs.size > 1
+          champs.sort_by(&:id)[1..].each(&:destroy)
+        end
+      end
+    end
+  end
+end

--- a/spec/tasks/maintenance/t20241216remove_non_unique_champs_task_spec.rb
+++ b/spec/tasks/maintenance/t20241216remove_non_unique_champs_task_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe T20241216removeNonUniqueChampsTask do
+    describe "#process" do
+      subject(:process) { described_class.process(dossier) }
+      let(:procedure) { create(:procedure, types_de_champ_public: [{}]) }
+      let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
+      let(:type_de_champ) { dossier.revision.types_de_champ_public.first }
+      let(:champ_id) { dossier.champs.first.id }
+
+      before {
+        dossier.champs.create(**type_de_champ.params_for_champ)
+      }
+
+      it { expect { subject }.to change { dossier.reload.project_champ(type_de_champ).id }.from(dossier.champs.last.id).to(champ_id) }
+      it { expect { subject }.to change { Champ.count }.by(-1) }
+    end
+  end
+end


### PR DESCRIPTION
Si le `type_de_champ` d'un champ se désynchronise avec son `type`, le champ persisté ne fera pas partie de la collection `filled_champs`. Dans le code de merge des fork, nous devons supprimer le champ précédent, sans tenir compte de son type. Le problème aurait dû être détecté plus tôt, mais notre index unique n'est pas réellement unique parce que notre version de PG ne prend pas en charge `NULLS NOT DISTINCT`. L'index unique ne fonctionne que pour les champs dans les répétitions.

https://demarches-simplifiees.sentry.io/issues/6122522207/events/068fb3ab31a14bc1aaf23c5d9cf036af/