### PR TITLE
[Bug design] ETQ admin ma liste de labels revient à la ligne

### DIFF
--- a/app/assets/stylesheets/02_utils.scss
+++ b/app/assets/stylesheets/02_utils.scss
@@ -66,11 +66,16 @@
 }
 
 .horizontal-list {
-  display: flex;
-  gap: 20px;
   list-style-type: none;
   padding: 0;
   margin: 0;
+  & li {
+    display: inline-block;
+    margin-right: 10px;
+  }
+  & li:last-child {
+    margin-right: 0;
+  }
 }
 
 .empty-text {


### PR DESCRIPTION
**APRES** 
<img width="1234" alt="Capture d’écran 2025-02-04 à 14 40 40" src="https://github.com/user-attachments/assets/548f95a2-b34c-41c0-b5d2-777c8560ee61" />

**AVANT**
<img width="1270" alt="Capture d’écran 2025-02-04 à 14 41 23" src="https://github.com/user-attachments/assets/30153a60-a02e-48b3-b05f-5e706aca1944" />
