### PR TITLE
fix: ETQ-admin, ne pas permettre de choisir un groupe inactif comme par défaut

### DIFF
--- a/app/components/procedure/groupes_management_component/groupes_management_component.html.haml
+++ b/app/components/procedure/groupes_management_component/groupes_management_component.html.haml
@@ -56,9 +56,11 @@
   .fr-mt-1w
     = paginate @groupe_instructeurs
 
-= form_tag admin_procedure_update_defaut_groupe_instructeur_path,
+= form_for @procedure,
+  method: :patch,
+  url: admin_procedure_update_defaut_groupe_instructeur_path,
   class: 'fr-my-3w',
-  data: { controller: 'autosave' } do
+  data: { controller: 'autosubmit', turbo: 'true' } do
   = label_tag :defaut_groupe_instructeur_id, 'Et si aucune règle ne correspond, router vers :', class: 'fr-label'
   = select_tag :defaut_groupe_instructeur_id,
     options_for_select(@procedure.groupe_instructeurs.pluck(:label, :id), selected: @procedure.defaut_groupe_instructeur.id),

--- a/app/components/procedure/one_groupe_management_component/one_groupe_management_component.html.haml
+++ b/app/components/procedure/one_groupe_management_component/one_groupe_management_component.html.haml
@@ -15,19 +15,23 @@
       url: admin_procedure_groupe_instructeur_update_state_path(@procedure, @groupe_instructeur),
       method: :patch,
       data: { turbo: true, controller: 'autosubmit' } do |f|
-      .fr-checkbox-group.fr-my-3w
-        = f.check_box :closed, { id: 'closed', "aria-describedby" => "closed-messages", :name => "closed" }
+      .fr-checkbox-group.fr-mt-3w
+        = f.check_box :closed, { id: 'closed', "aria-describedby" => "closed-messages", :name => "closed", disabled: (!@groupe_instructeur.can_close?) }
         %label.fr-label{ :for => "closed" }
           Groupe inactif
           %span.fr-hint-text Si cette option est activée, les dossiers ne seront pas routés dans ce groupe si les usagers sélectionnent ce choix.
+    - if !@groupe_instructeur.can_close?
+      .fr-mt-1w
+        %em Vous ne pouvez pas désactiver le groupe d’instructeurs par défaut.
     - if @groupe_instructeur.can_delete?
       = button_to admin_procedure_groupe_instructeur_path(@procedure, @groupe_instructeur),
-      class: 'fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-delete-line',
+      class: 'fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-delete-line fr-mt-3w',
       method: :delete,
       data: { confirm: t('.delete_confirmation', group_name: @groupe_instructeur.label) } do
         Supprimer ce groupe
     - else
-      %em Vous ne pouvez pas supprimer ce groupe car des dossiers lui sont affectés.
+      .fr-mt-3w
+        %em Vous ne pouvez pas supprimer ce groupe car des dossiers lui sont affectés.
 
   %h2.fr-h3#dossiers-affectes Dossiers affectés
   .card

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -176,14 +176,10 @@ module Administrateurs
     def update_state
       @groupe_instructeur = procedure.groupe_instructeurs.find(params[:groupe_instructeur_id])
 
-      if @groupe_instructeur.update(closed: params[:closed])
-        state_for_notice = @groupe_instructeur.closed ? 'désactivé' : 'activé'
-        redirect_to admin_procedure_groupe_instructeur_path(procedure, @groupe_instructeur),
-          notice: "Le groupe #{@groupe_instructeur.label} est #{state_for_notice}."
-      else
-        redirect_to admin_procedure_groupe_instructeur_path(procedure, @groupe_instructeur),
-          alert: @groupe_instructeur.errors.messages_for(:closed).to_sentence
-      end
+      @groupe_instructeur.update!(closed: params[:closed])
+      state_for_notice = @groupe_instructeur.closed ? 'désactivé' : 'activé'
+      redirect_to admin_procedure_groupe_instructeur_path(procedure, @groupe_instructeur),
+        notice: "Le groupe « #{@groupe_instructeur.label} » est #{state_for_notice}."
     end
 
     def destroy

