### PR TITLE
ETQ instructeur: la page de la liste des démarche va plus vite s'il y a des milliers de dossiers

### DIFF
--- a/db/migrate/20250107155455_add_index_to_dossiers_on_groupe_instructeur_id_and_state.rb
+++ b/db/migrate/20250107155455_add_index_to_dossiers_on_groupe_instructeur_id_and_state.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddIndexToDossiersOnGroupeInstructeurIdAndState < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :dossiers, [:groupe_instructeur_id, :state, :archived], where: "hidden_by_administration_at IS NULL AND hidden_by_expired_at IS NULL", algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_12_24_085004) do
+ActiveRecord::Schema[7.0].define(version: 2025_01_07_155455) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_stat_statements"
@@ -524,6 +524,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_24_085004) do
     t.index ["batch_operation_id"], name: "index_dossiers_on_batch_operation_id"
     t.index ["dossier_transfer_id"], name: "index_dossiers_on_dossier_transfer_id"
     t.index ["editing_fork_origin_id"], name: "index_dossiers_on_editing_fork_origin_id"
+    t.index ["groupe_instructeur_id", "state", "archived"], name: "index_dossiers_on_groupe_instructeur_id_and_state_and_archived", where: "((hidden_by_administration_at IS NULL) AND (hidden_by_expired_at IS NULL))"
     t.index ["groupe_instructeur_id"], name: "index_dossiers_on_groupe_instructeur_id"
     t.index ["parent_dossier_id"], name: "index_dossiers_on_parent_dossier_id"
     t.index ["prefill_token"], name: "index_dossiers_on_prefill_token", unique: true


### PR DESCRIPTION
ETQ instructeur sur une ou plusieurs démarches à plusieurs milliers de dossiers, l'index des démarches génère des queries qui mettent plusieurs secondes. La cause est le compteur de dossiers par type de statut (à suivre, tous, à archiver…) qui nécessitent de loader du disque une grande partie dee ces dossiers avant de les filtrer pour les compter.

Une première solution assez efficace est de créér un nouvel index composite et partiel qui permet dans certains cas de ne plus faire de filter sur state + archived + hidden_by_* . Dans le cas d'un exemple d'une démarche à quelques milliers de dossiers, PG n'a plus à charger ~ 2000 rows à filtrer, mais récupère directement les 259 dossiers à retourner.

Ce choix d'index précis est un compromis pour être utilisable par 2 ou 3 types de requêtes, et il est tout petit (~ 100 mb)

C'est pas encore miraculeux (on passe de quelques secondes à quelques centaines de ms à cause d'autres conditions compliquées). Prochaines étapes possibles : 
- simplifier les requêtes car on a une double jointure sur groupe_instructeurs et dans certains cas des clauses redondantes
- une seule grosse requête pour ces différents compteurs
- ou alternativement avec Rails 7.1 on pourra aussi faire du `.async_count` pour paralléliser
- cache?
- loader les compteurs en XHR 

J'ai l'espoir que cet index serve aussi à quelques autres endroits de l'app 

## Requête pour le compte "TRAITÉS" : 
Cf index_dossiers_on_groupe_instructeur_id_and_state_and_archived vers la fin

