### PR TITLE
correctif: ETQ instructeur, je souhaite pouvoir visualiser les PJs d'un dossiers meme si celui ci contient une pj qui n'est pas sur la version du dossier

### DIFF
--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -537,8 +537,8 @@ module Instructeurs
     def set_gallery_attachments
       gallery_attachments_ids = Rails.cache.fetch([dossier, "gallery_attachments"], expires_in: 10.minutes) do
         champs_attachments_ids = dossier
-          .champs
-          .where(type: [Champs::PieceJustificativeChamp.name, Champs::TitreIdentiteChamp.name])
+          .filled_champs
+          .filter { _1.class.in?([Champs::PieceJustificativeChamp, Champs::TitreIdentiteChamp]) }
           .flat_map(&:piece_justificative_file)
           .map(&:id)
 


### PR DESCRIPTION
sentry: https://demarches-simplifiees.sentry.io/issues/6164166856/?project=1429550&query=&referrer=issue-stream&sort=date&statsPeriod=14d&stream_index=0

# problème

on fait appel a la methode `.champs`, or on devrait utiliser les projetctions


# solution 

on passe par les projections qui s'occupent de bien construire la liste des champs