### PR TITLE
Tech: remove double logique de nettoyage des options du champ formaté

### DIFF
--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -224,7 +224,6 @@ class TypeDeChamp < ApplicationRecord
   before_validation :set_default_libelle, if: -> { type_champ_changed? }
   before_validation :normalize_libelle
   before_validation :set_drop_down_list_options, if: -> { type_champ_changed? }
-  before_validation :clean_formatted_options, if: -> { type_champ_changed? }
 
   before_save :remove_attachment, if: -> { type_champ_changed? }
 
@@ -775,13 +774,6 @@ class TypeDeChamp < ApplicationRecord
     elsif linked_drop_down_list? && drop_down_options.none?(/^--.*--$/)
       self.drop_down_options = ['--Fromage--', 'bleu de sassenage', 'picodon', '--Dessert--', 'éclair', 'tarte aux pommes']
     end
-  end
-
-  def clean_formatted_options
-    return if options.blank?
-    return if formatted?
-
-    options.except!(*TypesDeChamp::FormattedTypeDeChamp::OPTIONS)
   end
 
   def normalize_libelle

--- a/app/models/types_de_champ/formatted_type_de_champ.rb
+++ b/app/models/types_de_champ/formatted_type_de_champ.rb
@@ -1,19 +1,6 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::FormattedTypeDeChamp < TypesDeChamp::TypeDeChampBase
-  OPTIONS = %w[
-    formatted_mode
-    letters_accepted
-    numbers_accepted
-    special_characters_accepted
-    min_character_length
-    max_character_length
-    expression_reguliere
-    expression_reguliere_indications
-    expression_reguliere_exemple_text
-    expression_reguliere_error_message
-  ].freeze
-
   def initialize(*args)
     super
     if @type_de_champ.options&.empty?

--- a/spec/factories/type_de_champ.rb
+++ b/spec/factories/type_de_champ.rb
@@ -103,8 +103,10 @@ FactoryBot.define do
     end
     factory :type_de_champ_formatted do
       type_champ { TypeDeChamp.type_champs.fetch(:formatted) }
-      options do
-        { formatted_mode: "simple" }
+      trait :simple do
+        options do
+          { formatted: "simple" }
+        end
       end
       trait :numbers_accepted do
         options do

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -150,7 +150,7 @@ describe TypeDeChamp do
   end
 
   describe "validate_regexp" do
-    let(:tdc) { create(:type_de_champ_formatted, :advanced, expression_reguliere:, expression_reguliere_exemple_text:) }
+    let(:tdc) { create(:type_de_champ_formatted, expression_reguliere:, expression_reguliere_exemple_text:) }
     subject { tdc.invalid_regexp? }
 
     context "expression_reguliere and bad example" do
@@ -175,18 +175,6 @@ describe TypeDeChamp do
         expect(subject).to be_truthy
         expect(tdc.errors.messages[:expression_reguliere]).to be_present
       end
-    end
-  end
-
-  describe 'formatted options cleaning' do
-    let(:tdc) { build(:type_de_champ_formatted) }
-    it 'keeps only simple options' do
-      expect(tdc.options["formatted_mode"]).to be_present
-      expect(tdc.options["drop_down_options"]).to be_blank
-      tdc.type_champ = "drop_down_list"
-      tdc.save!
-      expect(tdc.options["formatted_mode"]).to be_blank
-      expect(tdc.options["drop_down_options"]).to be_present
     end
   end
 


### PR DESCRIPTION
This reverts commit 469229a4668dd7e644a56c13f5065010c7e8f074.

C'était [déjà codé autrement avec le moyen générique](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/commit/8a8ff0dbfa2f93836dd2095acf3cd1bb53a0bf95#diff-7a7e64a7012843012c6699e7cdac6b5a18f6e9889c9dc8a7cbcb8cf8637949a6)