### PR TITLE
Tech: rollback sidekiq-cron because of keys command

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,7 +96,7 @@ gem 'sentry-ruby'
 gem 'sentry-sidekiq'
 gem 'sib-api-v3-sdk'
 gem 'sidekiq', '< 7.3' # 7.3 needs to migrate to sidekiq-cron 2.0
-gem 'sidekiq-cron'
+gem 'sidekiq-cron', '< 2.0' # wait for a release without "keys command"
 gem 'skylight'
 gem 'spreadsheet_architect'
 gem 'string-similarity'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,9 +182,6 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
-    cronex (0.15.0)
-      tzinfo
-      unicode (>= 0.4.4.5)
     css_parser (1.21.0)
       addressable
     csv (3.3.2)
@@ -763,9 +760,8 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.19.0)
-    sidekiq-cron (2.0.1)
-      cronex (>= 0.13.0)
-      fugit (~> 1.8, >= 1.11.1)
+    sidekiq-cron (1.12.0)
+      fugit (~> 1.8)
       globalid (>= 1.0.1)
       sidekiq (>= 6)
     simple_xlsx_reader (5.0.0)
@@ -833,7 +829,6 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     ulid-ruby (1.0.2)
-    unicode (0.4.4.5)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
@@ -1047,7 +1042,7 @@ DEPENDENCIES
   shoulda-matchers
   sib-api-v3-sdk
   sidekiq (< 7.3)
-  sidekiq-cron
+  sidekiq-cron (< 2.0)
   simple_xlsx_reader
   simplecov
   simplecov-cobertura


### PR DESCRIPTION
Contexte:

- passer à sidekiq 7.3 nécessite sidekiq-cron 2
- or sidekiq-cron 2 utilise la commande "keys" de redis qui n'est pas forcément autorisé dans les infras

On attend le suivi de https://github.com/sidekiq-cron/sidekiq-cron/issues/516 pour une éventuelle future release sans keys pour se débloquer.

La maj initiale avait été faite dans https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11188