### PR TITLE
Etq admin je peux relancer le routage sur tous les dossiers

### DIFF
--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -392,6 +392,22 @@ module Administrateurs
       end
     end
 
+    def bulk_route
+      dossiers = procedure.dossiers
+
+      dossiers.update_all(forced_groupe_instructeur: false)
+
+      dossiers.each do |dossier|
+        RoutingEngine.compute(dossier, assignment_mode: DossierAssignment.modes.fetch(:bulk_routing))
+      end
+
+      procedure.update!(routing_alert: false)
+
+      flash[:notice] = "Les dossiers ont étés routés vers les groupes d’instructeurs"
+
+      redirect_to admin_procedure_groupe_instructeurs_path(procedure)
+    end
+
     private
 
     def closed_params?

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -393,14 +393,12 @@ module Administrateurs
     end
 
     def bulk_route
-      dossiers = procedure.dossiers.state_not_termine
-
-      dossiers.update_all(forced_groupe_instructeur: false)
+      dossiers = procedure.dossiers.includes(:procedure, :groupe_instructeur, :champs, revision: [:types_de_champ]).state_not_termine
 
       dossiers.each do |dossier|
+        dossier.update_column(:forced_groupe_instructeur, false)
         RoutingEngine.compute(dossier, assignment_mode: DossierAssignment.modes.fetch(:bulk_routing))
       end
-
       procedure.update!(routing_alert: false)
 
       flash[:notice] = "Les dossiers ont étés routés vers les groupes d’instructeurs"

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -121,7 +121,7 @@ module Administrateurs
     def destroy_all_groups_but_defaut
       reaffecter_all_dossiers_to_defaut_groupe
       procedure.groupe_instructeurs_but_defaut.each(&:destroy!)
