### PR TITLE
Tech : Correction d'un comportement étrange sur la connexion par email / mot de passe 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -98,6 +98,14 @@ class ApplicationController < ActionController::Base
     current_expert.present?
   end
 
+  # calling current_user in a before_action will trigger the warden authentication (devise behavior)
+  # which is not what we want in a before_action of a sign_in action (current_user should be nil before explicit sign_in)
+  # so we need to override current_user to avoid this
+  # https://github.com/heartcombo/devise/issues/5602#issuecomment-1876164084
+  def current_user
+    super if warden.authenticated?(scope: :user)
+  end
+
   def current_account
     {
       gestionnaire: current_gestionnaire,

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -99,11 +99,12 @@ describe Users::SessionsController, type: :controller do
 
     context 'when email domain is in mandatory list' do
       let(:email) { 'user@beta.gouv.fr' }
-      it 'redirects to agent connect with force parameter' do
+      it 'redirects to agent connect with force parameter and is not logged in' do
         expect(AgentConnectService).to receive(:enabled?).and_return(true)
         subject
         expect(response).to redirect_to(agent_connect_path(force_agent_connect: true))
         expect(flash[:alert]).to eq("La connexion des agents passe à présent systématiquement par AgentConnect")
+        expect(controller.current_user).to be_nil
       end
     end
   end


### PR DESCRIPTION
Comportement étrange trouvé avec Sim sur la fonctionnalité qui bloque l'authentication par email/mdp si l'email est sur un domaine dont la connexion doit être gérée exclusivement par AgentConnect (ex @beta.gouv.fr). 
L'utilisateur ne devrait pas pouvoir se connecter par email/mdp (bloqué par un `redirect` dans le  `before_action` sur `sessions#create`) or c'est le cas (la redirection se passe bien, mais l'utilisateur est quand même connecté).

Après investigation nous avons remarqué que si aucun utilisateur n'est connecté, mais que dans le code on appelle `current_user`, Devise par Warden va essayer d'authentifier l'utilisateur en utilisant le contexte de la requête en cours.

Cela pose problème chez nous dans le cas d'une requête de connexion `POST /users/sign_in` car si on appelle dans un before_action la méthode `current_user`, Devise va connecter l'utilisateur avant de passer dans le code de l'action `sessions#create`. 

Issues : https://github.com/heartcombo/devise/issues/4951 https://github.com/heartcombo/devise/issues/5602

Réponse officielle de Devise

> Since the code is out there for almost 10 years we can't know the impact a change like that would have, that's why we rather not change this behavior, even in a major version (we don't want to make it a pain for people to update it).

Cette PR surchage donc `current_user` pour éviter l'authentification non intentionnelle


