### PR TITLE
ETQ DS, pour les champs carte je veux des géométrie parfaites lorsque celles ci sont issues de la source cadastrale

### DIFF
--- a/app/jobs/cron/fallback_fetch_cadastre_real_geometry_job.rb
+++ b/app/jobs/cron/fallback_fetch_cadastre_real_geometry_job.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Cron::FallbackFetchCadastreRealGeometryJob < Cron::CronJob
+  self.schedule_expression = "every hour"
+
+  queue_as :low
+
+  def perform
+    GeoArea.pending_cadastre
+      .limit(1_000)
+      .find_each(batch_size: 100) do |geo_area|
+      FetchCadastreRealGeometryJob.set(wait:).perform_later(geo_area)
+    end
+  end
+
+  private
+
+  def wait = rand(0..1.hour)
+end

--- a/app/jobs/fetch_cadastre_real_geometry_job.rb
+++ b/app/jobs/fetch_cadastre_real_geometry_job.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class FetchCadastreRealGeometryJob < ApplicationJob
+  MAX_ATTEMPT = 10
+  retry_on StandardError, attempts: MAX_ATTEMPT, wait: :exponentially_longer
+
+  def perform(geo_area)
+    parcelle_data = APIIgn::API.fetch_parcelle(id: geo_area.parcelle_id)
+    if parcelle_data.present?
+      geo_area.update_columns(
+        cadastre_state: :cadastre_fetched,
+        geometry: parcelle_data
+      )
+    else
+      geo_area.update_columns(
+        cadastre_state: :cadastre_error,
+        cadastre_error: :not_found
+      )
+    end
+  rescue ArgumentError
+    if executions == MAX_ATTEMPT
+      geo_area.update_columns(
+        cadastre_state: :cadastre_error,
+        cadastre_error: :api_error
+      )
+    end
+  end
+end

--- a/app/lib/api_ign/api.rb
+++ b/app/lib/api_ign/api.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class APIIgn::API
+  include Dry::Monads[:result]
+
+  def self.fetch_parcelle(id:)
+    uri = URI("https://data.geopf.fr/geocodage/search")
+    uri.query = URI.encode_www_form({ q: id, index: 'parcel', returntruegeometry: "1" })
+
+    result = API::Client.new.(url: uri.to_s)
+
+    case result
+    in Success(body:)
+      body.dig(:features, 0, :properties, :truegeometry)
+    else
+      raise ArgumentError, "Lookup error: #{result.inspect}"
+    end
+  end
+end

--- a/db/migrate/20250124161022_add_cadastre_status_to_geo_areas.rb
+++ b/db/migrate/20250124161022_add_cadastre_status_to_geo_areas.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddCadastreStatusToGeoAreas < ActiveRecord::Migration[7.0]
+  def change
+    add_column :geo_areas, :cadastre_state, :string
+    add_column :geo_areas, :cadastre_error, :string
+  end
+end

--- a/db/migrate/20250127093613_add_index_to_cadastre_state_on_geo_areas.rb
+++ b/db/migrate/20250127093613_add_index_to_cadastre_state_on_geo_areas.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddIndexToCadastreStateOnGeoAreas < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :geo_areas, :cadastre_state, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_01_07_155455) do
+ActiveRecord::Schema[7.0].define(version: 2025_01_27_093613) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_stat_statements"
@@ -740,6 +740,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_07_155455) do
   end
 
   create_table "geo_areas", force: :cascade do |t|
+    t.string "cadastre_error"
+    t.string "cadastre_state"
     t.bigint "champ_id"
     t.datetime "created_at", precision: nil
     t.string "geo_reference_id"
@@ -747,6 +749,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_07_155455) do
     t.jsonb "properties"
     t.string "source"
     t.datetime "updated_at", precision: nil
+    t.index ["cadastre_state"], name: "index_geo_areas_on_cadastre_state"
     t.index ["champ_id"], name: "index_geo_areas_on_champ_id"
     t.index ["source"], name: "index_geo_areas_on_source"
   end

