### PR TITLE
ETQ usager je ne reçois pas l'email à la création du dossier brouillon s'il est déposé dans l'heure

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -362,7 +362,7 @@ module Users
       )
       dossier.build_default_values
       dossier.save!
-      DossierMailer.with(dossier:).notify_new_draft.deliver_later
+      DossierMailer.with(dossier:).notify_new_draft.deliver_later(wait: 1.hour)
 
       if dossier.procedure.for_individual
         redirect_to identite_dossier_path(dossier)

--- a/app/mailers/dossier_mailer.rb
+++ b/app/mailers/dossier_mailer.rb
@@ -19,6 +19,8 @@ class DossierMailer < ApplicationMailer
 
   def notify_new_draft
     @dossier = params[:dossier]
+    raise AbortDeliveryError if !@dossier.brouillon? || @dossier.hidden_by_user_at.present?
+
     configure_defaults_for_user(@dossier.user)
 
     I18n.with_locale(@dossier.user_locale) do

--- a/spec/mailers/dossier_mailer_spec.rb
+++ b/spec/mailers/dossier_mailer_spec.rb
@@ -38,6 +38,19 @@ RSpec.describe DossierMailer, type: :mailer do
         expect(header_value("From", subject)).to include("ne-pas-repondre@demarches.gouv.fr")
       end
     end
+
+    it 'when dossier is hidden, it does not send the email' do
+      dossier.hide_and_keep_track!(user, :user_request)
+      expect(subject.subject).to be_nil
+    end
+
+    context 'when dossier is not brouillon anymore' do
+      let(:dossier) { create(:dossier, :en_construction, user:) }
+
+      it 'does not send the email' do
+        expect(subject.subject).to be_nil
+      end
+    end
   end
 
   describe '.notify_new_answer with dossier brouillon' do


### PR DESCRIPTION
54% des dossiers sont déposés dans l'heure du dépôt et créé un mail pour pas grand chose, voir contreproductif avec bcp de mails envoyés à l'usager en peu de temps.

J'ai compilé quelque stats sur le délai entre la création d'un dossier et son dépot (sur les 4 derniers mois, ~ 1,5 million de dossiers créés) : 
- 35% des dossiers sont déposés en moins de 10 minutes
- 54% en moins d'1 heure 
- 68% en 1 semaine
- 73% en 1 mois
- 25 derniers % ne sont jamais déposés

Donc on devrait pouvoir envoyer la notif de brouillon à T+1 heure et se passer de la moitié de ces emails.
On touche pas aux dossiers créés par préremplissage qui reçoivent l'email tout de suite.