### PR TITLE
ETQ admin : je peux ordonner les labels

### DIFF
--- a/app/controllers/administrateurs/labels_controller.rb
+++ b/app/controllers/administrateurs/labels_controller.rb
@@ -47,6 +47,14 @@ module Administrateurs
       redirect_to [:admin, @procedure, :labels]
     end
 
+    def order_positions
+      @labels = @procedure.labels
+      render layout: "empty_layout"
+    end
+
+    def update_order_positions
+    end
+
     private
 
     def label_params

--- a/app/controllers/administrateurs/labels_controller.rb
+++ b/app/controllers/administrateurs/labels_controller.rb
@@ -53,12 +53,18 @@ module Administrateurs
     end
 
     def update_order_positions
+      @procedure.update_labels_position(ordered_label_ids_params)
+      redirect_to admin_procedure_labels_path, notice: "L'ordre des labels a été mis à jour."
     end
 
     private
 
     def label_params
       params.require(:label).permit(:name, :color)
+    end
+
+    def ordered_label_ids_params
+      params.require(:ordered_label_ids)
     end
 
     def retrieve_label

--- a/app/javascript/controllers/move_cards_position_controller.ts
+++ b/app/javascript/controllers/move_cards_position_controller.ts
@@ -1,6 +1,6 @@
 import { ApplicationController } from './application_controller';
 