--- a/spec/controllers/champs/carte_controller_spec.rb
+++ b/spec/controllers/champs/carte_controller_spec.rb
@@ -21,14 +21,6 @@ describe Champs::CarteController, type: :controller do
   describe 'features' do
     let(:feature) { attributes_for(:geo_area, :polygon) }
     let(:geo_area) { create(:geo_area, :selection_utilisateur, :polygon, champ: champ) }
-    let(:params) do
-      {
-        dossier_id: champ.dossier_id,
-        stable_id: champ.stable_id,
-        feature: feature,
-        source: GeoArea.sources.fetch(:selection_utilisateur)
-      }
-    end
 
     before do
       sign_in user
@@ -39,10 +31,39 @@ describe Champs::CarteController, type: :controller do
     describe 'POST #create' do
       subject { post :create, params: params }
 
-      context 'success' do
+      context 'when success (selection utilisateur)' do
+        let(:params) do
+          {
+            dossier_id: champ.dossier_id,
+            stable_id: champ.stable_id,
+            feature: feature,
+            source: GeoArea.sources.fetch(:selection_utilisateur)
+          }
+        end
+
         it do
           expect { subject } .to change { dossier.reload.last_champ_updated_at }
           expect(response).to have_http_status(:created)
+        end
+      end
+
+      context 'when success (cadastre)' do
+        let(:params) do
+          {
+            dossier_id: champ.dossier_id,
+            stable_id: champ.stable_id,
+            feature: feature,
+            source: GeoArea.sources.fetch(:cadastre)
+          }
+        end
+
+        it do
+          expect { subject } .to change { dossier.reload.last_champ_updated_at }
+          expect(response).to have_http_status(:created)
+        end
+
+        it 'enqueues a FetchCadastreRealGeometryJob' do
+          expect { subject }.to have_enqueued_job(FetchCadastreRealGeometryJob)
         end
       end
 

--- a/spec/fixtures/cassettes/cadastre_argument_error.yml
+++ b/spec/fixtures/cassettes/cadastre_argument_error.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://data.geopf.fr/geocodage/search?index=parcel&q=&returntruegeometry=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - demarches-simplifiees.fr
+      Expect:
+      - ''
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Tue, 28 Jan 2025 10:41:48 GMT
+      Set-Cookie:
+      - session=bQZmWmZ4eBJ0O229h0XQKw|1738064508|Reqc9tXfg6fbmNq5jRnGEA|PCOCRRWf0CrNYU9HxfMy6KavvSM;
+        Path=/; SameSite=Lax; Secure; HttpOnly
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '73'
+      Vary:
+      - Origin
+      Etag:
+      - W/"49-KXTe/7S5qADz9W1HcnpzetPFTEQ"
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE, PATCH, OPTIONS
+      Access-Control-Allow-Headers:
+      - DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,Content-Disposition,Content-Length,X-Community
+      Access-Control-Max-Age:
+      - '1728000'
+      X-Iplb-Request-Id:
+      - 5D108AFD:F39A_91EFC1E7:01BB_6798B46C_9B383EBD:50FE
+      X-Iplb-Instance:
+      - '61218'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"code":400,"message":"departmentcode is required for structured search"}'
+  recorded_at: Tue, 28 Jan 2025 10:41:48 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/cassettes/cadastre_ko.yml
+++ b/spec/fixtures/cassettes/cadastre_ko.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://data.geopf.fr/geocodage/search?index=parcel&q=666660000C0001&returntruegeometry=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - demarches-simplifiees.fr
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 28 Jan 2025 10:41:48 GMT
+      Set-Cookie:
+      - session=KmXZINo68ZSNEqixMBvIVA|1738064508|l4NCOgBCJOykYed6x3Pxpg|rrfz1Eh7_Sv7dHCicRMYuQo2qiY;
+        Path=/; SameSite=Lax; Secure; HttpOnly
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '42'
+      Vary:
+      - Origin
+      Etag:
+      - W/"2a-YF4qkQu1OiQfcNelFeHSJ4hLkOE"
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE, PATCH, OPTIONS
+      Access-Control-Allow-Headers:
+      - DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,Content-Disposition,Content-Length,X-Community
+      Access-Control-Max-Age:
+      - '1728000'
+      X-Iplb-Request-Id:
+      - 5D108AFD:F39A_91EFC1E7:01BB_6798B46C_9B383C43:50FE
+      X-Iplb-Instance:
+      - '61218'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"type":"FeatureCollection","features":[]}'
+  recorded_at: Tue, 28 Jan 2025 10:41:48 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/cassettes/cadastre_ok.yml
+++ b/spec/fixtures/cassettes/cadastre_ok.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://data.geopf.fr/geocodage/search?index=parcel&q=54084000AC0001&returntruegeometry=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - demarches-simplifiees.fr
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 28 Jan 2025 10:41:48 GMT
+      Set-Cookie:
+      - session=WZ-Zi71DrtuXg8ssXoz67A|1738064508|rzvqqdtYuxRnt2txwIkTeQ|RHfSu-QB5VzCMZ7T47f6eIcz6l4;
+        Path=/; SameSite=Lax; Secure; HttpOnly
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '704'
+      Vary:
+      - Origin
+      Etag:
+      - W/"2c0-r4W7I3jkMy3aJpxMMokOI/nMFtA"
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, PUT, POST, DELETE, PATCH, OPTIONS
+      Access-Control-Allow-Headers:
+      - DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,Content-Disposition,Content-Length,X-Community
+      Access-Control-Max-Age:
+      - '1728000'
+      X-Iplb-Request-Id:
+      - 5D108AFD:F39A_91EFC1E7:01BB_6798B46C_9B38423E:50FE
+      X-Iplb-Instance:
+      - '61218'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[5.8218044630002606,49.32765568104129]},"properties":{"id":"54084000AC0001","departmentcode":"54","municipalitycode":"084","oldmunicipalitycode":"000","districtcode":"000","section":"AC","sheet":"01","number":"0001","city":"Mont-Bonvillers","truegeometry":{"type":"Polygon","coordinates":[[[5.823564,49.327646],[5.822122,49.327555],[5.8218,49.327533],[5.820329,49.327418],[5.820328,49.327542],[5.820462,49.327623],[5.820958,49.327659],[5.821478,49.327699],[5.821861,49.327729],[5.822157,49.327753],[5.822235,49.327756],[5.822622,49.327778],[5.823543,49.327833],[5.823564,49.327646]]]},"_type":"parcel"}}]}'
+  recorded_at: Tue, 28 Jan 2025 10:41:48 GMT
+recorded_with: VCR 6.3.1

