### PR TITLE
ETQ instructeur, je souhaite que le tableau de suivis d'une démarche ne plante pas quand un dossier ayant un champ de type deux menu déroulant lié est vide

### DIFF
--- a/app/models/columns/linked_drop_down_column.rb
+++ b/app/models/columns/linked_drop_down_column.rb
@@ -59,7 +59,8 @@ class Columns::LinkedDropDownColumn < Columns::ChampColumn
 
   def unpack_values(value)
     JSON.parse(value)
-  rescue JSON::ParserError
+  rescue JSON::ParserError,
+         TypeError # case of value.nil?.eq(true)
     []
   end
 

--- a/spec/models/columns/linked_drop_down_column_spec.rb
+++ b/spec/models/columns/linked_drop_down_column_spec.rb
@@ -75,4 +75,15 @@ describe Columns::LinkedDropDownColumn do
       end
     end
   end
+
+  describe 'unpack_values' do
+    let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :linked_drop_down_list, libelle: 'linked' }]) }
+    let(:type_de_champ) { procedure.active_revision.types_de_champ_public.first }
+    let(:column) { procedure.find_column(label: 'linked') }
+    subject { column.send(:unpack_values, nil) }
+
+    context 'when value is nil' do
+      it { is_expected.to eq([]) }
+    end
+  end
 end


### PR DESCRIPTION
sentry: https://demarches-simplifiees.sentry.io/issues/6307122323/?project=1429550&query=&referrer=issue-stream&sort=date&statsPeriod=14d&stream_index=5
crisp: https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_151db10b-c7c7-4a9e-93b1-c8bf4d460afa/