### PR TITLE
ETQ utilisateur d'un lecteur d'écran, je veux que les messages d'alertes/d'info me soient restitués

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -28,12 +28,12 @@ class AttachmentsController < ApplicationController
         champ.update_timestamps
       end
       champ.piece_justificative_file.reload
+      flash.notice = "La pièce jointe (#{@attachment.blob.filename}) a bien été supprimée. Vous pouvez en <a href=\"##{@champ.input_id}\">ajouter une autre</a>"
     else
       @attachment.purge_later
       @attachment_options = attachment_options
+      flash.notice = "La pièce jointe a bien été supprimée."
     end
-
-    flash.notice = 'La pièce jointe a bien été supprimée.'
 
     respond_to do |format|
       format.turbo_stream

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -28,11 +28,11 @@ class AttachmentsController < ApplicationController
         champ.update_timestamps
       end
       champ.piece_justificative_file.reload
-      flash.notice = "La pièce jointe (#{@attachment.blob.filename}) a bien été supprimée. Vous pouvez en <a href=\"##{@champ.input_id}\">ajouter une autre</a>"
+      flash.notice = t("activerecord.models.attachment.successfully_deleted_with_anchor", attachment: @attachment.blob.filename, champ: @champ.input_id)
     else
       @attachment.purge_later
       @attachment_options = attachment_options
-      flash.notice = "La pièce jointe a bien été supprimée."
+      flash.notice = t("activerecord.models.attachment.successfully_deleted_without_anchor", attachment: @attachment.blob.filename)
     end
 
     respond_to do |format|

--- a/app/views/attachments/destroy.turbo_stream.haml
+++ b/app/views/attachments/destroy.turbo_stream.haml
@@ -2,7 +2,6 @@
   = fields_for @champ.input_name, @champ do |form|
     = turbo_stream.replace @champ.input_group_id do
       = render EditableChamp::EditableChampComponent.new champ: @champ, form: form
-  = turbo_stream.focus_all "#attachment-multiple-empty-#{@champ.public_id} input"
 - else
   = turbo_stream.replace dom_id(@attachment, :edit) do
     = render Attachment::EditComponent.new(**@attachment_options)

--- a/app/views/layouts/_flash_messages.html.haml
+++ b/app/views/layouts/_flash_messages.html.haml
@@ -1,5 +1,5 @@
 - displayable_flash = flash.filter { |key, _| key.in?(['notice', 'alert']) }
-#flash_messages{ tabindex: '-1', data: { turbo_force: :server } }
+#flash_messages{ tabindex: '-1', data: { turbo_force: :server }.merge(displayable_flash.any? ? {controller: :autofocus} : {}) }
   #flash_message.center{ class: defined?(unique_classname) ? unique_classname : '' }
     - if displayable_flash.any?
       - displayable_flash.each do |key, value|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -597,6 +597,9 @@ en:
       user:
         one: User
         other: Users
+      attachment:
+        successfully_deleted_with_anchor: 'The attachment (%{attachment}) has been deleted. You can now <a href="#%{champ}">add another</a>.'
+        successfully_deleted_without_anchor: 'The attachment (%{attachment}) has been deleted.'
 
     attributes:
       default_attributes: &default_attributes

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -318,9 +318,9 @@ en:
         resent: 'Resend the confirmation email'
     invites:
       create:
-        success: "One invitation has been sent to %{email}."
+        success: 'An invitation has been sent to %{email}. You can <a href="#invite-content_button">create another one</a>.'
       destroy:
-        success: "The permission given to %{email} had been revoked."
+        success: 'The permission given to %{email} had been revoked. You can <a href="#invite-content_button">create another one</a>.'
         error: "You can't revoke this invitation"
       dropdown:
         invite_to_edit: Invite someone to edit this file

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -604,6 +604,9 @@ fr:
       user:
         one: Utilisateur
         other: Utilisateurs
+      attachment:
+        successfully_deleted_with_anchor: 'La pièce jointe (%{attachment}) a bien été supprimée. Vous pouvez en <a href="#%{champ}">ajouter une autre</a>.'
+        successfully_deleted_without_anchor: 'La pièce jointe (%{attachment}) a bien été supprimée.'
 
     attributes:
       default_attributes: &default_attributes

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -315,9 +315,9 @@ fr:
         resent: 'Renvoyer un email de confirmation'
     invites:
       create:
-        success: "Une invitation a été envoyée à %{email}."
+        success: 'Une invitation a été envoyée à %{email}. Vous pouvez en <a href="#invite-content_button">créer une autre</a>.'
       destroy:
-        success: "L’autorisation de %{email} vient d’être révoquée."
+        success: 'L’autorisation de %{email} vient d’être révoquée. Vous pouvez en <a href="#invite-content_button">créer une autre</a>.'
         error: "Vous ne pouvez pas révoquer cette autorisation"
       dropdown:
         invite_to_edit: Inviter une personne à modifier ce dossier

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -388,8 +388,7 @@ describe 'The user', js: true do
     expect(page).to have_text('white.png')
 
     click_on("Supprimer le fichier file.pdf")
-    expect(page).not_to have_text('file.pdf')
-    expect(page).to have_text("La pièce jointe a bien été supprimée")
+    expect(page).to have_text("La pièce jointe (file.pdf) a bien été supprimée. Vous pouvez en ajouter une autre.")
 
     attach_file('Pièce justificative 1', Rails.root + 'spec/fixtures/files/black.png')
 

--- a/spec/system/users/en_construction_spec.rb
+++ b/spec/system/users/en_construction_spec.rb
@@ -20,7 +20,7 @@ describe "Dossier en_construction", js: true do
     click_on "Supprimer le fichier toto.txt"
 
     wait_until { champ.reload.blank? }
-    expect(page).not_to have_text("toto.txt")
+    expect(page).to have_text("La pièce jointe (toto.txt) a bien été supprimée. Vous pouvez en ajouter une autre.")
   end
 
   context "with a mandatory piece justificative" do
@@ -32,7 +32,7 @@ describe "Dossier en_construction", js: true do
       visit_dossier(dossier)
 
       click_on "Supprimer le fichier toto.txt"
-      expect(page).not_to have_text("toto.txt")
+      expect(page).to have_text("La pièce jointe (toto.txt) a bien été supprimée. Vous pouvez en ajouter une autre.")
 
       input_selector = "#attachment-multiple-empty-#{champ.public_id}"
       expect(page).to have_selector(input_selector)
@@ -56,7 +56,7 @@ describe "Dossier en_construction", js: true do
       visit_dossier(dossier)
 
       click_on "Supprimer le fichier toto.png"
-      expect(page).not_to have_text("toto.png")
+      expect(page).to have_text("La pièce jointe (toto.png) a bien été supprimée. Vous pouvez en ajouter une autre.")
 
       input_selector = "##{champ.input_id}"
       expect(page).to have_selector(input_selector)


### PR DESCRIPTION
Fix #6780

- Lorsqu'un bandeau est affiché suite à un changement de page, le focus est déplacé sur ce dernier.   
- Lorsqu'un bandeau est affiché suite à un rechargement de page, le focus est déplacé sur ce dernier et un lien pointant vers une ancre dans la page est ajouté. Cela permet à l'usager de retourner sur le champs ou sur le bouton permettant d'afficher le champ qu'il était en train de remplir.

Il reste possiblement des trous dans la raquettes qui seront traitées au cas par cas.