--- a/spec/jobs/cron/fallback_fetch_cadastre_real_geometry_job_spec.rb
+++ b/spec/jobs/cron/fallback_fetch_cadastre_real_geometry_job_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+describe Cron::FallbackFetchCadastreRealGeometryJob, type: :job do
+  describe '#perform' do
+    let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :carte, options: { cadastres: true } }]) }
+    let(:dossier) { create(:dossier, procedure: procedure) }
+    let(:champ) { dossier.champs.first }
+
+    context 'when cadastre lookup works' do
+      it 'processes pending geo areas' do
+        create(:geo_area, :selection_utilisateur, cadastre_state: nil, champ:)
+        create(:geo_area, :cadastre, cadastre_state: :cadastre_fetched, champ:)
+        enqueued_geoarea = create(:geo_area, :cadastre, cadastre_state: nil, champ:)
+        expect { described_class.perform_now }.to have_enqueued_job(FetchCadastreRealGeometryJob).with(enqueued_geoarea)
+      end
+    end
+  end
+end

--- a/spec/jobs/fetch_cadastre_real_geometry_job_spec.rb
+++ b/spec/jobs/fetch_cadastre_real_geometry_job_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+describe FetchCadastreRealGeometryJob, type: :job do
+  describe '#perform' do
+    let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :carte, options: { cadastres: true } }]) }
+    let(:dossier) { create(:dossier, procedure: procedure) }
+    let(:champ) { dossier.champs.first }
+    let!(:geo_area) { create(:geo_area, :cadastre, properties:, champ:) }
+    let(:job) { described_class.new(geo_area) }
+    subject { job.perform_now }
+
+    context 'when cadastre lookup works' do
+      let(:properties) do
+        {
+          id: '54084000AC0001'
+        }
+      end
+      it 'fetch geo areas from IGN for proper data', vcr: { cassette_name: :cadastre_ok } do
+        expect(GeoArea.cadastre_fetched.count).to eq(0)
+        expect { subject }.to change { geo_area.geometry }
+        expect(GeoArea.cadastre_fetched.count).to eq(1)
+      end
+    end
+    context 'when cadastre lookup fails by not found', vcr: { cassette_name: :cadastre_ko } do
+      let(:properties) do
+        {
+          id: '666660000C0001'
+        }
+      end
+
+      it 'marks geo areas with error status' do
+        expect { subject }.to change { geo_area.reload.cadastre_state }.to('cadastre_error')
+        expect(geo_area.cadastre_error).to eq('not_found')
+      end
+    end
+
+    context 'when cadastre lookup fails by argument error', vcr: { cassette_name: :cadastre_argument_error } do
+      let(:properties) do
+        {
+          id: ''
+        }
+      end
+
+      it 'marks geo areas as not found' do
+        expect { subject }.not_to change { geo_area.reload.cadastre_state }
+      end
+
+      it 'marks error after max attempts threshold reached' do
+        expect(job).to receive(:executions).and_return(FetchCadastreRealGeometryJob::MAX_ATTEMPT).at_least(1)
+        expect { subject }.to change { geo_area.reload.cadastre_state }
+        expect(geo_area.cadastre_error).to eq('api_error')
+      end
+    end
+  end
+end


