### PR TITLE
ETQ Usager, je veux que l'intitulé des champs email soit le même partout

### DIFF
--- a/app/components/dsfr/input_component/input_component.fr.yml
+++ b/app/components/dsfr/input_component/input_component.fr.yml
@@ -4,5 +4,5 @@ fr:
     aria_label: "Afficher le mot de passe"
     label: "Afficher"
   email_suggest:
-    mistake: "L'adresse semble erronée"
+    mistake: "L'adresse électronique semble erronée"
     wanna_say: "Vouliez-vous écrire :"

--- a/app/components/procedure/import_component/import_component.fr.yml
+++ b/app/components/procedure/import_component/import_component.fr.yml
@@ -7,7 +7,7 @@ fr:
     file_size_limit: "Taille maximale : %{max_file_size}."
     groupes:
       title: Ajout de groupes / instructeurs avec import de fichier
-      notice_1_html: Pour l’import, votre fichier csv doit comporter <strong>2 colonnes (Groupe, Email)</strong> (voir modèle de fichier ci-dessous). Le poids du fichier doit être inférieur à %{csv_max_size}.
+      notice_1_html: Pour l’import, votre fichier csv doit comporter <strong>2 colonnes (Groupe, Adresse électronique)</strong> (voir modèle de fichier ci-dessous). Le poids du fichier doit être inférieur à %{csv_max_size}.
       notice_2_html: L’import n’écrase pas les groupes et instructeurs existants. Il permet uniquement <strong>d’en ajouter</strong>.
       notice_3_html: Une fois votre import effectué, vous devrez ensuite <strong>configurer les règles de routage</strong> pour chacun des groupes ajoutés.
       notification_alert_html: Même si votre démarche est encore en test / non publiée, tous les instructeurs que vous ajouterez à la démarche <strong>seront notifiés par email</strong>.
@@ -15,5 +15,5 @@ fr:
 
     instructeurs:
       title: Ajout d’instructeurs avec import de fichier
-      notice_1_html: Pour l’import, votre fichier csv doit comporter <strong>1 seule colonne (Email)</strong> listant les adresses emails des instructeurs (voir modèle de fichier ci-dessous). Le poids du fichier doit être inférieur à %{csv_max_size}.
+      notice_1_html: Pour l’import, votre fichier csv doit comporter <strong>1 seule colonne (Adresse électronique)</strong> listant les adresses électroniques des instructeurs (voir modèle de fichier ci-dessous). Le poids du fichier doit être inférieur à %{csv_max_size}.
       notice_2_html: L’import n’écrase pas les instructeurs existants. Il permet uniquement <strong>d’en ajouter</strong>.

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -39,7 +39,7 @@ class UserMailer < ApplicationMailer
   def custom_confirmation_instructions(user, token)
     @user = user
     @token = token
-    mail(to: @user.email, subject: 'Confirmez votre email')
+    mail(to: @user.email, subject: 'Confirmez votre adresse électronique')
   end
 
   def invite_instructeur(user, reset_password_token)
@@ -60,7 +60,7 @@ class UserMailer < ApplicationMailer
     @token = token
     @user = user
     @dossier = dossier
-    subject = "Vérification de votre mail"
+    subject = "Vérification de votre adresse électronique"
 
     configure_defaults_for_user(user)
 
@@ -74,7 +74,7 @@ class UserMailer < ApplicationMailer
   def resend_confirmation_email(user, token)
     @token = token
     @user = user
-    subject = "Vérification de votre mail"
+    subject = "Vérification de votre adresse électronique"
 
     configure_defaults_for_user(user)
 

--- a/app/views/devise_mailer/email_changed.html.haml
+++ b/app/views/devise_mailer/email_changed.html.haml
@@ -1,17 +1,17 @@
-- content_for(:title, 'Votre nouvelle adresse email')
+- content_for(:title, 'Votre nouvelle adresse électronique')
 
 %p= t(:hello, scope: [:views, :shared, :greetings])
 
 - unconfirmed_email = @resource.try(:unconfirmed_email?)
 - if unconfirmed_email.present?
   %p
-    Nous avons reçu une demande de changement d’adresse email pour votre
+    Nous avons reçu une demande de changement d’adresse électronique pour votre
     compte #{@email} sur #{Current.application_name}.
-    Une fois la demande prise en compte, la nouvelle adresse email de
+    Une fois la demande prise en compte, la nouvelle adresse électronique de
     votre compte sera #{unconfirmed_email}.
 - else
   %p
-    Le changement d’adresse email de votre compte #{@email} sur
+    Le changement d’adresse électronique de votre compte #{@email} sur
     #{Current.application_name} a bien été pris en compte.
     Vous pouvez désormais vous connecter avec l’adresse #{@resource.email}.
 

--- a/app/views/shared/dossiers/_mandataire_infos.html.haml
+++ b/app/views/shared/dossiers/_mandataire_infos.html.haml
@@ -1,4 +1,4 @@
-= render Dossiers::RowShowComponent.new(label: 'Email', profile: @profile) do |c|
+= render Dossiers::RowShowComponent.new(label: t('views.shared.label.email'), profile: @profile) do |c|
   - c.with_value do
     = user_deleted ? "#{email} (l’usager a supprimé son compte)" : email
 

--- a/app/views/shared/dossiers/_user_infos.html.haml
+++ b/app/views/shared/dossiers/_user_infos.html.haml
@@ -1,4 +1,4 @@
-= render Dossiers::RowShowComponent.new(label: 'Email', profile: @profile) do |c|
+= render Dossiers::RowShowComponent.new(label: t('views.shared.label.email'), profile: @profile) do |c|
   - c.with_value do
     - if for_tiers
       = beneficiaire_mail

--- a/config/locales/api_particulier.fr.yml
+++ b/config/locales/api_particulier.fr.yml
@@ -94,7 +94,7 @@ fr:
             ligneNom: nom
           contact:
             libelle: Contact
-            email: email
+            email: adresse électronique
             telephone: téléphone
             telephone2: téléphone 2
           inscription:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -347,6 +347,8 @@ en:
       first: First
       truncate: '&hellip;'
     shared:
+      label:
+        email: 'Email'
       greetings:
         hello: Dear Sir or Madam,
         best_regards: Best Regards,

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -243,7 +243,7 @@ fr:
           decimal_number_html: Un nombre décimal
           integer_number_html: Un nombre entier
           formatted_html: Un texte qui respecte les règles de formattage
-          email_html: Une adresse email
+          email_html: Une adresse électronique
           civilite_html: '"M." pour Monsieur, "Mme" pour Madame'
           phone_html: Un numéro de téléphone
           iban_html: Un numéro Iban
@@ -303,12 +303,12 @@ fr:
     registrations:
       new:
         title: "Creation de compte sur %{name}"
-        subtitle: "Se créer un compte avec une adresse email"
-        email_label: 'Email'
+        subtitle: "Se créer un compte avec une adresse électronique"
+        email_label: 'Adresse électronique'
         password_label: "Mot de passe (%{min_length} caractères minimum)"
     confirmation:
       new:
-        title: 'Confirmez votre adresse email'
+        title: 'Confirmez votre adresse électronique'
         email_cta_html: "Avant d’effectuer votre démarche, nous avons besoin de vérifier votre adresse électronique <strong>%{email}</strong>."
         email_guidelines_html: "Ouvrez votre boîte email, et <strong>cliquez sur le lien d’activation</strong> dans le message que vous avez reçu."
         email_missing: "Si vous n’avez pas reçu notre message (avez-vous vérifié les indésirables ?), nous pouvons vous le renvoyer."
@@ -327,7 +327,7 @@ fr:
         modal_title: "Gestion des invités"
         modal_highlight: Les invités ont le droit de voir et modifier votre dossier.
         title: Ajouter un invité
-        email: Adresse mail
+        email: Adresse électronique
         email_hint: 'Exemple : adresse@mail.com'
         invite_message: Ajouter un message à la personne invitée (optionnel)
         send_invitation: Envoyer une invitation
@@ -345,6 +345,8 @@ fr:
       first: Premier
       truncate: '&hellip;'
     shared:
+      label:
+        email: 'Adresse électronique'
       actions:
         save: Enregistrer
         edit: Modifier
