### PR TITLE
Correction erreur lors de l'envoie des emails a l'ajout d'instructeurs via GraphQL

### DIFF
--- a/app/graphql/mutations/groupe_instructeur_ajouter_instructeurs.rb
+++ b/app/graphql/mutations/groupe_instructeur_ajouter_instructeurs.rb
@@ -13,12 +13,12 @@ module Mutations
 
     def resolve(groupe_instructeur:, instructeurs:)
       ids, emails = partition_instructeurs_by(instructeurs)
-      _, invalid_emails = groupe_instructeur.add_instructeurs(ids:, emails:)
+      added_instructers, invalid_emails = groupe_instructeur.add_instructeurs(ids:, emails:)
 
-      if instructeurs.present?
+      if added_instructers.present?
         groupe_instructeur.reload
         GroupeInstructeurMailer
-          .notify_added_instructeurs(groupe_instructeur, instructeurs, current_administrateur.email)
+          .notify_added_instructeurs(groupe_instructeur, added_instructers, current_administrateur.email)
           .deliver_later
       end
 


### PR DESCRIPTION
Fix #10816 

Correction de l'erreur `'{"extensions":{"code":"bad_request"},"message":"Unsupported argument type: Types::ProfileInput"}'` lors de la tentative d'ajout en GraphQL d'un nouvel instructeurs


Mutation utilisé : 
```graphql
mutation AjouterInstructeur($groupeInstructeurId: ID!, $email: String!) {
  groupeInstructeurAjouterInstructeurs(
    input: {groupeInstructeurId: $groupeInstructeurId, instructeurs: { email: $email } }
  ) {
    clientMutationId
  }
}
```