### PR TITLE
correctif: ETQ usager je ne peux editer mon dossier en brouillon que si celui ci est dans l'etat de brouillon

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -16,6 +16,7 @@ module Users
     before_action :ensure_dossier_can_be_updated, only: [:update_identite, :update_siret, :brouillon, :submit_brouillon, :submit_en_construction, :modifier, :update, :champ]
     before_action :ensure_dossier_can_be_filled, only: [:brouillon, :modifier, :submit_brouillon, :submit_en_construction, :update]
     before_action :ensure_dossier_can_be_viewed, only: [:show]
+    before_action :ensure_editing_brouillon, only: [:brouillon]
     before_action :forbid_closed_submission!, only: [:submit_brouillon]
     before_action :set_dossier_as_editing_fork, only: [:submit_en_construction]
     before_action :show_demarche_en_test_banner
@@ -458,6 +459,12 @@ module Users
     def ensure_dossier_can_be_viewed
       if dossier.brouillon?
         redirect_to brouillon_dossier_path(dossier)
+      end
+    end
+
+    def ensure_editing_brouillon
+      if !dossier.brouillon?
+        redirect_to modifier_dossier_path(@dossier)
       end
     end
 

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -371,6 +371,11 @@ describe Users::DossiersController, type: :controller do
         it { is_expected.to redirect_to(identite_dossier_path(dossier)) }
       end
     end
+
+    context 'when the dossier is en_construction' do
+      let!(:dossier) { create(:dossier, :en_construction, user: user, autorisation_donnees: true) }
+      it { is_expected.to redirect_to(modifier_dossier_path(dossier)) }
+    end
   end
 
   describe '#edit' do


### PR DESCRIPTION
hs: https://mattermost.incubateur.net/betagouv/pl/9jynry4szjf1p8a7tfnziywdza

# probleme 

ac @tchak nous sommes tombés sur ce [cas étrange](https://mattermost.incubateur.net/betagouv/pl/9jynry4szjf1p8a7tfnziywdza) en prod. Un dossier "master", étant `en_construction` avec un `champs`.`discarded_at` présent. 
1. Après avoir exploré le code, pas de bug apparent. 
2. Apres avoir exploré les logs d'elastic, on retrouve l'usager qui était sur `/dossiers/:id/brouillon` (juste après s'être connecté, on suppose qu'il est arrivé sur cet url via les mails). Bref, derrière il a donc édité son dossier "master" plutôt qu'un fork car il était sur la page du brouillon 😞 ... 

# solution 

ETQ usager, si j'arrive sur la route `/dossiers/:id/brouillon` alors que mon dossier n'est pas dans ce statut, `rediect_to(modifier_dossier_path(:dossier_id))`