-      procedure.update!(routing_enabled: false)
+      procedure.update!(routing_enabled: false, routing_alert: false)
       procedure.defaut_groupe_instructeur.update!(
         routing_rule: nil,
         label: GroupeInstructeur::DEFAUT_LABEL,
@@ -199,6 +199,7 @@ module Administrateurs
         @groupe_instructeur.destroy!
         if procedure.groupe_instructeurs.active.one?
           procedure.toggle_routing
+          procedure.update!(routing_alert: false)
           procedure.defaut_groupe_instructeur.update!(
             routing_rule: nil,
             label: GroupeInstructeur::DEFAUT_LABEL,

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -89,7 +89,7 @@ module Administrateurs
         defaut.destroy!
       end
 
-      procedure.update!(routing_alert: true) if procedure.dossiers.soumis.any?
+      procedure.update!(routing_alert: true) if procedure.dossiers.state_en_construction_ou_instruction.any?
 
       flash[:routing_mode] = 'simple'
 
@@ -111,7 +111,7 @@ module Administrateurs
 
       procedure.toggle_routing
 
-      procedure.update!(routing_alert: true) if procedure.dossiers.soumis.any?
+      procedure.update!(routing_alert: true) if procedure.dossiers.state_en_construction_ou_instruction.any?
 
       flash[:routing_mode] = 'custom'
 
@@ -393,7 +393,7 @@ module Administrateurs
     end
 
     def bulk_route
-      dossiers = procedure.dossiers
+      dossiers = procedure.dossiers.state_not_termine
 
       dossiers.update_all(forced_groupe_instructeur: false)
 

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -89,6 +89,8 @@ module Administrateurs
         defaut.destroy!
       end
 
+      procedure.update!(routing_alert: true) if procedure.dossiers.soumis.any?
+
       flash[:routing_mode] = 'simple'
 
       redirect_to admin_procedure_groupe_instructeurs_path(@procedure)
@@ -108,6 +110,8 @@ module Administrateurs
         .create({ label: 'Groupe 2 (à renommer et configurer)', instructeurs: [current_administrateur.instructeur] })
 
       procedure.toggle_routing
+
+      procedure.update!(routing_alert: true) if procedure.dossiers.soumis.any?
 
       flash[:routing_mode] = 'custom'
 

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -394,15 +394,9 @@ module Administrateurs
     end
 
     def bulk_route
-      dossiers = procedure.dossiers.includes(:procedure, :groupe_instructeur, :champs, revision: [:types_de_champ]).state_not_termine
+      BulkRouteJob.perform_later(procedure)
 
-      dossiers.each do |dossier|
-        dossier.update_column(:forced_groupe_instructeur, false)
-        RoutingEngine.compute(dossier, assignment_mode: DossierAssignment.modes.fetch(:bulk_routing))
-      end
-      procedure.update!(routing_alert: false)
-
-      flash[:notice] = "Les dossiers ont étés routés vers les groupes d’instructeurs"
+      flash[:notice] = "Le routage des dossiers est lancé."
 
       redirect_to admin_procedure_groupe_instructeurs_path(procedure)
     end

--- a/app/jobs/bulk_route_job.rb
+++ b/app/jobs/bulk_route_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class BulkRouteJob < ApplicationJob
+  queue_as :critical
+
+  def perform(procedure)
+    dossiers = procedure.dossiers
+      .includes(:procedure, :groupe_instructeur, :champs, revision: [:types_de_champ])
+      .state_not_termine
+
+    dossiers.each do |dossier|
+      dossier.update_column(:forced_groupe_instructeur, false)
+      RoutingEngine.compute(dossier, assignment_mode: DossierAssignment.modes.fetch(:bulk_routing))
+    end
+
+    procedure.update!(routing_alert: false)
+  end
+end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -222,6 +222,7 @@ class Dossier < ApplicationRecord
   scope :state_accepte,                        -> { where(state: states.fetch(:accepte)) }
   scope :state_refuse,                         -> { where(state: states.fetch(:refuse)) }
   scope :state_sans_suite,                     -> { where(state: states.fetch(:sans_suite)) }
+  scope :soumis,                               -> { where(state: SOUMIS) }
 
   scope :archived,                  -> { where(archived: true) }
   scope :not_archived,              -> { where(archived: false) }

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -680,7 +680,7 @@ class Dossier < ApplicationRecord
 
   def assign_to_groupe_instructeur(groupe_instructeur, mode, author = nil)
     return if groupe_instructeur.present? && groupe_instructeur.procedure != procedure
-    return if self.groupe_instructeur == groupe_instructeur
+    return if self.groupe_instructeur == groupe_instructeur && mode == self.dossier_assignment&.mode
 
     previous_groupe_instructeur = self.groupe_instructeur
 

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -222,7 +222,6 @@ class Dossier < ApplicationRecord
   scope :state_accepte,                        -> { where(state: states.fetch(:accepte)) }
   scope :state_refuse,                         -> { where(state: states.fetch(:refuse)) }
   scope :state_sans_suite,                     -> { where(state: states.fetch(:sans_suite)) }
-  scope :soumis,                               -> { where(state: SOUMIS) }
 
   scope :archived,                  -> { where(archived: true) }
   scope :not_archived,              -> { where(archived: false) }

--- a/app/models/dossier_assignment.rb
+++ b/app/models/dossier_assignment.rb
@@ -9,7 +9,8 @@ class DossierAssignment < ApplicationRecord
   enum :mode, {
     auto: 'auto',
     manual: 'manual',
-    tech: 'tech'
+    tech: 'tech',
+    bulk_routing: 'bulk_routing'
   }
 
   scope :manual, -> { where(mode: :manual) }

--- a/app/views/administrateurs/groupe_instructeurs/_routing_alert_sticky_header.html.haml
+++ b/app/views/administrateurs/groupe_instructeurs/_routing_alert_sticky_header.html.haml
@@ -4,7 +4,7 @@
       %span
         = dsfr_icon("fr-icon-warning-fill fr-mr-1v")
         - if @procedure.groupe_instructeurs.any?(&:invalid_rule?)
-          = t('.routing_alert_with_invalid_rules_html', count: @procedure.dossiers.soumis.count)
+          = t('.routing_alert_with_invalid_rules_html', count: @procedure.dossiers.state_en_construction_ou_instruction.count)
         - else
-          = t('.routing_alert_html', count: @procedure.dossiers.soumis.count)
+          = t('.routing_alert_html', count: @procedure.dossiers.state_en_construction_ou_instruction.count)
       = button_to t('.bulk_route'), bulk_route_admin_procedure_groupe_instructeurs_path(@procedure), class: 'fr-btn no-wrap', disabled: @procedure.groupe_instructeurs.any?(&:invalid_rule?), data: { disable_with: "Routage en cours…", confirm: t('.bulk_routing_confirm') }

--- a/app/views/administrateurs/groupe_instructeurs/_routing_alert_sticky_header.html.haml
+++ b/app/views/administrateurs/groupe_instructeurs/_routing_alert_sticky_header.html.haml
@@ -1,0 +1,10 @@
+.sticky-header.sticky-header-warning
+  .fr-container
+    .flex.justify-between.align-center.fr-text-default--warning
+      %span
+        = dsfr_icon("fr-icon-warning-fill fr-mr-1v")
+        - if @procedure.groupe_instructeurs.any?(&:invalid_rule?)
+          = t('.routing_alert_with_invalid_rules_html', count: @procedure.dossiers.soumis.count)
+        - else
+          = t('.routing_alert_html', count: @procedure.dossiers.soumis.count)
+      = button_to t('.bulk_route'), bulk_route_admin_procedure_groupe_instructeurs_path(@procedure), class: 'fr-btn no-wrap', disabled: @procedure.groupe_instructeurs.any?(&:invalid_rule?), data: { disable_with: "Routage en cours…", confirm: t('.bulk_routing_confirm') }

--- a/app/views/administrateurs/groupe_instructeurs/index.html.haml
+++ b/app/views/administrateurs/groupe_instructeurs/index.html.haml
@@ -1,3 +1,7 @@
+- if @procedure.routing_alert
+  - content_for(:sticky_header) do
+    = render partial: 'administrateurs/groupe_instructeurs/routing_alert_sticky_header', locals: { procedure: @procedure }
+
 = render partial: 'administrateurs/breadcrumbs',
   locals: { steps: [[t('.procedures'), admin_procedures_path],
                     [@procedure.libelle.truncate_words(10), admin_procedure_path(@procedure)],

--- a/config/locales/views/administrateurs/groupe_instructeurs/en.yml
+++ b/config/locales/views/administrateurs/groupe_instructeurs/en.yml
@@ -19,3 +19,8 @@ en:
         existing_groupe:
           one: "%{count} group exist"
           other: "%{count} groups exist"
+      routing_alert_sticky_header:
+        routing_alert_html: "<strong>%{count} dossiers</strong> have already been deposited on this procedure and have <strong>not been routed according to the configured routing</strong>. You must launch the routing to distribute these files to the different groups."
+        routing_alert_with_invalid_rules_html: "<strong>%{count} dossiers</strong> have already been deposited on this procedure and have <strong>not yet been routed</strong>. Once you have configured your routing rules, you will need to launch the routing to distribute these files to the different groups."
+        bulk_route: Launch routing
+        bulk_routing_confirm: "Are you sure you want to launch the routing for the deposited files?"

--- a/config/locales/views/administrateurs/groupe_instructeurs/en.yml
+++ b/config/locales/views/administrateurs/groupe_instructeurs/en.yml
@@ -20,7 +20,7 @@ en:
           one: "%{count} group exist"
           other: "%{count} groups exist"
       routing_alert_sticky_header:
-        routing_alert_html: "<strong>%{count} dossiers</strong> have already been deposited on this procedure and have <strong>not been routed according to the configured routing</strong>. You must launch the routing to distribute these files to the different groups."
-        routing_alert_with_invalid_rules_html: "<strong>%{count} dossiers</strong> have already been deposited on this procedure and have <strong>not yet been routed</strong>. Once you have configured your routing rules, you will need to launch the routing to distribute these files to the different groups."
+        routing_alert_html: "<strong>%{count} files</strong> have been deposited and are waiting to be processed on this procedure. These files have <strong>not been routed according to the configured routing</strong>. You must launch the routing to distribute them to the different groups."
+        routing_alert_with_invalid_rules_html: "<strong>%{count} files</strong> have been deposited and are waiting to be processed on this procedure. These files have <strong>not yet been routed</strong>. Once you have configured your routing rules, you will need to launch the routing to distribute them to the different groups."
         bulk_route: Launch routing
-        bulk_routing_confirm: "Are you sure you want to launch the routing for the deposited files?"
+        bulk_routing_confirm: "Are you sure you want to launch the routing for the deposited files waiting to be processed ?"

--- a/config/locales/views/administrateurs/groupe_instructeurs/fr.yml
+++ b/config/locales/views/administrateurs/groupe_instructeurs/fr.yml
@@ -39,3 +39,8 @@ fr:
         procedures: Démarches
       simple_routing:
         procedures: Démarches
+      routing_alert_sticky_header:
+        routing_alert_html: "<strong>%{count} dossiers</strong> ont déjà été déposés sur cette démarche et n’ont <strong>pas été routés selon le routage configuré</strong>. Vous devez lancer le routage pour répartir ces dossiers dans les différents groupes."
+        routing_alert_with_invalid_rules_html: "<strong>%{count} dossiers</strong> ont déjà été déposés sur cette démarche et n’ont <strong>pas encore été routés</strong>. Une fois que vous aurez configuré vos règles de routage, vous devrez lancer le routage pour répartir ces dossiers dans les différents groupes."
+        bulk_route: Lancer le routage
+        bulk_routing_confirm: "Êtes-vous sûr de vouloir lancer le routage pour les dossiers déposés ?"

--- a/config/locales/views/administrateurs/groupe_instructeurs/fr.yml
+++ b/config/locales/views/administrateurs/groupe_instructeurs/fr.yml
@@ -40,7 +40,7 @@ fr:
       simple_routing:
         procedures: Démarches
       routing_alert_sticky_header:
-        routing_alert_html: "<strong>%{count} dossiers</strong> ont déjà été déposés sur cette démarche et n’ont <strong>pas été routés selon le routage configuré</strong>. Vous devez lancer le routage pour répartir ces dossiers dans les différents groupes."
-        routing_alert_with_invalid_rules_html: "<strong>%{count} dossiers</strong> ont déjà été déposés sur cette démarche et n’ont <strong>pas encore été routés</strong>. Une fois que vous aurez configuré vos règles de routage, vous devrez lancer le routage pour répartir ces dossiers dans les différents groupes."
+        routing_alert_html: "Il y a <strong>%{count} dossiers</strong> déposés et en attente de traitement sur cette démarche. Ces dossiers n’ont <strong>pas été routés selon le routage configuré</strong>. Vous devez lancer le routage pour les répartir dans les différents groupes."
+        routing_alert_with_invalid_rules_html: "Il y a <strong>%{count} dossiers</strong> déposés et en attente de traitement sur cette démarche. Ces dossiers n’ont <strong>pas encore été routés</strong>. Une fois que vous aurez configuré vos règles de routage, vous devrez lancer le routage pour les répartir dans les différents groupes."
         bulk_route: Lancer le routage
-        bulk_routing_confirm: "Êtes-vous sûr de vouloir lancer le routage pour les dossiers déposés ?"
+        bulk_routing_confirm: "Êtes-vous sûr de vouloir lancer le routage pour les dossiers déposés et en attente de traitement ?"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -729,6 +729,7 @@ Rails.application.routes.draw do
           patch 'update_instructeurs_self_management_enabled'
           post 'import'
           get 'export_groupe_instructeurs'
+          post 'bulk_route'
         end
       end
 

--- a/db/migrate/20250212084747_add_routing_alert_to_procedures.rb
+++ b/db/migrate/20250212084747_add_routing_alert_to_procedures.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRoutingAlertToProcedures < ActiveRecord::Migration[7.0]
+  def change
+    add_column :procedures, :routing_alert, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1039,6 +1039,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_20_153834) do
     t.bigint "published_revision_id"
     t.boolean "rdv_enabled", default: false, null: false
     t.bigint "replaced_by_procedure_id"
+    t.boolean "routing_alert", default: false, null: false
     t.boolean "routing_enabled"
     t.bigint "service_id"
     t.jsonb "sva_svr", default: {}, null: false

--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -909,6 +909,7 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
       end
 
       let!(:drop_down_tdc) { procedure3.draft_revision.types_de_champ.first }
+      let!(:dossier) { create(:dossier, procedure: procedure3, state: :en_construction) }
 
       before { post :create_simple_routing, params: { procedure_id: procedure3.id, create_simple_routing: { stable_id: drop_down_tdc.stable_id } } }
 
@@ -918,6 +919,7 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
         expect(procedure3.groupe_instructeurs.pluck(:label)).to match_array(['Paris', 'Lyon', 'Marseille'])
         expect(procedure3.reload.defaut_groupe_instructeur.routing_rule).to eq(ds_eq(champ_value(drop_down_tdc.stable_id), constant('Lyon')))
         expect(procedure3.routing_enabled).to be_truthy
+        expect(procedure3.routing_alert).to be_truthy
       end
     end
 
@@ -938,6 +940,7 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
         expect(procedure3.groupe_instructeurs.pluck(:label)).to include("01 – Ain")
         expect(procedure3.reload.defaut_groupe_instructeur.routing_rule).to eq(ds_eq(champ_value(departements_tdc.stable_id), constant('01')))
         expect(procedure3.routing_enabled).to be_truthy
+        expect(procedure3.routing_alert).to be_falsey
       end
     end
 

--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -1099,17 +1099,21 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
     let!(:drop_down_tdc) { procedure.draft_revision.types_de_champ.first }
     let!(:dossier1) { create(:dossier, :with_populated_champs, procedure: procedure, state: :en_construction) }
     let!(:dossier2) { create(:dossier, :with_populated_champs, procedure: procedure, state: :en_construction) }
+    let!(:dossier3) { create(:dossier, :with_populated_champs, procedure: procedure, state: :accepte) }
 
     before do
       dossier1.champs.first.update(value: 'Paris')
       dossier2.champs.first.update(value: 'Lyon')
+      dossier3.champs.first.update(value: 'Marseille')
       post :create_simple_routing, params: { procedure_id: procedure.id, create_simple_routing: { stable_id: drop_down_tdc.stable_id } }
       post :bulk_route, params: { procedure_id: procedure.id }
     end
 
-    it do
+    it 'routes only dossiers en construction or en instruction' do
       expect(dossier1.reload.groupe_instructeur.label).to eq 'Paris'
       expect(dossier2.reload.groupe_instructeur.label).to eq 'Lyon'
+      expect(dossier3.reload.groupe_instructeur.label).to eq 'Lyon'
+      # Lyon is default group
       expect(procedure.reload.routing_alert).to be_falsey
     end
   end

--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -1106,22 +1106,11 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
       dossier2.champs.first.update(value: 'Lyon')
       dossier3.champs.first.update(value: 'Marseille')
       post :create_simple_routing, params: { procedure_id: procedure.id, create_simple_routing: { stable_id: drop_down_tdc.stable_id } }
+      post :bulk_route, params: { procedure_id: procedure.id }
     end
 
     it 'routes only dossiers en construction or en instruction' do
-      query_count = 0
-      ActiveSupport::Notifications.subscribed(lambda { |*_args| query_count += 1 }, "sql.active_record") do
-        post :bulk_route, params: { procedure_id: procedure.id }
-      end
-      expect(query_count).to be_between(60, 90)
-      expect(dossier1.reload.groupe_instructeur.label).to eq 'Paris'
-      expect(dossier1.reload.dossier_assignment.mode).to eq 'bulk_routing'
-      expect(dossier2.reload.groupe_instructeur.label).to eq 'Lyon'
-      expect(dossier2.reload.dossier_assignment.mode).to eq 'bulk_routing'
-      expect(dossier3.reload.groupe_instructeur.label).to eq 'Lyon'
-      expect(dossier3.reload.dossier_assignment.mode).to eq 'auto'
-      # Lyon is default group
-      expect(procedure.reload.routing_alert).to be_falsey
+      expect(BulkRouteJob).to have_been_enqueued.with(procedure)
     end
   end
 end

--- a/spec/jobs/bulk_route_job_spec.rb
+++ b/spec/jobs/bulk_route_job_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+describe BulkRouteJob, type: :job do
+  include Logic
+  describe 'perform' do
+    let(:admin) { administrateurs(:default_admin) }
+    let!(:procedure) do
+      create(:procedure,
+             types_de_champ_public: [
+               { type: :drop_down_list, libelle: 'Votre ville', options: ['Paris', 'Lyon', 'Marseille'] },
+               { type: :text, libelle: 'Un champ texte' }
+             ],
+             administrateurs: [admin])
+    end
+
+    let!(:drop_down_tdc) { procedure.draft_revision.types_de_champ.first }
+    let!(:dossier1) { create(:dossier, :with_populated_champs, procedure: procedure, state: :en_construction) }
+    let!(:dossier2) { create(:dossier, :with_populated_champs, procedure: procedure, state: :en_construction) }
+    let!(:dossier3) { create(:dossier, :with_populated_champs, procedure: procedure, state: :accepte) }
+    let!(:groupe_instructeur_paris) { create(:groupe_instructeur, procedure: procedure, label: 'Paris', routing_rule: ds_eq(champ_value(drop_down_tdc.stable_id), constant('Paris'))) }
+    let!(:groupe_instructeur_lyon) { create(:groupe_instructeur, procedure: procedure, label: 'Lyon', routing_rule: ds_eq(champ_value(drop_down_tdc.stable_id), constant('Lyon'))) }
+    let!(:groupe_instructeur_marseille) { create(:groupe_instructeur, procedure: procedure, label: 'Marseille', routing_rule: ds_eq(champ_value(drop_down_tdc.stable_id), constant('Marseille'))) }
+
+    subject do
+      BulkRouteJob.perform_now(procedure)
+    end
+
+    before do
+      dossier1.champs.first.update(value: 'Paris')
+      dossier2.champs.first.update(value: 'Lyon')
+      dossier3.champs.first.update(value: 'Marseille')
+      subject
+    end
+
+    it 'routes only dossiers en construction or en instruction' do
+      expect(dossier1.reload.groupe_instructeur.label).to eq 'Paris'
+      expect(dossier1.dossier_assignment.mode).to eq 'bulk_routing'
+      expect(dossier2.reload.groupe_instructeur.reload.label).to eq 'Lyon'
+      expect(dossier2.dossier_assignment.mode).to eq 'bulk_routing'
+      expect(dossier3.reload.groupe_instructeur.label).to eq 'défaut'
+      expect(dossier3.dossier_assignment).to be_nil
+      expect(procedure.reload.routing_alert).to be_falsey
+    end
+  end
+end

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -426,7 +426,7 @@ describe Dossier, type: :model do
       travel_to(date3)
       d.accepter!(instructeur: instructeur, motivation: "Motivation")
       travel_back
-      d
+      d.reload
     end
 
     describe "followers_instructeurs" do


### PR DESCRIPTION
Voir #10766

Si un admin route sa démarche alors que des dossiers ont déjà été déposés, on lui affiche une alerte avec un bouton permettant de lancer le routage sur tous les dossiers (quel que soit leur statut) :


<img width="1707" alt="Capture d’écran 2025-02-14 à 15 07 16" src="https://github.com/user-attachments/assets/28055ebd-e71c-427d-8222-cf06541322b3" />


Si toutes les règles de routage ne sont pas valides, on désactive le bouton et le texte est un peu différent : 


<img width="1707" alt="Capture d’écran 2025-02-14 à 15 06 18" src="https://github.com/user-attachments/assets/24607150-65fd-412d-9118-2795f99163a4" />


NB : J'hésite à lancer ce bulk_routing dans un job assynchrone parce que ça risque de faire un timeout si on a beaucoup de dossiers. En même temps je m'attends plutôt à ce que les admins veuillent router quand il y a encore peu de dossiers déposés. Donc je serais partant de laisser en synchrone pour l'instant