### PR TITLE
ETQ Administrateur - ajouter un lien ou un email à un service

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -26,7 +26,7 @@ class Service < ApplicationRecord
   validates :siret, siret_format: true
   validates :siret, comparison: { other_than: SIRET_TEST, message: "n'est pas valide" }, on: :update
   validates :type_organisme, presence: { message: 'doit être renseigné' }, allow_nil: false
-  validates :email, presence: { message: 'doit être renseigné' }, allow_nil: false, url: { no_local: true, allow_blank: false, accept_email: true }
+  validates :email, presence: { message: 'doit être renseigné' }, allow_nil: false, url: { no_local: true, allow_blank: true, accept_email: true }
   validates :telephone, phone: { possible: true, allow_blank: true }
   validates :horaires, presence: { message: 'doivent être renseignés' }, allow_nil: false
   validates :adresse, presence: { message: 'doit être renseignée' }, allow_nil: false

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -72,10 +72,8 @@ class Service < ApplicationRecord
   def validate_email_or_url
     return if email.blank?
 
-    # Vérifie d'abord si c'est un email valide avec StrictEmailValidator
     return if StrictEmailValidator::REGEXP.match?(email)
 
-    # Si ce n'est pas un email valide, vérifie si c'est une URL valide
     url_validator = URLValidator.new(
       attributes: { allow_blank: true },
       no_local: true,

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -26,8 +26,7 @@ class Service < ApplicationRecord
   validates :siret, siret_format: true
   validates :siret, comparison: { other_than: SIRET_TEST, message: "n'est pas valide" }, on: :update
   validates :type_organisme, presence: { message: 'doit être renseigné' }, allow_nil: false
-  validates :email, presence: { message: 'doit être renseigné' }, allow_nil: false
-  validates :email, url: { no_local: true, allow_blank: false, accept_email: true }
+  validates :email, presence: { message: 'doit être renseigné' }, allow_nil: false, url: { no_local: true, allow_blank: false, accept_email: true }
   validates :telephone, phone: { possible: true, allow_blank: true }
   validates :horaires, presence: { message: 'doivent être renseignés' }, allow_nil: false
   validates :adresse, presence: { message: 'doit être renseignée' }, allow_nil: false

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -76,9 +76,8 @@ class Service < ApplicationRecord
 
     url_validator = URLValidator.new(
       attributes: { allow_blank: true },
-      no_local: true,
+      no_local: true
     )
-    
     url_validator.validate_each(self, :email, email)
   end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -78,6 +78,7 @@ class Service < ApplicationRecord
       attributes: { allow_blank: true },
       no_local: true,
     )
+    
     url_validator.validate_each(self, :email, email)
   end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -27,6 +27,7 @@ class Service < ApplicationRecord
   validates :siret, comparison: { other_than: SIRET_TEST, message: "n'est pas valide" }, on: :update
   validates :type_organisme, presence: { message: 'doit être renseigné' }, allow_nil: false
   validates :email, presence: { message: 'doit être renseigné' }, allow_nil: false
+  validates :email, url: { no_local: true, allow_blank: false, accept_email: true }
   validates :telephone, phone: { possible: true, allow_blank: true }
   validates :horaires, presence: { message: 'doivent être renseignés' }, allow_nil: false
   validates :adresse, presence: { message: 'doit être renseignée' }, allow_nil: false

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -80,6 +80,7 @@ class Service < ApplicationRecord
       attributes: { allow_blank: true },
       no_local: true,
     )
+    
     url_validator.validate_each(self, :email, email)
   end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -78,7 +78,6 @@ class Service < ApplicationRecord
       attributes: { allow_blank: true },
       no_local: true,
     )
-    
     url_validator.validate_each(self, :email, email)
   end
 end

--- a/app/validators/url_validator.rb
+++ b/app/validators/url_validator.rb
@@ -5,8 +5,7 @@ require 'active_support/i18n'
 require 'public_suffix'
 require 'addressable/uri'
 
-# Most of this code is borowed from https://github.com/perfectline/validates_url
-# Most of this code is borowed from https://github.com/perfectline/validates_url
+# Most of this code is borrowed from https://github.com/perfectline/validates_url
 
 class URLValidator < ActiveModel::EachValidator
   RESERVED_OPTIONS = [:schemes, :no_local]
@@ -62,19 +61,10 @@ class URLValidator < ActiveModel::EachValidator
       host = uri && uri.host
       scheme = uri && uri.scheme
 
