### PR TITLE
ETQ utilisateur d'un lecteur d'écran, je veux que les titres soient balisés comme tels

### DIFF
--- a/app/assets/stylesheets/02_utils.scss
+++ b/app/assets/stylesheets/02_utils.scss
@@ -44,10 +44,6 @@
   font-size: 14px !important;
 }
 
-.text-lg {
-  font-size: 18px;
-}
-
 .font-weight-bold {
   font-weight: bold !important;
 }

--- a/app/views/targeted_user_links/show.html.haml
+++ b/app/views/targeted_user_links/show.html.haml
@@ -4,13 +4,13 @@
   .container
     = image_tag('user/envoi-dossier.svg', alt: '', class: 'mt-8')
     %h1.mt-4.mb-3.mx-0 Attention, ce lien ne vous est pas destiné
-    %p.send.m-2.text-lg
+    %p.send.fr-text--lg
       L'invitation est à destination de
       %strong.test-target-email= @targeted_user_link.target_email
       %br
       Mais vous êtes connecté avec
       %strong.test-current-email= current_user.email
-    %p.m-2
+    %p
       Veuillez vous reconnecter avec la bonne adresse email
 
     .flex.column.align-center

--- a/app/views/users/dossiers/_merci.html.haml
+++ b/app/views/users/dossiers/_merci.html.haml
@@ -6,7 +6,7 @@
         %p.fr-h1.fr-mt-4w= t('views.users.dossiers.merci.thanks')
         %h1.send.fr-m-2w.text-lg
           = t('views.users.dossiers.merci.dossier_send_l1')
-          %strong= procedure.libelle
+          = procedure.libelle
           = t('views.users.dossiers.merci.dossier_send_l2')
         %p.fr-m-2w
           = t('views.users.dossiers.merci.dossier_acces_l1')
@@ -28,7 +28,7 @@
 
       - if procedure.monavis_embed
         .monavis
-          %p.fr-mt-5w.fr-mb-1w
-            %strong= t('views.users.dossiers.merci.jdma_l1')
+          %h2.fr-mt-5w.fr-mb-1w.fr-text--lg
+            = t('views.users.dossiers.merci.jdma_l1')
           %p= t('views.users.dossiers.merci.jdma_l2')
           != procedure.monavis_embed_html_source("site")

--- a/app/views/users/dossiers/_merci.html.haml
+++ b/app/views/users/dossiers/_merci.html.haml
@@ -4,7 +4,7 @@
       .fr-col-12
         = image_tag('user/envoi-dossier.svg', alt: '', class: 'mt-8')
         %p.fr-h1.fr-mt-4w= t('views.users.dossiers.merci.thanks')
-        %h1.send.fr-m-2w.text-lg
+        %h1.send.fr-m-2w.fr-text--lg
           = t('views.users.dossiers.merci.dossier_send_l1')
           = procedure.libelle
           = t('views.users.dossiers.merci.dossier_send_l2')


### PR DESCRIPTION
Remplacement du `<p>`par un `<h2>` autour du titre _Aidez-nous à améliorer ce service !_

__Après__
![Capture d’écran 2025-03-11 à 10 24 34](https://github.com/user-attachments/assets/0a852b4e-4d57-4fb7-9478-4ed16f1a1f8b)
![Capture d’écran 2025-03-11 à 10 23 54](https://github.com/user-attachments/assets/db345e22-32c7-4224-8707-81594f87cb05)

__Avant__
![Capture d’écran 2025-03-11 à 10 24 25](https://github.com/user-attachments/assets/b283ea63-d211-4142-b917-80633d41e0e3)
![Capture d’écran 2025-03-11 à 10 24 16](https://github.com/user-attachments/assets/756674d0-b086-4d40-a8fa-0c93e0ee603b)
