### PR TITLE
ETQ usager, avec un mandat sans notification, je peux modifier mon identité

### DIFF
--- a/app/components/dossiers/individual_form_component/individual_form_component.html.haml
+++ b/app/components/dossiers/individual_form_component/individual_form_component.html.haml
@@ -78,6 +78,6 @@
 
 
       .fr-fieldset__element.fr-fieldset__element--short-text{ "data-for-tiers-target" => "emailContainer", class: class_names(hidden: !email_notifications?(individual)) }
-        = render Dsfr::InputComponent.new(form: individual, attribute: :email, input_type: :email_field, opts: { "data-for-tiers-target" => "emailInput" })
+        = render Dsfr::InputComponent.new(form: individual, attribute: :email, input_type: :email_field, required: email_notifications?(individual), opts: { "data-for-tiers-target" => "emailInput" })
 
   = f.submit t('views.users.dossiers.identite.continue'), class: "fr-btn", "data-email-input-target": "next"


### PR DESCRIPTION
HS 2134962

Le champ individual email était `required` par défaut ce qui rendait la modification de l'identité d'un dossier ayant un mandataire sans notification impossible.