### PR TITLE
ETQ admin, quand je confirme/infirme l'email d'un instructeur, je peux ensuite également confirmer les autres emails avec une potentielle faute de frappe

### DIFF
--- a/app/components/procedure/invitation_with_typo_component/invitation_with_typo_component.html.haml
+++ b/app/components/procedure/invitation_with_typo_component/invitation_with_typo_component.html.haml
@@ -3,8 +3,9 @@
     %p= @title
     %ul#maybe_typos_errors
       - @maybe_typos.each do |(actual_email, suggested_email)|
+        - emails_with_typos = (@maybe_typos.map(&:first) - [actual_email]).to_json
         %li
           = "Je confirme "
-          = button_to "#{actual_email}", @url, method: :POST, params: { final_email: actual_email }, class: 'fr-btn fr-btn--tertiary fr-btn--sm', form: {class: 'inline'}
+          = button_to "#{actual_email}", @url, method: :POST, params: { final_email: actual_email, emails_with_typos: }, class: 'fr-btn fr-btn--tertiary fr-btn--sm', form: {class: 'inline'}
           = " ou "
-          = button_to "#{suggested_email}", @url, method: :POST, params: { final_email: suggested_email }, class: 'fr-btn fr-btn--tertiary fr-btn--sm', form: {class: 'inline'}
+          = button_to "#{suggested_email}", @url, method: :POST, params: { final_email: suggested_email, emails_with_typos: }, class: 'fr-btn fr-btn--tertiary fr-btn--sm', form: {class: 'inline'}

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -236,7 +236,9 @@ module Administrateurs
     end
 
     def add_instructeur
+      emails_with_typos = JSON.parse(params[:emails_with_typos]) if params[:emails_with_typos]
       emails = params['emails'].presence || []
+      emails.push(emails_with_typos).flatten! if emails_with_typos
       emails = check_if_typo(emails)
       errors = Array.wrap(generate_emails_suggestions_message(@maybe_typos))
 

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -22,6 +22,7 @@ module Administrateurs
 
       @instructeurs = paginated_instructeurs
       @available_instructeur_emails = available_instructeur_emails
+      @maybe_typos = JSON.parse(params[:maybe_typos]) if params[:maybe_typos]
     end
 
     def options
@@ -131,6 +132,7 @@ module Administrateurs
       @groupe_instructeur = groupe_instructeur
       @instructeurs = paginated_instructeurs
       @available_instructeur_emails = available_instructeur_emails
+      @maybe_typos = JSON.parse(params[:maybe_typos]) if params[:maybe_typos]
     end
 
     def create
@@ -277,12 +279,13 @@ module Administrateurs
       @instructeurs = paginated_instructeurs
       @available_instructeur_emails = available_instructeur_emails
 
+      query_param = { maybe_typos: @maybe_typos.to_json } if @maybe_typos.present?
       if procedure.routing_enabled?
         @groupe_instructeur = groupe_instructeur
-        redirect_to admin_procedure_groupe_instructeur_path(@procedure, @groupe_instructeur)
+        redirect_to admin_procedure_groupe_instructeur_path(@procedure, @groupe_instructeur, query_param)
       else
         @groupes_instructeurs = paginated_groupe_instructeurs
-        redirect_to admin_procedure_groupe_instructeurs_path(@procedure)
+        redirect_to admin_procedure_groupe_instructeurs_path(@procedure, query_param)
       end
     end
 

--- a/app/controllers/instructeurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/instructeurs/groupe_instructeurs_controller.rb
@@ -61,11 +61,9 @@ module Instructeurs
       @groupe_instructeur = groupe_instructeur
       @instructeurs = paginated_instructeurs
 
-      if !errors.empty?
-        flash.now[:alert] = errors.join(". ") if !errors.empty?
-      end
+      flash[:alert] = errors.join(". ") if !errors.empty?
 
-      render :show
+      redirect_to instructeur_groupe_path(@procedure, @groupe_instructeur)
     end
 
     def remove_instructeur

--- a/app/controllers/instructeurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/instructeurs/groupe_instructeurs_controller.rb
@@ -18,10 +18,13 @@ module Instructeurs
       @procedure = procedure
       @groupe_instructeur = groupe_instructeur
       @instructeurs = paginated_instructeurs
