### PR TITLE
Correctif du design de la page Gestion des groupes (etq admin)

### DIFF
--- a/app/components/procedure/groupes_management_component/groupes_management_component.html.haml
+++ b/app/components/procedure/groupes_management_component/groupes_management_component.html.haml
@@ -33,7 +33,7 @@
           %tbody
             - @groupe_instructeurs.each do |gi|
               %tr
-                %td.fr-col-9{ scope: 'col' }
+                %td.fr-cell--multiline{ scope: 'col' }
                   = link_to admin_procedure_groupe_instructeur_path(@procedure, gi), class: 'fr-link' do
                     %span= gi.label
                   - if gi.closed
@@ -44,11 +44,11 @@
                     %p.fr-badge.fr-badge--warning.fr-badge--sm.fr-ml-1w règle déjà attribuée à #{gi.groups_with_same_rule}
                   %p= gi.routing_rule&.to_s(@procedure.active_revision.types_de_champ)
 
-                %td.fr-col-1{ scope: 'col' }
+                %td{ scope: 'col' }
                   %span.fr-mr-1w
                     #{gi.dossiers.visible_by_administration.size}
                   %span.fr-icon.fr-icon-folder-2-line.fr-mr-2w{ style: 'width: 25px; text-align: center;' }
-                %td.fr-col-2.fr-cell--right{ scope: 'col' }
+                %td.fr-cell--right{ scope: 'col' }
                   %span.fr-mr-1w
                     #{gi.instructeurs.count}
                   %span.fr-icon.fr-icon-user-line{ style: 'width: 25px; text-align: center;' }


### PR DESCRIPTION
Avant

<img width="1285" alt="Capture d’écran 2025-03-04 à 15 00 22" src="https://github.com/user-attachments/assets/338bdff8-578a-4cb6-bcbe-21163e314022" />


Après

<img width="1280" alt="Capture d’écran 2025-03-04 à 15 11 45" src="https://github.com/user-attachments/assets/f70ceeba-2694-4e14-92f7-6193b2b217a2" />
