### PR TITLE
Tech: fix un flaky test

### DIFF
--- a/spec/system/instructeurs/procedure_filters_spec.rb
+++ b/spec/system/instructeurs/procedure_filters_spec.rb
@@ -177,7 +177,7 @@ describe "procedure filters" do
       DossierLabel.create!(dossier_id: new_unfollow_dossier.id, label_id: procedure.labels.first.id)
       add_filter('Labels', procedure.labels.first.name, type: :enum)
       expect(page).to have_link(new_unfollow_dossier.id.to_s)
-      expect(page).not_to have_link(new_unfollow_dossier_2.id.to_s)
+      expect(page).not_to have_link(new_unfollow_dossier_2.id.to_s, exact: true)
     end
   end
 


### PR DESCRIPTION
 Comme les autres tests du même fichier, on matchait un lien `user12@email.com` alors qu'on veut juste chercher `12`

Par exemple: https://github.com/demarches-simplifiees/demarches-simplifiees.fr/actions/runs/13032431467/job/36357600732?pr=11272