-    valid_scheme = host && scheme && schemes.include?(scheme)
-    valid_no_local = !options.fetch(:no_local) || (host && host.include?('.'))
-    valid_suffix = !options.fetch(:public_suffix) || (host && PublicSuffix.valid?(host, default_rule: nil))
-    valid_scheme = host && scheme && schemes.include?(scheme)
-    valid_no_local = !options.fetch(:no_local) || (host && host.include?('.'))
-    valid_suffix = !options.fetch(:public_suffix) || (host && PublicSuffix.valid?(host, default_rule: nil))
       valid_scheme = host && scheme && schemes.include?(scheme)
       valid_no_local = !options.fetch(:no_local) || (host && host.include?('.'))
       valid_suffix = !options.fetch(:public_suffix) || (host && PublicSuffix.valid?(host, default_rule: nil))
 
-      unless valid_scheme && valid_no_local && valid_suffix
-        record.errors.add(attribute, message, **filtered_options(value))
-      end
       unless valid_scheme && valid_no_local && valid_suffix
         record.errors.add(attribute, message, **filtered_options(value))
       end

--- a/app/validators/url_validator.rb
+++ b/app/validators/url_validator.rb
@@ -5,8 +5,7 @@ require 'active_support/i18n'
 require 'public_suffix'
 require 'addressable/uri'
 
-# Most of this code is borrowed from https://github.com/perfectline/validates_url
-# Most of this code is borrowed from https://github.com/perfectline/validates_url
+# Most of this code is borowed from https://github.com/perfectline/validates_url
 
 class URLValidator < ActiveModel::EachValidator
   RESERVED_OPTIONS = [:schemes, :no_local]
@@ -56,24 +55,9 @@ class URLValidator < ActiveModel::EachValidator
   end
 
   def validate_url(record, attribute, value, message, schemes)
-    # First check if it's an email when accept_email is true
-    if options.fetch(:accept_email) && value.to_s.match?(/\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i)
-      return true
-    end
+    uri = Addressable::URI.parse(value)
 
-    # If not an email, validate as URL
-    # First check if it's an email when accept_email is true
-    if options.fetch(:accept_email) && value.to_s.match?(/\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i)
-      return true
-    end
-
-    # If not an email, validate as URL
-    begin
-      uri = if value.present?
-        encoded_value = Addressable::URI.encode(value.to_s)
-        Addressable::URI.parse(encoded_value)
-      end
-
+    unless options.fetch(:accept_email) && uri.path.match?(/^(.+)@(.+)$/)
       host = uri && uri.host
       scheme = uri && uri.scheme
 
@@ -87,8 +71,8 @@ class URLValidator < ActiveModel::EachValidator
       unless valid_scheme && valid_no_local && valid_suffix
         record.errors.add(attribute, message, **filtered_options(value))
       end
-    rescue Addressable::URI::InvalidURIError
-      record.errors.add(attribute, message, **filtered_options(value))
     end
+  rescue Addressable::URI::InvalidURIError
+    record.errors.add(attribute, message, **filtered_options(value))
   end
 end

--- a/app/views/administrateurs/services/_form.html.haml
+++ b/app/views/administrateurs/services/_form.html.haml
@@ -44,7 +44,7 @@
       %br
       Ces informations de contact seront visibles par les utilisateurs de la démarche, affichées dans le menu « Aide », ainsi qu’en pied de page lors du dépôt d’un dossier. En cas d’informations invalides, #{Current.application_name} se réserve le droit de suspendre la publication de la démarche.
 
-  = render Dsfr::InputComponent.new(form: f, attribute: :email, input_type: :email_field)
+  = render Dsfr::InputComponent.new(form: f, attribute: :email, input_type: :text_field)
   = render Dsfr::InputComponent.new(form: f, attribute: :telephone, input_type: :telephone_field)
   = render Dsfr::InputComponent.new(form: f, attribute: :horaires, input_type: :text_area)
   = render Dsfr::InputComponent.new(form: f, attribute: :adresse, input_type: :text_area)

--- a/app/views/shared/dossiers/_update_contact_information.html.haml
+++ b/app/views/shared/dossiers/_update_contact_information.html.haml
@@ -14,8 +14,11 @@
     - elsif service.present?
       %li
         %span.fr-footer__top-link
