### PR TITLE
ETQ usager - j'aimerais avoir plus d'infos sur la durée de l'extension de la conservation de mon dossier

### DIFF
--- a/app/views/users/dossiers/_dossiers_list.html.haml
+++ b/app/views/users/dossiers/_dossiers_list.html.haml
@@ -109,7 +109,7 @@
           - else
             - if dossier.expiration_can_be_extended?
               = button_to users_dossier_repousser_expiration_and_restore_path(dossier), class: 'fr-btn fr-btn--sm' do
-                Restaurer et étendre la conservation
+                Restaurer et étendre la conservation (#{dossier.procedure.duree_conservation_dossiers_dans_ds} mois)
 
 
             - else


### PR DESCRIPTION
closes [#10995](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/10995)

Aujourd'hui un usager peut déjà prolonger la conservation de son dossier, du temps de conservation prévue pour la procédure (et non qq jours). Soit 6 mois supplémentaires, si la durée est de 6 mois. 
Mais pour clarifier, je me suis permise d'afficher cette période dès le bouton sur l'interface.

(Pour rappel pour un instructeur la durée de prolongation est d'un mois)

**INCHANGÉ**
<img width="1273" alt="Capture d’écran 2025-02-18 à 11 04 32" src="https://github.com/user-attachments/assets/ce98ada7-2315-4bfd-877a-e11219294306" />


**APRES**
<img width="1036" alt="Capture d’écran 2025-02-18 à 11 30 45" src="https://github.com/user-attachments/assets/35695154-d5fb-4d53-a45b-065d3e59c439" />

**AVANT**
<img width="1043" alt="Capture d’écran 2025-02-18 à 11 08 54" src="https://github.com/user-attachments/assets/7e70e997-63c1-4c0e-882a-aef172275750" />
