### PR TITLE
Tech: permet de désactiver provisoirement la notif et suppression des brouillons par var d'env

### DIFF
--- a/app/services/expired/dossiers_deletion_service.rb
+++ b/app/services/expired/dossiers_deletion_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Expired::DossiersDeletionService < Expired::MailRateLimiter
-  MAX_BROUILLON_DELETION_EMAILS_TO_PROCESS_PER_DAY = 10000
+  BROUILLON_DELETION_EMAILS_LIMIT_PER_DAY = ENV.fetch("BROUILLON_DELETION_EMAILS_LIMIT_PER_DAY", 10_000).to_i
 
   def process_expired_dossiers_brouillon
     send_brouillon_expiration_notices
@@ -22,7 +22,7 @@ class Expired::DossiersDeletionService < Expired::MailRateLimiter
     dossiers_close_to_expiration = Dossier
       .brouillon_close_to_expiration
       .without_brouillon_expiration_notice_sent
-      .limit(MAX_BROUILLON_DELETION_EMAILS_TO_PROCESS_PER_DAY)
+      .limit(BROUILLON_DELETION_EMAILS_LIMIT_PER_DAY)
 
     user_notifications = group_by_user_email(dossiers_close_to_expiration)
 

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -269,6 +269,10 @@ BULK_EMAIL_QUEUE="low_priority"
 # Use this env var customize the max number of deleted user per day
 EXPIRE_USER_DELETION_JOB_LIMIT=10000
 
+# Maximum daily emails sent notifying users about brouillons deletion.
+# Set to 0 to disable (temporarily) the deletion.
+BROUILLON_DELETION_EMAILS_LIMIT_PER_DAY=10000
+
 # write anything to disable cron jobs
 CRON_JOBS_DISABLED=""
 


### PR DESCRIPTION
Cf weekly du 30/01, et l'attente de nouveaux quotas d'emails avec le nouveau marché