### PR TITLE
ETQ Administrateur je peux lister les administrateurs d'une démarche via l'api GraphQL

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -905,6 +905,11 @@ Une démarche
 """
 type Demarche {
   activeRevision: Revision!
+
+  """
+  Liste les administrateurs de la démarche
+  """
+  administrateurs: [Profile!]!
   annotationDescriptors: [ChampDescriptor!]! @deprecated(reason: "Utilisez le champ `activeRevision.annotationDescriptors` à la place.")
   champDescriptors: [ChampDescriptor!]! @deprecated(reason: "Utilisez le champ `activeRevision.champDescriptors` à la place.")
 

--- a/app/graphql/types/demarche_type.rb
+++ b/app/graphql/types/demarche_type.rb
@@ -67,6 +67,7 @@ module Types
     field :revisions, [Types::RevisionType], null: false
     field :chorus_configuration, Types::ChorusConfigurationType, null: true, description: "Cadre budgétaire Chorus"
     field :labels, [Types::LabelType], null: false, description: 'Liste des labels associables aux dossiers'
+    field :administrateurs, [Types::ProfileType], null: false, description: "Liste les administrateurs de la démarche"
 
     def state
       object.aasm.current_state


### PR DESCRIPTION
En complément de la #11403, nous avons pour nos synchronisations automatiques des administrateurs et instructeurs depuis notre annuaire technique, besoin de la possibilité de lister les administrateurs d'une démarche (pour savoir si faut les ajouter/supprimer). 

