### PR TITLE
Tech: API Geo: cache communes by code postal pour ne pas désérialiser en permanence les communes

### DIFF
--- a/app/services/api_geo_service.rb
+++ b/app/services/api_geo_service.rb
@@ -81,9 +81,11 @@ class APIGeoService
     end
 
     def communes_by_postal_code(postal_code)
-      communes_by_postal_code_map.fetch(postal_code, [])
-        .filter { !_1[:code].in?(['75056', '13055', '69123']) }
-        .sort_by { I18n.transliterate([_1[:name], _1[:postal_code]].join(' ')) }
+      Rails.cache.fetch("api_geo_communes_by_pc_#{postal_code}", expires_in: 1.week, version: 3) do
+        communes_by_postal_code_map.fetch(postal_code, [])
+          .filter { !_1[:code].in?(['75056', '13055', '69123']) }
+          .sort_by { I18n.transliterate([_1[:name], _1[:postal_code]].join(' ')) }
+      end
     end
 
     def commune_name(departement_code, code)


### PR DESCRIPTION
On faisait du cache pour par taper en permanence chaque .json des communes par département , mais : 
- dans redis ce cache est sérialisé en marshal et __à chaque accès__ il nécessite d'être déserialisé
- il est assez volumineux et chaque désérialisation coûte chère (get redis + désérialisation etc…)

**Solution**: on créé aussi des portions de cache beaucoup plus petites, au  niveau de chaque postal.
C'est efficace car il n'y a que 6 300 codes postaux, et encore ceux des grandes villes doivent être sur-représentés.  On tape autant redis qu'avant. Cela bénéficiera aussi à quelques autres endroits, pas qu'à l'API.
 
En local avec cache redis : 

- Impact sur l'API pour 100 dossiers de personne morale : 11s -> 1.8s
- Mémoire, première requête API après démarrage : 571 MB -> 371 MB. (Pour comparaison le chargement page d'accueil admin=  310 MB.)
- Quasi le même impact que les 100 dossiers tapent dans le même CP, ou dans 100 CP différents

Note: la première requête après invalidation du cache = aussi lent que maintenant ;)

## AVANT 71%
![Capture d’écran 2024-12-20 à 09 37 42](https://github.com/user-attachments/assets/f8722851-db71-49f4-9abf-d1cb854fbd78)


## APRES 7% (tellement petit que je zoom)
![Capture d’écran 2024-12-20 à 09 28 38](https://github.com/user-attachments/assets/4e00d920-cbb8-417c-a813-9d72575810f3)

Comparaison mémoire sur 100 requêtes consécutives
![memory_comparison](https://github.com/user-attachments/assets/78cf9688-991b-4da0-a7f2-ccedccb2e0f8)
