### PR TITLE
ETQ admin on m'informe du nb de dossiers attachés à un label au moment ou j'essaye de le supprimer

### DIFF
--- a/app/views/administrateurs/labels/index.html.haml
+++ b/app/views/administrateurs/labels/index.html.haml
@@ -44,7 +44,7 @@
                       = link_to 'Supprimer',
                         [:admin, @procedure, label],
                         method: :delete,
-                        data: { confirm: "Confirmez vous la suppression de #{label.name}" },
+                        data: { confirm: t("administrateurs.labels.delete_labels", count: label.dossier_labels.count, label_name: label.name) },
                         class: 'fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-delete-line fr-ml-1w'
 
 = render Procedure::FixedFooterComponent.new(procedure: @procedure)

--- a/config/locales/views/administrateurs/labels/en.yml
+++ b/config/locales/views/administrateurs/labels/en.yml
@@ -1,0 +1,7 @@
+en:
+  administrateurs:
+    labels:
+      delete_labels:
+        zero: Are you sure you want to remove the label “%{label_name}”?
+        one: The label “%{label_name}” is already assigned to a file, are you sure you want to remove it?
+        other: The label “%{label_name}” is already assigned to %{count} files, are you sure you want to remove it?

--- a/config/locales/views/administrateurs/labels/fr.yml
+++ b/config/locales/views/administrateurs/labels/fr.yml
@@ -1,0 +1,7 @@
+fr:
+  administrateurs:
+    labels:
+      delete_labels:
+        zero: Êtes-vous sûr de vouloir supprimer le label « %{label_name} » ?
+        one: Le label « %{label_name} » est déjà assigné à un dossier, êtes-vous sûr de vouloir le supprimer ?
+        other: Le label « %{label_name} » est déjà assigné à %{count} dossiers, êtes-vous sûr de vouloir le supprimer ?


### PR DESCRIPTION
On garde la possibilité de supprimer des labels par l'administrateur mais on lui donne plus d'informations, en lui indiquant le nb de dossiers auxquels les labels sont rattachés.


<img width="1250" alt="Capture d’écran 2025-02-04 à 17 16 13" src="https://github.com/user-attachments/assets/1a41be77-c6cf-47cb-9cdb-c5449ad719ab" />
