### PR TITLE
ETQ usager, je veux que l'exemple du champ RNF ne soit pas indiqué comme un format

### DIFF
--- a/config/locales/models/champs/rnf_champ/en.yml
+++ b/config/locales/models/champs/rnf_champ/en.yml
@@ -18,4 +18,4 @@ en:
     attributes:
       champs/rnf_champ:
           hints:
-            value_html: "Expected format: <span aria-hidden='true'>075-FDD-00003-01</span> <span class='sr-only'>075 hyphen FDD hyphen 00003 hyphen 01</span>"
+            value_html: "Example: <span aria-hidden='true'>075-FDD-00003-01</span> <span class='sr-only'>075 hyphen FDD hyphen 00003 hyphen 01</span>"

--- a/config/locales/models/champs/rnf_champ/fr.yml
+++ b/config/locales/models/champs/rnf_champ/fr.yml
@@ -18,4 +18,4 @@ fr:
     attributes:
       champs/rnf_champ:
           hints:
-            value_html: "Format attendu : <span aria-hidden='true'>075-FDD-00003-01</span> <span class='sr-only'>075 tiret FDD tiret 00003 tiret 01</span>"
+            value_html: "Exemple : <span aria-hidden='true'>075-FDD-00003-01</span> <span class='sr-only'>075 tiret FDD tiret 00003 tiret 01</span>"


### PR DESCRIPTION
Fix #11356

__Après__
<img width="427" alt="" src="https://github.com/user-attachments/assets/70657e34-3a71-41a9-ade1-b7387a56a711" />

__Avant__
<img width="426" alt="" src="https://github.com/user-attachments/assets/f177a6af-65fd-47db-98df-139a95868a51" />
