### PR TITLE
ETQ admin, le compteur de dossiers à archiver correspond aux dossiers réellement téléchargés

### DIFF
--- a/app/controllers/administrateurs/archives_controller.rb
+++ b/app/controllers/administrateurs/archives_controller.rb
@@ -10,7 +10,7 @@ module Administrateurs
     def index
       @exports = Export.ante_chronological.by_key(all_groupe_instructeurs.map(&:id))
       @average_dossier_weight = @procedure.average_dossier_weight
-      @count_dossiers_termines_by_month = @procedure.dossiers.processed_by_month(all_groupe_instructeurs).count
+      @count_dossiers_termines_by_month = @procedure.dossiers.visible_by_administration.processed_by_month(all_groupe_instructeurs).count
       @archives = Archive.for_groupe_instructeur(all_groupe_instructeurs).to_a
     end
 

--- a/spec/controllers/administrateurs/archives_controller_spec.rb
+++ b/spec/controllers/administrateurs/archives_controller_spec.rb
@@ -26,7 +26,19 @@ describe Administrateurs::ArchivesController, type: :controller do
         expect(Archive).to receive(:for_groupe_instructeur).and_return([])
         subject
       end
+
+      it 'counts only dossiers visible by administration' do
+        travel_to Date.new(2025, 1, 29)
+        create(:dossier, :accepte, procedure:, hidden_by_expired_at: nil)
+        create(:dossier, :accepte, :hidden_by_expired, procedure:)
+        create(:dossier, :accepte, :hidden_by_user, procedure:)
+        create(:dossier, :accepte, :hidden_by_administration, procedure:)
+
+        subject
+        expect(assigns(:count_dossiers_termines_by_month)).to eq({ Date.new(2025, 1, 1) => 2 })
+      end
     end
+
     context 'when logged in as administrateur_procedure.manager=true' do
       let(:manager) { true }
 


### PR DESCRIPTION
Les archives n'exportent pas les dossiers masqués ou expirés.

https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_10c38162-7fcc-4213-b81c-dcf1e71fcd60/