### PR TITLE
ETQ admin: page liste des démarches plus rapide sur des grosses démarches

### DIFF
--- a/app/views/administrateurs/procedure_administrateurs/index.html.haml
+++ b/app/views/administrateurs/procedure_administrateurs/index.html.haml
@@ -9,15 +9,18 @@
   .fr-mb-4w
     = render 'add_admin_form', procedure: @procedure, disabled_as_super_admin: administrateur_as_manager?
 
-  .fr-table.fr-table--bordered.fr-table--layout-fixed
-    %table
-      %caption Liste des administrateurs
-      %thead
-        %th= 'Adresse email'
-        %th= 'Enregistré le'
-        %th= 'État'
-        %th= 'Action'
-      %tbody#administrateurs
-        = render(Procedure::ProcedureAdministrateurs::AdministrateurComponent.with_collection(@procedure.administrateurs.order('users.email'), procedure: @procedure))
+  .fr-table
+    .fr-table__wrapper
+      .fr-table__container
+        .fr-table__content
+          %table
+            %caption Liste des administrateurs
+            %thead
+              %th{ scope: 'col' }= 'Adresse email'
+              %th{ scope: 'col' }= 'Enregistré le'
+              %th{ scope: 'col' }= 'État'
+              %th{ scope: 'col' }= 'Action'
+            %tbody#administrateurs
+              = render(Procedure::ProcedureAdministrateurs::AdministrateurComponent.with_collection(@procedure.administrateurs.order('users.email'), procedure: @procedure))
 
 = render Procedure::FixedFooterComponent.new(procedure: @procedure)

--- a/app/views/administrateurs/procedures/_procedures_list.html.haml
+++ b/app/views/administrateurs/procedures/_procedures_list.html.haml
@@ -50,7 +50,7 @@
                 %span.fr-badge= procedure.instructeurs_count
 
               = dsfr_icon('fr-icon-file-text-fill fr-ml-1w')
-              %span.fr-badge= procedure.dossiers.state_not_brouillon.visible_by_administration.count
+              %span.fr-badge= procedure.estimated_dossiers_count
 
       .text-right
         %p.fr-mb-0.width-max-content N° #{number_with_html_delimiter(procedure.id)}


### PR DESCRIPTION
Utilise le counter cache qui a le même scope (`visible_by_administration`) plutôt que le compte exact qui peut prendre plusieurs dizaines de ms sur chaque démarche à > 1 000 dossiers

Dans ce screenshot  je compare les 2 compteurs côte à côte : ce sont les mêmes données modulo la durée de vie du cache : 
![Capture d’écran 2024-12-19 à 10 00 01](https://github.com/user-attachments/assets/ffb3de28-39ba-4123-97fc-18986d385664)


Et j'embarque une petite amélioration visuelle tableau liste des admins de la démarche