### PR TITLE
Tech: fix formattage de column date stringifiée issue d'un jsonpath

### DIFF
--- a/app/components/instructeurs/cell_component.rb
+++ b/app/components/instructeurs/cell_component.rb
@@ -55,7 +55,11 @@ class Instructeurs::CellComponent < ApplicationComponent
       format_enum(column: @column, raw_value:)
     when :enums
       format_enums(column: @column, raw_values: raw_value)
-    when :datetime, :date
+    when :date
+      raw_value = Date.parse(raw_value) if raw_value.is_a?(String)
+      I18n.l(raw_value)
+    when :datetime
+      raw_value = DateTime.parse(raw_value) if raw_value.is_a?(String)
       I18n.l(raw_value)
     else
       raw_value

--- a/spec/components/instructeurs/cell_component_spec.rb
+++ b/spec/components/instructeurs/cell_component_spec.rb
@@ -92,6 +92,19 @@ describe Instructeurs::CellComponent do
       it { is_expected.to eq('12 février 2025 09:19') }
     end
 
+    context 'for a date column with value as string' do
+      let(:types_de_champ_public) { [{ type: :siret, libelle: 'siret' }] }
+      let(:column) { dossier.procedure.find_column(label: 'siret – Entreprise date de création') }
+      let(:etablissement) { build(:etablissement, entreprise_date_creation: Date.new(2015, 8, 10)) }
+
+      before {
+        dossier.champs.first.update(value: etablissement.siret, etablissement:)
+        etablissement.update_champ_value_json!
+      }
+
+      it { is_expected.to eq('10/08/2015') }
+    end
+
     context 'for a enum column' do
       let(:types_de_champ_public) { [{ type: :drop_down_list, libelle: 'drop_down_list', options: ['a', 'b', 'c'] }] }
       let(:column) { dossier.procedure.find_column(label: 'drop_down_list') }


### PR DESCRIPTION
Dans un jsonpath les colonnes sont stockées au format iso8601, donc il faut la convertir en objet date avant le formattage

(suite de #11226 )