### PR TITLE
ETQ admin: empêche de récupérer l'unique et dernier lien pointant sur une autre de ses démarches

### DIFF
--- a/app/models/concerns/procedure_path_concern.rb
+++ b/app/models/concerns/procedure_path_concern.rb
@@ -45,10 +45,13 @@ module ProcedurePathConcern
       return if new_path.blank?
 
       other_procedure = other_procedure_with_path(new_path)
-
-      if other_procedure.present? && !administrateur.owns?(other_procedure)
-        errors.add(:path, :taken)
-        raise ActiveRecord::RecordInvalid
+      if other_procedure.present?
+        if !administrateur.owns?(other_procedure)
+          errors.add(:path, :taken)
+        elsif other_procedure.procedure_paths.count == 1
+          errors.add(:path, :last_path)
+        end
+        raise ActiveRecord::RecordInvalid if errors.any?
       end
 
       procedure_path = procedure_paths.find { _1.path == new_path } || ProcedurePath.find_or_initialize_by(path: new_path)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -673,6 +673,7 @@ en:
             path:
               taken: is already used for procedure. You cannot use it because it belongs to another administrator.
               invalid: is not valid. It must countain between 3 and 200 characters among a-z, 0-9, '_' and '-'.
+              last_path: cannot be used because it is the last path of the procedure.
         procedure_revision:
           attributes:
             ineligibilite_rules:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -673,6 +673,7 @@ fr:
             path:
               taken: est déjà utilisé par une démarche. Vous ne pouvez pas l’utiliser car il appartient à un autre administrateur.
               invalid: n’est pas valide. Il doit comporter au moins 3 caractères, au plus 200 caractères et seuls les caractères a-z, 0-9, '_' et '-' sont autorisés.
+              last_path: ne peut pas être utilisé car c'est le dernier lien de la démarche.
         procedure_revision:
           attributes:
             ineligibilite_rules:

--- a/spec/models/concerns/procedure_path_concern_spec.rb
+++ b/spec/models/concerns/procedure_path_concern_spec.rb
@@ -144,7 +144,24 @@ describe ProcedurePathConcern do
       end
     end
 
-    # test if the procedure path is owned by another administrateur
+    context "when trying to claim the last procedure_path of another procedure" do
+      let!(:procedure_2) { create(:procedure) }
+
+      before do
+        first_procedure_path = procedure_2.procedure_paths.order(:created_at).first
+        procedure_2.procedure_paths.where.not(id: first_procedure_path.id).delete_all
+      end
+
+      let(:path_to_claim) { procedure_2.canonical_path }
+
+      it "does not assign the procedure to the procedure_path" do
+        puts "procedure_2.canonical_path: #{procedure_2.canonical_path}"
+        expect(procedure_2.procedure_paths.count).to eq(1)
+        expect(procedure_2.canonical_path).to eq(procedure_2.procedure_paths.first.path)
+        expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+        expect(procedure.errors.full_messages).to include("Le champ « Lien public » ne peut pas être utilisé car c'est le dernier lien de la démarche.")
+      end
+    end
   end
 
   describe '#previous_paths' do


### PR DESCRIPTION
Ce correctif empêche un administrateur de récupérer l'unique et dernier lien pointant sur une autre de ses démarches.