+      @maybe_typos = JSON.parse(params[:maybe_typos]) if params[:maybe_typos]
     end
 
     def add_instructeur
+      emails_with_typos = JSON.parse(params[:emails_with_typos]) if params[:emails_with_typos]
       emails = params['emails'].presence || []
+      emails.push(emails_with_typos).flatten! if emails_with_typos
       emails = check_if_typo(emails)
       errors = Array.wrap(generate_emails_suggestions_message(@maybe_typos))
 
@@ -63,7 +66,8 @@ module Instructeurs
 
       flash[:alert] = errors.join(". ") if !errors.empty?
 
-      redirect_to instructeur_groupe_path(@procedure, @groupe_instructeur)
+      query_param = { maybe_typos: @maybe_typos.to_json } if @maybe_typos.present?
+      redirect_to instructeur_groupe_path(@procedure, @groupe_instructeur, query_param)
     end
 
     def remove_instructeur

--- a/spec/controllers/instructeurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/instructeurs/groupe_instructeurs_controller_spec.rb
@@ -99,7 +99,7 @@ describe Instructeurs::GroupeInstructeursController, type: :controller do
       it "works" do
         expect(gi_1_2.instructeurs.map(&:email)).to include(new_instructeur_email)
         expect(flash.notice).to be_present
-        expect(response).to have_http_status(:success)
+        expect(subject).to redirect_to(instructeur_groupe_path(procedure, gi_1_2))
         expect(InstructeurMailer).to have_received(:confirm_and_notify_added_instructeur).with(instance_of(Instructeur), gi_1_2, anything)
         expect(GroupeInstructeurMailer).not_to have_received(:notify_added_instructeurs)
       end
@@ -114,7 +114,7 @@ describe Instructeurs::GroupeInstructeursController, type: :controller do
       it "works" do
         expect(gi_1_2.instructeurs.map(&:email)).to include(new_instructeur_email)
         expect(flash.notice).to be_present
-        expect(response).to have_http_status(:success)
+        expect(subject).to redirect_to(instructeur_groupe_path(procedure, gi_1_2))
         expect(InstructeurMailer).not_to have_received(:confirm_and_notify_added_instructeur)
         expect(GroupeInstructeurMailer).to have_received(:notify_added_instructeurs)
       end
@@ -129,7 +129,7 @@ describe Instructeurs::GroupeInstructeursController, type: :controller do
       it "works" do
         expect(gi_1_2.instructeurs.map(&:email)).to include(new_instructeur_email)
         expect(flash.notice).to be_present
-        expect(response).to have_http_status(:success)
+        expect(subject).to redirect_to(instructeur_groupe_path(procedure, gi_1_2))
         expect(InstructeurMailer).to have_received(:confirm_and_notify_added_instructeur)
         expect(GroupeInstructeurMailer).not_to have_received(:notify_added_instructeurs)
       end
@@ -143,7 +143,7 @@ describe Instructeurs::GroupeInstructeursController, type: :controller do
       end
 
       it "works" do
-        expect(response).to have_http_status(:success)
+        expect(subject).to redirect_to(instructeur_groupe_path(procedure, gi_1_2))
         expect(InstructeurMailer).not_to have_received(:confirm_and_notify_added_instructeur)
         expect(GroupeInstructeurMailer).not_to have_received(:notify_added_instructeurs)
       end


### PR DESCRIPTION
Cette PR fixe 2 bugs

- elle affiche, pour les admin et instructeurs qui veulent ajouter un instructeur, les emails à confirmer
- lorsqu'il y a plusieurs mails avec potentielle faute de frappe, elle permet de confirmer plusieurs adresses emails

Voici le comportement :

- Un admin ou instructeur saisit plusieurs adresses emails d'instructeurs pour les ajouter à la démarche.
-  Il y a plusieurs fautes de frappe potentielles.
-  Il clique sur confirmer pour une adresse email
-  La page se recharge et les autres propositions sont désormais proposées

<img width="784" alt="emails" src="https://github.com/user-attachments/assets/a3e4e099-4970-4c50-b173-d8dc21bf0e94" />