@@ -609,7 +611,7 @@ fr:
       default_attributes: &default_attributes
         email: Adresse électronique
         password: 'Mot de passe'
-        requested_merge_into: 'La nouvelle adresse email'
+        requested_merge_into: 'La nouvelle adresse électronique'
         hints:
           email: 'Format attendu : adresse@mail.com'
       user:
@@ -641,7 +643,7 @@ fr:
 
     errors:
       messages:
-        not_a_phone: 'Numéro de téléphone invalide'
+        not_a_phone: 'est invalide. Saisir un numéro de téléphone valide, par exemple : 0612345678'
         not_a_rna: 'Numéro RNA invalide'
         url: 'n’est pas un lien valide'
         invalid_email_format: 'est invalide. Saisir une adresse électronique valide, exemple : adresse@mail.com'
@@ -668,7 +670,7 @@ fr:
             password_confirmation:
               confirmation: ': Les deux mots de passe ne correspondent pas'
             requested_merge_into:
-              same: "ne peut être identique à l’ancienne. Saisir une autre adresse email"
+              same: "ne peut être identique à l’ancienne. Saisir une autre adresse électronique"
 
         instructeur:
           attributes:
@@ -828,7 +830,7 @@ fr:
   users:
     dossiers:
       test_procedure: "Ce dossier est déposé sur une démarche en test. Toute modification de la démarche par l’administrateur (ajout d’un champ, publication de la démarche...) entraînera sa suppression."
-      no_access_html: "Vous n’avez pas accès à ce dossier.<br>Vérifiez que votre adresse email de connexion <b>%{email}</b> est bien celle utilisée pour remplir cette démarche.<br> Si ce n’est pas le cas, déconnectez-vous"
+      no_access_html: "Vous n’avez pas accès à ce dossier.<br>Vérifiez que votre adresse électronique de connexion <b>%{email}</b> est bien celle utilisée pour remplir cette démarche.<br> Si ce n’est pas le cas, déconnectez-vous"
       no_longer_editable: "Votre dossier ne peut plus être modifié"
       en_construction_submitted: "Les modifications ont déjà été déposées"
       fill_identity:
@@ -938,27 +940,27 @@ fr:
         intro_html: "Votre compte FranceConnect utilise <span class='fr-badge fr-badge--info fr-badge--no-icon fr-badge--lowercase'>%{email}</span> comme email de contact."
         use_email_for_notifications: Souhaitez-vous l’utiliser pour recevoir les notifications concernant l’avancement de vos dossiers ?
         confirm: Valider
-        choose_email_contact: Choisissez votre email de contact pour finaliser votre connexion
+        choose_email_contact: Choisissez votre adresse électronique de contact pour finaliser votre connexion
         alternative_email: Veuillez nous fournir l’adresse électronique à utiliser pour vous contacter
-        keep_fc_email_html: "<span>Oui, utiliser <b>%{email}</b> comme email de contact</span>"
+        keep_fc_email_html: "<span>Oui, utiliser <b>%{email}</b> comme adresse électronique de contact</span>"
         use_another_email: Non, utiliser une autre adresse
         email_suggest:
           wanna_say: 'Voulez-vous dire ?'
       merge:
         title: "Fusion des comptes FranceConnect et %{application_name}"
-        subtitle_html: "Bonjour,<br /><br />Votre compte FranceConnect utilise <b class='bold'>%{email}</b> comme email de contact.<br />Or il existe un compte sur %{application_name} avec cet email."
+        subtitle_html: "Bonjour,<br /><br />Votre compte FranceConnect utilise <b class='bold'>%{email}</b> comme adresse électronique de contact.<br />Or il existe un compte sur %{application_name} avec cette adresse électronique."
         label_select_merge_flow: Ce compte %{email} vous appartient-il ?
         title_fill_in_password:  Pour les fusionner, entrez votre mot de passe
         button_merge: Fusionner les comptes
-        title_fill_in_email: Donnez-nous alors le mail que %{application_name} utilisera pour vous contacter
-        button_use_this_email: Utiliser ce mail
+        title_fill_in_email: Donnez-nous alors l'adresse électronique que %{application_name} utilisera pour vous contacter
+        button_use_this_email: Utiliser cette adresse électronique
         link_confirm_by_email: Confirmer mon compte par email
       flash:
         confirmation_mail_sent: "Nous venons de vous envoyer le mail de confirmation, veuillez cliquer sur le lien contenu dans ce mail pour fusionner vos comptes"
         confirmation_mail_resent: "Le lien de confirmation a expiré. Un nouveau lien de confirmation vous a été envoyé par email."
         confirmation_mail_resent_error: "Une erreur inattendue est survenue. Veuillez contacter le support si le problème persiste."
         redirect_new_user_session: "Vous avez été déconnecté de votre précédent compte. Veuillez cliquer à nouveau sur le lien de confirmation."
-        email_confirmed: 'Votre email est bien vérifié'
+        email_confirmed: 'Votre adresse électronique est bien vérifiée'
         user_not_found: 'Utilisateur non trouvé'
         invalid_password: "Mot de passe incorrect"
         connection_done: "Les comptes FranceConnect et %{application_name} sont à présent fusionnés"

--- a/config/locales/models/champs/rnf_champ/fr.yml
+++ b/config/locales/models/champs/rnf_champ/fr.yml
@@ -5,7 +5,7 @@ fr:
         rnf_id: Numéro RNF
         data:
           title: Nom de la fondation
-          email: Email
+          email: Adresse électronique
           phone: Téléphone
           createdAt: Créée le
           updatedAt: Mise à jour le

--- a/config/locales/models/dossier_transfer/fr.yml
+++ b/config/locales/models/dossier_transfer/fr.yml
@@ -5,5 +5,5 @@ fr:
         dossier_transfer:
           attributes:
             email:
-              format: "L’adresse email %{message}"
+              format: "L’adresse électronique %{message}"
               invalid: "est invalide"

--- a/config/locales/models/groupe_gestionnaire/fr.yml
+++ b/config/locales/models/groupe_gestionnaire/fr.yml
@@ -8,15 +8,15 @@ fr:
         one: Groupe Gestionnaire
         other: Groupes Gestionnaire
     errors:
-      duplicate_email: 
+      duplicate_email:
         one: "%{emails} est déjà gestionnaire de ce groupe"
         other: "%{emails} sont déjà gestionnaires de ce groupe"
-      administrateurs_already_in_groupe_gestionnaire: 
+      administrateurs_already_in_groupe_gestionnaire:
         one: Ajout impossible. Cet administrateur fait déjà partie d'un groupe.
         other: Ajout impossible. Ces administrateurs font déjà partie d'un groupe.
     wrong_address:
-      one: "%{emails} n’est pas une adresse email valide"
-      other: "%{emails} ne sont pas des adresses emails valides"
-    not_found: 
+      one: "%{emails} n’est pas une adresse électronique valide"
+      other: "%{emails} ne sont pas des adresses électroniques valides"
+    not_found:
       one: "%{emails} n'a pas encore de compte."
       other: "%{emails} n'ont pas encore de compte."

--- a/config/locales/models/individual/fr.yml
+++ b/config/locales/models/individual/fr.yml
@@ -12,10 +12,10 @@ fr:
         nom: Nom
         prenom: Prénom
         birthdate: Date de naissance
-        email: Email
+        email: Adresse électronique
         notification_method: "Notifier le bénéficiaire :"
         notification_methods:
-          email: Par e-mail
+          email: Par adresse électronique
           no_notification: Pas de notification
       individual/gender:
         female: Madame

--- a/config/locales/models/instructeur/fr.yml
+++ b/config/locales/models/instructeur/fr.yml
@@ -6,8 +6,8 @@ fr:
         other: Instructeurs
     attributes:
       instructeur:
-        bypass_email_login_token: Autoriser la connexion sans confirmer l’email
+        bypass_email_login_token: Autoriser la connexion sans confirmer l’adresse électronique
   helpers:
     label:
       instructeur:
-        bypass_email_login_token: Autoriser la connexion sans confirmer l’email
+        bypass_email_login_token: Autoriser la connexion sans confirmer l’adresse électronique

