### PR TITLE
ETQ usager fix liste des dossiers quand une procédure qui en remplace une autre a été supprimée

### DIFF
--- a/app/views/users/dossiers/_dossiers_list.html.haml
+++ b/app/views/users/dossiers/_dossiers_list.html.haml
@@ -62,15 +62,15 @@
         = render Dsfr::AlertComponent.new(state: :info, size: :sm, extra_class_names: "fr-mb-2w") do |c|
           - c.with_body do
             %p
-              - if dossier.brouillon? && dossier.procedure.closing_reason_internal_procedure?
+              - if dossier.brouillon? && dossier.procedure.closing_reason_internal_procedure? && dossier.procedure.replaced_by_procedure.present?
                 = t('views.users.dossiers.dossiers_list.procedure_closed.brouillon.internal_procedure_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.procedure'), commencer_path(dossier.procedure.replaced_by_procedure.path), **external_link_attributes, title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_new_procedure'))).html_safe)
               - elsif dossier.brouillon?
                 = t('views.users.dossiers.dossiers_list.procedure_closed.brouillon.other_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.more_details'), closing_details_path(dossier.procedure.path), **external_link_attributes, title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_closing_details'))).html_safe)
-              - elsif dossier.en_construction_ou_instruction? && dossier.procedure.closing_reason_internal_procedure?
+              - elsif dossier.en_construction_ou_instruction? && dossier.procedure.closing_reason_internal_procedure? && dossier.procedure.replaced_by_procedure.present?
                 = t('views.users.dossiers.dossiers_list.procedure_closed.en_cours.internal_procedure_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.procedure'), commencer_path(dossier.procedure.replaced_by_procedure.path), **external_link_attributes, title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_new_procedure'))).html_safe)
               - elsif dossier.en_construction_ou_instruction?
                 = t('views.users.dossiers.dossiers_list.procedure_closed.en_cours.other_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.more_details'), closing_details_path(dossier.procedure.path), **external_link_attributes, title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_closing_details'))).html_safe)
-              - elsif dossier.termine? && dossier.procedure.closing_reason_internal_procedure?
+              - elsif dossier.termine? && dossier.procedure.closing_reason_internal_procedure? && dossier.procedure.replaced_by_procedure.present?
                 = t('views.users.dossiers.dossiers_list.procedure_closed.termine.internal_procedure_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.this_procedure'), commencer_path(dossier.procedure.replaced_by_procedure.path), **external_link_attributes, title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_new_procedure'))).html_safe)
               - elsif dossier.termine?
                 = t('views.users.dossiers.dossiers_list.procedure_closed.termine.other_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.more_details'), closing_details_path(dossier.procedure.path), **external_link_attributes, title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_closing_details'))).html_safe)


### PR DESCRIPTION
https://demarches-simplifiees.sentry.io/issues/6359798999/

La [relation de remplacement est nullifiable](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/blob/748fd1d8508e9741ffd37028133d3bbb2f68d449/app/models/procedure.rb#L47) , donc on peut avoir une procédure en closing_reason_internal_procedure qui ne pointe plus vers une procédure existante.
