### PR TITLE
ETQ instructeur, corrrige le tri par "code naf" des dossiers

### DIFF
--- a/app/services/dossier_filter_service.rb
+++ b/app/services/dossier_filter_service.rb
@@ -138,7 +138,10 @@ class DossierFilterService
     table = if association == 'self'
       Dossier.table_name
     elsif (association_reflection = Dossier.reflect_on_association(association))
-      association_reflection.klass.table_name
+      klass = association_reflection.klass
+      # Get real db name if column has been aliased (cf etablissements.code_naf => naf)
+      column = klass.attribute_aliases[column.to_s] || column
+      klass.table_name
     else
       # Allow filtering on a joined table alias (which doesn’t exist
       # in the ActiveRecord domain).

--- a/spec/services/dossier_filter_service_spec.rb
+++ b/spec/services/dossier_filter_service_spec.rb
@@ -315,6 +315,16 @@ describe DossierFilterService do
 
       it { is_expected.to eq([huitieme_dossier, vingtieme_dossier].map(&:id)) }
     end
+
+    context 'for etablissement code_naf column (aliased to naf)' do
+      let(:column) { procedure.find_column(label: 'Code NAF') }
+      let(:order) { 'asc' }
+
+      let!(:first_dossier) { create(:dossier, procedure:, etablissement: create(:etablissement, naf: '1234Z')) }
+      let!(:second_dossier) { create(:dossier, procedure:, etablissement: create(:etablissement, naf: '9999Z')) }
+
+      it { is_expected.to eq([first_dossier.id, second_dossier.id]) }
+    end
   end
 
   describe '#filtered_ids' do


### PR DESCRIPTION
Le colonne a été renommée en "code naf" mais en base il s'agit d'`etablissements.naf`

https://secure.helpscout.net/conversation/2820585026/2136807?viewId=1653799
https://demarches-simplifiees.sentry.io/issues/6221289634/