### PR TITLE
ETQ instructeur, je peux cibler mes messages envoyé aux usager ayant des dossiers en brouillon, vers des groupes d'instructeurs ou sans groupe d'instructeur

### DIFF
--- a/app/components/dsfr/input_component.rb
+++ b/app/components/dsfr/input_component.rb
@@ -13,13 +13,14 @@ class Dsfr::InputComponent < ApplicationComponent
   renders_one :describedby
   renders_one :label
 
-  def initialize(form:, attribute:, input_type: :text_field, opts: {}, required: true, autoresize: true)
+  def initialize(form:, attribute:, input_type: :text_field, opts: {}, required: true, autoresize: true, label_opts: {})
     @form = form
     @attribute = attribute
     @input_type = input_type
     @opts = opts
     @required = required
     @autoresize = autoresize
+    @label_opts = label_opts
   end
 
   def dsfr_champ_container
@@ -41,8 +42,12 @@ class Dsfr::InputComponent < ApplicationComponent
     opts
   end
 
-  def label_opts
-    { class: class_names('fr-label': true, 'fr-password__label': password?) }
+  def label_class_names
+    class_names(
+      'fr-label': true,
+      'fr-password__label': password?,
+      @label_opts[:class] => @label_opts[:class].present?
+    )
   end
 
   # errors helpers

--- a/app/components/dsfr/input_component/input_component.html.haml
+++ b/app/components/dsfr/input_component/input_component.html.haml
@@ -1,5 +1,5 @@
 = content_tag(:div, input_group_opts) do
-  = @form.label @attribute, label_opts do
+  = @form.label @attribute, class: label_class_names do
     - capture do
       = label
 

--- a/app/components/dsfr/toggle_component.rb
+++ b/app/components/dsfr/toggle_component.rb
@@ -10,7 +10,7 @@ class Dsfr::ToggleComponent < ApplicationComponent
   attr_reader :data
   attr_reader :extra_class_names
 
-  def initialize(form:, target:, title: nil, html_title: nil, disabled: nil, hint: nil, toggle_labels: { checked: 'Activé', unchecked: 'Désactivé' }, opt: nil, extra_class_names: nil)
+  def initialize(form:, target:, title: nil, html_title: nil, disabled: nil, hint: nil, toggle_labels: { checked: 'Activé', unchecked: 'Désactivé' }, opt: nil, extra_class_names: "fr-toggle--label-left")
     @form = form
     @target = target
     @title = title

--- a/app/components/dsfr/toggle_component/toggle_component.html.haml
+++ b/app/components/dsfr/toggle_component/toggle_component.html.haml
@@ -1,4 +1,4 @@
-%div{ class: "fr-toggle fr-toggle--label-left #{extra_class_names}" }
+%div{ class: "fr-toggle #{extra_class_names}" }
   = @form.check_box target, class: 'fr-toggle__input', disabled:, data:, id: input_id
   = @form.label target,
     title || html_title&.html_safe,

--- a/app/components/instructeurs/bulk_message_form_component.rb
+++ b/app/components/instructeurs/bulk_message_form_component.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class Instructeurs::BulkMessageFormComponent < ApplicationComponent
+  attr_reader :current_instructeur, :procedure, :dossiers_count_per_groupe_instructeur
+
+  def initialize(current_instructeur:, procedure:, dossiers_count_per_groupe_instructeur:)
+    @current_instructeur = current_instructeur
+    @procedure = procedure
+    @dossiers_count_per_groupe_instructeur = dossiers_count_per_groupe_instructeur
+  end
+
+  def default_dossiers_count
+    if procedure.routing_enabled
+      @dossiers_count_per_groupe_instructeur.sum do |groupe_instructeur_id, dossier_count|
+        if instructeur_in_all_groupes? || current_instructeur_in_groupe?(groupe_instructeur_id)
+          dossier_count
+        else
+          0
+        end
+      end
+    else
+      @dossiers_count_per_groupe_instructeur.values.sum
+    end
+  end
+
+  def instructeur_in_all_groupes? = @in_all_groupes ||= procedure.groupe_instructeurs.size == instructeur_groupe_ids.size
+
+  private
+
+  def current_instructeur_in_groupe?(groupe_instructeur_id) = groupe_instructeur_id.in?(instructeur_groupe_ids)
+
+  def instructeur_groupe_ids
+    @instructeur_groupe_ids ||= current_instructeur
+      .groupe_instructeurs
+      .filter { _1.procedure_id == procedure.id }
+      .map(&:id)
+  end
+end

--- a/app/components/instructeurs/bulk_message_form_component.rb
+++ b/app/components/instructeurs/bulk_message_form_component.rb
@@ -35,6 +35,9 @@ class Instructeurs::BulkMessageFormComponent < ApplicationComponent
       groupe_instructeur.id,
       {
         checked: current_instructeur_in_groupe?(groupe_instructeur.id),
+        data: {
+          "checkbox-select-all-target": "checkbox",
+        }
       },
       'true',
       'false'
@@ -55,6 +58,9 @@ class Instructeurs::BulkMessageFormComponent < ApplicationComponent
       ])
     end
   end
+
+
+  def render_select_all? = @select_all ||= groupe_instructeurs_with_brouillon.size >= 6
 
   def instructeur_in_all_groupes? = @in_all_groupes ||= procedure.groupe_instructeurs.size == instructeur_groupe_ids.size
 

