### PR TITLE
ETQ Adminsitrateur, je peux cloner une démarche avec une drop_down_list utilisant un référentiel

### DIFF
--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -304,7 +304,13 @@ FactoryBot.define do
 end
 
 def build_types_de_champ(types_de_champ, revision:, scope: :public, parent: nil)
-  types_de_champ.deep_dup.each.with_index do |type_de_champ_attributes, i|
+  types_de_champ.map do |type_de_champ_attributes|
+    referentiel = type_de_champ_attributes.delete(:referentiel)
+    if referentiel.present?
+      type_de_champ_attributes[:referentiel_id] = referentiel.id
+    end
+    type_de_champ_attributes
+  end.deep_dup.each.with_index do |type_de_champ_attributes, i|
     type = TypeDeChamp.type_champs.fetch(type_de_champ_attributes.delete(:type) || :text).to_sym
     position = type_de_champ_attributes.delete(:position) || i
     children = type_de_champ_attributes.delete(:children)

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -949,6 +949,20 @@ describe Procedure do
       end
     end
 
+    context 'with a drop_down_list referentiel' do
+      let(:procedure) { create(:procedure, types_de_champ_public:, service:) }
+      let(:types_de_champ_public) { [{ type: :drop_down_list, referentiel:, drop_down_mode: 'advanced' }] }
+      let(:referentiel) { create(:csv_referentiel, :with_items) }
+      let(:drop_down_list) { procedure.draft_revision.types_de_champ_public.first }
+      let(:cloned_drop_down_list) { subject.draft_revision.types_de_champ_public.first }
+
+      it {
+        expect(cloned_drop_down_list.drop_down_mode).to eq('advanced')
+        expect(cloned_drop_down_list.referentiel_id).to eq(referentiel.id)
+        is_expected.to be_valid
+      }
+    end
+
     describe 'feature flag' do
       context 'with a feature flag enabled' do
         before do


### PR DESCRIPTION
[sentry](https://demarches-simplifiees.sentry.io/issues/6296518049/?environment=production&project=1429550&query=user.id%3AUser%236450823&referrer=issue-stream&sort=date&statsPeriod=7d&stream_index=1) , [HS](https://secure.helpscout.net/conversation/2845507144/2147088?folderId=1653799) 

J'ai l'impression qu'il y a un 2e soucis qui semble plus correspondre à la conversation HS : [
sentry](https://demarches-simplifiees.sentry.io/issues/6317435383/?environment=production&project=1429550&query=is%3Aunresolved&referrer=issue-stream&sort=date&statsPeriod=14d&stream_index=4)

Le 1er lien sentry correspond au cas reproductible en local : si on clone une procédure en "mode référentiel", mais qui n'a pas de csv ajouté.

Par contre le 2e sentry, semble correspondre au HelpScout, et la personne ne peut pas du tout accéder à sa procédure et je ne sais pas pourquoi.