### PR TITLE
ETQ Usager, je veux que les aides à la saisie soient uniformes

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -227,6 +227,7 @@
   }
 
   .fr-label + .fr-hint-text > *,
+  .fr-label + .fr-hint-text > * > p,
   .fr-fieldset__legend + .fr-hint-text > * {
     // la description d'un champ peut contenir du markup (markdown->html),
     // on herite donc la taille de police, la couleur et l'interlignage de fr-hint-text


### PR DESCRIPTION
# Uniformisation des aides à la saisie
__Après__
<img width="612" alt="" src="https://github.com/user-attachments/assets/ea5cd9a4-75b2-4b85-9aa5-4184af974054" />

__Avant__
<img width="792" alt="" src="https://github.com/user-attachments/assets/51c7354d-68e2-490d-ad32-f663efcee36e" />