--- a/app/controllers/administrateurs/routing_rules_controller.rb
+++ b/app/controllers/administrateurs/routing_rules_controller.rb
@@ -35,8 +35,16 @@ module Administrateurs
     end
 
     def update_defaut_groupe_instructeur
-      new_defaut = @procedure.groupe_instructeurs.find(defaut_groupe_instructeur_id)
-      @procedure.update!(defaut_groupe_instructeur: new_defaut)
+      new_defaut_groupe = @procedure.groupe_instructeurs.find(defaut_groupe_instructeur_id)
+
+      if new_defaut_groupe.closed
+        flash.alert = "Il n'est pas possible de définir un groupe inactif par défaut."
+        redirect_to admin_procedure_groupe_instructeurs_path(@procedure)
+      else
+        @procedure.update!(defaut_groupe_instructeur: new_defaut_groupe)
+        flash.notice = "Le groupe par défaut est : « #{new_defaut_groupe.label} »."
+        redirect_to admin_procedure_groupe_instructeurs_path(@procedure)
+      end
     end
 
     private

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -75,6 +75,10 @@ class GroupeInstructeur < ApplicationRecord
     dossiers.empty? && (procedure.groupe_instructeurs.active.many? || (procedure.groupe_instructeurs.active.one? && closed))
   end
 
+  def can_close?
+    id != procedure.defaut_groupe_instructeur_id
+  end
+
   def routing_to_configure?
     invalid_rule? || non_unique_rule?
   end

--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -293,10 +293,8 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
   end
 
   describe '#update_state' do
-    let(:closed_value) { '0' }
     let!(:procedure_non_routee) { create(:procedure, :published, :for_individual, administrateurs: [admin]) }
-    let!(:gi_1_1) { procedure_non_routee.defaut_groupe_instructeur }
-    let!(:gi_1_2) { procedure_non_routee.groupe_instructeurs.create(label: 'deuxième groupe') }
+    let!(:group) { procedure_non_routee.groupe_instructeurs.create(label: 'groupe_instructeur') }
 
     before do
       patch :update_state,
@@ -308,25 +306,23 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
       group.reload
     end
 
-    context 'when we try do disable the default groupe instructeur' do
-      let(:closed_value) { '1' }
-      let(:group) { gi_1_1 }
+    context 'when we try to enable a groupe instructeur' do
+      let(:closed_value) { '0' }
 
       it do
-        expect(subject).to redirect_to admin_procedure_groupe_instructeur_path(procedure_non_routee, gi_1_1)
-        expect(gi_1_1.closed).to eq(false)
-        expect(flash.alert).to eq('Il est impossible de désactiver le groupe d’instructeurs par défaut.')
+        expect(subject).to redirect_to admin_procedure_groupe_instructeur_path(procedure_non_routee, group)
+        expect(group.closed).to eq(false)
+        expect(flash.notice).to eq('Le groupe « groupe_instructeur » est activé.')
       end
     end
 
-    context 'when we try do disable the second groupe instructeur' do
+    context 'when we try to disable a groupe instructeur' do
       let(:closed_value) { '1' }
-      let(:group) { gi_1_2 }
 
       it do
-        expect(subject).to redirect_to admin_procedure_groupe_instructeur_path(procedure_non_routee, gi_1_2)
-        expect(gi_1_2.closed).to eq(true)
-        expect(flash.notice).to eq('Le groupe deuxième groupe est désactivé.')
+        expect(subject).to redirect_to admin_procedure_groupe_instructeur_path(procedure_non_routee, group)
+        expect(group.closed).to eq(true)
+        expect(flash.notice).to eq('Le groupe « groupe_instructeur » est désactivé.')
       end
     end
   end


### PR DESCRIPTION
Pour une procédure dont le routage est activé, on a un groupe par défaut.

Actuellement, quand on cherche à rendre inactif celui-ci on a l'alerte et on bloque comme quoi on peut pas rendre inactif le groupe par défaut.
En revanche, quand on est sur la liste des groupes pour choisir celui que l'on désignera par défaut, on peut faire le choix comme groupe par défaut, un groupe même si celui est inactif.
Donc cela fait que l'instance devient invalide au regard des règles de validations. Ce qui pose des problème de création par ailleurs par le jeu des associations.