### PR TITLE
ETQ instructeur, la navigation suivant/precedent est homogène

### DIFF
--- a/app/components/instructeurs/dossiers_navigation_component.rb
+++ b/app/components/instructeurs/dossiers_navigation_component.rb
@@ -18,10 +18,10 @@ class Instructeurs::DossiersNavigationComponent < ApplicationComponent
   def link_next
     if has_next?
       html_tag = :a
-      options = { class: "fr-link no-wrap fr-ml-3w", href: next_instructeur_dossier_path(dossier:, statut:) }
+      options = { class: "fr-link no-wrap fr-text--sm fr-ml-3w", href: next_instructeur_dossier_path(dossier:, statut:) }
     else
       html_tag = :span
-      options = { class: "fr-link no-wrap fr-ml-3w fr-text-mention--grey" }
+      options = { class: "fr-link no-wrap fr-text--sm fr-ml-3w fr-text-mention--grey" }
     end
 
     tag.send(html_tag, t('.next').html_safe + tag.span(class: 'fr-icon-arrow-right-line fr-ml-1w'), **options)
@@ -30,10 +30,10 @@ class Instructeurs::DossiersNavigationComponent < ApplicationComponent
   def link_previous
     if has_previous?
       html_tag = :a
-      options = { class: "fr-link no-wrap", href: previous_instructeur_dossier_path(dossier:, statut:) }
+      options = { class: "fr-link no-wrap fr-text--sm", href: previous_instructeur_dossier_path(dossier:, statut:) }
     else
       html_tag = :span
-      options = { class: "fr-link no-wrap fr-text-mention--grey" }
+      options = { class: "fr-link no-wrap fr-text--sm fr-text-mention--grey" }
     end
 
     tag.send(html_tag, tag.span(class: 'fr-icon-arrow-left-line fr-mr-1w') + t('.previous'), **options)

--- a/app/components/instructeurs/dossiers_navigation_component/dossiers_navigation_component.html.haml
+++ b/app/components/instructeurs/dossiers_navigation_component/dossiers_navigation_component.html.haml
@@ -4,7 +4,7 @@
   %h1.fr-h3.fr-mb-0
     = t('show_dossier', scope: [:layouts, :breadcrumb], dossier_id: dossier.id, owner_name: dossier.owner_name)
 
-  .fr.ml-auto.align-center.flex.fr-mt-1v
+  .fr.ml-auto.align-center.flex.fr-mt-2v
     = link_previous
     = link_next
 


### PR DESCRIPTION
apres: 
<img width="1114" alt="Capture d’écran 2025-01-07 à 11 16 28 AM" src="https://github.com/user-attachments/assets/dc701070-a534-48df-99c6-bab56517a1fc" />
(on passe de 16 -> 14px) 

avant : 
<img width="1246" alt="Capture d’écran 2025-01-07 à 11 36 49 AM" src="https://github.com/user-attachments/assets/f9bed53f-e609-4bd1-a9ee-99be8c4d125e" />

