### PR TITLE
[Tech] Migrer les PathRewrite vers ProcedurePath 

### DIFF
--- a/app/tasks/maintenance/t20250219_migrate_path_rewrite_to_procedure_paths_task.rb
+++ b/app/tasks/maintenance/t20250219_migrate_path_rewrite_to_procedure_paths_task.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20250219MigratePathRewriteToProcedurePathsTask < MaintenanceTasks::Task
+    # Documentation: cette tâche modifie les données pour ne plus utiliser les PathRewrite mais les ProcedurePaths
+
+    include RunnableOnDeployConcern
+    include StatementsHelpersConcern
+
+    # Uncomment only if this task MUST run imperatively on its first deployment.
+    # If possible, leave commented for manual execution later.
+    run_on_first_deploy
+
+    def collection
+      PathRewrite.all
+    end
+
+    def process(element)
+      destination_procedure = Procedure.find_with_path(element.to).first
+
+      if destination_procedure.nil?
+        Rails.logger.info("Destination procedure not found for #{element.to} (#{element.id}), skipping")
+        return
+      end
+
+      origin_procedure = Procedure.find_with_path(element.from).first
+
+      if origin_procedure == destination_procedure
+        Rails.logger.info("Destination procedure is the same as the source procedure (#{element.id}), skipping")
+        return
+      end
+
+      previous_canonical_path = destination_procedure.canonical_path
+
+      destination_procedure.claim_path!(destination_procedure.administrateurs.first, element.from)
+
+      # reset the canonical path
+      destination_procedure.claim_path!(destination_procedure.administrateurs.first, previous_canonical_path)
+    end
+  end
+end

--- a/spec/factories/path_rewrite.rb
+++ b/spec/factories/path_rewrite.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  sequence(:unique_from_path) { |n| "source-path#{n}" }
+
+  factory :path_rewrite do
+    from { generate(:unique_from_path) }
+    to { "destination-path" }
+  end
+end

--- a/spec/tasks/maintenance/t20250219_migrate_path_rewrite_to_procedure_paths_task_spec.rb
+++ b/spec/tasks/maintenance/t20250219_migrate_path_rewrite_to_procedure_paths_task_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe T20250219MigratePathRewriteToProcedurePathsTask do
+    describe "#process" do
+      subject(:process) { described_class.process(path_rewrite) }
+
+      let(:administrateur) { create(:administrateur) }
+      let(:path_rewrite) { create(:path_rewrite, from: "source-path", to: "destination-path") }
+
+      context "when destination procedure exists" do
+        let!(:destination_procedure) { create(:procedure, path: "destination-path", administrateurs: [administrateur]) }
+
+        it "adds the source path to the destination procedure" do
+          expect { process }.to change {
+            destination_procedure.reload.procedure_paths.where(path: "source-path").count
+          }.from(0).to(1)
+        end
+
+        it "maintains the original canonical path" do
+          original_canonical_path = destination_procedure.canonical_path
+          process
+          expect(destination_procedure.reload.canonical_path).to eq(original_canonical_path)
+        end
+      end
+
+      context "when destination procedure does not exist" do
+        it "skips processing and logs a message" do
+          expect(Procedure).to receive(:find_with_path).with(path_rewrite.to).and_return([])
+          expect(Rails.logger).to receive(:info).with(/Destination procedure not found/)
+
+          process
+        end
+      end
+
+      context "when source and destination paths already link to the same procedure" do
+        let!(:destination_procedure) { create(:procedure, path: "destination-path", administrateurs: [administrateur]) }
+
+        before do
+          destination_procedure.claim_path!(administrateur, "source-path")
+        end
+
+        it "skips processing and logs a message" do
+          expect(Rails.logger).to receive(:info).with(/Destination procedure is the same as the source procedure/)
+
+          expect { process }.not_to change { ProcedurePath.count }
+        end
+      end
+    end
+
+    describe "#collection" do
+      subject { described_class.new.collection }
+
+      before do
+        create_list(:path_rewrite, 3)
+      end
+
+      it "returns all PathRewrite records" do
+        expect(subject.count).to eq(3)
+        expect(subject).to all(be_a(PathRewrite))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Maintenant qu'on peut avoir plusieurs chemin qui mène à la même démarche, on peut migrer les PathRewrite vers le nouveau système.
