### PR TITLE
ETQ DS, on souhaite retarder la suppression effective des PJs

### DIFF
--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -289,7 +289,7 @@ module Instructeurs
         flash.notice = "Message envoyé"
         redirect_to messagerie_instructeur_dossier_path(procedure, dossier, statut: statut)
       else
-        @commentaire.piece_jointe.purge.reload
+        @commentaire.piece_jointe.purge.reload # only allowed here, sync action
         flash.alert = @commentaire.errors.full_messages
         render :messagerie
       end

--- a/app/jobs/delayed_purge_job.rb
+++ b/app/jobs/delayed_purge_job.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class DelayedPurgeJob < ApplicationJob
+  discard_on ActiveRecord::RecordNotFound
+
+  delegate :service, :key, to: :blob
+  delegate :container, to: :service
+
+  attr_reader :blob
+
+  def perform(blob)
+    @blob = blob
+
+    if !soft_delete_enabled?
+      blob.purge
+    else
+      soft_delete
+    end
+  end
+
+  private
+
+  def delay = Integer(ENV['PURGE_LATER_DELAY_IN_DAY']).day.from_now.to_i.to_s
+
+  # head object to update metadata makes pj unreadable. copy with extra headers
+  def soft_delete
+    excon_response = client.copy_object(container, key, container, key, { "Content-Type" => blob.content_type, 'X-Delete-At' => delay })
+    if excon_response.status != 201
+      Sentry.capture_message("Can't expire blob", extra: { key:, headers: })
+    else
+      service.delete_prefixed("variants/#{key}/") if blob.image?
+    end
+  end
+
+  def client
+    Fog::OpenStack::Storage.new(service.settings)
+  end
+
+  def soft_delete_enabled?
+    Rails.application.config.active_storage.service == :openstack &&
+    delay
+  rescue
+    false
+  end
+end

--- a/app/services/archive_uploader.rb
+++ b/app/services/archive_uploader.rb
@@ -9,7 +9,7 @@ class ArchiveUploader
   def upload(archive)
     uploaded_blob = create_and_upload_blob
     begin
-      archive.file.purge if archive.file.attached?
+      archive.file.purge_later if archive.file.attached?
     rescue ActiveStorage::FileNotFoundError
       archive.file.destroy
       archive.file.detach

--- a/app/services/archive_uploader.rb
+++ b/app/services/archive_uploader.rb
@@ -9,7 +9,7 @@ class ArchiveUploader
   def upload(archive)
     uploaded_blob = create_and_upload_blob
     begin
-      archive.file.purge_later if archive.file.attached?
+      archive.file.purge if archive.file.attached?
     rescue ActiveStorage::FileNotFoundError
       archive.file.destroy
       archive.file.detach

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -290,3 +290,6 @@ RAILS_QUEUE_ADAPTER="
 RDV_SERVICE_PUBLIC_OAUTH_APP_ID=""
 RDV_SERVICE_PUBLIC_OAUTH_APP_SECRET=""
 RDV_SERVICE_PUBLIC_URL=https://demo.rdv.anct.gouv.fr
+
+# allows to soft delete blobs 7 days after their purge_later call
+PURGE_LATER_DELAY_IN_DAY="7"

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -11,6 +11,12 @@ ActiveSupport.on_load(:active_storage_blob) do
   include BlobVirusScannerConcern
   include BlobSignedIdConcern
 
+  ActiveStorage::Blob.class_eval do
+    def purge_later
+      DelayedPurgeJob.perform_later(self)
+    end
+  end
+
   def self.generate_unique_secure_token(length: MINIMUM_TOKEN_LENGTH)
     token = super
     "#{Time.current.strftime('%Y/%m/%d')}/#{token[0..1]}/#{token}"

--- a/spec/jobs/delayed_purge_job_spec.rb
+++ b/spec/jobs/delayed_purge_job_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe DelayedPurgeJob, type: :job do
+  let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative }]) }
+  let!(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
+  let(:blob) { dossier.champs.first.piece_justificative_file.first.blob }
+  let(:job) { described_class.new(blob) }
+
+  before do
+    stub_const('ENV', ENV.to_hash.merge('PURGE_LATER_DELAY_IN_DAY' => '1'))
+  end
+
+  let(:subject) { job.perform_now }
+
+  it 'emit request instead of destroying it' do
+    container = "bucket"
+    double_service = double(container:)
+    allow_any_instance_of(ActiveStorage::Blob).to receive(:service).and_return(double_service)
+
+    double_client = double()
+    expect(double_client).to receive(:copy_object)
+      .with(container, blob.key, container, blob.key, { 'X-Delete-At' => anything, "Content-Type" => blob.content_type })
+      .and_return(double(status: 201))
+
+    expect(job).to receive(:client).and_return(double_client)
+
+    allow(Rails.application.config.active_storage).to receive(:service).and_return(:openstack)
+
+    subject
+
+    perform_enqueued_jobs
+  end
+
+  context 'when destroying an instance' do
+    it 'uses our custom job' do
+      expect { dossier.destroy }.to have_enqueued_job(DelayedPurgeJob)
+    end
+  end
+end

--- a/spec/jobs/virus_scanner_job_spec.rb
+++ b/spec/jobs/virus_scanner_job_spec.rb
@@ -53,7 +53,7 @@ describe VirusScannerJob, type: :job do
 
   context "when the blob has been deleted" do
     before do
-      ActiveStorage::Blob.find(blob.id).purge
+      ActiveStorage::Blob.find(blob.id).purge # allowed in spec
     end
 
     it "ignores the error" do


### PR DESCRIPTION
# Problème

ETQ DS, en cas de catastrophe dans le code, on peut supprimer des dossiers et leurs PJs
Aujourd'hui nous sommes equipé pour faire de la reprise sur erreur via notre namespace Recovery
Cependant, rien pr les PJs

# Solution

On utilise le header `X-Delete-At` pour deleguer au storage la suppression.
Je propose de faire comme pour les backup de bdd, retarder la suppression effective a 30 jours.
Cela se matérialise par une var d'env : `PURGE_LATER_DELAY_IN_DAY="30"`

⚠️ PURGE_LATER_DELAY_IN_DAY a ajouter ⚠️ 

# PS:

je supprime pas le blob en bdd, on a un job pr ça (par contre le purge_later s'occupe de `attachment.detach`)
