### PR TITLE
ETQ usager: n'intègre plus (provisoirement) l'attestation de dépôt de dossier dans l'email de dépôt

### DIFF
--- a/app/models/mails/initiated_mail.rb
+++ b/app/models/mails/initiated_mail.rb
@@ -27,12 +27,12 @@ module Mails
     DEFAULT_SUBJECT = I18n.t('activerecord.models.mail.initiated_mail.default_subject', dossier_number: '--numéro du dossier--', procedure_libelle: '--libellé démarche--')
     DOSSIER_STATE = Dossier.states.fetch(:en_construction)
 
-    def attachment_for_dossier(dossier)
-      {
-        filename: I18n.t('users.dossiers.show.papertrail.filename'),
-        content: deposit_receipt_for_dossier(dossier)
-      }
-    end
+    # def attachment_for_dossier(dossier)
+    #   {
+    #     filename: I18n.t('users.dossiers.show.papertrail.filename'),
+    #     content: deposit_receipt_for_dossier(dossier)
+    #   }
+    # end
 
     private
 

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe NotificationMailer, type: :mailer do
         expect(mail.subject).to eq("Votre dossier nº #{dossier.id} a bien été déposé (#{procedure.libelle})")
         expect(body).to include("Votre dossier nº #{dossier.id}")
         expect(body).to include(procedure.service.nom)
-        expect(mail.attachments.first.filename).to eq("attestation-de-depot.pdf")
+        # expect(mail.attachments.first.filename).to eq("attestation-de-depot.pdf")
       end
     end
 
@@ -76,7 +76,7 @@ RSpec.describe NotificationMailer, type: :mailer do
       it 'renders the template' do
         expect(mail.subject).to eq('Email subject')
         expect(body).to include('Your dossier was received')
-        expect(mail.attachments.first.filename).to eq("attestation-de-depot.pdf")
+        # expect(mail.attachments.first.filename).to eq("attestation-de-depot.pdf")
       end
     end
   end


### PR DESCRIPTION
Provisoire en attendant de récupérer du quota Brevo pour les PJ