### PR TITLE
feat(dossier): add revision to traitements

### DIFF
--- a/app/graphql/api/v2/stored_query.rb
+++ b/app/graphql/api/v2/stored_query.rb
@@ -325,6 +325,10 @@ class API::V2::StoredQuery
       emailAgentTraitant
       dateTraitement
       motivation
+      revision {
+        id
+        datePublication
+      }
     }
     champs @include(if: $includeChamps) {
       ...ChampFragment

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -4475,6 +4475,7 @@ type Traitement {
   emailAgentTraitant: String
   id: ID!
   motivation: String
+  revision: Revision
   state: DossierState!
 }
 

--- a/app/graphql/types/traitement_type.rb
+++ b/app/graphql/types/traitement_type.rb
@@ -7,5 +7,10 @@ module Types
     field :date_traitement, GraphQL::Types::ISO8601DateTime, null: false, method: :processed_at
     field :email_agent_traitant, String, null: true, method: :instructeur_email
     field :motivation, String, null: true
+    field :revision, Types::RevisionType, null: true
+
+    def revision
+      Loaders::Association.for(object.class, :revision).load(object)
+    end
   end
 end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -63,12 +63,14 @@ class Dossier < ApplicationRecord
       build(state: Dossier.states.fetch(:en_construction),
         instructeur_email: instructeur&.email,
         processed_at:,
+        revision_id: proxy_association.owner.revision_id,
         browser: Current.browser)
     end
 
     def submit_en_construction(processed_at: Time.zone.now)
       build(state: Dossier.states.fetch(:en_construction),
         processed_at:,
+        revision_id: proxy_association.owner.revision_id,
         browser: Current.browser)
     end
 
@@ -76,12 +78,14 @@ class Dossier < ApplicationRecord
       build(state: Dossier.states.fetch(:en_instruction),
         instructeur_email: instructeur&.email,
         processed_at:,
+        revision_id: proxy_association.owner.revision_id,
         browser: Current.browser)
     end
 
     def accepter_automatiquement(processed_at: Time.zone.now)
       build(state: Dossier.states.fetch(:accepte),
-        processed_at:)
+        processed_at:,
+        revision_id: proxy_association.owner.revision_id)
     end
 
     def accepter(motivation: nil, instructeur: nil, processed_at: Time.zone.now)
@@ -89,6 +93,7 @@ class Dossier < ApplicationRecord
         instructeur_email: instructeur&.email,
         motivation:,
         processed_at:,
+        revision_id: proxy_association.owner.revision_id,
         browser: Current.browser)
     end
 
@@ -97,13 +102,15 @@ class Dossier < ApplicationRecord
         instructeur_email: instructeur&.email,
         motivation:,
         processed_at:,
+        revision_id: proxy_association.owner.revision_id,
         browser: Current.browser)
     end
 
     def refuser_automatiquement(processed_at: Time.zone.now, motivation:)
       build(state: Dossier.states.fetch(:refuse),
         motivation:,
-        processed_at:)
+        processed_at:,
+        revision_id: proxy_association.owner.revision_id)
     end
 
     def classer_sans_suite(motivation: nil, instructeur: nil, processed_at: Time.zone.now)
@@ -111,6 +118,7 @@ class Dossier < ApplicationRecord
         instructeur_email: instructeur&.email,
         motivation:,
         processed_at:,
+        revision_id: proxy_association.owner.revision_id,
         browser: Current.browser)
     end
   end

--- a/app/models/traitement.rb
+++ b/app/models/traitement.rb
@@ -2,6 +2,7 @@
 
 class Traitement < ApplicationRecord
   belongs_to :dossier, optional: false
+  belongs_to :revision, optional: true, class_name: 'ProcedureRevision'
   scope :en_construction, -> { where(state: Dossier.states.fetch(:en_construction)) }
   scope :en_instruction, -> { where(state: Dossier.states.fetch(:en_instruction)) }
   scope :termine, -> { where(state: Dossier::TERMINE) }

--- a/db/migrate/20250203174841_add_revision_id_to_traitements.rb
+++ b/db/migrate/20250203174841_add_revision_id_to_traitements.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRevisionIdToTraitements < ActiveRecord::Migration[7.0]
+  def change
+    add_column :traitements, :revision_id, :bigint, null: true
+  end
+end

--- a/db/migrate/20250203191101_add_revision_id_foreign_key_to_traitements.rb
+++ b/db/migrate/20250203191101_add_revision_id_foreign_key_to_traitements.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRevisionIdForeignKeyToTraitements < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :traitements, :procedure_revisions, validate: false, column: :revision_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_01_27_093613) do
+ActiveRecord::Schema[7.0].define(version: 2025_02_03_191101) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_stat_statements"
@@ -1224,6 +1224,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_27_093613) do
     t.string "instructeur_email"
     t.string "motivation"
     t.datetime "processed_at", precision: nil
+    t.bigint "revision_id"
     t.string "state"
     t.index ["dossier_id"], name: "index_traitements_on_dossier_id"
   end
@@ -1398,6 +1399,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_27_093613) do
   add_foreign_key "services", "administrateurs"
   add_foreign_key "targeted_user_links", "users"
   add_foreign_key "traitements", "dossiers"
+  add_foreign_key "traitements", "procedure_revisions", column: "revision_id"
   add_foreign_key "trusted_device_tokens", "instructeurs"
   add_foreign_key "types_de_champ", "referentiels"
   add_foreign_key "users", "users", column: "requested_merge_into_id"


### PR DESCRIPTION
Maintenant que le rebase est automatique, au support, on me fait remarquer que ce serait intéressant d'avoir accès à la révision sur laquelle un dossier a été déposé. Il y a plusieurs cas d'usages possibles :

- exposée l'information dans l'API
- afficher l'info aux instructeurs : ce dossier a été déposé par le porteur sur la version X.XX de la démarche publiée le JJ/MM/AAAA à HH:MM
- dans l'onglet demande, pouvoir basculer entre les réponses à la version de dépôt et la dernière version

Le souci, c'est qu'aujourd'hui, on perd cette info. Je propose déjà d'enregistrer l'info de la révision sur chaque `traitement`. J'ai aussi exposé l'information dans l'API parce que c'est facile et que ça rend service aux "fonds vert".

~~Pour les données historiques, si on avait la motivation, je pense qu'il serait possible de mouliner les dossier_operation_logs et de récupérer l'info. À voir si on le fait dans un second temps.~~

