### PR TITLE
ETQ usager du champ formaté, je ne veux pas voir le format du mode avancé quand c'est le mode simple

### DIFF
--- a/app/components/editable_champ/champ_label_component/champ_label_component.html.haml
+++ b/app/components/editable_champ/champ_label_component/champ_label_component.html.haml
@@ -5,7 +5,7 @@
     - render EditableChamp::ChampLabelContentComponent.new form: @form, champ: @champ, seen_at: @seen_at
   - if @champ.description.present?
     .fr-hint-text{ id: @champ.describedby_id }= render SimpleFormatComponent.new(@champ.description, allow_a: true)
-  - if @champ.type_de_champ.expression_reguliere_indications.present?
+  - if @champ.type_de_champ.formatted_advanced? &&  @champ.type_de_champ.expression_reguliere_indications.present?
     .fr-hint-text{ id: @champ.describedby_id }= @champ.type_de_champ.expression_reguliere_indications
 - elsif @champ.legend_label?
   %legend.fr-fieldset__legend.fr-text--regular.fr-pb-1w{ id: @champ.labelledby_id }= render EditableChamp::ChampLabelContentComponent.new form: @form, champ: @champ, seen_at: @seen_at

--- a/app/components/editable_champ/formatted_component/formatted_component.html.haml
+++ b/app/components/editable_champ/formatted_component/formatted_component.html.haml
@@ -1,1 +1,1 @@
-= @form.text_field(:value, input_opts(id: @champ.input_id, placeholder: @champ.expression_reguliere_exemple_text, required: @champ.required?, aria: { describedby: @champ.describedby_id }))
+= @form.text_field(:value, input_opts(id: @champ.input_id, placeholder: @champ.formatted_advanced? ? @champ.expression_reguliere_exemple_text : nil, required: @champ.required?, aria: { describedby: @champ.describedby_id }))

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -47,6 +47,7 @@ class Champ < ApplicationRecord
     :mandatory?,
     :prefillable?,
     :refresh_after_update?,
+    :formatted_advanced?,
     :character_limit?,
     :character_limit,
     :letters_accepted,

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -424,6 +424,10 @@ class TypeDeChamp < ApplicationRecord
     self.drop_down_options = text.to_s.lines.map(&:strip).reject(&:empty?)
   end
 
+  def formatted_advanced?
+    formatted? && options['formatted_mode'] == 'advanced'
+  end
+
   def header_section_level_value
     if header_section_level.presence
       header_section_level.to_i

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -223,6 +223,7 @@ class TypeDeChamp < ApplicationRecord
   before_validation :set_default_libelle, if: -> { type_champ_changed? }
   before_validation :normalize_libelle
   before_validation :set_drop_down_list_options, if: -> { type_champ_changed? }
+  before_validation :clean_formatted_options, if: -> { type_champ_changed? }
 
   before_save :remove_attachment, if: -> { type_champ_changed? }
 
@@ -764,6 +765,13 @@ class TypeDeChamp < ApplicationRecord
     elsif linked_drop_down_list? && drop_down_options.none?(/^--.*--$/)
       self.drop_down_options = ['--Fromage--', 'bleu de sassenage', 'picodon', '--Dessert--', 'éclair', 'tarte aux pommes']
     end
+  end
+
+  def clean_formatted_options
+    return if options.blank?
+    return if formatted?
+
+    options.except!(*TypesDeChamp::FormattedTypeDeChamp::OPTIONS)
   end
 
   def normalize_libelle

--- a/app/models/types_de_champ/formatted_type_de_champ.rb
+++ b/app/models/types_de_champ/formatted_type_de_champ.rb
@@ -1,6 +1,19 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::FormattedTypeDeChamp < TypesDeChamp::TypeDeChampBase
+  OPTIONS = %w[
+    formatted_mode
+    letters_accepted
+    numbers_accepted
+    special_characters_accepted
+    min_character_length
+    max_character_length
+    expression_reguliere
+    expression_reguliere_indications
+    expression_reguliere_exemple_text
+    expression_reguliere_error_message
+  ].freeze
+
   def initialize(*args)
     super
     if @type_de_champ.options&.empty?

--- a/spec/factories/type_de_champ.rb
+++ b/spec/factories/type_de_champ.rb
@@ -103,10 +103,8 @@ FactoryBot.define do
     end
     factory :type_de_champ_formatted do
       type_champ { TypeDeChamp.type_champs.fetch(:formatted) }
-      trait :simple do
-        options do
-          { formatted: "simple" }
-        end
+      options do
+        { formatted_mode: "simple" }
       end
       trait :numbers_accepted do
         options do

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -150,7 +150,7 @@ describe TypeDeChamp do
   end
 
   describe "validate_regexp" do
-    let(:tdc) { create(:type_de_champ_formatted, expression_reguliere:, expression_reguliere_exemple_text:) }
+    let(:tdc) { create(:type_de_champ_formatted, :advanced, expression_reguliere:, expression_reguliere_exemple_text:) }
     subject { tdc.invalid_regexp? }
 
     context "expression_reguliere and bad example" do
@@ -175,6 +175,18 @@ describe TypeDeChamp do
         expect(subject).to be_truthy
         expect(tdc.errors.messages[:expression_reguliere]).to be_present
       end
+    end
+  end
+
+  describe 'formatted options cleaning' do
+    let(:tdc) { build(:type_de_champ_formatted) }
+    it 'keeps only simple options' do
+      expect(tdc.options["formatted_mode"]).to be_present
+      expect(tdc.options["drop_down_options"]).to be_blank
+      tdc.type_champ = "drop_down_list"
+      tdc.save!
+      expect(tdc.options["formatted_mode"]).to be_blank
+      expect(tdc.options["drop_down_options"]).to be_present
     end
   end
 


### PR DESCRIPTION
ça arrive si l'admin passe d'un mode à l'autre. Pour des raisons pratiques pour l'admin on garde toute les options de chaque mode, c'est l'affichage qui s'adapte.
Par contre on supprime toutes les options de formattage quand le type du champ change.