### PR TITLE
ETQ ds, dans le manager, je souhaite pouvoir acceder a une page d'une demarche meme si celle ci a une attestation ayant une signature

### DIFF
--- a/app/views/fields/attestation_template_field/_show.html.haml
+++ b/app/views/fields/attestation_template_field/_show.html.haml
@@ -21,7 +21,7 @@
   %strong Signature
   %p
     - if field.data.signature.attached?
-      = image_tag field.data.signature_url
+      = image_tag field.data.signature
     - else
       Aucun
 


### PR DESCRIPTION
sentry: https://demarches-simplifiees.sentry.io/issues/6199159383/?project=1429550&query=&referrer=issue-stream&sort=date&statsPeriod=14d&stream_index=14

oublié de supprimé l'appel à une methode 'morte' (enfait pas si morte que ca)