### PR TITLE
[#11293] ETQ instructeur, la liste des dossiers une fois plusieurs filtres appliqués est désormais correcte

### DIFF
--- a/app/models/columns/dossier_column.rb
+++ b/app/models/columns/dossier_column.rb
@@ -19,4 +19,54 @@ class Columns::DossierColumn < Column
   end
 
   def dossier_column? = true
+
+  def filtered_ids(dossiers, values)
+    case table
+    when 'self'
+      if type == :date || type == :datetime
+        dates = values
+          .filter_map { |v| Time.zone.parse(v).beginning_of_day rescue nil }
+
+        dossiers.filter_by_datetimes(column, dates)
+      elsif column == "state" && values.include?("pending_correction")
+        dossiers.joins(:corrections).where(corrections: DossierCorrection.pending)
+      elsif column == "state" && values.include?("en_construction")
+        dossiers.where("dossiers.#{column} IN (?)", values).includes(:corrections).where.not(corrections: DossierCorrection.pending)
+      elsif type == :integer
+        dossiers.where("dossiers.#{column} IN (?)", values.filter_map { Integer(_1) rescue nil })
+      else
+        dossiers.where("dossiers.#{column} IN (?)", values)
+      end
+    when 'etablissement'
+      if column == 'entreprise_date_creation'
+        dates = values
+          .filter_map { |v| v.to_date rescue nil }
+
+        dossiers
+          .includes(table)
+          .where(table.pluralize => { column => dates })
+      else
+        dossiers
+          .includes(table)
+          .filter_ilike(table, column, values)
+      end
+    when 'followers_instructeurs'
+      dossiers
+        .includes(:followers_instructeurs)
+        .joins('INNER JOIN users instructeurs_users ON instructeurs_users.id = instructeurs.user_id')
+        .filter_ilike('instructeurs_users', :email, values) # ilike OK, user may want to search by *@domain
+    when 'user', 'individual' # user_columns: [email], individual_columns: ['nom', 'prenom', 'gender']
+      dossiers
+        .includes(table)
+        .filter_ilike(table, column, values) # ilike or where column == 'value' are both valid, we opted for ilike
+    when 'dossier_labels'
+      dossiers
+        .joins(:dossier_labels)
+        .where(dossier_labels: { label_id: values })
+    when 'groupe_instructeur'
+      dossiers
+        .joins(:groupe_instructeur)
+        .where(groupe_instructeur_id: values)
+    end.ids
+  end
 end

--- a/app/services/dossier_filter_service.rb
+++ b/app/services/dossier_filter_service.rb
@@ -44,7 +44,6 @@ class DossierFilterService
         ids
       end
     when 'followers_instructeurs'
-      assert_supported_column(table, column)
       # LEFT OUTER JOIN allows to keep dossiers without assigned instructeurs yet
       dossiers
         .includes(:followers_instructeurs)
@@ -108,7 +107,6 @@ class DossierFilterService
                 .filter_ilike(table, db_column, values)
             end
           when 'followers_instructeurs'
-            assert_supported_column(table, db_column)
             dossiers
               .includes(:followers_instructeurs)
               .joins('INNER JOIN users instructeurs_users ON instructeurs_users.id = instructeurs.user_id')
@@ -118,13 +116,10 @@ class DossierFilterService
               .includes(table)
               .filter_ilike(table, db_column, values) # ilike or where db_column == 'value' are both valid, we opted for ilike
           when 'dossier_labels'
-            assert_supported_column(table, db_column)
             dossiers
               .joins(:dossier_labels)
               .where(dossier_labels: { label_id: values })
           when 'groupe_instructeur'
-            assert_supported_column(table, db_column)
-
             dossiers
               .joins(:groupe_instructeur)
               .where(groupe_instructeur_id: values)
@@ -151,14 +146,5 @@ class DossierFilterService
     [table, column]
       .map { |name| ActiveRecord::Base.connection.quote_column_name(name) }
       .join('.')
-  end
-
-  def self.assert_supported_column(table, column)
-    if table == 'followers_instructeurs' && column != 'email'
-      raise ArgumentError, 'Table `followers_instructeurs` only supports the `email` column.'
-    end
-    if table == 'groupe_instructeur' && (column != 'label' && column != 'id')
-      raise ArgumentError, 'Table `groupe_instructeur` only supports the `label` or `id` column.'
-    end
   end
 end

--- a/app/services/dossier_filter_service.rb
+++ b/app/services/dossier_filter_service.rb
@@ -85,9 +85,9 @@ class DossierFilterService
                 .filter_map { |v| Time.zone.parse(v).beginning_of_day rescue nil }
 
               dossiers.filter_by_datetimes(db_column, dates)
-            elsif filtered_column.column == "state" && values.include?("pending_correction")
+            elsif db_column == "state" && values.include?("pending_correction")
               dossiers.joins(:corrections).where(corrections: DossierCorrection.pending)
-            elsif filtered_column.column == "state" && values.include?("en_construction")
+            elsif db_column == "state" && values.include?("en_construction")
               dossiers.where("dossiers.#{db_column} IN (?)", values).includes(:corrections).where.not(corrections: DossierCorrection.pending)
             elsif filtered_column.type == :integer
               dossiers.where("dossiers.#{db_column} IN (?)", values.filter_map { Integer(_1) rescue nil })

--- a/app/services/dossier_filter_service.rb
+++ b/app/services/dossier_filter_service.rb
@@ -74,13 +74,13 @@ class DossierFilterService
       .group_by { |filtered_column| filtered_column.column.then { [_1.table, _1.column] } }
       .map do |(table, db_column), grouped_filtered_columns|
       values = grouped_filtered_columns.map(&:filter)
-      grouped_filtered_columns.map(&:column).map do |filtered_column|
-        if filtered_column.respond_to?(:filtered_ids)
-          filtered_column.filtered_ids(dossiers, values)
+      grouped_filtered_columns.map(&:column).map do |column|
+        if column.respond_to?(:filtered_ids)
+          column.filtered_ids(dossiers, values)
         else
           case table
           when 'self'
-            if filtered_column.type == :date || filtered_column.type == :datetime
+            if column.type == :date || column.type == :datetime
               dates = values
                 .filter_map { |v| Time.zone.parse(v).beginning_of_day rescue nil }
 
@@ -89,7 +89,7 @@ class DossierFilterService
               dossiers.joins(:corrections).where(corrections: DossierCorrection.pending)
             elsif db_column == "state" && values.include?("en_construction")
               dossiers.where("dossiers.#{db_column} IN (?)", values).includes(:corrections).where.not(corrections: DossierCorrection.pending)
-            elsif filtered_column.type == :integer
+            elsif column.type == :integer
               dossiers.where("dossiers.#{db_column} IN (?)", values.filter_map { Integer(_1) rescue nil })
             else
               dossiers.where("dossiers.#{db_column} IN (?)", values)

--- a/app/services/dossier_filter_service.rb
+++ b/app/services/dossier_filter_service.rb
@@ -71,61 +71,7 @@ class DossierFilterService
   def self.filtered_ids(dossiers, filtered_columns)
     values_by_column = filtered_columns.group_by(&:column).transform_values { _1.map(&:filter) }
 
-    values_by_column.map do |column, values|
-      if column.respond_to?(:filtered_ids)
-        column.filtered_ids(dossiers, values)
-      else
-        table, db_column = [column.table, column.column]
-
-        case table
-        when 'self'
-          if column.type == :date || column.type == :datetime
-            dates = values
-              .filter_map { |v| Time.zone.parse(v).beginning_of_day rescue nil }
-
-            dossiers.filter_by_datetimes(db_column, dates)
-          elsif db_column == "state" && values.include?("pending_correction")
-            dossiers.joins(:corrections).where(corrections: DossierCorrection.pending)
-          elsif db_column == "state" && values.include?("en_construction")
-            dossiers.where("dossiers.#{db_column} IN (?)", values).includes(:corrections).where.not(corrections: DossierCorrection.pending)
-          elsif column.type == :integer
-            dossiers.where("dossiers.#{db_column} IN (?)", values.filter_map { Integer(_1) rescue nil })
-          else
-            dossiers.where("dossiers.#{db_column} IN (?)", values)
-          end
-        when 'etablissement'
-          if db_column == 'entreprise_date_creation'
-            dates = values
-              .filter_map { |v| v.to_date rescue nil }
-
-            dossiers
-              .includes(table)
-              .where(table.pluralize => { db_column => dates })
-          else
-            dossiers
-              .includes(table)
-              .filter_ilike(table, db_column, values)
-          end
-        when 'followers_instructeurs'
-          dossiers
-            .includes(:followers_instructeurs)
-            .joins('INNER JOIN users instructeurs_users ON instructeurs_users.id = instructeurs.user_id')
-            .filter_ilike('instructeurs_users', :email, values) # ilike OK, user may want to search by *@domain
-        when 'user', 'individual' # user_columns: [email], individual_columns: ['nom', 'prenom', 'gender']
-          dossiers
-            .includes(table)
-            .filter_ilike(table, db_column, values) # ilike or where db_column == 'value' are both valid, we opted for ilike
-        when 'dossier_labels'
-          dossiers
-            .joins(:dossier_labels)
-            .where(dossier_labels: { label_id: values })
-        when 'groupe_instructeur'
-          dossiers
-            .joins(:groupe_instructeur)
-            .where(groupe_instructeur_id: values)
-        end.pluck(:id)
-      end
-    end.reduce(:&)
+    values_by_column.map { |column, values| column.filtered_ids(dossiers, values) }.reduce(:intersection)
   end
 
   def self.sanitized_column(association, column)

--- a/app/services/dossier_filter_service.rb
+++ b/app/services/dossier_filter_service.rb
@@ -3,12 +3,12 @@
 class DossierFilterService
   TYPE_DE_CHAMP = 'type_de_champ'
 
-  def self.filtered_sorted_ids(dossiers, statut, filters, sorted_column, instructeur, count: nil, include_archived: false)
+  def self.filtered_sorted_ids(dossiers, statut, filtered_columns, sorted_column, instructeur, count: nil, include_archived: false)
     dossiers_by_statut = dossiers.by_statut(statut, instructeur:, include_archived:)
     dossiers_sorted_ids = self.sorted_ids(dossiers_by_statut, sorted_column, instructeur, count || dossiers_by_statut.size)
 
-    if filters.present?
-      dossiers_sorted_ids.intersection(filtered_ids(dossiers_by_statut, filters))
+    if filtered_columns.present?
+      dossiers_sorted_ids.intersection(filtered_ids(dossiers_by_statut, filtered_columns))
     else
       dossiers_sorted_ids
     end
@@ -69,9 +69,9 @@ class DossierFilterService
     end
   end
 
-  def self.filtered_ids(dossiers, filters)
-    filters
-      .group_by { |filter| filter.column.then { [_1.table, _1.column] } }
+  def self.filtered_ids(dossiers, filtered_columns)
+    filtered_columns
+      .group_by { |filtered_column| filtered_column.column.then { [_1.table, _1.column] } }
       .map do |(table, column), filters_for_column|
       values = filters_for_column.map(&:filter)
       filters_for_column.map(&:column).map do |filtered_column|

--- a/app/services/dossier_filter_service.rb
+++ b/app/services/dossier_filter_service.rb
@@ -72,9 +72,9 @@ class DossierFilterService
   def self.filtered_ids(dossiers, filtered_columns)
     filtered_columns
       .group_by { |filtered_column| filtered_column.column.then { [_1.table, _1.column] } }
-      .map do |(table, db_column), filters_for_column|
-      values = filters_for_column.map(&:filter)
-      filters_for_column.map(&:column).map do |filtered_column|
+      .map do |(table, db_column), grouped_filtered_columns|
+      values = grouped_filtered_columns.map(&:filter)
+      grouped_filtered_columns.map(&:column).map do |filtered_column|
         if filtered_column.respond_to?(:filtered_ids)
           filtered_column.filtered_ids(dossiers, values)
         else

--- a/spec/services/dossier_filter_service_spec.rb
+++ b/spec/services/dossier_filter_service_spec.rb
@@ -529,6 +529,50 @@ describe DossierFilterService do
         it { is_expected.to contain_exactly(kept_dossier.id) }
       end
 
+      context 'with multiple filters' do
+        let(:filters) { [filter_resto, filter_a_emporter] }
+        let(:filter_resto) { [type_de_champ_resto.libelle, 'pizzeria'] }
+        let(:filter_a_emporter) { [type_de_champ_a_emporter.libelle, 'true'] }
+
+        let(:types_de_champ_public) do
+          [
+            { type: :drop_down_list, options: ['pizzeria', 'gastronomique'] },
+            { type: :yes_no }
+          ]
+        end
+        let(:types_de_champ) { procedure.active_revision.types_de_champ_public }
+        let(:type_de_champ_resto) { types_de_champ[0] }
+        let(:type_de_champ_a_emporter) { types_de_champ[1] }
+
+        let(:another_discarded_dossier) { create(:dossier, procedure:) }
+
+        before do
+          kept_champ_resto = kept_dossier.champs.find_by(stable_id: type_de_champ_resto.stable_id)
+          kept_champ_resto.value = 'pizzeria'
+          kept_champ_resto.save!
+
+          kept_champ_a_emporter = kept_dossier.champs.find_by(stable_id: type_de_champ_a_emporter.stable_id)
+          kept_champ_a_emporter.value = 'true'
+          kept_champ_a_emporter.save!
+
+          discarded_champ_resto = discarded_dossier.champs.find_by(stable_id: type_de_champ_resto.stable_id)
+          discarded_champ_resto.value = 'pizzeria'
+          discarded_champ_a_emporter = discarded_dossier.champs.find_by(stable_id: type_de_champ_a_emporter.stable_id)
+          discarded_champ_a_emporter.value = 'false'
+          discarded_champ_resto.save!
+          discarded_champ_a_emporter.save!
+
+          another_discarded_champ_resto = another_discarded_dossier.champs.find_by(stable_id: type_de_champ_resto.stable_id)
+          another_discarded_champ_resto.value = 'fast-food'
+          another_discarded_champ_a_emporter = another_discarded_dossier.champs.find_by(stable_id: type_de_champ_a_emporter.stable_id)
+          another_discarded_champ_a_emporter.value = 'true'
+          another_discarded_champ_resto.save!
+          another_discarded_champ_a_emporter.save!
+        end
+
+        it { is_expected.to contain_exactly(kept_dossier.id) }
+      end
+
       context 'with enums type_de_champ' do
         let(:filter) { [type_de_champ.libelle, search_term] }
         let(:types_de_champ_public) { [{ type: :multiple_drop_down_list, options: ['champ', 'champignon'] }] }


### PR DESCRIPTION
close #11293 

Cette PR corrige le bug suivant : Lorsqu'un instructeur veut appliquer plusieurs critères de filtres, cela ne prenait en compte que le premier critère appliqué.