### PR TITLE
Tech: CI avec postgresql 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     services:
       postgres:
-        image: postgis/postgis:14-3.3
+        image: postgis/postgis:17-3.5
         env:
           POSTGRES_USER: tps_test
           POSTGRES_DB: tps_test
@@ -64,7 +64,7 @@ jobs:
       RUBY_YJIT_ENABLE: "1"
     services:
       postgres:
-        image: postgis/postgis:14-3.3
+        image: postgis/postgis:17-3.5
         env:
           POSTGRES_USER: tps_test
           POSTGRES_DB: tps_test
@@ -120,7 +120,7 @@ jobs:
       RUBY_YJIT_ENABLE: "1"
     services:
       postgres:
-        image: postgis/postgis:14-3.3
+        image: postgis/postgis:17-3.5
         env:
           POSTGRES_USER: tps_test
           POSTGRES_DB: tps_test

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,6 +17,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_27_093613) do
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
   enable_extension "postgis"
+  disable_extension "postgis_tiger_geocoder"
   enable_extension "sslinfo"
   enable_extension "unaccent"
 


### PR DESCRIPTION
Désactive l'extension `postgis_tiger_geocoder` qui est maintenant inclus dans postgis, sinon le setup sur CI ne passe  pas: visiblement l'extension bloque le drop table de certains schemas créés dans la base , et la réinitialisation de la base pour les tests a besoin de drop.
Et de toute façon OSEF car c'est pour du géocodage aux US.