-export class MoveProceduresPositionController extends ApplicationController {
+export class MoveCardsPositionController extends ApplicationController {
   connect() {
     this.updateButtonsStates();
   }

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -135,7 +135,7 @@ class Dossier < ApplicationRecord
   belongs_to :transfer, class_name: 'DossierTransfer', foreign_key: 'dossier_transfer_id', optional: true, inverse_of: :dossiers
   has_many :transfer_logs, class_name: 'DossierTransferLog', dependent: :destroy
   has_many :dossier_labels, dependent: :destroy
-  has_many :labels, through: :dossier_labels
+  has_many :labels, -> { order(:position, :id) }, through: :dossier_labels
 
   after_destroy_commit :log_destroy
 

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -803,6 +803,15 @@ class Procedure < ApplicationRecord
     end
   end
 
+  def update_labels_position(ordered_label_ids)
+    label_ids_positions = ordered_label_ids.each.with_index.to_h
+    Label.transaction do
+      label_ids_positions.each do |label_id, position|
+        Label.where(id: label_id).update(position:)
+      end
+    end
+  end
+
   def used_by_routing_rules?(type_de_champ)
     type_de_champ.stable_id.in?(stable_ids_used_by_routing_rules)
   end

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -62,7 +62,7 @@ class Procedure < ApplicationRecord
   has_and_belongs_to_many :procedure_tags
 
   has_many :bulk_messages, dependent: :destroy
-  has_many :labels, dependent: :destroy
+  has_many :labels, -> { order(:position, :id) }, dependent: :destroy, inverse_of: :procedure
 
   has_many :instructeurs_procedures, dependent: :destroy
 

--- a/app/services/dossier_projection_service.rb
+++ b/app/services/dossier_projection_service.rb
@@ -115,8 +115,9 @@ class DossierProjectionService
 
         id_value_h =
           DossierLabel
-            .includes(:label)
+            .joins(:label)
             .where(dossier_id: dossiers_ids)
+            .order('labels.position ASC, labels.id ASC')
             .pluck('dossier_id, labels.name, labels.color')
             .group_by { |dossier_id, _| dossier_id }
 

--- a/app/views/administrateurs/labels/index.html.haml
+++ b/app/views/administrateurs/labels/index.html.haml
@@ -10,15 +10,19 @@
 
   = link_to "Nouveau label",
     [:new, :admin, @procedure, :label],
-    class: "fr-btn fr-btn--primary fr-btn--icon-left fr-icon-add-circle-line mb-3"
+    class: "fr-btn fr-btn--primary fr-btn--icon-left fr-icon-add-circle-line fr-mb-4w"
 
-  - if @procedure.labels.present?
+  - if @labels.present?
+    .fr-container.flex.justify-between.fr-mb-2w.fr-p-0
+      %h2.fr-h6.fr-m-0
+        Liste des labels
+      - if @labels.size > 1
+        = link_to "Personnaliser l'ordre", order_positions_admin_procedure_labels_path, class: 'fr-btn fr-btn--sm fr-btn--tertiary fr-btn--icon-left fr-icon-settings-5-line'
     .fr-table.fr-table--lg
       .fr-table__wrapper
         .fr-table__container
           .fr-table__content
             %table
-              %caption Liste des labels
               %thead
                 %tr
                   %th{ scope: "col" }

--- a/app/views/administrateurs/labels/order_positions.html.haml
+++ b/app/views/administrateurs/labels/order_positions.html.haml
@@ -4,13 +4,13 @@
     Personnaliser l'ordre des #{@labels.size} labels
   %p Déplacez les labels dans la liste pour définir leur ordre d'affichage pour les instructeurs :
 
-  %fr-container
+  %fr-container{ data: { controller: 'move-cards-position' } }
     = form_tag update_order_positions_admin_procedure_labels_path, method: :patch, id: 'order-admin-procedure-labels-form' do
       - @labels.each do |label|
         .fr-card.fr-mb-1w.fr-py-1w.fr-px-2w
           .flex.align-center
-            %button.fr-btn.fr-btn--sm.fr-icon-arrow-up-line.fr-btn--secondary.fr-col-1
-            %button.fr-btn.fr-btn--sm.fr-icon-arrow-down-line.fr-btn--secondary.fr-col-1.fr-ml-2w.fr-mr-4w
+            %button.fr-btn.fr-btn--sm.fr-icon-arrow-up-line.fr-btn--secondary.fr-col-1{ data: { action: "move-cards-position#moveUp" } }
+            %button.fr-btn.fr-btn--sm.fr-icon-arrow-down-line.fr-btn--secondary.fr-col-1.fr-ml-2w.fr-mr-4w{ data: { action: "move-cards-position#moveDown" } }
             = tag_label(label.name, label.color)
           = hidden_field_tag "ordered_label_ids[]", label.id
 

--- a/app/views/administrateurs/labels/order_positions.html.haml
+++ b/app/views/administrateurs/labels/order_positions.html.haml
@@ -1,0 +1,20 @@
+.fr-container.fr-mt-6w.fr-mb-15w
+  = link_to " Liste des labels", admin_procedure_labels_path, class: 'fr-link fr-icon-arrow-left-line fr-link--icon--left fr-icon--sm'
+  %h3.fr-my-3w
+    Personnaliser l'ordre des #{@labels.size} labels
+  %p Déplacez les labels dans la liste pour définir leur ordre d'affichage pour les instructeurs :
+
+  %fr-container
+    = form_tag update_order_positions_admin_procedure_labels_path, method: :patch, id: 'order-admin-procedure-labels-form' do
+      - @labels.each do |label|
+        .fr-card.fr-mb-1w.fr-py-1w.fr-px-2w
+          .flex.align-center
+            %button.fr-btn.fr-btn--sm.fr-icon-arrow-up-line.fr-btn--secondary.fr-col-1
+            %button.fr-btn.fr-btn--sm.fr-icon-arrow-down-line.fr-btn--secondary.fr-col-1.fr-ml-2w.fr-mr-4w
+            = tag_label(label.name, label.color)
+          = hidden_field_tag "ordered_label_ids[]", label.id
+
+.fixed-footer.fr-py-1w
+  .fr-btns-group.fr-btns-group--center.fr-btns-group--inline.fr-btns-group--inline-lg
+    = link_to "Annuler", admin_procedure_labels_path, class: 'fr-btn fr-btn--secondary fr-my-1w'
+    %button.fr-btn.fr-my-1w{ type: "submit", form: 'order-admin-procedure-labels-form' } Valider

--- a/app/views/instructeurs/procedures/order_positions.html.haml
+++ b/app/views/instructeurs/procedures/order_positions.html.haml
@@ -4,13 +4,13 @@
     Personnaliser l'ordre des #{@procedures.size} démarches « en cours »
   %p Déplacez les démarches dans la liste pour les classer en fonction de vos préférences :
 
-  %fr-container{ data: { controller: 'move-procedures-position' } }
+  %fr-container{ data: { controller: 'move-cards-position' } }
     = form_tag update_order_positions_instructeur_procedures_path, method: :patch, id: 'order-instructeur-procedures-form' do
       - @procedures.each do |procedure|
         .fr-card.fr-mb-1w.fr-py-1w.fr-px-2w
           .flex.align-center
-            %button.fr-btn.fr-icon-arrow-up-line.fr-btn--secondary.fr-col-1{ data: { action: "move-procedures-position#moveUp" } }
-            %button.fr-btn.fr-icon-arrow-down-line.fr-btn--secondary.fr-col-1.fr-mx-2w{ data: { action: "move-procedures-position#moveDown" } }
+            %button.fr-btn.fr-icon-arrow-up-line.fr-btn--secondary.fr-col-1{ data: { action: "move-cards-position#moveUp" } }
+            %button.fr-btn.fr-icon-arrow-down-line.fr-btn--secondary.fr-col-1.fr-mx-2w{ data: { action: "move-cards-position#moveDown" } }
             - if procedure.close?
               %span.fr-badge.fr-mr-2w Close
             - elsif procedure.depubliee?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -730,11 +730,17 @@ Rails.application.routes.draw do
         get 'preview', on: :member
       end
 
-      resources :labels, controller: 'labels'
+      resources :labels, controller: 'labels' do
+        collection do
+          get 'order_positions'
+          patch 'update_order_positions'
+        end
+      end
 
       resource :attestation_template, only: [:show, :edit, :update, :create] do
         get 'preview', on: :member
       end
+
       resource :chorus, only: [:edit, :update] do
         get 'add_champ_engagement_juridique'
       end

--- a/db/migrate/20250120083052_add_position_to_labels.rb
+++ b/db/migrate/20250120083052_add_position_to_labels.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPositionToLabels < ActiveRecord::Migration[7.0]
+  def change
+    add_column :labels, :position, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -853,6 +853,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_27_093613) do
     t.string "color"
     t.datetime "created_at", null: false
     t.string "name"
+    t.integer "position"
     t.bigint "procedure_id", null: false
     t.datetime "updated_at", null: false
     t.index ["procedure_id"], name: "index_labels_on_procedure_id"

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -1927,6 +1927,23 @@ describe Procedure do
     end
   end
 
+  describe '#update_labels_position' do
+    let(:procedure) { create(:procedure) }
+    let!(:labels) { create_list(:label, 5, procedure_id: procedure.id) }
+
+    it 'updates the positions of the specified instructeurs_procedures' do
+      procedure.update_labels_position(labels.map(&:id))
+
+      expect(procedure.labels.reload.pluck(:id, :position)).to match_array([
+        [labels[0].id, 0],
+        [labels[1].id, 1],
+        [labels[2].id, 2],
+        [labels[3].id, 3],
+        [labels[4].id, 4]
+      ])
+    end
+  end
+
   private
 
   def create_dossier_with_pj_of_size(size, procedure)


### PR DESCRIPTION
issue: https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/11116

Résultat : 
1- L'admin peut ordonner les labels : 
![Capture d’écran 2025-01-22 à 16 27 43](https://github.com/user-attachments/assets/0b67c401-95de-4cce-988b-3dbd115155b7)

2- Les instructeurs ont ainsi le même ordre dans : 
- le filtre "labels" ;
- la colonne "labels" sur le tableau des dossiers ;
- la liste des labels déjà associés dans la vue du dossier ;
- la liste des labels pouvant être associés dans la vue dossier ;
- l'export des dossiers, colonne labels.

![Capture d’écran 2025-01-22 à 16 32 55](https://github.com/user-attachments/assets/63408946-be43-4d38-ae8c-70b3cca1f0b8)
![Capture d’écran 2025-01-22 à 16 34 42](https://github.com/user-attachments/assets/08c339ed-fbb9-4927-80b0-618235a9fe6d)
![Capture d’écran 2025-01-22 à 16 35 22](https://github.com/user-attachments/assets/f29dbd37-42d1-4c5e-beae-ceff746a60de)
![Capture d’écran 2025-01-22 à 16 36 22](https://github.com/user-attachments/assets/e4693f26-8a77-4b01-bd10-94136f3a5fed)