--- a/config/locales/models/procedure/fr.yml
+++ b/config/locales/models/procedure/fr.yml
@@ -40,7 +40,7 @@ fr:
         procedure_path: Lien de la démarche à diffuser aux usagers
         procedure_path_placeholder: nom-de-la-demarche
         cadre_juridique: Cadre juridique - lien web vers le texte
-        lien_dpo: Lien ou email pour contacter le Délégué à la Protection des Données (DPO)
+        lien_dpo: Lien ou adresse électronique pour contacter le Délégué à la Protection des Données (DPO)
         published_at: 'Date de publication'
         aasm_state: 'Statut'
         admin_count: 'Nb administrateurs'
@@ -63,11 +63,11 @@ fr:
         declarative_with_state/accepte: Accepté
         api_entreprise_token: Jeton API Entreprise
         api_particulier_token: Jeton API Particulier
-        initiated_mail: L’email de notification de passage de dossier en instruction
-        received_mail: L’email de notification de dépôt de dossier
-        closed_mail: L’email de notification d’acceptation de dossier
-        refused_mail: L’email de notification de refus de dossier
-        without_continuation_mail: L’email de notification de classement sans suite de dossier
+        initiated_mail: L’adresse électronique de notification de passage de dossier en instruction
+        received_mail: L’adresse électronique de notification de dépôt de dossier
+        closed_mail: L’adresse électronique de notification d’acceptation de dossier
+        refused_mail: L’adresse électronique de notification de refus de dossier
+        without_continuation_mail: L’adresse électronique de notification de classement sans suite de dossier
         attestation_template: Le modèle d’attestation
         draft_revision: Le formulaire
         auto_archive_on: Date limite de dépôt des dossiers
@@ -117,7 +117,7 @@ fr:
             re_instructed_mail:
               format: "%{attribute} %{message}"
             lien_dpo:
-              invalid_uri_or_email: "Veuillez saisir un mail ou un lien"
+              invalid_uri_or_email: "Veuillez saisir une adresse électronique ou un lien"
             auto_archive_on:
               future: doit être dans le futur
             sva_svr:

--- a/config/locales/models/procedure_presentation/fr.yml
+++ b/config/locales/models/procedure_presentation/fr.yml
@@ -5,7 +5,7 @@ fr:
         fields:
           self:
             id: Nº dossier
-            user_email_for_display: Email
+            user_email_for_display: Adresse électronique
             state: État du dossier
             created_at: Date de création
             updated_at: Date du dernier évènement

--- a/config/locales/models/service/fr.yml
+++ b/config/locales/models/service/fr.yml
@@ -7,7 +7,7 @@ fr:
     attributes:
       service: &service
         adresse: 'Adresse postale'
-        email: 'Email de contact'
+        email: 'Adresse électronique de contact'
         telephone: 'Téléphone'
         nom: Nom du service
         organisme: Organisme(s)
@@ -19,7 +19,7 @@ fr:
             Indiquez les organismes depuis l’échelon territorial jusqu’au ministère séparés par une virgule.
             Exemple : mairie de Mours, préfecture de l'Oise, ministère de la Culture
           email: |
-            Indiquez une adresse email valide qui permettra de recevoir et de répondre aux questions des usagers.
+            Indiquez une adresse électronique valide qui permettra de recevoir et de répondre aux questions des usagers.
             Exemple : contact@mairie-de-mours.fr
           telephone: "Indiquez le numéro de téléphone du service valide le plus à même de fournir des réponses pertinentes à vos usagers. Exemple : 01 23 45 67 89"
           horaires: |

--- a/config/locales/views/administrateurs/groupe_instructeurs/fr.yml
+++ b/config/locales/views/administrateurs/groupe_instructeurs/fr.yml
@@ -2,8 +2,8 @@ fr:
   administrateurs:
     experts_procedures:
       wrong_address:
-          one: "%{value} n’est pas une adresse email valide"
-          other: "%{value} ne sont pas des adresses emails valides"
+          one: "%{value} n’est pas une adresse électronique valide"
+          other: "%{value} ne sont pas des adresses électroniques valides"
       create:
         experts_assignment:
           one: "L’expert %{value} a été affecté à la démarche n° %{procedure}"
@@ -17,8 +17,8 @@ fr:
           other: "%{count} groupes existent"
       add_instructeur:
         wrong_address:
-          one: "%{emails} n’est pas une adresse email valide"
-          other: "%{emails} ne sont pas des adresses emails valides"
+          one: "%{emails} n’est pas une adresse électronique valide"
+          other: "%{emails} ne sont pas des adresses électroniques valides"
         assignment:
           one: "L’instructeur %{emails} a été affecté au groupe « %{groupe} »."
           other: "Les instructeurs %{emails} ont été affectés au groupe « %{groupe} »."

--- a/config/locales/views/contact/fr.yml
+++ b/config/locales/views/contact/fr.yml
@@ -2,8 +2,8 @@ fr:
   activerecord:
     attributes:
       contact_form:
-        email: 'Votre adresse email'
-        email_pro: Votre adresse email professionnelle
+        email: 'Votre adresse électronique'
+        email_pro: Votre adresse électronique professionnelle
         phone: Numéro de téléphone professionnel (ligne directe)
         subject: Sujet
         text: Message
@@ -66,7 +66,7 @@ fr:
       admin_suggestion_produit:
         question: J’ai une proposition d’évolution
       admin_demande_compte:
-        question: Je souhaite ouvrir un compte administrateur avec un email Orange, Wanadoo, etc.
+        question: Je souhaite ouvrir un compte administrateur avec une adresse électronique Orange, Wanadoo, etc.
       admin_autre:
         question: Autre sujet
     create:

--- a/config/locales/views/instructeurs/groupe_instructeurs/fr.yml
+++ b/config/locales/views/instructeurs/groupe_instructeurs/fr.yml
@@ -9,8 +9,8 @@ fr:
         wrong_adress: "L’adresse électronique saisie n’est pas valide."
       add_instructeur:
         wrong_address:
-          one: "%{emails} n’est pas une adresse email valide"
-          other: "%{emails} ne sont pas des adresses emails valides"
+          one: "%{emails} n’est pas une adresse électronique valide"
+          other: "%{emails} ne sont pas des adresses électroniques valides"
         assignment:
           one: "L’instructeur %{emails} a été affecté au groupe « %{groupe} »."
           other: "Les instructeurs %{emails} ont été affectés au groupe « %{groupe} »."

--- a/config/locales/views/manager/fr.yml
+++ b/config/locales/views/manager/fr.yml
@@ -5,8 +5,8 @@ fr:
     groupe_gestionnaires:
       add_gestionnaire:
         wrong_address:
-          one: "%{emails} n’est pas une adresse email valide"
-          other: "%{emails} ne sont pas des adresses emails valides"
+          one: "%{emails} n’est pas une adresse électronique valide"
+          other: "%{emails} ne sont pas des adresses électroniques valides"
     administrateurs:
       delete:
         cannot_be_deleted: "L'administrateur ne peut pas être supprimé"

--- a/config/locales/views/users/dossier_transfer/fr.yml
+++ b/config/locales/views/users/dossier_transfer/fr.yml
@@ -6,7 +6,7 @@ fr:
         title: Transférer votre dossier
         detail: Vous vous apprêtez à transférer le dossier %{state} nº %{number} déposé par %{demandeur} le %{created_at} vers le compte d’un autre usager.
         irrevocable_html: Une fois la demande de transfert acceptée, le dossier sera associé au compte du destinataire et <strong>vous ne pourrez plus y accéder</strong>.
-        email_label: Email du compte destinataire
+        email_label: Adresse électronique du compte destinataire
         submit: Envoyer la demande de transfert
         notice_sent: L’invitation au transfert a été envoyée avec succès
         destroy: La demande de transfert a été supprimée avec succès

--- a/config/locales/views/users/profil/fr.yml
+++ b/config/locales/views/users/profil/fr.yml
@@ -4,8 +4,8 @@ fr:
       show:
         profile: Profil
         contact: Coordonnées