--- a/app/components/instructeurs/bulk_message_form_component.rb
+++ b/app/components/instructeurs/bulk_message_form_component.rb
@@ -37,6 +37,7 @@ class Instructeurs::BulkMessageFormComponent < ApplicationComponent
         checked: current_instructeur_in_groupe?(groupe_instructeur.id),
         data: {
           "checkbox-select-all-target": "checkbox",
+          **bulk_message_stimulus_data(dossier_count_for(groupe_instructeur))
         }
       },
       'true',
@@ -59,6 +60,13 @@ class Instructeurs::BulkMessageFormComponent < ApplicationComponent
     end
   end
 
+  def bulk_message_stimulus_data(count)
+    {
+      "bulk-message-target": "element",
+      "action": "change->bulk-message#change",
+      "count": count
+    }
+  end
 
   def render_select_all? = @select_all ||= groupe_instructeurs_with_brouillon.size >= 6
 

--- a/app/components/instructeurs/bulk_message_form_component.rb
+++ b/app/components/instructeurs/bulk_message_form_component.rb
@@ -23,6 +23,9 @@ class Instructeurs::BulkMessageFormComponent < ApplicationComponent
     end
   end
 
+  # grouped by groupe_instructeur_id, those without is indexed by nil
+  def dossier_count_without_group = @dossiers_count_per_groupe_instructeur[nil]
+
   def groupe_instructeurs_with_brouillon = procedure.groupe_instructeurs.filter { dossier_count_for(_1)&.> 0 }
 
   def splitted_groupe_instructeurs = yield(*groupe_instructeurs_with_brouillon.partition { current_instructeur_in_groupe?(_1.id) })

