### PR TITLE
Tech: retire une operation de nettoyage de champ inutile

### DIFF
--- a/app/models/concerns/dossier_state_concern.rb
+++ b/app/models/concerns/dossier_state_concern.rb
@@ -39,8 +39,6 @@ module DossierStateConcern
     groupe_instructeur.instructeurs.with_instant_email_dossier_notifications.each do |instructeur|
       DossierMailer.notify_new_dossier_depose_to_instructeur(self, instructeur.email).deliver_later
     end
-
-    clean_champs_after_submit!
   end
 
   def after_passer_en_instruction(h)


### PR DESCRIPTION
car on a deja un `clean_champs_after_submit!` dans `submit_en_construction!` ?