### PR TITLE
ETQ Usager naviguant au clavier sur mobile, je veux que la prise de focus soit toujours visible

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -218,6 +218,14 @@
     }
   }
 
+  .fr-label .fr-hint-text,
+  .fr-label + .fr-hint-text {
+    clear: right;
+    // Évite (en version mobile) que les premiers mots de l'aide
+    // ne remontent en vis à vis de l'encart
+    // "champ actualisé par l'administration", lorsqu'il est présent
+  }
+
   .fr-label + .fr-hint-text > *,
   .fr-fieldset__legend + .fr-hint-text > * {
     // la description d'un champ peut contenir du markup (markdown->html),

--- a/app/assets/stylesheets/layouts.scss
+++ b/app/assets/stylesheets/layouts.scss
@@ -73,5 +73,15 @@
 }
 
 html.scroll-margins-for-sticky-footer {
-  scroll-padding: 0 0 100px 0;
+  @media (max-width: $two-columns-breakpoint) {
+    scroll-padding-bottom: 9.5rem;
+    // 9.5rem = padding-top + text height + button height + line-height + padding-bottom + empty space
+    // 9.5rem = 0.5 + 1.5✕2 + 2.5 + 1 + 0.5 + 2
+  }
+
+  @media (min-width: $two-columns-breakpoint) {
+    scroll-padding-bottom: 6.5rem;
+    // 6.5rem = padding-top + height + padding-bottom + empty space
+    // 6.5rem = 1 + 2.5 + 1 + 2
+  }
 }


### PR DESCRIPTION
# Le message d'enregistrement n'obstrue plus la prise de focus
Fix partiellement #11266

__Après__

https://github.com/user-attachments/assets/9cf68760-0d45-42e9-af5d-312ab491f9a3

__Avant__

https://github.com/user-attachments/assets/78cb8341-9c45-4ed4-8616-07053e43b489

# En version mobile, les messages d'aide ne remontent plus à côté de l'encart indiquant la mise à jour du champ
__Après__
<img width="538" alt="" src="https://github.com/user-attachments/assets/c86a297e-fe77-4e71-b70e-2383f55bc480" />

__Avant__
<img width="623" alt="" src="https://github.com/user-attachments/assets/ca359227-1ffd-4239-adcb-4fff7686fcba" />
