### PR TITLE
ETQ user l'email qui annonce la suppression à venir du compte rappelle de quel compte (email) il s'agit

### DIFF
--- a/app/views/user_mailer/notify_inactive_close_to_deletion.html.haml
+++ b/app/views/user_mailer/notify_inactive_close_to_deletion.html.haml
@@ -4,7 +4,8 @@
   Bonjour,
 
 %p
-  Cela fait plus de deux ans que vous ne vous êtes pas connecté à #{Current.application_name}.
+  Cela fait plus de deux ans que vous ne vous êtes pas connecté à #{Current.application_name}
+  avec le compte <strong>#{@user.email}</strong> .
   - if @user.dossiers.not_brouillon.count == 0
     Aussi vous n'avez plus de dossier sur la plateforme.
 
@@ -15,7 +16,7 @@
 - if @user.dossiers.not_brouillon.count > 0
   %p
     %strong Ne vous en faites pas,
-    vos dossiers traités sont conservés par l'administration. Aussi, à tout moment vous pourrez re-créer une compte sur notre plateforme.
+    vos dossiers traités sont conservés par l'administration. Aussi, à tout moment vous pourrez re-créer un compte sur notre plateforme.
     Au besoin, vous pouvez télécharger vos dossiers en suivant ce lien :
     = link_to dossiers_url, dossiers_url
 

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe UserMailer, type: :mailer do
 
     it 'alerts user of inactivity with correct recipient and message' do
       expect(subject.to).to eq([user.email])
-      expect(subject.body).to include("Cela fait plus de deux ans que vous ne vous êtes pas connecté à #{APPLICATION_NAME}.")
+      expect(subject.body).to have_text("Cela fait plus de deux ans que vous ne vous êtes pas connecté à #{APPLICATION_NAME}\r\navec le compte #{user.email} .")
     end
 
     context 'when perform_later is called' do


### PR DESCRIPTION
Au support des gens sont perdus à cause des transferts d'emails au sein des services