### PR TITLE
ETQ usager: corrige l'affichage "Brouillon enregistré automatiquement"

### DIFF
--- a/app/components/dossiers/autosave_footer_component/autosave_footer_component.html.haml
+++ b/app/components/dossiers/autosave_footer_component/autosave_footer_component.html.haml
@@ -1,4 +1,4 @@
-.autosave.autosave-state-failed{ data: { controller: 'autosave-status' } }
+.autosave.autosave-state-idle{ data: { controller: 'autosave-status' } }
   %p.autosave-explanation.fr-text--sm.fr-mb-0
     %span.autosave-explanation-text
       - if annotation?


### PR DESCRIPTION
Régression introduite dans e6ab02045073c42d6d7e6b66206d149f2ea37b27 qui faisait qu'on n'affichait l'erreur "Impossible…" à la place du status "idle" "Votre brouillon est automatiquement enregistré"