### PR DESCRIPTION
# probleme
hs: https://secure.helpscout.net/conversation/2766182168/2119361
un usager avait identifié le prob sur les parcelles suivantes :
1. Parcelle n° 22 - Feuille 000 ZN - 11710 m² – commune 49194
2. Parcelle n° 73 - Feuille 000 ZN - 15893 m² – commune 49194

Le prob : notre visualisation de la carte fonctionne car on demande a MapLibreGL d'highlighter une parcelle cadastrale que nous identifions par ID (une sorte de CSS mais pour la carto).

Sauf que quand on regarde la parcelle dans le code (`event.features[0].geometry`), on a pas la même valeur. En vert l'highlight, en bleu le tracée

<img width="471" alt="Capture d’écran 2025-01-23 à 4 19 10 PM" src="https://github.com/user-attachments/assets/e209ac02-9e4d-4333-b108-fab71d0e42ff" />

c'est ennuyant par exemple si on vient a instruire des démarches ou les géométries impliqueraient des subventions, des contentieux etc... donc 

# enquete

On a échangé avec @jdesboeufs (un grand merci car il a libéré du temps alors qu'il est plus sur le projet :bow:). 

Le problème résidait dans le fait que nous récupérions les features directement depuis la source cadastre/parcelle. De ce que j'ai compris et que Jérôme m'a expliqué, nous étions face à deux probs :

1. avec la mechanique de MapLibreGL, les "tuiles" peuvent être adaptées pour des raisons de perf.
2. la source de donnée (data/cadastre.json) a été taillée pour faire de la "dataviz" (et ETQ DS, cette data peut être utilisé pour instruire des dossiers, bref je crois comprendre qu'on doit se baser sur de la donnée opposable)

# solution 

Donc la solution : on fait un petit lookup via https://apicarto.ign.fr/api/cadastre/parcelle afin de récupérer les bonnes geométrie d'une parcelle.

<img width="541" alt="Capture d’écran 2025-01-27 à 11 29 55 AM" src="https://github.com/user-attachments/assets/048acf93-dce3-43f1-917b-1327a6cc78d1" />

En bonus, on a 70k parcelles cadastrales en prod qui peuvent être sujette a ce prob. Le cron job permettra de les cleané et gerer de la reprise sur erreur en cas d'api IGN down

PS: si des probs devaient ressurgir autour des géometrie, un petit patch en souvenir pour les redissiner facilement : [0001-patch-draw-cadastre-geometries.patch](https://github.com/user-attachments/files/18556785/0001-patch-draw-cadastre-geometries.patch)

PPS: comme suggéré par Jérome, j'ai aussi exploré l'usage de [queryRenderedFeatures](https://maplibre.org/maplibre-gl-js/docs/API/classes/Map/#queryrenderedfeatures) dans l'espoir d'extraire au moins une géometrie identique à source, mais même avec cette approche, c'etait pas satisfaisant.