### PR TITLE
ETQ instructeur, ne met plus en copie cachée les autres instructeurs du groupe lors de l'ajout d'un instructeur

### DIFF
--- a/app/mailers/groupe_instructeur_mailer.rb
+++ b/app/mailers/groupe_instructeur_mailer.rb
@@ -17,7 +17,6 @@ class GroupeInstructeurMailer < ApplicationMailer
   end
 
   def notify_added_instructeurs(group, added_instructeurs, current_instructeur_email)
-    added_instructeur_emails = added_instructeurs.map(&:email)
     @group = group
     @current_instructeur_email = current_instructeur_email
 
@@ -27,7 +26,7 @@ class GroupeInstructeurMailer < ApplicationMailer
       "Vous avez été affecté(e) à la démarche « #{group.procedure.libelle} »"
     end
 
-    mail(bcc: added_instructeur_emails, subject: subject)
+    mail(subject: subject)
   end
 
   def self.critical_email?(action_name)

--- a/spec/mailers/groupe_instructeur_mailer_spec.rb
+++ b/spec/mailers/groupe_instructeur_mailer_spec.rb
@@ -50,7 +50,6 @@ RSpec.describe GroupeInstructeurMailer, type: :mailer do
 
     context 'when there is only one group on procedure' do
       it { expect(subject.body).to include('Vous avez été affecté(e) à la démarche') }
-      it { expect(subject.bcc).to match_array(['int3@g.fr', 'int4@g.fr']) }
     end
 
     context 'when there are many groups on procedure' do
@@ -58,7 +57,6 @@ RSpec.describe GroupeInstructeurMailer, type: :mailer do
         GroupeInstructeur.create(label: 'gi2', procedure: procedure)
       end
       it { expect(subject.body).to include('Vous avez été ajouté(e) au groupe') }
-      it { expect(subject.bcc).to match_array(['int3@g.fr', 'int4@g.fr']) }
     end
   end
 end


### PR DESCRIPTION
- Permet au moins provisoirement d'envoyer ces emails avec Dolist (car pas de possibilité de `bcc` avec eux)
- C'était confusant car le sujet est "VOUS avez été ajouté…"