### PR TITLE
ETQ ds, je souhaite prévenir une race condition sur la mise a jour du formulaire d'une demarche qui peut entrainer la suppression des dossiers

### DIFF
--- a/app/models/concerns/dossier_rebase_concern.rb
+++ b/app/models/concerns/dossier_rebase_concern.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module DossierRebaseConcern
+  RACE_CONDITION_DELAY = 30.seconds
+
   extend ActiveSupport::Concern
 
   def rebase!
@@ -12,7 +14,7 @@ module DossierRebaseConcern
   end
 
   def rebase_later
-    DossierRebaseJob.perform_later(self)
+    DossierRebaseJob.set(wait: RACE_CONDITION_DELAY).perform_later(self)
   end
 
   def can_rebase?


### PR DESCRIPTION

# Dossiers disparus démarche 107694

enquété ac @colinux @tchak et moi même. voici le resumé de notre taff

## Logs de destruction

le 3 mars à 8:46:51.617 suite à PATCH sur type de champ (duration 2101ms) 
request_id `b7cf1592-7fd4-4192-88f5-172f0d5210b2`
par user 5893404

à 8:46:49.768 le même user fait un publish_revision (duration 320ms)

## Logs de changement de revision 

On a un changement de révision au meme moment que les logs de destructions

```
[#<ProcedureRevision:0x00007fb0bcf2e800
  id: 175876,
  procedure_id: 107694,
  created_at: Thu, 16 Jan 2025 10:26:19.502203000 CET +01:00,
  updated_at: Mon, 03 Mar 2025 08:46:49.748279000 CET +01:00,
-->  published_at: Mon, 03 Mar 2025 08:46:49.748279000 CET +01:00,
  dossier_submitted_message_id: 12085,
  ineligibilite_rules: nil,
  ineligibilite_message: nil,
  ineligibilite_enabled: false>,
```

## liste des dossiers impactés

Dossiers : 
(mfo) 22,134,650 : retrouve pas la trace initial...
(mfo) dossier#22_454_031 : us    er#779_214. 
(colin) 22,508,526 => pas dans kibana ?
(colin) 22,544,203
22,163,932
21,728,688 créé le 6 janvier 8:52 par user 4477232, déposé le 7/01 09:01
21,734,093 créé le 6 janvier 11:32 par user 2476404, déposé le 20/02 11:29
22,134,657
21,598,959
21,956,330
21,944,082


## Exemple dossier 22544203

déposé le 20/02 17:46 par user#6771036
créé le 17/02 à 16:20 : 
   200 /commencer/caf-83-demande-de-bonus…
   302 /dossiers/new
   200 /dossiers/22544203/siret
   200 /dossiers/22544203/etablissement
   200 /dossiers/22544203/brouillon
  
  
## Exemple dossier 22_454_031
```
Feb 12, 2025 @ 09:13:04.266	[200] GET /dossiers/22454031/siret (Users::DossiersController#siret)
Feb 12, 2025 @ 09:13:04.086	[302] GET /dossiers/new (Users::DossiersController#new)
Feb 12, 2025 @ 09:12:56.558	[200] GET /commencer/caf-83-demande-de-bonus-avs-centres-sociaux (Users::CommencerController#commencer)
Feb 12, 2025 @ 09:12:56.209	[302] GET /users/sign_in (Users::SessionsController#new)
Feb 11, 2025 @ 10:58:39.366	[200] GET /dossiers (Users::DossiersController#index)![](https://storage.gra.cloud.ovh.net/v1/AUTH_0f20d409cb2a4c9786c769e2edec0e06/padnumerique/uploads/30ec3011-89e1-4afd-be02-bad0e0c21091.png)
```


## Exemple dossier 22163932
créé le 28 janvier à 11:53
déposé le 11 février par 4447328

```
Jan 28, 2025 @ 11:53:59.955	[200] GET /dossiers/22163932/brouillon (Users::DossiersController#brouillon)	-
Jan 28, 2025 @ 11:53:55.988	[200] GET /dossiers/22163932/etablissement (Users::DossiersController#etablissement)	-
Jan 28, 2025 @ 11:53:55.907	[302] POST /dossiers/22163932/siret (Users::DossiersController#update_siret)	-
Jan 28, 2025 @ 11:53:52.518	[200] GET /dossiers/22163932/siret (Users::DossiersController#siret)	-
Jan 28, 2025 @ 11:53:52.433	[302] GET /dossiers/new (Users::DossiersController#new)	-
Jan 28, 2025 @ 11:53:49.178	[200] GET /commencer/caf-83-demande-de-bonus-avs-centres-sociaux (Users::CommencerController#commencer)	-
```


T0 Procedure sur revision publiée P1, draft revision = P2
T0 Dossier créé sur P1
T1 Req A: patch type de champ
    on load la procedure draft = P2, published = P1
T2 Req B publish P1 => P2
T3 rebase d'un dossier dossier P1 => P2
T4 Req A: load les dossiers de sa draft revision => ça renvoie les dossiers

    
    draft_revision.dossiers.destoy_all
    
    Dossier.joins(:revision).where(procedure_revisions: { published_at: nil, procedure: self }).destroy_all

