### PR TITLE
fix(gallery): invalidate cache on revision change

### DIFF
--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -535,7 +535,7 @@ module Instructeurs
     end
 
     def set_gallery_attachments
-      gallery_attachments_ids = Rails.cache.fetch([dossier, "gallery_attachments"], expires_in: 10.minutes) do
+      gallery_attachments_ids = Rails.cache.fetch([dossier, dossier.revision, "gallery_attachments"], expires_in: 10.minutes) do
         champs_attachments_ids = dossier
           .filled_champs
           .filter { _1.class.in?([Champs::PieceJustificativeChamp, Champs::TitreIdentiteChamp]) }


### PR DESCRIPTION
J'ai regardé l'historique des révisions, et effectivement, la galerie était affichée juste avant et juste après la publication d'une révision qui supprime un champ pièce justificative

https://demarches-simplifiees.sentry.io/issues/6191351251/events/f4e1b2b0b55a48f6bf97849985e16433/