### PR TITLE
procedure: only reset dossiers on demarche type change

### DIFF
--- a/app/controllers/administrateurs/administrateur_controller.rb
+++ b/app/controllers/administrateurs/administrateur_controller.rb
@@ -24,10 +24,6 @@ module Administrateurs
       redirect_to admin_procedures_path, status: 404
     end
 
-    def reset_procedure
-      @procedure.reset!
-    end
-
     def preload_revisions
       ProcedureRevisionPreloader.new(@procedure.revisions).all
 

--- a/app/controllers/administrateurs/conditions_controller.rb
+++ b/app/controllers/administrateurs/conditions_controller.rb
@@ -5,7 +5,6 @@ module Administrateurs
     include Logic
 
     before_action :retrieve_procedure, :retrieve_coordinate_and_uppers
-    after_action :reset_procedure
 
     def update
       condition = condition_form.to_condition

--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -7,7 +7,7 @@ module Administrateurs
 
     before_action :retrieve_procedure, only: [:champs, :annotations, :modifications, :edit, :zones, :monavis, :update_monavis, :accuse_lecture, :update_accuse_lecture, :jeton, :update_jeton, :publication, :publish, :transfert, :close, :confirmation, :allow_expert_review, :allow_expert_messaging, :experts_require_administrateur_invitation, :reset_draft, :publish_revision, :check_path, :api_champ_columns, :path, :update_path, :rdv, :update_rdv]
     before_action :draft_valid?, only: [:apercu]
-    after_action :reset_procedure, only: [:update]
+    after_action :reset_draft_procedure, only: [:update]
 
     ITEMS_PER_PAGE = 25
 
@@ -475,6 +475,10 @@ module Administrateurs
     end
 
     private
+
+    def reset_draft_procedure
+      @procedure.reset!
+    end
 
     def paginated_published_procedures
       paginate_procedures(current_administrateur

--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -5,7 +5,6 @@ module Administrateurs
     include ActiveSupport::NumberHelper
 
     before_action :retrieve_procedure
-    after_action :reset_procedure, only: [:create, :update, :destroy, :piece_justificative_template]
     before_action :reload_procedure_with_includes, only: [:destroy]
 
     CSV_MAX_SIZE = 1.megabyte


### PR DESCRIPTION
Depuis le rebase v2, nous n'avons plus besoin de supprimer les dossiers sur la démarche en brouillon à chaque changement de révision. On garde le "reset" lors de la publication et au changement de type de démarche.