### PR TITLE
[ETQ instructeur] je retrouve les labels dans les exports

### DIFF
--- a/app/assets/stylesheets/dsfr.scss
+++ b/app/assets/stylesheets/dsfr.scss
@@ -262,3 +262,8 @@ input[type='radio'] {
     display: none !important;
   }
 }
+
+// We want labels to be centered inside dossiers table
+.fr-table .fr-tags-group .fr-tag {
+  margin-top: 0.5rem;
+}

--- a/app/models/columns/dossier_column.rb
+++ b/app/models/columns/dossier_column.rb
@@ -11,6 +11,8 @@ class Columns::DossierColumn < Column
       dossier.individual.public_send(column)
     when 'groupe_instructeur'
       dossier.groupe_instructeur.label
+    when 'dossier_labels'
+      dossier.labels.map(&:name).join(' ')
     when 'followers_instructeurs'
       dossier.followers_instructeurs.map(&:email).join(' ')
     end

--- a/app/models/concerns/columns_concern.rb
+++ b/app/models/concerns/columns_concern.rb
@@ -54,6 +54,7 @@ module ColumnsConcern
       columns.concat([dossier_motivation_column])
       columns.concat(sva_svr_columns(for_export: true)) if sva_svr_enabled?
       columns.concat([groupe_instructeurs_id_column, followers_instructeurs_email_column])
+      columns.concat([dossier_labels_column])
 
       # ensure the columns exist in main list
       # otherwise, they will be found by the find_column method

--- a/spec/models/concerns/columns_concern_spec.rb
+++ b/spec/models/concerns/columns_concern_spec.rb
@@ -247,7 +247,8 @@ describe ColumnsConcern do
           procedure.find_column(label: "Date de traitement"),
           procedure.find_column(label: "Motivation de la décision"),
           procedure.find_column(label: "Instructeurs"),
-          procedure.find_column(label: "Groupe instructeur")
+          procedure.find_column(label: "Groupe instructeur"),
+          procedure.find_column(label: "Labels")
         ]
         actuals = procedure.dossier_columns_for_export.map(&:h_id)
         expected.each do |expected_col|


### PR DESCRIPTION
Suite de la PR sur les labels afin de les rendre disponible à l'export.
<img width="262" alt="Capture d’écran 2025-01-14 à 16 59 40" src="https://github.com/user-attachments/assets/83ebf5af-a7b9-491c-b491-a90161e437bc" />



J'en ai profité pour faire une petite correction d'alignement repérée par @marleneklok.
Le DSFR ajoute une marge en bas lorsqu'il y a plusieurs tags, j'ai donc rajouté une marge haute pour garder les labels centrés dans le tableau.
**APRES**
<img width="444" alt="Capture d’écran 2025-01-14 à 17 00 51" src="https://github.com/user-attachments/assets/0fa9929c-feb1-4361-8cdd-4e23a1e0a381" />

**AVANT**
<img width="446" alt="Capture d’écran 2025-01-14 à 17 01 10" src="https://github.com/user-attachments/assets/9e48ccc2-f540-4806-9a09-5621e69c0ea2" />

