### PR TITLE
ETQ instructeur : un message m'incite à ajouter la colonne "Labels" dans mon tableau de suivi des dossiers

### DIFF
--- a/app/views/instructeurs/dossiers/_header_top.html.haml
+++ b/app/views/instructeurs/dossiers/_header_top.html.haml
@@ -46,6 +46,12 @@
                   %br
                   Contactez les
                   = link_to 'administrateurs de la démarche', administrateurs_instructeur_procedure_path(dossier.procedure), class: 'fr-link fr-link--sm', **external_link_attributes
+                .fr-notice.fr-notice--info.fr-mt-2w
+                  .fr-container
+                    .fr-notice__body.fr-p-0
+                      %p
+                        %span.fr-notice__title Pensez à personnaliser votre tableau
+                        %span.fr-notice__desc de suivi des dossiers en ajoutant la colonne « Labels ».
 
     .header-actions.fr-ml-auto
       = render partial: 'instructeurs/dossiers/header_actions', locals: { dossier: }

--- a/app/views/instructeurs/dossiers/_header_top.html.haml
+++ b/app/views/instructeurs/dossiers/_header_top.html.haml
@@ -46,6 +46,7 @@
                   %br
                   Contactez les
                   = link_to 'administrateurs de la démarche', administrateurs_instructeur_procedure_path(dossier.procedure), class: 'fr-link fr-link--sm', **external_link_attributes
+              - if !@procedure_presentation.displayed_columns.any? { |c| c.column == "label_id" }
                 .fr-notice.fr-notice--info.fr-mt-2w
                   .fr-container
                     .fr-notice__body.fr-p-0

--- a/app/views/instructeurs/dossiers/_header_top.html.haml
+++ b/app/views/instructeurs/dossiers/_header_top.html.haml
@@ -40,14 +40,15 @@
                       = b.check_box(checked: DossierLabel.find_by(dossier_id: dossier.id, label_id: b.value).present?  )
                       = b.label(class: "fr-label fr-tag fr-tag--sm fr-tag--#{Label.colors.fetch(b.object.color)}") { b.text }
 
-              %hr
+              %hr.fr-pb-2w
                 %p.fr-text--sm.fr-text-mention--grey.fr-mb-0
                   %b Besoin d'autres labels ?
                   %br
                   Contactez les
                   = link_to 'administrateurs de la démarche', administrateurs_instructeur_procedure_path(dossier.procedure), class: 'fr-link fr-link--sm', **external_link_attributes
               - if !@procedure_presentation.displayed_columns.any? { |c| c.column == "label_id" }
-                .fr-notice.fr-notice--info.fr-mt-2w
+                %hr.fr-mt-2w
+                .fr-notice.fr-notice--info
                   .fr-container
                     .fr-notice__body.fr-p-0
                       %p

--- a/spec/views/instructeur/dossiers/show.html.haml_spec.rb
+++ b/spec/views/instructeur/dossiers/show.html.haml_spec.rb
@@ -4,7 +4,7 @@ describe 'instructeurs/dossiers/show', type: :view do
   let(:current_instructeur) { create(:instructeur) }
   let(:dossier) { create(:dossier, :en_construction) }
   let(:statut) { { statut: 'tous' } }
-  let(:procedure_presentation) { double(instructeur: current_instructeur, procedure: dossier.procedure) }
+  let(:procedure_presentation) { double(instructeur: current_instructeur, procedure: dossier.procedure, displayed_columns: []) }
 
   before do
     sign_in(current_instructeur.user)


### PR DESCRIPTION
issue : https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/11115

Résultat : 
![Capture d’écran 2025-01-23 à 19 24 14](https://github.com/user-attachments/assets/b295bdcf-b83a-4a6b-935b-92444ab92b1a)

Pour info, la caractère ouvert/fermé du bandeau d'information est à la maille de l'instructeur/procédure. Donc dès lors qu'il est fermé depuis l'un des dossiers d'une procédure, celui-ci ne s'affichera plus pour les autres dossiers. En revanche, quand ce même instructeur consultera un des dossiers d'une autre procédure, celui-ci sera affiché.