-        new_email_address: Nouvelle adresse email
-        your_email: Votre email est actuellement
+        new_email_address: Nouvelle adresse électronique
+        your_email: Votre adresse électronique actuelle
         change_address: Changer mon adresse
         transfer_title: Transférer tous vos dossiers
         transfer_explication_html: "<p>Cette fonctionnalité vous permet de changer le propriétaire de tous vos dossiers. C’est généralement utile lors d’un changement de poste ou si vous souhaitez fusionner plusieurs comptes.</p>"
@@ -40,6 +40,6 @@ fr:
       ensure_update_email_is_authorized:
         email_not_allowed: "L’email %{requested_email} ne peut être utilisé, contactez le support : <a href='mailto:%{contact_email}'>%{contact_email}</a>"
       transfer_all_dossiers:
-        new_transfer: 
+        new_transfer:
           one: "Le transfert d’un dossier à %{email} est en cours"
           other: "Le transfert de %{count} dossiers à %{email} est en cours"

--- a/doc/faqs/administrateur/ajouter-plusieurs-administrateurs-sur-une-meme-demarche.fr.md
+++ b/doc/faqs/administrateur/ajouter-plusieurs-administrateurs-sur-une-meme-demarche.fr.md
@@ -20,6 +20,6 @@ Il est possible d’avoir plusieurs administrateurs sur une même démarche. Cel
 1. Si les personnes en question n’ont pas encore de compte administrateur, **faites une [demande de compte administrateur](%{application_base_url}/demandes/new)** et attendez que le compte soit approuvé.
 2. Connectez-vous en tant qu’Administrateur et **allez sur le tableau de bord de la démarche**.
 3. Cliquez sur l’onglet **« Administrateurs »** de la démarche.
-4. **Ajoutez l’adresse email** du nouvel administrateur à la liste.
+4. **Ajoutez l’adresse électronique** du nouvel administrateur à la liste.
 
 👏 La nouvelle personne pourra alors administrer la démarche !