-          = I18n.t('users.procedure_footer.contact.email.link')
-        = link_to service.email, "mailto:#{service.email}", class: "fr-footer__link"
+          - if service.email.include?('@')
+            = I18n.t('users.procedure_footer.contact.email.mail_link')
+          - else
+            = I18n.t('users.procedure_footer.contact.email.url_link')
+        = link_to service.email, service.email.include?('@') ? "mailto:#{service.email}" : service.email, class: "fr-footer__link"
 
       - if service.telephone.present?
         %li

--- a/config/locales/models/service/fr.yml
+++ b/config/locales/models/service/fr.yml
@@ -7,10 +7,11 @@ fr:
     attributes:
       service: &service
         adresse: 'Adresse postale'
-        email: 'Email de contact'
+        email: 'Email ou lien de contact'
         telephone: 'Téléphone'
         nom: Nom du service
-        organisme: Organisme(s)
+        organisme: Organisme
+        type_organisme: Type d'organisme
         hints:
           nom: |
             Indiquez le nom et la direction rattachée, séparés par une virgule.
@@ -19,8 +20,8 @@ fr:
             Indiquez les organismes depuis l’échelon territorial jusqu’au ministère séparés par une virgule.
             Exemple : mairie de Mours, préfecture de l'Oise, ministère de la Culture
           email: |
-            Indiquez une adresse email valide qui permettra de recevoir et de répondre aux questions des usagers.
-            Exemple : contact@mairie-de-mours.fr
+            Indiquez une adresse email valide ou une URL qui permettra de recevoir et de répondre aux questions des usagers.
+            Exemples : contact@mairie-de-mours.fr, https://www.mairie-de-mours.fr/contact
           telephone: "Indiquez le numéro de téléphone du service valide le plus à même de fournir des réponses pertinentes à vos usagers. Exemple : 01 23 45 67 89"
           horaires: |
             Indiquez les jours ouvrables et les horaires où les usagers peuvent vous joindre.

--- a/config/locales/views/users/procedure_footer/en.yml
+++ b/config/locales/views/users/procedure_footer/en.yml
@@ -8,7 +8,8 @@ en:
         in_app_mail:
           link: "Direclty via the chat"
         email:
-          link: "Directly by email: "
+          mail_link: "Directly by email: "
+          url_link: "From the following link: "
         phone:
           label: 'By phone: '
         schedule:

--- a/config/locales/views/users/procedure_footer/fr.yml
+++ b/config/locales/views/users/procedure_footer/fr.yml
@@ -8,7 +8,8 @@ fr:
         in_app_mail:
           link: "Directement par la messagerie"
         email:
-          link: "Directement par courriel :"
+          mail_link: "Directement par courriel :"
+          url_link: "Depuis le lien suivant :"
         phone:
           label: 'Par téléphone au : '
           link: '%{service_telephone}'

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -87,6 +87,35 @@ describe Service, type: :model do
         expect { Service.new(params.merge(type_organisme: 'choucroute')) }.to raise_error(ArgumentError)
       end
     end
+
+    describe "email ou lien de contact" do
+      it 'devrait accepter une URL valide' do
+        subject.email = 'https://www.service-public.fr/contact'
+        expect(subject).to be_valid
+      end
+
+      it 'devrait accepter un email correctement formaté' do
+        subject.email = 'contact@service-public.fr'
+        expect(subject).to be_valid
+      end
+
+      it 'ne devrait pas accepter un email mal formaté' do
+        subject.email = 'contact@domain'
+        expect(subject).not_to be_valid
+      end
+
+      it 'ne devrait pas accepter une URL invalide' do
+        subject.email = 'not-an-url'
+        expect(subject).not_to be_valid
+      end
+
+      it 'ne devrait pas accepter un champ vide' do
+        subject.email = ''
+        expect(subject).not_to be_valid
+        subject.email = nil
+        expect(subject).not_to be_valid
+      end
+    end
   end
 
   describe 'validation on update' do


### PR DESCRIPTION
Sur le même modèle que le champ relatif au contact DPO, possibilité d'ouvrir aux services l'ajout d'un lien, en plus de l'email :
![screen pr](https://github.com/user-attachments/assets/364f2ce9-9072-47fa-99c2-d155fade52d2)

Les modifications apportées concernent l'écran administrateur pour la création ou la modification du service et rendent visible les éléments côté instructeurs avec une adaptation de la traduction selon qu'il s'agit d'un mail ou d'un lien.
Le format de l'input est également contrôlé pour assurer le format.