### PR TITLE
ETQ Usager ayant des difficultés à saisir du contenu, je veux que les champs me proposent l'autocompletion

### DIFF
--- a/app/components/editable_champ/email_component/email_component.html.haml
+++ b/app/components/editable_champ/email_component/email_component.html.haml
@@ -1,1 +1,1 @@
-= @form.email_field(:value, input_opts(id: @champ.input_id, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, required: @champ.required?))
+= @form.email_field(:value, input_opts(id: @champ.input_id, autocomplete: @champ.dossier.for_tiers? ? "off" : "email", aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, required: @champ.required?))

--- a/app/components/editable_champ/pays_component/pays_component.html.haml
+++ b/app/components/editable_champ/pays_component/pays_component.html.haml
@@ -1,1 +1,1 @@
-= @form.select :value, options, select_options, required: @champ.required?, id: @champ.input_id, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, class: "width-33-desktop width-100-mobile fr-select"
+= @form.select :value, options, select_options, required: @champ.required?, id: @champ.input_id, autocomplete: @champ.dossier.for_tiers? ? "off" : "country-name", aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, class: "width-33-desktop width-100-mobile fr-select"

--- a/app/components/editable_champ/phone_component/phone_component.html.haml
+++ b/app/components/editable_champ/phone_component/phone_component.html.haml
@@ -1,4 +1,4 @@
 -# Allowed @formats:
 -# very light validation is made client-side
 -# stronger validation is made server-side
-= @form.phone_field(:value, input_opts(id: @champ.input_id, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, required: @champ.required?, pattern: "[^a-z^A-Z]+"))
+= @form.phone_field(:value, input_opts(id: @champ.input_id, autocomplete: @champ.dossier.for_tiers? ? "off" : "tel", aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, required: @champ.required?, pattern: "[^a-z^A-Z]+"))

--- a/app/views/users/dossiers/transferer.html.haml
+++ b/app/views/users/dossiers/transferer.html.haml
@@ -14,7 +14,7 @@
       = form_for @transfer, url: transfers_path, class: "fr-mt-4w" do |f|
         .fr-input-group
           = f.label :email, t('.email_label'), class: "fr-label"
-          = f.email_field :email, required: true, class: "fr-input", autocomplete: "email"
+          = f.email_field :email, required: true, class: "fr-input"
 
         = f.hidden_field :dossier, value: @dossier.id
         = f.submit t('.submit'), class: 'fr-btn'


### PR DESCRIPTION
Fix #11378

# Ajout de l'autocomplétion pour les personnes remplissant une démarche pour elle-même
<img width="1112" alt="" src="https://github.com/user-attachments/assets/42d37a27-679a-4072-9993-c410b215de51" />
<img width="1107" alt="" src="https://github.com/user-attachments/assets/96d3b9cf-e02c-4216-9ee3-48b3ae50561c" />
<img width="1111" alt="" src="https://github.com/user-attachments/assets/0a78f5ea-4f6c-4283-b92e-b5c51f7d6390" />

# Désactivation de l'autocomplétion pour les personnes remplissant une démarche pour un tiers
<img width="940" alt="" src="https://github.com/user-attachments/assets/31d994eb-f083-477c-8a50-12d33fb6b5fd" />
<img width="932" alt="" src="https://github.com/user-attachments/assets/4fa3d8f7-92af-42d4-b4ae-3fa05636289f" />
<img width="960" alt="" src="https://github.com/user-attachments/assets/781cc605-f84b-494f-8351-0b68bcc80e7c" />

# Divers
- Suppression de l'attribut `autocomplete` sur le champ demandant l'adresse email d'un tiers pour lui transférer le dossier.