--- a/doc/faqs/administrateur/comment-obtenir-un-compte-administrateur.fr.md
+++ b/doc/faqs/administrateur/comment-obtenir-un-compte-administrateur.fr.md
@@ -11,7 +11,7 @@ title: "Comment obtenir un compte administrateur ?"
 
 Pour obtenir un compte administrateur, il suffit d’en faire la demande en déposant un dossier via le lien suivant : [Demande d'inscription à %{application_name}](%{application_base_url}/commencer/demande-d-inscription-a-demarches-simplifiees)
 
-Le profil administrateur est le seul profil réservé strictement aux agents publics. Nous vous demandons donc de bien vouloir **faire la demande avec votre adresse mail professionnelle**.
+Le profil administrateur est le seul profil réservé strictement aux agents publics. Nous vous demandons donc de bien vouloir **faire la demande avec votre adresse électronique professionnelle**.
 
 👉 **Attention**, la création de compte administrateur est **réservée uniquement aux organismes publics**. Elle ne concerne ni les particuliers, ni les entreprises, ni les associations (sauf celles reconnues d'utilité publique), ni les personnes souhaitant remplir un dossier ou faire une démarche en ligne. Ce compte vous permettra de dématérialiser des démarches papier sur demarches-simplifiees.fr, vous pourrez ensuite les diffuser en ligne auprès de vos usagers (sur votre site web, par exemple).
 

--- a/doc/faqs/administrateur/guide-de-bonnes-pratiques-pour-tester-une-demarche.fr.md
+++ b/doc/faqs/administrateur/guide-de-bonnes-pratiques-pour-tester-une-demarche.fr.md
@@ -54,7 +54,7 @@ N’hésitez pas à [transmettre le lien vers la démarche test à vos collègue
 
 Vous avez déposé à l’étape précédente un premier dossier. Rendez-vous désormais dans la partie instructeur.
 
-Passez à l’interface instructeur via le lien [%{application_base_url}/procedures](/procedures) ou en changeant de profil depuis le menu en haut à droite en cliquant sur votre adresse email.
+Passez à l’interface instructeur via le lien [%{application_base_url}/procedures](/procedures) ou en changeant de profil depuis le menu en haut à droite en cliquant sur votre adresse électronique.
 
 ![Menu pour passer instructeur {aria-hidden="true"}](faq/administrateur-profile-switch.png)
 
@@ -75,8 +75,8 @@ Voici le tutoriel pour instruire un dossier en tant qu’instructeur : [Tutorie
 Vous pourrez ici tester différents éléments secondaires :
 
 - Demande d’**avis externe** (partie instruction) . Pour plus d’information, vous pouvez consulter [notre tutoriel expert invité](https://doc.demarches-simplifiees.fr/tutoriels/tutoriel-expert-invite)
-- **Vérifiez les e-mails** d’accusé de réception, de passage en instruction, d’acceptation, de refus et de classement sans suite (partie usager)
-- Testez la **messagerie du dossier** en envoyant un message à l’usager. Si vous souhaitez anonymiser l’adresse mail des instructeurs dans la messagerie, vous pouvez [nous contacter à l’adresse %{contact_email}](mailto:%{contact_email})
+- **Vérifiez les adresses électroniques** d’accusé de réception, de passage en instruction, d’acceptation, de refus et de classement sans suite (partie usager)
+- Testez la **messagerie du dossier** en envoyant un message à l’usager. Si vous souhaitez anonymiser l’adresse électronique des instructeurs dans la messagerie, vous pouvez [nous contacter à l’adresse %{contact_email}](mailto:%{contact_email})
 - Si l’**attestation automatique d’acceptation** et la partie annotations privées ont été paramétrées, vérifiez qu’il n’y a pas d’erreur
 
 En cas d’erreur et/ou en fonction des retours de vos collègues suite à la phase de test, vous pouvez modifier la démarche depuis votre profil administrateur.

--- a/doc/faqs/administrateur/je-ne-trouve-pas-ma-demarche-dans-le-catalogue-de-demarches.fr.md
+++ b/doc/faqs/administrateur/je-ne-trouve-pas-ma-demarche-dans-le-catalogue-de-demarches.fr.md
@@ -21,7 +21,7 @@ Dans cette situation, vous pouvez partager directement votre démarche avec votr
 - Cliquez sur votre démarche.
 - Accédez à l’onglet publication.
 - Suivez le bouton « _Envoyer une copie_ » en haut à droite.
-- Entrez l’adresse email de votre collègue.
+- Entrez l’adresse électronique de votre collègue.
 
 Votre collègue trouvera alors une copie de votre démarche dans ses démarches « En test ».
 

--- a/doc/faqs/administrateur/les-instructeurs-n-ont-pas-recu-d-email-d-invitation.fr.md
+++ b/doc/faqs/administrateur/les-instructeurs-n-ont-pas-recu-d-email-d-invitation.fr.md
@@ -13,7 +13,7 @@ En tant qu’administrateur, si après avoir nommé des instructeurs sur votre
 démarche ces derniers ne reçoivent pas d’email d’invitation à se connecter à %{application_name},
 alors vous vous trouvez peut-être dans la situation suivante :
 
-- Vous avez fait une erreur dans la saisie des adresses email en nommant les instructeurs.
+- Vous avez fait une erreur dans la saisie des adresses électroniques en nommant les instructeurs.
 
 - Les instructeurs sont déjà nommés sur une autre démarche. Leur compte étant déjà validé, ils ne reçoivent plus de nouvel email.
 

--- a/doc/faqs/instructeur/je-n-arrive-pas-a-acceder-aux-dossiers-que-je-souhaite-instruire.fr.md
+++ b/doc/faqs/instructeur/je-n-arrive-pas-a-acceder-aux-dossiers-que-je-souhaite-instruire.fr.md
@@ -4,15 +4,15 @@ category: instructeur
 subcategory: instructeur_account
 slug: "je-n-arrive-pas-a-acceder-aux-dossiers-que-je-souhaite-instruire"
 locale: "fr"
-keywords: "acces dossiers, administrateur demarche, affectation instructeur, 
+keywords: "acces dossiers, administrateur demarche, affectation instructeur,
 contact administrateur"
 ---
 
 # Je n’arrive pas à accéder aux dossiers que je souhaite instruire
 
-Cela signifie que l’administrateur de la démarche qui vous intéresse ne vous a 
-pas affecté à celle-ci. En effet, seul l’administrateur est en mesure d’ajouter 
-ou de retirer l’affectation d’une démarche à un instructeur. Vous devez donc 
+Cela signifie que l’administrateur de la démarche qui vous intéresse ne vous a
+pas affecté à celle-ci. En effet, seul l’administrateur est en mesure d’ajouter
+ou de retirer l’affectation d’une démarche à un instructeur. Vous devez donc
 lui envoyer un email pour lui demander l’accès.
 
 ## Vous ne savez pas qui est l’administrateur de la démarche ?
@@ -20,8 +20,8 @@ lui envoyer un email pour lui demander l’accès.
 Si c’est le cas, envoyez un email à [%{contact_email}](mailto:%{contact_email}),
 en décrivant précisément la démarche à laquelle vous voulez
 être affecté (intitulé, organisation, région, ou département…)
-afin que nous puissions retrouver 
-cette démarche et vous communiquer l’adresse email de l’administrateur.
+afin que nous puissions retrouver
+cette démarche et vous communiquer l’adresse électronique de l’administrateur.
 
-N’hésitez pas également à vous rapprocher de vos collègues déjà instructeurs 
+N’hésitez pas également à vous rapprocher de vos collègues déjà instructeurs
 de la démarche concernée pour obtenir de l’aide.

--- a/doc/faqs/usager/01_comment-trouver-ma-demarche.fr.md
+++ b/doc/faqs/usager/01_comment-trouver-ma-demarche.fr.md
@@ -69,7 +69,7 @@ Si l’administration en charge de votre démarche n’a pas choisi d’utiliser
 
 ## 4. Compléter un dossier déjà créé
 
-Pour compléter un dossier, [connectez-vous sur votre espace %{application_name}](/users/sign_in) en renseignant l’adresse email et le mot de passe utilisés lors de la création de votre dossier.
+Pour compléter un dossier, [connectez-vous sur votre espace %{application_name}](/users/sign_in) en renseignant l’adresse électronique et le mot de passe utilisés lors de la création de votre dossier.
 
 ## 5. Je veux déposer un nouveau dossier
 

--- a/doc/faqs/usager/j-ai-depose-moi-meme-mon-dossier-mais-je-ne-le-retrouve-pas.fr.md
+++ b/doc/faqs/usager/j-ai-depose-moi-meme-mon-dossier-mais-je-ne-le-retrouve-pas.fr.md
@@ -4,21 +4,21 @@ category: usager
 subcategory: find_dossier
 slug: "j-ai-depose-moi-meme-mon-dossier-mais-je-ne-le-retrouve-pas"
 locale: "fr"
-keywords: "dossier perdu, retrouver dossier, email confirmation, attestation depot, 
+keywords: "dossier perdu, retrouver dossier, email confirmation, attestation depot,
 contact service instructeur"
 ---
 
 # J'ai déposé moi-même mon dossier mais je ne le retrouve pas
 
-Il se peut que vous ayez déposé votre dossier en utilisant une autre adresse email.
+Il se peut que vous ayez déposé votre dossier en utilisant une autre adresse électronique.
 
 Si c'est le cas, vous avez 3 solutions pour le retrouver :
 
-- Recherchez parmi les emails reçus lors de la création de votre compte ou lors 
-du dépôt de votre dossier sur %{application_name}. L'adresse email associée à 
+- Recherchez parmi les emails reçus lors de la création de votre compte ou lors
+du dépôt de votre dossier sur %{application_name}. L'adresse électronique associée à
 votre dossier est mentionnée dans l'entête de ces emails.
-- Consultez le corps de l'attestation de dépôt du dossier, où l'adresse email
+- Consultez le corps de l'attestation de dépôt du dossier, où l'adresse électronique
 utilisée est également indiquée.
 - Contactez le service instructeur de la démarche pour qu'il vous aide dans la
-procédure de transfert de votre dossier. Les coordonnées de ce service sont 
+procédure de transfert de votre dossier. Les coordonnées de ce service sont
 disponibles en bas de la page de présentation de la démarche.

--- a/doc/faqs/usager/je-ne-recois-pas-d-email.fr.md
+++ b/doc/faqs/usager/je-ne-recois-pas-d-email.fr.md
@@ -11,7 +11,7 @@ locale: "fr"
 Si vous ne recevez pas d’email, vous vous trouvez peut-être dans la situation suivante :
 
 - **Le mail est arrivé dans vos courriers indésirables.** Avez-vous vérifié dedans ?
-- **Votre compte est associé à une autre adresse email.** Avez-vous bien vérifié qu'il s'agit de la bonne adresse mail de dépôt de dossier ?
-- **Vous avez fait une erreur dans la saisie de votre adresse email.** Vous pouvez [créer à nouveau un compte](/users/sign_up), avec la bonne adresse.
+- **Votre compte est associé à une autre adresse électronique.** Avez-vous renseigné la bonne adresse de dépôt de dossier ?
+- **Vous avez fait une erreur dans la saisie de votre adresse électronique.** Vous pouvez [créer à nouveau un compte](/users/sign_up), avec la bonne adresse.
 - **Vous utilisez un outil de gestion des spams** (type MailInBlack) qui empêche la réception des emails. Il faut donc autoriser la réception des emails depuis %{application_name}.
 - **Vous ne vous trouvez dans aucune des situations mentionnées** auquel cas nous vous prions de [nous contacter par email](/contact).

--- a/doc/faqs/usager/je-veux-changer-mon-adresse-email.fr.md
+++ b/doc/faqs/usager/je-veux-changer-mon-adresse-email.fr.md
@@ -4,41 +4,41 @@ category: "usager"
 subcategory: "account"
 slug: "je-veux-changer-mon-adresse-email"
 locale: "fr"
-keywords: "adresse email, compte usager, sécurité, changement, profil"
-title: "Je veux changer mon adresse email"
+keywords: "adresse électronique, adresse email, adresse mail, compte usager, sécurité, changement, profil"
+title: "Je veux changer mon adresse électronique"
 ---
 
-# Je veux changer mon adresse email
+# Je veux changer mon adresse électronique
 
-Si vous disposez d’un compte usager sur %{application_name}, il est possible de changer l’adresse email associée à celui-ci.
+Si vous disposez d’un compte usager sur %{application_name}, il est possible de changer l’adresse électronique associée à celui-ci.
 
 **Attention** : pour des raisons de sécurité, les comptes instructeur et administrateur sur %{application_name} doivent nous contacter à %{contact_email} pour demander ce changement.
 
 Cette adresse correspond à l’identifiant avec lequel vous vous connectez à %{application_name}. C’est également à cette adresse que nous envoyons les messages concernant l’avancement de votre dossier.
 
-## Changer mon adresse email
+## Changer mon adresse électronique
 
-Pour changer l’adresse email associée à votre compte, suivez les étapes suivantes :
+Pour changer l’adresse électronique associée à votre compte, suivez les étapes suivantes :
 
 1. [Connectez-vous](/users/sign_in) à votre compte sur %{application_name} ;
-2. Cliquez sur le menu contenant votre adresse email en haut à droite de la page, puis sur _« Voir mon profil »_, ou [suivez directement ce lien si vous êtes déjà connecté(e)](/profil).
+2. Cliquez sur le menu contenant votre adresse électronique en haut à droite de la page, puis sur _« Voir mon profil »_, ou [suivez directement ce lien si vous êtes déjà connecté(e)](/profil).
 ![Menu Usager avec lien Voir mon profil {aria-hidden="true"}](faq/usager-dropdown.png)
 
-3. Dans l’encadré _« Coordonnées »_, renseignez la nouvelle adresse email que vous souhaitez utiliser. Puis cliquez sur _« Changer mon adresse »_. **Attention** : Cette adresse ne doit pas être déjà utilisée par un autre compte sur %{application_name}.
+3. Dans l’encadré _« Coordonnées »_, renseignez la nouvelle adresse électronique que vous souhaitez utiliser. Puis cliquez sur _« Changer mon adresse »_. **Attention** : Cette adresse ne doit pas être déjà utilisée par un autre compte sur %{application_name}.
 ![Section Coordonées avec formulaire de modification d’email {aria-hidden="true"}](faq/usager-edit-email.png)
 
 4. Ouvrez la boîte email de votre nouvelle adresse, et cliquez sur le lien de confirmation que nous vous avons envoyé.
 
 ## Si l’adresse est déjà utilisée par un autre compte
 
-La nouvelle adresse email ne doit pas être déjà utilisée par un compte existant sur %{application_name}.
+La nouvelle adresse électronique ne doit pas être déjà utilisée par un compte existant sur %{application_name}.
 
 **Si la nouvelle adresse est déjà utilisée, vous recevrez un email vous informant que le changement d’adresse ne peut pas être pris en compte.**
 
-Dans ce cas, revenez sur la page _« Profil »_, et choisissez une autre adresse email disponible.
+Dans ce cas, revenez sur la page _« Profil »_, et choisissez une autre adresse électronique disponible.
 
-## Par ailleurs, si le changement d'adresse mail depuis votre profil ne fonctionne pas, vous avez également la possibilité de transférer vos dossiers vers votre nouvelle adresse mail. 
+## Par ailleurs, si le changement d'adresse électronique depuis votre profil ne fonctionne pas, vous avez également la possibilité de transférer vos dossiers vers votre nouvelle adresse.
 Pour savoir comment transférer des dossiers, nous vous invitons à consulter la page suivante : https://www.demarches-simplifiees.fr/faq/usager/mon-dossier-a-ete-depose-par-un-tiers-et-je-souhaite-y-acceder
 
 
-Une fois le transfert opéré, nous pourrons procéder à la suppression de votre ancien compte en nous contactant à l'adresse contact@demarches-simplifiees.fr . 
+Une fois le transfert opéré, nous pourrons procéder à la suppression de votre ancien compte en nous contactant à l'adresse contact@demarches-simplifiees.fr.

--- a/doc/faqs/usager/je-veux-changer-mon-mot-de-passe.fr.md
+++ b/doc/faqs/usager/je-veux-changer-mon-mot-de-passe.fr.md
@@ -14,7 +14,7 @@ Si vous souhaitez modifier le mot de passe de votre compte, vous pouvez demander
 Pour cela :
 
 1. Ouvrez la page de [réinitialisation de mot de passe](/users/password/new)
-2. Indiquez l’adresse email de votre compte %{application_name}
+2. Indiquez l’adresse électronique de votre compte %{application_name}
 3. Vous recevrez par email un lien pour réinitialiser votre mot de passe.
 4. Cliquez sur ce lien, et rentrez le nouveau mot de passe que vous souhaitez utiliser.
 

--- a/doc/faqs/usager/je-veux-contacter-le-service-en-charge-de-ma-demarche.fr.md
+++ b/doc/faqs/usager/je-veux-contacter-le-service-en-charge-de-ma-demarche.fr.md
@@ -23,7 +23,7 @@ Pour contacter les services en charge de votre démarche, vous pouvez :
 
 2. Contacter **les services compétents aux contacts renseignés pour la démarche**
 
-    Si des contacts d’adresse email ou numéro de téléphone sont spécifiés pour la démarche que vous suivez, vous pouvez les utiliser pour obtenir des renseignements supplémentaires ou pour toute question spécifique concernant votre dossier.
+    Si des contacts d’adresse électronique ou numéro de téléphone sont spécifiés pour la démarche que vous suivez, vous pouvez les utiliser pour obtenir des renseignements supplémentaires ou pour toute question spécifique concernant votre dossier.
     Ces informations se retrouvent dans le pied de page du dossier.
 
     ![Coordonnées de contact du service traitant un dossier {aria-hidden="true"}](faq/usager-footer-contact.png)

--- a/doc/faqs/usager/mon-dossier-a-ete-depose-par-un-tiers-et-je-souhaite-y-acceder.fr.md
+++ b/doc/faqs/usager/mon-dossier-a-ete-depose-par-un-tiers-et-je-souhaite-y-acceder.fr.md
@@ -16,9 +16,9 @@ Pour cela, la personne doit cliquer sur le bouton **« Action »** (ou _« Au
 
 ![Image illustration le bouton Autres actions avec le menu de transfert de dossier {aria-hidden="true"}](faq/usager-dossier-actions-menu-transfer.png)
 
-Et ensuite cliquer sur **« Transférer le dossier »** en indiquant votre adresse mail.
+Et ensuite cliquer sur **« Transférer le dossier »** en indiquant votre adresse électronique.
 
 ![Image illustration l’interface de transfert de dossier vers un autre compte {aria-hidden="true"}](faq/usager-transfer-dossier.png)
 
-Vous recevrez alors un mail de transfert de dossier que vous pourrez accepter ou rejeter depuis votre interface usager. 
-> **Une fois la demande de transfert acceptée, vous serez propriétaire du dossier.** 
+Vous recevrez alors un mail de transfert de dossier que vous pourrez accepter ou rejeter depuis votre interface usager.
+> **Une fois la demande de transfert acceptée, vous serez propriétaire du dossier.**

--- a/spec/components/procedures/errors_summary_spec.rb
+++ b/spec/components/procedures/errors_summary_spec.rb
@@ -102,7 +102,7 @@ describe Procedure::ErrorsSummary, type: :component do
     it 'render error nicely' do
       expect(page).to have_selector("a", text: "Les règles d’inéligibilité")
       expect(page).to have_selector("a[href*='v2']", text: "Le modèle d’attestation")
-      expect(page).to have_selector("a", text: "L’email de notification de passage de dossier en instruction")
+      expect(page).to have_selector("a", text: "L’adresse électronique de notification de passage de dossier en instruction")
       expect(page).to have_text("n'est pas valide", count: 2)
     end
   end

--- a/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
@@ -1319,7 +1319,7 @@ describe API::V2::GraphqlController do
       it {
         expect(gql_errors).to be_nil
         expect(gql_data[:groupeInstructeurAjouterInstructeurs][:errors]).to be_nil
-        expect(gql_data[:groupeInstructeurAjouterInstructeurs][:warnings]).to eq([message: "yolo n’est pas une adresse email valide"])
+        expect(gql_data[:groupeInstructeurAjouterInstructeurs][:warnings]).to eq([message: "yolo n’est pas une adresse électronique valide"])
         expect(gql_data[:groupeInstructeurAjouterInstructeurs][:groupeInstructeur][:id]).to eq(groupe_instructeur.to_typed_id)
         expect(groupe_instructeur.instructeurs.count).to eq(2)
         expect(gql_data[:groupeInstructeurAjouterInstructeurs][:groupeInstructeur][:instructeurs]).to match_array([{ id: existing_instructeur.to_typed_id, email: existing_instructeur.email }, { id: Instructeur.last.to_typed_id, email: }])

--- a/spec/controllers/contact_controller_spec.rb
+++ b/spec/controllers/contact_controller_spec.rb
@@ -14,7 +14,7 @@ describe ContactController, question_type: :controller do
       get :index
 
       expect(response.status).to eq(200)
-      expect(response.body).not_to have_content("Votre adresse email")
+      expect(response.body).not_to have_content("Votre adresse électronique")
     end
 
     describe "with dossier" do
@@ -153,7 +153,7 @@ describe ContactController, question_type: :controller do
         get :index
 
         expect(response.status).to eq(200)
-        expect(response.body).to have_text("Votre adresse email")
+        expect(response.body).to have_text("Votre adresse électronique")
       end
     end
 
@@ -193,7 +193,7 @@ describe ContactController, question_type: :controller do
 
         it 'creates a conversation on HelpScout' do
           expect { subject }.not_to have_enqueued_job(HelpscoutCreateConversationJob)
-          expect(response.body).to include("Le champ « Votre adresse email » est invalide")
+          expect(response.body).to include("Le champ « Votre adresse électronique » est invalide")
           expect(response.body).to include("bonjour")
           expect(response.body).to include("un message")
         end
@@ -215,7 +215,7 @@ describe ContactController, question_type: :controller do
     context 'index' do
       it 'should have professionnal email field' do
         get :admin
-        expect(response.body).to have_text('Votre adresse email professionnelle')
+        expect(response.body).to have_text('Votre adresse électronique professionnelle')
         expect(response.body).to have_text('téléphone')
         expect(response.body).to include('for_admin')
       end

--- a/spec/controllers/faq_controller_spec.rb
+++ b/spec/controllers/faq_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe FAQController, type: :controller do
 
       # Usager
       expect(response.body).to include("Gestion de mon compte")
-      expect(response.body).to include("Je veux changer mon adresse email")
+      expect(response.body).to include("Je veux changer mon adresse électronique")
       expect(response.body).to include(faq_path(category: "usager", slug: "je-veux-changer-mon-adresse-email"))
 
       # Instructeur

--- a/spec/controllers/france_connect/particulier_controller_spec.rb
+++ b/spec/controllers/france_connect/particulier_controller_spec.rb
@@ -203,7 +203,7 @@ describe FranceConnect::ParticulierController, type: :controller do
         expect(user.confirmation_token).to be_nil
 
         expect(response).to redirect_to(root_path(user))
-        expect(flash[:notice]).to eq('Votre email est bien vérifié')
+        expect(flash[:notice]).to eq('Votre adresse électronique est bien vérifiée')
       end
     end
 

--- a/spec/controllers/manager/dossiers_controller_spec.rb
+++ b/spec/controllers/manager/dossiers_controller_spec.rb
@@ -56,7 +56,7 @@ describe Manager::DossiersController, type: :controller do
 
       it do
         expect { subject }.not_to have_enqueued_mail
-        expect(flash[:alert]).to eq("L’adresse email est invalide. Saisir une adresse électronique valide, exemple : adresse@mail.com")
+        expect(flash[:alert]).to eq("L’adresse électronique est invalide. Saisir une adresse électronique valide, exemple : adresse@mail.com")
       end
     end
   end

--- a/spec/controllers/users/profil_controller_spec.rb
+++ b/spec/controllers/users/profil_controller_spec.rb
@@ -38,7 +38,7 @@ describe Users::ProfilController, type: :controller do
       it 'fails' do
         patch :update_email, params: { user: { email: user.email } }
         expect(response).to have_http_status(302)
-        expect(flash[:alert]).to eq(["Le champ « La nouvelle adresse email » ne peut être identique à l’ancienne. Saisir une autre adresse email"])
+        expect(flash[:alert]).to eq(["Le champ « La nouvelle adresse électronique » ne peut être identique à l’ancienne. Saisir une autre adresse électronique"])
       end
     end
 
@@ -136,7 +136,7 @@ describe Users::ProfilController, type: :controller do
 
       it "should not transfer to an empty email" do
         expect { subject }.not_to change { DossierTransfer.count }
-        expect(flash.alert).to eq(["L’adresse email doit être rempli"])
+        expect(flash.alert).to eq(["L’adresse électronique doit être rempli"])
       end
     end
   end

--- a/spec/controllers/users/transfers_controller_spec.rb
+++ b/spec/controllers/users/transfers_controller_spec.rb
@@ -93,14 +93,14 @@ describe Users::TransfersController, type: :controller do
     context "when email is empty" do
       let(:email) { "" }
       it_behaves_like 'email error' do
-        let(:expected_error) { 'L’adresse email doit être rempli' }
+        let(:expected_error) { 'L’adresse électronique doit être rempli' }
       end
     end
 
     context "when email is invalid" do
       let(:email) { "not-an-email" }
       it_behaves_like 'email error' do
-        let(:expected_error) { "L’adresse email est invalide. Saisir une adresse électronique valide, exemple : adresse@mail.com" }
+        let(:expected_error) { "L’adresse électronique est invalide. Saisir une adresse électronique valide, exemple : adresse@mail.com" }
       end
     end
   end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe UserMailer, type: :mailer do
     let(:mail) { UserMailer.custom_confirmation_instructions(user, token) }
 
     it 'renders the headers' do
-      expect(mail.subject).to eq('Confirmez votre email')
+      expect(mail.subject).to eq('Confirmez votre adresse électronique')
       expect(mail.to).to eq([user.email])
       expect(mail.from).to eq(['contact@demarches-simplifiees.fr'])
     end

--- a/spec/models/columns/dossier_column_spec.rb
+++ b/spec/models/columns/dossier_column_spec.rb
@@ -26,7 +26,7 @@ describe Columns::DossierColumn do
 
         it 'retrieve entreprise information' do
           expect(procedure.find_column(label: "Nº dossier").value(dossier)).to eq(dossier.id)
-          expect(procedure.find_column(label: "Email").value(dossier)).to eq(dossier.user_email_for(:display))
+          expect(procedure.find_column(label: "Adresse électronique").value(dossier)).to eq(dossier.user_email_for(:display))
           expect(procedure.find_column(label: "France connecté ?").value(dossier)).to eq(false)
           expect(procedure.find_column(label: "Entreprise forme juridique").value(dossier)).to eq("SA à conseil d'administration (s.a.i.)")
           expect(procedure.find_column(label: "Entreprise SIREN").value(dossier)).to eq('440117620')

--- a/spec/models/concerns/columns_concern_spec.rb
+++ b/spec/models/concerns/columns_concern_spec.rb
@@ -90,7 +90,7 @@ describe ColumnsConcern do
           { label: "Motivation de la décision", table: "self", column: "motivation", displayable: false, type: :text, filterable: false },
           { label: "Date de dernière modification (usager)", table: "self", column: "last_champ_updated_at", displayable: false, type: :text, filterable: false },
           { label: 'Demandeur', table: 'user', column: 'email', displayable: true, type: :text, filterable: true },
-          { label: 'Email instructeur', table: 'followers_instructeurs', column: 'email', displayable: true, type: :text, filterable: true },
+          { label: 'Adresse électronique instructeur', table: 'followers_instructeurs', column: 'email', displayable: true, type: :text, filterable: true },
           { label: 'Groupe instructeur', table: 'groupe_instructeur', column: 'id', displayable: true, type: :enum, filterable: true },
           { label: 'Avis oui/non', table: 'avis', column: 'question_answer', displayable: true, type: :text, filterable: false },
           { label: 'France connecté ?', table: 'self', column: 'user_from_france_connect?', displayable: false, type: :text, filterable: false },
@@ -201,7 +201,7 @@ describe ColumnsConcern do
         it "returns all usager columns" do
           expected = [
             procedure.find_column(label: "Nº dossier"),
-            procedure.find_column(label: "Email"),
+            procedure.find_column(label: "Adresse électronique"),
             procedure.find_column(label: "France connecté ?"),
             procedure.find_column(label: "Civilité"),
             procedure.find_column(label: "Nom"),
@@ -223,7 +223,7 @@ describe ColumnsConcern do
         it "returns all usager columns" do
           expected = [
             procedure.find_column(label: "Nº dossier"),
-            procedure.find_column(label: "Email"),
+            procedure.find_column(label: "Adresse électronique"),
             procedure.find_column(label: "France connecté ?"),
             procedure.find_column(label: "Établissement SIRET"),
             procedure.find_column(label: "Établissement siège social"),

--- a/spec/models/export_template_tabular_spec.rb
+++ b/spec/models/export_template_tabular_spec.rb
@@ -93,7 +93,7 @@ describe ExportTemplate do
     context 'when exported_columns is not empty' do
       before do
         export_template.exported_columns = [
-          ExportedColumn.new(libelle: 'Colonne usager', column: procedure.find_column(label: "Email")),
+          ExportedColumn.new(libelle: 'Colonne usager', column: procedure.find_column(label: "Adresse électronique")),
           ExportedColumn.new(libelle: 'Ça va ?', column: procedure.find_column(label: "Ca va ?"))
         ]
       end

--- a/spec/services/procedure_export_service_tabular_spec.rb
+++ b/spec/services/procedure_export_service_tabular_spec.rb
@@ -53,7 +53,7 @@ describe ProcedureExportService do
         let(:exported_columns) do
           [
             ExportedColumn.new(libelle: 'Date du dernier évènement', column: procedure.find_column(label: 'Date du dernier évènement')),
-            ExportedColumn.new(libelle: 'Email', column: procedure.find_column(label: 'Email')),
+            ExportedColumn.new(libelle: 'Adresse électronique', column: procedure.find_column(label: 'Adresse électronique')),
             ExportedColumn.new(libelle: 'Groupe instructeur', column: procedure.find_column(label: 'Groupe instructeur')),
             ExportedColumn.new(libelle: 'État du dossier', column: procedure.dossier_state_column),
             ExportedColumn.new(libelle: 'first champ', column: procedure.find_column(label: 'first champ')),
@@ -63,7 +63,7 @@ describe ProcedureExportService do
         end
 
         let!(:dossier) { create(:dossier, :en_instruction, :with_populated_champs, :with_individual, procedure: procedure) }
-        let(:selected_headers) { ["Email", "first champ", "Commune", "Groupe instructeur", "Date du dernier évènement", "État du dossier", "PJ"] }
+        let(:selected_headers) { ["Adresse électronique", "first champ", "Commune", "Groupe instructeur", "Date du dernier évènement", "État du dossier", "PJ"] }
 
         it 'should have only headers from export template' do
           expect(dossiers_sheet.headers).to match_array(selected_headers)

--- a/spec/system/api_particulier/api_particulier_spec.rb
+++ b/spec/system/api_particulier/api_particulier_spec.rb
@@ -308,7 +308,6 @@ describe 'fetch API Particulier Data', js: true do
         login_as instructeur.user, scope: :user
 
         visit instructeur_dossier_path(procedure, dossier)
-
         expect(page).to have_content('code postal et ville 92110 Clichy')
         expect(page).to have_content('identité Mr SNOW Eric')
         expect(page).to have_content('complément d’identité ne connait rien')
@@ -394,7 +393,7 @@ describe 'fetch API Particulier Data', js: true do
 
         expect(page).not_to have_content('téléphone 2')
         expect(page).not_to have_content('destinataire')
-        expect(page).not_to have_content('adresse')
+        expect(page).not_to have_content('complément d’identité')
         expect(page).not_to have_content('distribution')
       end
     end

--- a/spec/system/api_particulier/api_particulier_spec.rb
+++ b/spec/system/api_particulier/api_particulier_spec.rb
@@ -154,7 +154,7 @@ describe 'fetch API Particulier Data', js: true do
       end
 
       within('#pole_emploi-contact') do
-        check('email')
+        check('adresse électronique')
         check('téléphone')
         check('téléphone 2')
       end
@@ -383,7 +383,7 @@ describe 'fetch API Particulier Data', js: true do
         expect(page).to have_content('voie 3 rue des Huttes')
         expect(page).to have_content('nom MOUSTAKI')
 
-        expect(page).to have_content('email georges@moustaki.fr')
+        expect(page).to have_content('adresse électronique georges@moustaki.fr')
         expect(page).to have_content('téléphone 0629212921')
 
         expect(page).to have_content("date d’inscription 3 mai 1965")

--- a/spec/system/france_connect/france_connect_particulier_spec.rb
+++ b/spec/system/france_connect/france_connect_particulier_spec.rb
@@ -45,9 +45,9 @@ describe 'France Connect Particulier Connexion' do
             end
 
             scenario 'he is redirected to user dossiers page', js: true do
-              expect(page).to have_content("Choisissez votre email de contact pour finaliser votre connexion")
+              expect(page).to have_content("Choisissez votre adresse électronique de contact pour finaliser votre connexion")
 
-              find('label', text: "Oui, utiliser #{fc_email} comme email de contact").click
+              find('label', text: "Oui, utiliser #{fc_email} comme adresse électronique de contact").click
 
               click_on 'Valider'
               expect(User.find_by(email: fc_email).email_verified_at).to be_present
@@ -56,7 +56,7 @@ describe 'France Connect Particulier Connexion' do
             scenario 'he can choose not to use FranceConnect email and input an alternative email', js: true do
               alternative_email = 'alternative@example.com'
 
-              expect(page).to have_content("Choisissez votre email de contact pour finaliser votre connexion")
+              expect(page).to have_content("Choisissez votre adresse électronique de contact pour finaliser votre connexion")
               find('label', text: 'utiliser une autre adresse').click
 
               expect(page).to have_selector("input[name='email']", visible: true, wait: 10)
@@ -103,7 +103,7 @@ describe 'France Connect Particulier Connexion' do
             scenario 'it uses another email that belongs to nobody' do
               page.find('#it-is-not-mine').click
               fill_in 'email', with: 'new_email@a.com'
-              click_on 'Utiliser ce mail'
+              click_on 'Utiliser cette adresse électronique'
 
               expect(page).to have_content('Nous venons de vous envoyer le mail de confirmation')
             end
@@ -118,7 +118,7 @@ describe 'France Connect Particulier Connexion' do
 
                 within '.new-account' do
                   fill_in 'email', with: 'an_existing_email@a.com'
-                  click_on 'Utiliser ce mail'
+                  click_on 'Utiliser cette adresse électronique'
                 end
 
                 expect(page).to have_content('Nous venons de vous envoyer le mail de confirmation')

--- a/spec/system/users/dossier_creation_spec.rb
+++ b/spec/system/users/dossier_creation_spec.rb
@@ -73,12 +73,12 @@ describe 'Creating a new dossier:', js: true do
             fill_in('Nom', with: 'nom')
           end
 
-          find('label', text: 'Par e-mail').click
+          find('label', text: 'Par adresse électronique').click
           fill_in('dossier_individual_attributes_email', with: 'prenom.nom@mail.com')
           find('label', text: 'Monsieur').click # force focus out
           within "#identite-form" do
             within '.suspect-email' do
-              expect(page).to have_content("L'adresse semble erronée Vouliez-vous écrire : prenom.nom@gmail.com ? Oui Non")
+              expect(page).to have_content("L'adresse électronique semble erronée Vouliez-vous écrire : prenom.nom@gmail.com ? Oui Non")
               click_button("Oui")
             end
             click_button("Continuer")

--- a/spec/system/users/dossier_prefill_get_spec.rb
+++ b/spec/system/users/dossier_prefill_get_spec.rb
@@ -181,9 +181,9 @@ describe 'Prefilling a dossier (with a GET request):', js: true do
 
           page.find('.fr-connect').click
 
-          expect(page).to have_content("Choisissez votre email de contact pour finaliser votre connexion")
+          expect(page).to have_content("Choisissez votre adresse électronique de contact pour finaliser votre connexion")
 
-          find('label', text: /Oui, utiliser .* comme email de contact/).click
+          find('label', text: /Oui, utiliser .* comme adresse électronique de contact/).click
 
           click_on 'Valider'
           expect(page).to have_content('Vous avez un dossier prérempli')

--- a/spec/system/users/dossier_prefill_post_spec.rb
+++ b/spec/system/users/dossier_prefill_post_spec.rb
@@ -134,9 +134,9 @@ describe 'Prefilling a dossier (with a POST request):', js: true do
             allow(FranceConnectService).to receive(:retrieve_user_informations_particulier).and_return(build(:france_connect_information))
 
             page.find('.fr-connect').click
-            expect(page).to have_content("Choisissez votre email de contact pour finaliser votre connexion")
+            expect(page).to have_content("Choisissez votre adresse électronique de contact pour finaliser votre connexion")
 
-            find('label', text: /Oui, utiliser .* comme email de contact/).click
+            find('label', text: /Oui, utiliser .* comme adresse électronique de contact/).click
 
             click_on 'Valider'
             expect(page).to have_content('Vous avez un dossier prérempli')

--- a/spec/system/users/transfer_dossier_spec.rb
+++ b/spec/system/users/transfer_dossier_spec.rb
@@ -20,7 +20,7 @@ describe 'Transfer dossier:' do
 
     expect(page).to have_current_path(transferer_dossier_path(dossier))
     expect(page).to have_content("transférer le dossier en construction nº #{dossier.id}")
-    fill_in 'Email du compte destinataire', with: other_user.email
+    fill_in 'Adresse électronique du compte destinataire', with: other_user.email
     click_on 'Envoyer la demande de transfert'
 
     logout


### PR DESCRIPTION
Fix partiellement #11331

Premier lot de correctif sur les pages usagers et la doc.   
Les termes "adresse email",  "adresse e-mail", "email" et "e-mail" sont remplacées par ""adresse électronique".