--- a/app/components/instructeurs/bulk_message_form_component.rb
+++ b/app/components/instructeurs/bulk_message_form_component.rb
@@ -45,6 +45,7 @@ class Instructeurs::BulkMessageFormComponent < ApplicationComponent
     form.label groupe_instructeur.id, class: 'fr-label' do
       safe_join([
         groupe_instructeur.label,
+        tooltip_tag(groupe_instructeur),
         tag.span(class: 'fr-hint-text') do
           safe_join([
             t('.dossier_count_per_group', count: dossier_count_for(groupe_instructeur)),
@@ -69,6 +70,26 @@ class Instructeurs::BulkMessageFormComponent < ApplicationComponent
     else
       tag.span(t('.not_present_in_group'))
     end
+  end
+
+  def tooltip_tag(groupe_instructeur)
+    return if groupe_instructeur.routing_rule.blank?
+
+    safe_join([
+      tag.span(
+        "",
+        class: "fr-icon-information-line fr-icon--sm ml-1",
+        id: "link-#{groupe_instructeur.id}",
+        aria: { describedby: "tooltip-#{groupe_instructeur.id}" }
+      ),
+      tag.span(
+        groupe_instructeur.routing_rule.to_s(procedure.active_revision.types_de_champ),
+        class: 'fr-tooltip fr-placement',
+        id: "tooltip-#{groupe_instructeur.id}",
+        role: "tooltip",
+        aria: { hidden: "true" }
+      )
+    ])
   end
 
   def instructeur_groupe_ids

--- a/app/components/instructeurs/bulk_message_form_component.rb
+++ b/app/components/instructeurs/bulk_message_form_component.rb
@@ -72,6 +72,14 @@ class Instructeurs::BulkMessageFormComponent < ApplicationComponent
 
   def instructeur_in_all_groupes? = @in_all_groupes ||= procedure.groupe_instructeurs.size == instructeur_groupe_ids.size
 
+  def bulk_message
+    current_instructeur
+      .bulk_messages
+      .build.tap do |bulk_message|
+        bulk_message.without_group = instructeur_in_all_groupes?
+      end
+  end
+
   private
 
   def dossier_count_for(groupe_instructeur) = @dossiers_count_per_groupe_instructeur[groupe_instructeur.id] || 0

--- a/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.en.yml
+++ b/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.en.yml
@@ -8,6 +8,7 @@ en:
     other: "%{count} users"
   form:
     target_group:  "Target users by instruction group having file in \"draft\" : "
+    select_all:  "Select all"
   alert:
     send_message_to: "You will send a message to "
     user: "users having a file in draft"

--- a/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.en.yml
+++ b/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.en.yml
@@ -1,0 +1,5 @@
+---
+en:
+  alert:
+    send_message_to: "You will send a message to "
+    user: "users having a file in draft"

--- a/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.en.yml
+++ b/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.en.yml
@@ -1,5 +1,8 @@
 ---
 en:
+  dossier_count_without_group_html:
+    one: "<span>Also contact the user who haven't filled routing fields</span>"
+    other: "<span>Also contact <strong>%{count}</strong> users who haven't filled routing fields</span>"
   dossier_count_per_group:
     one: "1 user"
     other: "%{count} users"

--- a/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.en.yml
+++ b/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.en.yml
@@ -1,5 +1,12 @@
 ---
 en:
+  dossier_count_per_group:
+    one: "1 user"
+    other: "%{count} users"
+  form:
+    target_group:  "Target users by instruction group having file in \"draft\" : "
   alert:
     send_message_to: "You will send a message to "
     user: "users having a file in draft"
+  present_in_group: " (you are in the instruction group)"
+  not_present_in_group: " (you are not in the instruction group)"

--- a/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.fr.yml
+++ b/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.fr.yml
@@ -1,0 +1,7 @@
+---
+fr:
+  alert:
+    send_message_to: "Vous allez envoyer un message à "
+    user: "usager(s) ayant un dossier en brouillon (dossier commencé mais pas encore déposé)"
+  present_in_group: " (vous êtes présent dans ce groupe instructeurs)"
+  not_present_in_group: " (vous n'êtes pas présent dans ce groupe instructeurs)"

--- a/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.fr.yml
+++ b/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.fr.yml
@@ -1,5 +1,11 @@
 ---
 fr:
+  dossier_count_per_group:
+    one: "1 usager"
+    other: "%{count} usagers"
+  form:
+    target_group:  "Ciblez les groupes d'usagers avec un dossier \"brouillon\" que vous souhaitez contacter "
+    select_all:  "Tout sélectionner"
   alert:
     send_message_to: "Vous allez envoyer un message à "
     user: "usager(s) ayant un dossier en brouillon (dossier commencé mais pas encore déposé)"

--- a/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.fr.yml
+++ b/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.fr.yml
@@ -8,7 +8,7 @@ fr:
     one: "1 usager"
     other: "%{count} usagers"
   form:
-    target_group:  "Ciblez les groupes d'usagers avec un dossier \"brouillon\" que vous souhaitez contacter "
+    target_group:  "Ciblez les groupes d'usagers avec un dossier \"brouillon\" que vous souhaitez contacter"
     select_all:  "Tout sélectionner"
   alert:
     send_message_to: "Vous allez envoyer un message à "

--- a/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.fr.yml
+++ b/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.fr.yml
@@ -1,5 +1,9 @@
 ---
 fr:
+  dossier_count_without_group_html:
+    zero: ""
+    one: "<span>Contacter également l'usager qui n'a pas encore renseigné le(s) champ(s) de routage</span>"
+    other: "<span>Contacter également les <strong>%{count}</strong> usagers qui n'ont pas encore renseigné le(s) champ(s) de routage</span>"
   dossier_count_per_group:
     one: "1 usager"
     other: "%{count} usagers"

--- a/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.html.haml
+++ b/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.html.haml
@@ -26,6 +26,10 @@
                       = groupe_instructeur_label(fgroup, groupe_instructeur)
 
 
+    - if dossier_count_without_group
+      %fieldset.fr-fieldset
+        .fr-fieldset__element
+          = render Dsfr::ToggleComponent.new(form: f, target: :without_group, title: t('.dossier_count_without_group_html', count: dossier_count_without_group), extra_class_names: "")
 
   .fr-alert.fr-alert--info.fr-alert--sm.fr-mb-3w
     %p

--- a/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.html.haml
+++ b/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.html.haml
@@ -1,4 +1,4 @@
-= form_for(current_instructeur.bulk_messages.build, url: create_multiple_commentaire_instructeur_procedure_path([procedure]), html: {  data: { controller: 'persisted-form bulk-message', persisted_form_key_value: dom_id(procedure, :bulk_message) } }) do |f|
+= form_for(bulk_message, url: create_multiple_commentaire_instructeur_procedure_path([procedure]), html: {  data: { controller: 'persisted-form bulk-message', persisted_form_key_value: dom_id(procedure, :bulk_message) } }) do |f|
   %p.mandatory-explanation= t('asterisk_html', scope: [:utils])
 
   - if procedure.routing_enabled?

--- a/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.html.haml
+++ b/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.html.haml
@@ -38,7 +38,7 @@
       = t('.alert.user')
 
   %fieldset.fr-fieldset
-    .fr-fieldset__element= render Dsfr::InputComponent.new(form: f, attribute: :body, input_type: :text_area, opts: { rows: 5, placeholder:  t('views.shared.dossiers.messages.form.write_message_placeholder'), title:  t('views.shared.dossiers.messages.form.write_message_placeholder'), class: 'fr-input message-textarea'})
+    .fr-fieldset__element= render Dsfr::InputComponent.new(form: f, attribute: :body, input_type: :text_area, required: true, opts: { rows: 5, placeholder:  t('views.shared.dossiers.messages.form.write_message_placeholder'), title:  t('views.shared.dossiers.messages.form.write_message_placeholder'), class: 'fr-input message-textarea'}, label_opts: { class: 'fr-text--bold' })
 
   .fr-mt-3w
     = f.submit t('views.shared.dossiers.messages.form.send_message'), class: 'fr-btn', data: { disable: true }

--- a/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.html.haml
+++ b/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.html.haml
@@ -41,7 +41,7 @@
   .fr-alert.fr-alert--info.fr-alert--sm.fr-mb-3w
     %p
       = t('.alert.send_message_to')
-      %strong= default_dossiers_count
+      %strong{ "data-bulk-message-target" => 'count' }= default_dossiers_count
       = t('.alert.user')
 
   %fieldset.fr-fieldset

--- a/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.html.haml
+++ b/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.html.haml
@@ -1,0 +1,14 @@
+= form_for(current_instructeur.bulk_messages.build, url: create_multiple_commentaire_instructeur_procedure_path, html: {  data: { controller: 'persisted-form bulk-message', persisted_form_key_value: dom_id(procedure, :bulk_message) } }) do |f|
+  %p.mandatory-explanation= t('asterisk_html', scope: [:utils])
+
+  .fr-alert.fr-alert--info.fr-alert--sm.fr-mb-3w
+    %p
+      = t('.alert.send_message_to')
+      %strong= default_dossiers_count
+      = t('.alert.user')
+
+  %fieldset.fr-fieldset
+    .fr-fieldset__element= render Dsfr::InputComponent.new(form: f, attribute: :body, input_type: :text_area, opts: { rows: 5, placeholder:  t('views.shared.dossiers.messages.form.write_message_placeholder'), title:  t('views.shared.dossiers.messages.form.write_message_placeholder'), class: 'fr-input message-textarea'})
+
+  .fr-mt-3w
+    = f.submit t('views.shared.dossiers.messages.form.send_message'), class: 'fr-btn', data: { disable: true }

--- a/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.html.haml
+++ b/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.html.haml
@@ -1,5 +1,31 @@
-= form_for(current_instructeur.bulk_messages.build, url: create_multiple_commentaire_instructeur_procedure_path, html: {  data: { controller: 'persisted-form bulk-message', persisted_form_key_value: dom_id(procedure, :bulk_message) } }) do |f|
+= form_for(current_instructeur.bulk_messages.build, url: create_multiple_commentaire_instructeur_procedure_path([procedure]), html: {  data: { controller: 'persisted-form bulk-message', persisted_form_key_value: dom_id(procedure, :bulk_message) } }) do |f|
   %p.mandatory-explanation= t('asterisk_html', scope: [:utils])
+
+  - if procedure.routing_enabled?
+    %fielset.fr-fieldset
+      %legend.fake-label.fr-mb-3w= t('.form.target_group')
+
+      .checkbox-group-bordered
+        %div{ style: "max-height: 430px; overflow-y: scroll" }
+          - splitted_groupe_instructeurs do |current_instructeur_groupes, other_groupe_instructeurs|
+            - current_instructeur_groupes.each do |groupe_instructeur|
+              .fr-fieldset__element.fr-px-4w.fr-mt-2w
+                = f.fields_for :groupe_instructeur_ids do |fgroup|
+                  .fr-checkbox-group
+                    = groupe_instructeur_checkbox(fgroup, groupe_instructeur)
+                    = groupe_instructeur_label(fgroup, groupe_instructeur)
+
+            - if other_groupe_instructeurs.any?
+              %hr.fr-hr.fr-mx-3w
+
+              - other_groupe_instructeurs.each do |groupe_instructeur|
+                .fr-fieldset__element.fr-px-4w.fr-mt-2w
+                  = f.fields_for :groupe_instructeur_ids do |fgroup|
+                    .fr-checkbox-group
+                      = groupe_instructeur_checkbox(fgroup, groupe_instructeur)
+                      = groupe_instructeur_label(fgroup, groupe_instructeur)
+
+
 
   .fr-alert.fr-alert--info.fr-alert--sm.fr-mb-3w
     %p

--- a/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.html.haml
+++ b/app/components/instructeurs/bulk_message_form_component/bulk_message_form_component.html.haml
@@ -2,10 +2,17 @@
   %p.mandatory-explanation= t('asterisk_html', scope: [:utils])
 
   - if procedure.routing_enabled?
-    %fielset.fr-fieldset
-      %legend.fake-label.fr-mb-3w= t('.form.target_group')
+    %fielset.fr-fieldset{ data: render_select_all? ? {controller: "checkbox-select-all"} : {} }
+      %legend.fake-label.fr-text--bold.fr-mb-3w
+        = t('.form.target_group')
+        = render EditableChamp::AsteriskMandatoryComponent.new
 
       .checkbox-group-bordered
+        - if render_select_all?
+          .fr-fieldset__element.fr-background-contrast--grey.fr-py-2w.fr-px-4w.fr-mb-0
+            .fr-checkbox-group
+              = check_box_tag "bulk-message-select-all", "select-all", false, data: { "checkbox-select-all-target": 'checkboxAll', "action": "change->bulk-message#change" }
+              = label_tag "bulk-message-select-all", t('.form.select_all')
         %div{ style: "max-height: 430px; overflow-y: scroll" }
           - splitted_groupe_instructeurs do |current_instructeur_groupes, other_groupe_instructeurs|
             - current_instructeur_groupes.each do |groupe_instructeur|
@@ -28,8 +35,8 @@
 
     - if dossier_count_without_group
       %fieldset.fr-fieldset
-        .fr-fieldset__element
-          = render Dsfr::ToggleComponent.new(form: f, target: :without_group, title: t('.dossier_count_without_group_html', count: dossier_count_without_group), extra_class_names: "")
+        .fr-fieldset__element.fr-mt-2w
+          = render Dsfr::ToggleComponent.new(form: f, target: :without_group, title: t('.dossier_count_without_group_html', count: dossier_count_without_group), extra_class_names: "", opt: bulk_message_stimulus_data(dossier_count_without_group))
 
   .fr-alert.fr-alert--info.fr-alert--sm.fr-mb-3w
     %p

--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -270,7 +270,6 @@ module Instructeurs
     def email_usagers
       @procedure = procedure
       @bulk_messages = BulkMessage.where(procedure: procedure)
-      @bulk_message = current_instructeur.bulk_messages.build
       @dossiers_count_per_groupe_instructeur = procedure.dossiers.state_brouillon.group(:groupe_instructeur_id).count
     end
 

--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -271,8 +271,7 @@ module Instructeurs
       @procedure = procedure
       @bulk_messages = BulkMessage.where(procedure: procedure)
       @bulk_message = current_instructeur.bulk_messages.build
-
-      @dossiers_count = reachable_brouillons.count
+      @dossiers_count_per_groupe_instructeur = procedure.dossiers.state_brouillon.group(:groupe_instructeur_id).count
     end
 
     def usagers_rdvs

--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -325,10 +325,17 @@ module Instructeurs
 
     private
 
+    def groupe_instructeur_ids_params
+      bulk_message_params = params.require(:bulk_message).permit(:without_group, groupe_instructeur_ids: {}).to_h
+      bulk_message_params
+        .fetch(:groupe_instructeur_ids) { [] }
+        .filter_map { |id, selected| selected == "true" ? id : nil }
+        .concat(bulk_message_params.dig(:without_group).eql?('1') ? [nil] : [])
+    end
+
     def reachable_brouillons
       if procedure.routing_enabled?
-        instructeur_groupe_ids = current_instructeur.groupe_instructeurs.where(procedure: procedure).ids
-        procedure.dossiers.brouillon.where(groupe_instructeur_id: instructeur_groupe_ids)
+        procedure.dossiers.brouillon.where(groupe_instructeur_id: groupe_instructeur_ids_params)
       else
         procedure.dossiers.brouillon
       end

--- a/app/javascript/controllers/bulk_message_controller.ts
+++ b/app/javascript/controllers/bulk_message_controller.ts
@@ -1,0 +1,22 @@
+import { ApplicationController } from './application_controller';
+
+export class BulkMessage extends ApplicationController {
+  declare readonly elementTargets: HTMLInputElement[];
+  declare readonly countTarget: HTMLSpanElement;
+
+  static targets = ['element', 'count'];
+
+  change() {
+    setTimeout(this.updateCounter.bind(this), 0); // delay execution when click on select all
+  }
+
+  private updateCounter() {
+    this.countTarget.textContent = this.elementTargets
+      .reduce((sum, element) => {
+        return element.dataset.count && element.checked
+          ? sum + parseInt(element.dataset.count, 10)
+          : sum;
+      }, 0)
+      .toString();
+  }
+}

--- a/app/models/bulk_message.rb
+++ b/app/models/bulk_message.rb
@@ -4,5 +4,5 @@ class BulkMessage < ApplicationRecord
   belongs_to :instructeur
   belongs_to :procedure
 
-  attr_reader :without_group
+  attr_accessor :without_group
 end

--- a/app/models/bulk_message.rb
+++ b/app/models/bulk_message.rb
@@ -3,4 +3,6 @@
 class BulkMessage < ApplicationRecord
   belongs_to :instructeur
   belongs_to :procedure
+
+  attr_reader :without_group
 end

--- a/app/views/instructeurs/procedures/email_usagers.html.haml
+++ b/app/views/instructeurs/procedures/email_usagers.html.haml
@@ -10,17 +10,9 @@
 
 .messagerie.fr-container
   %h1.fr-h4= t('instructeurs.dossiers.header.banner.contact_users')
-  %p.fr-highlight
-    = sanitize(t('.hint', count: @dossiers_count), tags: %w(strong))
-  - if @dossiers_count.positive?
-    = form_for(@bulk_message, url: create_multiple_commentaire_instructeur_procedure_path, html: {  data: { controller: 'persisted-form', persisted_form_key_value: dom_id(@procedure, :bulk_message) } }) do |f|
 
-      %p.mandatory-explanation= t('asterisk_html', scope: [:utils])
-
-      = render Dsfr::InputComponent.new(form: f, attribute: :body, input_type: :text_area, opts: { rows: 5, placeholder:  t('views.shared.dossiers.messages.form.write_message_placeholder'), title:  t('views.shared.dossiers.messages.form.write_message_placeholder'), class: 'fr-input message-textarea'})
-
-      .fr-mt-3w
-        = f.submit t('views.shared.dossiers.messages.form.send_message'), class: 'fr-btn', data: { disable: true }
+  - if @dossiers_count_per_groupe_instructeur.values.sum.positive?
+    = render Instructeurs::BulkMessageFormComponent.new(current_instructeur:, procedure: @procedure, dossiers_count_per_groupe_instructeur: @dossiers_count_per_groupe_instructeur)
   - else
     .page-title.center
       %h2 Il n’y a aucun dossier en brouillon

--- a/app/views/instructeurs/procedures/email_usagers.html.haml
+++ b/app/views/instructeurs/procedures/email_usagers.html.haml
@@ -37,5 +37,5 @@
             .width-100
               %h2.claimant
                 %span.email= message.instructeur.email
-                %span.date a envoyé ce message à #{@dossiers_count} usagers le #{message.sent_at.strftime('%d/%m/%y à %H:%M')}
+                %span.date a envoyé ce message à #{message.dossier_count} usagers le #{message.sent_at.strftime('%d/%m/%y à %H:%M')}
               %p= message.body

--- a/config/locales/models/bulk_message/fr.yml
+++ b/config/locales/models/bulk_message/fr.yml
@@ -6,4 +6,4 @@ fr:
         other: "Messages aux usagers"
     attributes:
       bulk_message:
-        body: "Message envoyé aux destinataires :"
+        body: "Message à envoyer aux usagers"

--- a/config/locales/views/instructeurs/procedures/en.yml
+++ b/config/locales/views/instructeurs/procedures/en.yml
@@ -7,11 +7,6 @@ en:
       show:
         file_tracking: File tracking
         reinit_display: Your display had to be reset due to a technical issue.
-      email_usagers:
-        hint:
-          zero: "There is no user with a draft."
-          one: "You will send a message to <strong>1</strong> user."
-          other: "You will send a message to <strong>%{count}</strong> users."
       administrators_list:
         title: Procedure administrators
       exports:

--- a/config/locales/views/instructeurs/procedures/fr.yml
+++ b/config/locales/views/instructeurs/procedures/fr.yml
@@ -7,10 +7,5 @@ fr:
       show:
         file_tracking: Suivi des dossiers
         reinit_display: Votre affichage a dû être réinitialisé en raison d'un problème technique.
-      email_usagers:
-        hint:
-          zero: "Aucun usager n'a de dossier en brouillon."
-          one: "Vous allez envoyer un message à <strong>1</strong> usager ayant un dossier en brouillon."
-          other: "Vous allez envoyer un message à <strong>%{count}</strong> usagers ayant un dossier en brouillon."
       administrators_list:
         title: Administrateurs de la démarche

--- a/spec/components/instructeurs/bulk_message_form_component_spec.rb
+++ b/spec/components/instructeurs/bulk_message_form_component_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-describe Instructeurs::BulkMessageFormComponent do
+describe Instructeurs::BulkMessageFormComponent, type: :component do
   let(:component) { described_class.new(procedure:, current_instructeur:, dossiers_count_per_groupe_instructeur:) }
   let(:current_instructeur) { create(:instructeur) }
-  let(:procedure) { create(:procedure) }
 
   describe ".default_dossiers_count" do
+    let(:procedure) { create(:procedure) }
     subject { component.default_dossiers_count }
 
     context 'when routing' do
@@ -47,6 +47,35 @@ describe Instructeurs::BulkMessageFormComponent do
       end
       it 'counts all (including count for dossier without groupe instructeur)' do
         expect(subject).to eq(dossiers_count_per_groupe_instructeur.values.sum)
+      end
+    end
+  end
+
+  describe 'render' do
+    let(:dossiers_count_per_groupe_instructeur) do
+      procedure.dossiers.state_brouillon.group(:groupe_instructeur_id).count
+    end
+    subject { render_inline(component).to_html }
+
+    context 'when group instructeur has a brouillon and has current instructeurs part of it' do
+      let(:procedure) { create(:procedure, routing_enabled: true, instructeurs: [current_instructeur]) }
+      it 'is expected to render the groupe' do
+        create(:dossier, :brouillon, procedure:, groupe_instructeur: procedure.groupe_instructeurs.first)
+        expect(subject).not_to have_selector("hr.fr-hr") # no other group from current_instructeur having brouillon, this part is not rendered
+        expect(subject).to have_selector("input#bulk_message_groupe_instructeur_ids_#{procedure.groupe_instructeurs.first.id}[checked=checked]")
+        expect(subject).to have_content("1 usager (vous êtes présent dans ce groupe instructeurs)")
+      end
+    end
+
+    context 'when group instructeur has a brouillon but current instructeurs is not part of it' do
+      let(:procedure) { create(:procedure, routing_enabled: true, instructeurs: []) }
+
+      it 'is expected to render the groupe' do
+        create(:dossier, :brouillon, procedure:, groupe_instructeur: procedure.groupe_instructeurs.first)
+        create(:dossier, :brouillon, procedure:, groupe_instructeur: procedure.groupe_instructeurs.first)
+        expect(subject).to have_selector("hr.fr-hr") # groupes having brouillon not part of current instructeur are separated by hr
+        expect(subject).not_to have_selector("input#bulk_message_groupe_instructeur_ids_#{procedure.groupe_instructeurs.first.id}[checked=checked]")
+        expect(subject).to have_content("2 usagers (vous n'êtes pas présent dans ce groupe instructeurs)")
       end
     end
   end

--- a/spec/components/instructeurs/bulk_message_form_component_spec.rb
+++ b/spec/components/instructeurs/bulk_message_form_component_spec.rb
@@ -87,5 +87,21 @@ describe Instructeurs::BulkMessageFormComponent, type: :component do
         expect(subject).to have_content("Contacter également l'usager qui n'a pas encore renseigné le(s) champ(s) de routage")
       end
     end
+
+    describe 'select all or not' do
+      context 'when groupe_instructeur < treshold' do
+        before { allow(component).to receive(:render_select_all?).and_return(false) }
+        let(:procedure) { create(:procedure, routing_enabled: true, instructeurs: []) }
+
+        it { is_expected.not_to have_selector("#bulk-message-select-all") }
+      end
+
+      context 'when groupe_instructeur > treshold' do
+        before { allow(component).to receive(:render_select_all?).and_return(true) }
+        let(:procedure) { create(:procedure, routing_enabled: true, instructeurs: []) }
+
+        it { is_expected.to have_selector("#bulk-message-select-all") }
+      end
+    end
   end
 end

--- a/spec/components/instructeurs/bulk_message_form_component_spec.rb
+++ b/spec/components/instructeurs/bulk_message_form_component_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+describe Instructeurs::BulkMessageFormComponent do
+  let(:component) { described_class.new(procedure:, current_instructeur:, dossiers_count_per_groupe_instructeur:) }
+  let(:current_instructeur) { create(:instructeur) }
+  let(:procedure) { create(:procedure) }
+
+  describe ".default_dossiers_count" do
+    subject { component.default_dossiers_count }
+
+    context 'when routing' do
+      let(:procedure) { create(:procedure, routing_enabled: true, groupe_instructeurs: [gi_1, gi_2]) }
+      let(:dossiers_count_per_groupe_instructeur) do
+        {
+          nil: 10,
+          gi_1.id => 15,
+          gi_2.id => 20
+        }
+      end
+
+      context 'when enabled and instructeur in all groupes' do
+        let(:gi_1) { create(:groupe_instructeur, instructeurs: [current_instructeur]) }
+        let(:gi_2) { create(:groupe_instructeur, instructeurs: [current_instructeur]) }
+
+        it 'counts all (including count for dossier without groupe instructeur)' do
+          expect(subject).to eq(dossiers_count_per_groupe_instructeur.values.sum)
+        end
+      end
+
+      context 'when enabled and instructeur in groupe' do
+        let(:gi_1) { create(:groupe_instructeur, instructeurs: [current_instructeur]) }
+        let(:gi_2) { create(:groupe_instructeur, instructeurs: [create(:instructeur)]) }
+
+        it 'counts only dossiers for his groupe_instructeurs' do
+          expect(subject).to eq(dossiers_count_per_groupe_instructeur[gi_1.id])
+        end
+      end
+    end
+
+    context 'when routing disabled' do
+      let(:procedure) { create(:procedure, routing_enabled: false) }
+      let(:dossiers_count_per_groupe_instructeur) do
+        {
+          nil: 10,
+          procedure.groupe_instructeurs.first.id => 15
+        }
+      end
+      it 'counts all (including count for dossier without groupe instructeur)' do
+        expect(subject).to eq(dossiers_count_per_groupe_instructeur.values.sum)
+      end
+    end
+  end
+end

--- a/spec/components/instructeurs/bulk_message_form_component_spec.rb
+++ b/spec/components/instructeurs/bulk_message_form_component_spec.rb
@@ -78,5 +78,14 @@ describe Instructeurs::BulkMessageFormComponent, type: :component do
         expect(subject).to have_content("2 usagers (vous n'êtes pas présent dans ce groupe instructeurs)")
       end
     end
+
+    context 'when dossier without group exists' do
+      let(:procedure) { create(:procedure, routing_enabled: true, instructeurs: []) }
+
+      it 'is expected to render the groupe' do
+        create(:dossier, :brouillon, procedure:, groupe_instructeur: nil)
+        expect(subject).to have_content("Contacter également l'usager qui n'a pas encore renseigné le(s) champ(s) de routage")
+      end
+    end
   end
 end

--- a/spec/controllers/instructeurs/procedures_controller_spec.rb
+++ b/spec/controllers/instructeurs/procedures_controller_spec.rb
@@ -781,7 +781,7 @@ describe Instructeurs::ProceduresController, type: :controller do
     context 'when authenticated' do
       before { sign_in(instructeur.user) }
 
-      context 'the procedure is not routed' do
+      context 'the procedure is not routed (or not)' do
         let(:instructeur) { create(:instructeur) }
         let(:defaut_groupe_instructeur) { procedure.defaut_groupe_instructeur }
         let!(:dossier_in_group) { create(:dossier, :brouillon, procedure:, groupe_instructeur: defaut_groupe_instructeur) }
@@ -789,24 +789,9 @@ describe Instructeurs::ProceduresController, type: :controller do
 
         before { defaut_groupe_instructeur.instructeurs << instructeur }
 
-        it 'lists all the brouillon' do
+        it 'count brouillon per group and not in group' do
           is_expected.to have_http_status(200)
-          expect(assigns(:dossiers_count)).to eq(2) # only dossier_in_group
-        end
-      end
-
-      context 'the procedure is routed' do
-        let!(:gi_1) { create(:groupe_instructeur, label: 'gi_1', procedure:, instructeurs: [instructeur]) }
-        let(:instructeur) { create(:instructeur) }
-
-        context 'when instructor has groups' do
-          let!(:dossier_in_group) { create(:dossier, :brouillon, procedure: procedure, groupe_instructeur: gi_1) }
-          let!(:dossier_without_groupe) { create(:dossier, :brouillon, procedure: procedure, groupe_instructeur: nil) }
-
-          it 'lists only dossiers in instructor groups' do
-            is_expected.to have_http_status(200)
-            expect(assigns(:dossiers_count)).to eq(1) # only dossier_in_group
-          end
+          expect(assigns(:dossiers_count_per_groupe_instructeur)).to match({ nil => 1, defaut_groupe_instructeur.id => 1 }) # only dossier_in_group
         end
       end
     end

--- a/spec/controllers/instructeurs/procedures_controller_spec.rb
+++ b/spec/controllers/instructeurs/procedures_controller_spec.rb
@@ -799,50 +799,89 @@ describe Instructeurs::ProceduresController, type: :controller do
 
   describe '#create_multiple_commentaire' do
     let(:instructeur) { create(:instructeur) }
-    let!(:gi_p1_1) { create(:groupe_instructeur, label: '1', procedure: procedure, instructeurs: [instructeur]) }
-    let!(:gi_p1_2) { create(:groupe_instructeur, label: '2', procedure: procedure) }
     let(:body) { "avant\napres" }
     let(:bulk_message) { BulkMessage.first }
-    let!(:dossier) { create(:dossier, state: "brouillon", procedure: procedure, groupe_instructeur: gi_p1_1) }
-    let!(:dossier_2) { create(:dossier, state: "brouillon", procedure: procedure, groupe_instructeur: gi_p1_1) }
-    let!(:dossier_3) { create(:dossier, state: "brouillon", procedure: procedure, groupe_instructeur: gi_p1_2) }
-    let!(:procedure) { create(:procedure, :published, instructeurs: [instructeur]) }
 
     before do
       sign_in(instructeur.user)
       procedure
     end
 
-    let!(:dossier_4) { create(:dossier, state: "brouillon", procedure: procedure, groupe_instructeur: nil) }
-    before do
-      post :create_multiple_commentaire,
+    context 'when routing not enabled' do
+      let(:procedure) { create(:procedure, :published, instructeurs: [instructeur], routing_enabled: false) }
+      let!(:dossier) { create(:dossier, :brouillon, procedure:) }
+      let!(:dossier_2) { create(:dossier, :brouillon, procedure:) }
+      let!(:dossier_3) { create(:dossier, :brouillon, procedure:) }
+      let!(:dossier_4) { create(:dossier, :brouillon, procedure:) }
+
+      it "creates commentaires for all dossiers, dossier.groupe_instructeur does not matter" do
+        expect do
+            post :create_multiple_commentaire,
+              params: {
+                procedure_id: procedure.id,
+                bulk_message: { body: body }
+              }
+          end.to change { Commentaire.count }.from(0).to(4)
+        [dossier, dossier_2, dossier_3, dossier_4].each do |any_dossier|
+          expect(any_dossier.commentaires.first.body).to eq("avant\napres")
+        end
+      end
+    end
+
+    context 'when routing_enabled' do
+      let!(:procedure) { create(:procedure, :published, instructeurs: [instructeur]) }
+
+      let!(:gi_p1_2) { create(:groupe_instructeur, label: '2', procedure: procedure) }
+      let!(:gi_p1_1) { create(:groupe_instructeur, label: '1', procedure: procedure, instructeurs: [instructeur]) }
+      let!(:dossier) { create(:dossier, state: "brouillon", procedure: procedure, groupe_instructeur: gi_p1_1) }
+      let!(:dossier_2) { create(:dossier, state: "brouillon", procedure: procedure, groupe_instructeur: gi_p1_1) }
+      let!(:dossier_3) { create(:dossier, state: "brouillon", procedure: procedure, groupe_instructeur: gi_p1_2) }
+      let!(:dossier_4) { create(:dossier, state: "brouillon", procedure: procedure, groupe_instructeur: nil) }
+
+      context 'when groupe instructeur id is specified' do
+        it "creates a Bulk Message for given group_instructeur_ids" do
+          expect do
+            post :create_multiple_commentaire,
             params: {
               procedure_id: procedure.id,
-              bulk_message: { body: body }
+              bulk_message: {
+                body: body,
+                groupe_instructeur_ids: { gi_p1_1.id => true, gi_p1_2.id => false }
+              }
             }
-    end
+          end.to change { Commentaire.count }.from(0).to(2)
+          expect(dossier.commentaires.first.body).to eq(body)
+          expect(dossier_2.commentaires.first.body).to eq(body)
+          expect(dossier_3.commentaires.count).to eq(0)
+          expect(dossier_4.commentaires.count).to eq(0)
+          expect(flash.notice).to be_present
+          expect(flash.notice).to eq("Tous les messages ont été envoyés avec succès")
+          expect(response).to redirect_to instructeur_procedure_path(procedure)
+        end
+      end
 
-    it "creates commentaires for dossiers in instructor's groups" do
-      expect(Commentaire.count).to eq(2)
-      expect(dossier.commentaires.first.body).to eq("avant\napres")
-      expect(dossier_2.commentaires.first.body).to eq("avant\napres")
-      expect(dossier_3.commentaires).to eq([])
-      expect(dossier_4.commentaires).to eq([])
-    end
-
-    it "creates a Bulk Message for 2 groupes instructeurs" do
-      expect(BulkMessage.count).to eq(1)
-      expect(bulk_message.body).to eq("avant\napres")
-      expect(bulk_message.procedure_id).to eq(procedure.id)
-    end
-
-    it "creates a flash notice" do
-      expect(flash.notice).to be_present
-      expect(flash.notice).to eq("Tous les messages ont été envoyés avec succès")
-    end
-
-    it "redirect to instructeur_procedure_path" do
-      expect(response).to redirect_to instructeur_procedure_path(procedure)
+      context 'when routing_enabled and without_group is specified' do
+        it "creates a Bulk Message for dossier without group_instructeur_ids" do
+          expect do
+            post :create_multiple_commentaire,
+            params: {
+              procedure_id: procedure.id,
+              bulk_message: {
+                body: body,
+                groupe_instructeur_ids: {},
+                without_group: "1"
+              }
+            }
+          end.to change { Commentaire.count }.from(0).to(1)
+          expect(dossier.commentaires.count).to eq(0)
+          expect(dossier_2.commentaires.count).to eq(0)
+          expect(dossier_3.commentaires.count).to eq(0)
+          expect(dossier_4.commentaires.first.body).to eq(body)
+          expect(flash.notice).to be_present
+          expect(flash.notice).to eq("Tous les messages ont été envoyés avec succès")
+          expect(response).to redirect_to instructeur_procedure_path(procedure)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
# probleme

on fait des A/Rs régulièrement sur cette feature. cf; https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/11157

# solution 

## demarche ac >= 6 groupes d'instructeur

![Screenshot 2025-02-21 at 07-11-20 Contacter les usagers pour Aide à la transmission à l’action culturelle et territoriale à la langue française et aux langues de France · demarches-simplifiees fr](https://github.com/user-attachments/assets/8f7aab12-e154-493a-9a69-f7592fa36b77)


## demarche ac < 6 groupe instructeur

![Screenshot 2025-02-21 at 07-11-54 Contacter les usagers pour Erreur de siret · demarches-simplifiees fr](https://github.com/user-attachments/assets/ca3a6270-fbbb-4af6-9fb8-20ff09496744)

## demarche sans groupe d'instructeur

![Screenshot 2025-02-21 at 07-14-35 Contacter les usagers pour repetition · demarches-simplifiees fr](https://github.com/user-attachments/assets/bf14cfd7-0ca7-4d24-aabd-6dae16a2e153)