```
explain analyze SELECT COUNT(*) AS "count_all",
       "groupe_instructeurs"."procedure_id" AS "groupe_instructeurs_procedure_id"
FROM "dossiers"
INNER JOIN "groupe_instructeurs"
  ON "dossiers"."groupe_instructeur_id" = "groupe_instructeurs"."id"
INNER JOIN "assign_tos"
  ON "groupe_instructeurs"."id" = "assign_tos"."groupe_instructeur_id"
INNER JOIN "groupe_instructeurs" "groupe_instructeurs_dossiers"
  ON "groupe_instructeurs_dossiers"."id" = "dossiers"."groupe_instructeur_id"
INNER JOIN "procedures"
  ON "procedures"."id" = "groupe_instructeurs_dossiers"."procedure_id"
WHERE "dossiers"."hidden_by_administration_at" IS NULL
AND "dossiers"."hidden_by_expired_at" IS NULL
AND "assign_tos"."instructeur_id" = 73423
AND "dossiers"."state" != 'brouillon'
AND "procedures"."hidden_at" IS NULL
AND (
  "dossiers"."for_procedure_preview" = false
  AND "dossiers"."hidden_by_user_at" IS NULL
  AND "dossiers"."editing_fork_origin_id" IS NULL
  AND "dossiers"."hidden_by_expired_at" IS NULL
  OR "dossiers"."state" != 'en_construction'
)
AND "dossiers"."archived" = false
AND "dossiers"."state" IN ('accepte', 'refuse', 'sans_suite')
GROUP BY "groupe_instructeurs"."procedure_id";

## AVANT
HashAggregate  (cost=1248.70..1253.01 rows=431 width=16) (actual time=5826.309..5826.315 rows=14 loops=1)
  Group Key: groupe_instructeurs.procedure_id
  Batches: 1  Memory Usage: 37kB
  ->  Nested Loop  (cost=1.98..1246.55 rows=431 width=8) (actual time=5.926..5784.565 rows=287217 loops=1)
        ->  Nested Loop  (cost=1.55..350.60 rows=27 width=32) (actual time=0.255..7.861 rows=154 loops=1)
              ->  Nested Loop  (cost=1.26..335.23 rows=27 width=40) (actual time=0.192..5.660 rows=155 loops=1)
                    ->  Nested Loop  (cost=0.84..320.75 rows=27 width=24) (actual time=0.139..5.397 rows=155 loops=1)
                          ->  Index Scan using index_assign_tos_on_instructeur_id on assign_tos  (cost=0.42..97.00 rows=27 width=8) (actual time=0.059..1.306 rows=155 loops=1)
                                Index Cond: (instructeur_id = 73423)
                          ->  Index Scan using groupe_instructeurs_pkey on groupe_instructeurs  (cost=0.42..8.29 rows=1 width=16) (actual time=0.025..0.025 rows=1 loops=155)
                                Index Cond: (id = assign_tos.groupe_instructeur_id)
                    ->  Index Scan using groupe_instructeurs_pkey on groupe_instructeurs groupe_instructeurs_dossiers  (cost=0.42..0.54 rows=1 width=16) (actual time=0.001..0.001 rows=1 loops=155)
                          Index Cond: (id = groupe_instructeurs.id)
              ->  Index Scan using procedures_pkey on procedures  (cost=0.29..0.57 rows=1 width=4) (actual time=0.014..0.014 rows=1 loops=155)
                    Index Cond: (id = groupe_instructeurs_dossiers.procedure_id)
                    Filter: (hidden_at IS NULL)
                    Rows Removed by Filter: 0
        ->  Index Scan using index_dossiers_on_groupe_instructeur_id on dossiers  (cost=0.43..30.52 rows=266 width=8) (actual time=0.447..37.381 rows=1865 loops=154)
              Index Cond: (groupe_instructeur_id = groupe_instructeurs.id)
              Filter: ((hidden_by_administration_at IS NULL) AND (hidden_by_expired_at IS NULL) AND (NOT archived) AND ((state)::text <> 'brouillon'::text) AND (((NOT for_procedure_preview) AND (hidden_by_user_at IS NULL) AND (editing_fork_origin_id IS NULL) AND (hidden_by_expired_at IS NULL)) OR ((state)::text <> 'en_construction'::text)) AND ((state)::text = ANY ('{accepte,refuse,sans_suite}'::text[])))
              Rows Removed by Filter: 462
Planning Time: 4.029 ms
Execution Time: 5826.509 ms


## APRES
HashAggregate  (cost=971.84..976.01 rows=417 width=16) (actual time=370.967..370.971 rows=14 loops=1)
  Group Key: groupe_instructeurs.procedure_id
  Batches: 1  Memory Usage: 37kB
  ->  Nested Loop  (cost=1.98..969.76 rows=417 width=8) (actual time=1.249..351.929 rows=287217 loops=1)
        ->  Nested Loop  (cost=1.55..350.60 rows=27 width=32) (actual time=0.732..7.680 rows=154 loops=1)
              ->  Nested Loop  (cost=1.26..335.23 rows=27 width=40) (actual time=0.558..5.529 rows=155 loops=1)
                    ->  Nested Loop  (cost=0.84..320.75 rows=27 width=24) (actual time=0.552..5.367 rows=155 loops=1)
                          ->  Index Scan using index_assign_tos_on_instructeur_id on assign_tos  (cost=0.42..97.00 rows=27 width=8) (actual time=0.373..1.820 rows=155 loops=1)
                                Index Cond: (instructeur_id = 73423)
                          ->  Index Scan using groupe_instructeurs_pkey on groupe_instructeurs  (cost=0.42..8.29 rows=1 width=16) (actual time=0.023..0.023 rows=1 loops=155)
                                Index Cond: (id = assign_tos.groupe_instructeur_id)
                    ->  Index Scan using groupe_instructeurs_pkey on groupe_instructeurs groupe_instructeurs_dossiers  (cost=0.42..0.54 rows=1 width=16) (actual time=0.001..0.001 rows=1 loops=155)
                          Index Cond: (id = groupe_instructeurs.id)
              ->  Index Scan using procedures_pkey on procedures  (cost=0.29..0.57 rows=1 width=4) (actual time=0.014..0.014 rows=1 loops=155)
                    Index Cond: (id = groupe_instructeurs_dossiers.procedure_id)
                    Filter: (hidden_at IS NULL)
                    Rows Removed by Filter: 0
        ->  Index Scan using index_dossiers_on_groupe_instructeur_id_and_state_and_archived on dossiers  (cost=0.43..20.34 rows=259 width=8) (actual time=0.003..2.166 rows=1865 loops=154)
              Index Cond: ((groupe_instructeur_id = groupe_instructeurs.id) AND ((state)::text = ANY ('{accepte,refuse,sans_suite}'::text[])) AND (archived = false))
Planning Time: 9.931 ms
Execution Time: 371.045 ms
```

