### PR TITLE
perf: accélère la sauvegarde des champs conditionnés en cachant les calculs de visibilité

### DIFF
--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -282,7 +282,8 @@ module DossierChampsConcern
   end
 
   def reset_champ_cache(champ)
-    champs_by_public_id[champ.public_id]&.reload
+    champs_by_public_id[champ.public_id]&.reload&.tap { _1.dossier = self }
+
     reset_champs_cache
   end
 end

--- a/spec/models/concerns/champ_validate_concern_spec.rb
+++ b/spec/models/concerns/champ_validate_concern_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe ChampValidateConcern do
       before {
         update_champ('test')
         dossier.revision.revision_types_de_champ.delete_all
+        dossier.reload
         dossier.validate(:champs_public_value)
       }
       it {
@@ -57,6 +58,7 @@ RSpec.describe ChampValidateConcern do
 
       before {
         dossier.revision.revision_types_de_champ.delete_all
+        dossier.reload
         dossier.validate(:champs_public_value)
       }
       it {
@@ -71,6 +73,7 @@ RSpec.describe ChampValidateConcern do
 
       before {
         dossier.revision.revision_types_de_champ.delete_all
+        dossier.reload
         dossier.validate(:champs_public_value)
       }
       it {
@@ -86,6 +89,7 @@ RSpec.describe ChampValidateConcern do
       before {
         update_champ('test')
         type_de_champ.update(type_champ: :text)
+        dossier.reload
         dossier.validate(:champs_public_value)
       }
       it {
@@ -129,6 +133,7 @@ RSpec.describe ChampValidateConcern do
       before {
         update_champ('test')
         dossier.repetition_remove_row(type_de_champ, row_id, updated_by: 'test')
+        dossier.reload
         dossier.validate(:champs_public_value)
       }
       it {


### PR DESCRIPTION
pour le fonds vert (69279) on passe de 2200 requêtes à 43 (*50)