### PR TITLE
ETQ admin, corrige le routage et conditionnel pour les champs référentiels

### DIFF
--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -66,7 +66,7 @@ module Administrateurs
         tdc_options = APIGeoService.countries.map { ["#{_1[:code]} – #{_1[:name]}", _1[:code]] }
         create_groups_from_territorial_tdc(tdc_options, stable_id, rule_operator)
       when TypeDeChamp.type_champs.fetch(:drop_down_list)
-        tdc_options = tdc.drop_down_options.reject(&:empty?)
+        tdc_options = tdc.drop_down_options(only_names: true).reject(&:empty?)
         create_groups_from_drop_down_list_tdc(tdc_options, stable_id)
       end
 

--- a/app/models/logic/champ_value.rb
+++ b/app/models/logic/champ_value.rb
@@ -137,7 +137,7 @@ class Logic::ChampValue < Logic::Term
     elsif tdc.type_champ == MANAGED_TYPE_DE_CHAMP.fetch(:pays)
       APIGeoService.countries.map { ["#{_1[:name]} – #{_1[:code]}", _1[:code]] }
     else
-      tdc.drop_down_options_with_other.map { _1.is_a?(Array) ? _1 : [_1, _1] }
+      tdc.drop_down_options_with_other(only_names: true).map { _1.is_a?(Array) ? _1 : [_1, _1] }
     end
   end
 

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -377,12 +377,17 @@ class TypeDeChamp < ApplicationRecord
     drop_down_mode == 'advanced'
   end
 
-  def drop_down_options(simple: false)
+  def drop_down_options(simple: false, only_names: false)
     return Array.wrap(super()) if simple
+
     if referentiel_mode?
       return if referentiel.nil?
       header = referentiel.headers.first.parameterize.underscore
-      Array.wrap(referentiel.items.map { [_1.data.values.first[header], _1.id] })
+      combined = Array.wrap(referentiel.items.map { [_1.data.values.first[header], _1.id] })
+
+      return combined unless only_names
+
+      combined.map(&:first)
     else
       Array.wrap(super())
     end
@@ -392,11 +397,11 @@ class TypeDeChamp < ApplicationRecord
     self.drop_down_options = text.to_s.lines.map(&:strip).reject(&:empty?)
   end
 
-  def drop_down_options_with_other
+  def drop_down_options_with_other(only_names: false)
     if drop_down_other?
-      drop_down_options + [[I18n.t('shared.champs.drop_down_list.other'), Champs::DropDownListChamp::OTHER]]
+      drop_down_options(only_names:) + [[I18n.t('shared.champs.drop_down_list.other'), Champs::DropDownListChamp::OTHER]]
     else
-      drop_down_options
+      drop_down_options(only_names:)
     end
   end
 

--- a/app/views/administrateurs/groupe_instructeurs/simple_routing.html.haml
+++ b/app/views/administrateurs/groupe_instructeurs/simple_routing.html.haml
@@ -42,7 +42,7 @@
         .card.fr-pb-0{ data: { 'action': "click->enable-submit-if-checked#click" } }
           .notice
             Sélectionner le champ à partir duquel créer des groupes d’instructeurs
-          - buttons_content = @procedure.active_revision.simple_routable_types_de_champ.map { |tdc| { label: tdc.libelle, value: tdc.stable_id, hint: "[#{I18n.t(tdc.type_champ, scope: 'activerecord.attributes.type_de_champ.type_champs')}]", tooltip: tdc.drop_down_options.join(", ")} }
+          - buttons_content = @procedure.active_revision.simple_routable_types_de_champ.map { |tdc| { label: tdc.libelle, value: tdc.stable_id, hint: "[#{I18n.t(tdc.type_champ, scope: 'activerecord.attributes.type_de_champ.type_champs')}]", tooltip: tdc.drop_down_options(only_names: true).join(", ")} }
           = render Dsfr::RadioButtonListComponent.new(form: f,
             target: :stable_id,
             buttons: buttons_content)

--- a/spec/models/logic/champ_value_spec.rb
+++ b/spec/models/logic/champ_value_spec.rb
@@ -87,6 +87,22 @@ describe Logic::ChampValue do
       end
     end
 
+    context 'dropdown tdc advanced' do
+      let(:tdc_type) { :drop_down_list }
+      let(:champ) { Champs::DropDownListChamp.new(value:, stable_id: tdc.stable_id, dossier:) }
+      let(:item) { tdc.referentiel.items.find { _1.data["row"]["option"] == "fromage" } }
+      let(:value) { item.id }
+      let(:referentiel) { create(:csv_referentiel, :with_items) }
+
+      before {
+        tdc.update!(referentiel:, drop_down_mode: "advanced")
+      }
+
+      it { expect(champ_value(champ.stable_id).type([champ.type_de_champ])).to eq(:enum) }
+      it { is_expected.to eq(item.id.to_s) }
+      it { expect(champ_value(champ.stable_id).options([champ.type_de_champ])).to match_array([["dessert", "dessert"], ["fromage", "fromage"], ["fruit", "fruit"]]) }
+    end
+
     context 'checkbox tdc' do
       let(:tdc_type) { :checkbox }
       let(:champ) { Champs::CheckboxChamp.new(value:, stable_id: tdc.stable_id, dossier:) }


### PR DESCRIPTION
(WIP)

Actuellement pour les champs refs on stock l'id de l'item pour la value et les méthodes pour récupérer les options renvoient [{name, id }]
Mais on peut pas réutiliser les ids pour les règles de routage et conditionnel, sinon ce sera pas clonable. Donc pour le moment j'ai du rajouter une couche qui renvoie les options sous forme [{name name }]. C'est aussi nécessaire pour avoir un affichage correct du nom d'un group de routage ou dans le conditionnel.

Rest à faire : matcher la value (ou sa row) avec ces labels pour faire tomber dans les bonnes règles de conditionnel  ou du routage


Je me demande si ça serait pas plus simple de stocker la valeur visible dans la value d'un champ plutôt que l'id de l'item pour éviter ces pirouettes dans les méthodes. Mais il y avait peut-être des bonnes raisons de faire comme ça ?