## Requête pour le compte "A SUIVRE" 
Meme genre de résultat: moins de dossiers sont chargés avant d'être filtrés

```
explain analyze SELECT COUNT(*) AS count_all, groupe_instructeurs.procedure_id AS groupe_instructeurs_procedure_id
FROM dossiers
INNER JOIN groupe_instructeurs ON dossiers.groupe_instructeur_id = groupe_instructeurs.id
INNER JOIN assign_tos ON groupe_instructeurs.id = assign_tos.groupe_instructeur_id
INNER JOIN groupe_instructeurs groupe_instructeurs_dossiers ON groupe_instructeurs_dossiers.id = dossiers.groupe_instructeur_id
INNER JOIN procedures ON procedures.id = groupe_instructeurs_dossiers.procedure_id
LEFT JOIN follows ON follows.dossier_id = dossiers.id AND follows.unfollowed_at IS NULL
WHERE dossiers.hidden_by_administration_at IS NULL
AND dossiers.hidden_by_expired_at IS NULL
AND assign_tos.instructeur_id = 73423
AND dossiers.state != 'brouillon'
AND procedures.hidden_at IS NULL
AND (dossiers.for_procedure_preview = false
    AND dossiers.hidden_by_user_at IS NULL
    AND dossiers.editing_fork_origin_id IS NULL
    AND dossiers.hidden_by_expired_at IS NULL
    OR dossiers.state != 'en_construction')
AND dossiers.archived = false
AND dossiers.state IN ('en_construction', 'en_instruction')
AND follows.id IS NULL
GROUP BY groupe_instructeurs.procedure_id;

#
# AVANT
# -------------------------------------------------------------------------------------------------------------------
 GroupAggregate  (cost=1244.59..1244.61 rows=1 width=16) (actual time=771.871..771.951 rows=16 loops=1)
   Group Key: groupe_instructeurs.procedure_id
   ->  Sort  (cost=1244.59..1244.59 rows=1 width=8) (actual time=771.864..771.897 rows=1636 loops=1)
         Sort Key: groupe_instructeurs.procedure_id
         Sort Method: quicksort  Memory: 125kB
         ->  Nested Loop  (cost=2.41..1244.58 rows=1 width=8) (actual time=1.952..771.562 rows=1636 loops=1)
               ->  Nested Loop  (cost=2.12..1244.01 rows=1 width=16) (actual time=1.594..768.225 rows=1636 loops=1)
                     ->  Nested Loop Left Join  (cost=1.70..1243.55 rows=1 width=32) (actual time=1.577..766.760 rows=1636 loops=1)
                           Filter: (follows.id IS NULL)
                           Rows Removed by Filter: 53399
                           ->  Nested Loop  (cost=1.27..1139.44 rows=110 width=36) (actual time=0.543..460.733 rows=54699 loops=1)
                                 ->  Nested Loop  (cost=0.84..320.75 rows=27 width=24) (actual time=0.502..6.069 rows=155 loops=1)
                                       ->  Index Scan using index_assign_tos_on_instructeur_id on assign_tos  (cost=0.42..97.00 rows=27 width=8) (actual time=0.311..2.113 rows=155 loops=1)
                                             Index Cond: (instructeur_id = 73423)
                                       ->  Index Scan using groupe_instructeurs_pkey on groupe_instructeurs  (cost=0.42..8.29 rows=1 width=16) (actual time=0.025..0.025 rows=1 loops=155)
                                             Index Cond: (id = assign_tos.groupe_instructeur_id)
                                 ->  Index Scan using index_dossiers_on_groupe_instructeur_id on dossiers  (cost=0.43..29.64 rows=68 width=12) (actual time=0.859..2.918 rows=353 loops=155)
                                       Index Cond: (groupe_instructeur_id = groupe_instructeurs.id)
                                       Filter: ((hidden_by_administration_at IS NULL) AND (hidden_by_expired_at IS NULL) AND (NOT archived) AND ((state)::text <> 'brouillon'::text) AND (((NOT for_procedure_preview) AND (hidden_by_user_at IS NULL) AND (editing_fork_origin_id IS NULL) AND (hidden_by_expired_at IS NULL)) OR ((state)::text <> 'en_construction'::text)) AND ((state)::text = ANY ('{en_construction,en_instruction}'::text[])))
                                       Rows Removed by Filter: 1959
                           ->  Index Scan using index_follows_on_dossier_id on follows  (cost=0.43..0.94 rows=1 width=8) (actual time=0.005..0.005 rows=1 loops=54699)
                                 Index Cond: (dossier_id = dossiers.id)
                                 Filter: (unfollowed_at IS NULL)
                                 Rows Removed by Filter: 0
                     ->  Index Scan using groupe_instructeurs_pkey on groupe_instructeurs groupe_instructeurs_dossiers  (cost=0.42..0.46 rows=1 width=16) (actual time=0.001..0.001 rows=1 loops=1636)
                           Index Cond: (id = dossiers.groupe_instructeur_id)
               ->  Index Scan using procedures_pkey on procedures  (cost=0.29..0.57 rows=1 width=4) (actual time=0.002..0.002 rows=1 loops=1636)
                     Index Cond: (id = groupe_instructeurs_dossiers.procedure_id)
                     Filter: (hidden_at IS NULL)
 Planning Time: 18.768 ms
 Execution Time: 772.074 ms

# APRES
# --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
GroupAggregate  (cost=789.04..789.06 rows=1 width=16) (actual time=275.373..275.450 rows=16 loops=1)
  Group Key: groupe_instructeurs.procedure_id
  ->  Sort  (cost=789.04..789.04 rows=1 width=8) (actual time=275.367..275.397 rows=1636 loops=1)
        Sort Key: groupe_instructeurs.procedure_id
        Sort Method: quicksort  Memory: 125kB
        ->  Nested Loop  (cost=2.41..789.03 rows=1 width=8) (actual time=0.614..275.214 rows=1636 loops=1)
              ->  Nested Loop  (cost=2.12..788.46 rows=1 width=16) (actual time=0.589..273.398 rows=1636 loops=1)
                    ->  Nested Loop Left Join  (cost=1.70..788.00 rows=1 width=32) (actual time=0.585..271.686 rows=1636 loops=1)
                          Filter: (follows.id IS NULL)
                          Rows Removed by Filter: 53399
                          ->  Nested Loop  (cost=1.27..684.42 rows=109 width=36) (actual time=0.545..106.829 rows=54699 loops=1)
                                ->  Nested Loop  (cost=0.84..320.75 rows=27 width=24) (actual time=0.508..1.645 rows=155 loops=1)
                                      ->  Index Scan using index_assign_tos_on_instructeur_id on assign_tos  (cost=0.42..97.00 rows=27 width=8) (actual time=0.483..0.638 rows=155 loops=1)
                                            Index Cond: (instructeur_id = 73423)
                                      ->  Index Scan using groupe_instructeurs_pkey on groupe_instructeurs  (cost=0.42..8.29 rows=1 width=16) (actual time=0.006..0.006 rows=1 loops=155)
                                            Index Cond: (id = assign_tos.groupe_instructeur_id)
                                ->  Index Scan using index_dossiers_on_groupe_instructeur_id_and_state_and_archived on dossiers  (cost=0.43..12.80 rows=67 width=12) (actual time=0.004..0.662 rows=353 loops=155)
                                      Index Cond: ((groupe_instructeur_id = groupe_instructeurs.id) AND ((state)::text = ANY ('{en_construction,en_instruction}'::text[])) AND (archived = false))
                                      Filter: (((NOT for_procedure_preview) AND (hidden_by_user_at IS NULL) AND (editing_fork_origin_id IS NULL) AND (hidden_by_expired_at IS NULL)) OR ((state)::text <> 'en_construction'::text))
                          ->  Index Scan using index_follows_on_dossier_id on follows  (cost=0.43..0.94 rows=1 width=8) (actual time=0.003..0.003 rows=1 loops=54699)
                                Index Cond: (dossier_id = dossiers.id)
                                Filter: (unfollowed_at IS NULL)
                                Rows Removed by Filter: 0
                    ->  Index Scan using groupe_instructeurs_pkey on groupe_instructeurs groupe_instructeurs_dossiers  (cost=0.42..0.46 rows=1 width=16) (actual time=0.001..0.001 rows=1 loops=1636)
                          Index Cond: (id = dossiers.groupe_instructeur_id)
              ->  Index Scan using procedures_pkey on procedures  (cost=0.29..0.57 rows=1 width=4) (actual time=0.001..0.001 rows=1 loops=1636)
                    Index Cond: (id = groupe_instructeurs_dossiers.procedure_id)
                    Filter: (hidden_at IS NULL)
Planning Time: 4.539 ms
Execution Time: 275.542 ms
```
