### PR TITLE
ETQ admin, la liste des démarches va plus vite

### DIFF
--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -513,6 +513,7 @@ module Administrateurs
       procedures
         .with_attached_logo
         .left_joins(groupe_instructeurs: :instructeurs)
+        .includes(:procedure_paths)
         .select('procedures.*,
                           COUNT(DISTINCT groupe_instructeurs.id) AS groupe_instructeurs_count,
                           COUNT(DISTINCT instructeurs.id) AS instructeurs_count')

--- a/app/models/concerns/procedure_path_concern.rb
+++ b/app/models/concerns/procedure_path_concern.rb
@@ -8,7 +8,6 @@ module ProcedurePathConcern
 
     has_many :procedure_paths, -> { order(updated_at: :asc) }, inverse_of: :procedure, dependent: :destroy, autosave: true
 
-    after_initialize :ensure_path_exists
     before_validation :ensure_path_exists
 
     validates :procedure_paths, length: { minimum: 1 }

--- a/app/models/concerns/procedure_path_concern.rb
+++ b/app/models/concerns/procedure_path_concern.rb
@@ -6,7 +6,7 @@ module ProcedurePathConcern
   included do
     self.ignored_columns += [:path]
 
-    has_many :procedure_paths, inverse_of: :procedure, dependent: :destroy, autosave: true
+    has_many :procedure_paths, -> { order(updated_at: :asc) }, inverse_of: :procedure, dependent: :destroy, autosave: true
 
     after_initialize :ensure_path_exists
     before_validation :ensure_path_exists
@@ -18,11 +18,11 @@ module ProcedurePathConcern
       left_joins(:procedure_paths).where(procedure_paths: { path: normalized_path }).limit(1)
     end
 
-    def path; canonical_path; end
+    def path = canonical_path
 
     def ensure_path_exists
-      uuid = SecureRandom.uuid
       if self.procedure_paths.empty?
+        uuid = SecureRandom.uuid
         self.procedure_paths.build(path: uuid)
       end
     end
@@ -34,7 +34,7 @@ module ProcedurePathConcern
     end
 
     def canonical_path
-      procedure_paths.by_updated_at.first&.path
+      procedure_paths.last&.path
     end
 
     def claim_path!(administrateur, new_path)

--- a/app/models/procedure_path.rb
+++ b/app/models/procedure_path.rb
@@ -7,8 +7,6 @@ class ProcedurePath < ApplicationRecord
 
   validates :path, presence: true, format: { with: /\A[a-z0-9_\-]{3,200}\z/ }, uniqueness: { case_sensitive: false }
 
-  scope :by_updated_at, -> { order(updated_at: :desc) }
-
   def ensure_one_path
     return if procedure.procedure_paths.count > 1 || destroyed_by_association
 

--- a/app/views/administrateurs/procedures/_procedures_list.html.haml
+++ b/app/views/administrateurs/procedures/_procedures_list.html.haml
@@ -95,13 +95,6 @@
                 .dropdown-description
                   %h4= t('administrateurs.dropdown_actions.to_clone')
 
-          - if procedure.publiee?
-            - menu.with_item do
-              = link_to(admin_procedure_close_path(procedure_id: procedure.id), role: 'menuitem') do
-                = dsfr_icon('fr-icon-calendar-close-fill')
-                .dropdown-description
-                  %h4= t('administrateurs.dropdown_actions.to_close')
-
           - if !procedure.discarded? && !procedure.publiee? && procedure.can_be_deleted_by_administrateur?
             - menu.with_item do
               = link_to admin_procedure_path(procedure), role: 'menuitem', method: :delete, data: { confirm: "Voulez-vous vraiment supprimer la démarche ? \nToute suppression est définitive et s'appliquera aux éventuels autres administrateurs de cette démarche !" } do

--- a/app/views/administrateurs/procedures/_procedures_list.html.haml
+++ b/app/views/administrateurs/procedures/_procedures_list.html.haml
@@ -102,7 +102,7 @@
                 .dropdown-description
                   %h4= t('administrateurs.dropdown_actions.to_close')
 
-          - if procedure.can_be_deleted_by_administrateur? && !procedure.discarded? && !procedure.publiee?
+          - if !procedure.discarded? && !procedure.publiee? && procedure.can_be_deleted_by_administrateur?
             - menu.with_item do
               = link_to admin_procedure_path(procedure), role: 'menuitem', method: :delete, data: { confirm: "Voulez-vous vraiment supprimer la démarche ? \nToute suppression est définitive et s'appliquera aux éventuels autres administrateurs de cette démarche !" } do
                 = dsfr_icon('fr-icon-delete-line')

--- a/spec/controllers/api/v2/graphql_controller_n+1_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_n+1_spec.rb
@@ -23,8 +23,8 @@ describe API::V2::GraphqlController do
     request.env['HTTP_AUTHORIZATION'] = authorization_header
   end
 
-  MIN_QUERY_COUNT = 50
-  MAX_QUERY_COUNT = 59
+  MIN_QUERY_COUNT = 47
+  MAX_QUERY_COUNT = 57
 
   describe 'demarche.dossiers' do
     let(:operation_name) { 'getDemarche' }

--- a/spec/models/concerns/procedure_path_concern_spec.rb
+++ b/spec/models/concerns/procedure_path_concern_spec.rb
@@ -157,6 +157,9 @@ describe ProcedurePathConcern do
       before do
         travel(1.minute)
         procedure.claim_path!(procedure.administrateurs.first, 'custom_path')
+        procedure.save!
+        procedure.reload
+
         travel(2.minutes)
         procedure.claim_path!(procedure.administrateurs.first, 'custom_path_2')
       end

--- a/spec/perf/heavy_dossier_spec.rb
+++ b/spec/perf/heavy_dossier_spec.rb
@@ -80,7 +80,7 @@ describe Users::DossiersController, type: :controller do
           post :submit_en_construction, params: { id: dossier.id }
         end
 
-        expect(query_count).to be_between(65, 75)
+        expect(query_count).to be_between(60, 70)
       end
     end
   end


### PR DESCRIPTION
supprime 3x N+1 

On pourra mettre un `strict_loading` une fois qu'on aura retiré la can_delete…? qui count les dossiers


NB: change l'order par défaut des procedure_paths pour avoir les plus récents en dernier, car quand on ajoute un nouveau record à une collection, il est forcément dernier tant qu'on a pas persisté la relation, et ça évite des reload dans tous les sens. 


J'ai aussi retirer l'action trop importante "clore" du menu suite à échange UX