### PR TITLE
ETQ usager, corrige les erreurs 404 en construction quand la révision est passée à un champ référentiel

### DIFF
--- a/app/models/champs/drop_down_list_champ.rb
+++ b/app/models/champs/drop_down_list_champ.rb
@@ -86,11 +86,18 @@ class Champs::DropDownListChamp < Champ
   private
 
   def referentiel_from(value)
-    if value.present?
-      referentiel_item = type_de_champ.referentiel.items.find(value)
-      headers = referentiel_item.referentiel.headers
-      { data: referentiel_item.data.merge(headers:) }
+    return if value.blank?
+
+    referentiel_item = type_de_champ.referentiel.items.find_by(id: value)
+
+    # When changing tdc type or simple/advanced mode, champ value is not an item id
+    if referentiel_item.blank?
+      self.value = nil
+      return
     end
+
+    headers = referentiel_item.referentiel.headers
+    { data: referentiel_item.data.merge(headers:) }
   end
 
   def validate_value_is_in_options

--- a/spec/models/champs/drop_down_list_champ_spec.rb
+++ b/spec/models/champs/drop_down_list_champ_spec.rb
@@ -99,5 +99,25 @@ describe Champs::DropDownListChamp do
     it '#referentiel_item_column_values' do
       expect(champ.referentiel_item_column_values).to eq([["option", "fromage"], ["calorie (kcal)", "145"], ["poids (g)", "60"]])
     end
+
+    context "when value is a value from simple mode" do
+      let(:types_de_champ_public) { [{ type: :drop_down_list, drop_down_mode: "simple" }] }
+      let(:value) { "fromage" }
+
+      before do
+        champ.save!
+        champ.reload
+      end
+
+      it "clear old value without error" do
+        expect(champ.value).to eq("fromage")
+
+        champ.type_de_champ.update!(options: { "drop_down_mode": "advanced" }, referentiel:)
+        champ.reload
+
+        champ.save!
+        expect(champ.value).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
# Scénario:

1. Révision A, champ liste simple
2. Un dossier saisit une valeur de la liste et dépose le dossier
3. Révision B, qui transforme le champ en référentiel
4. Le dossier monte de version mais conserve la valeur initiale saisie
5. Pour modifier ce dossier on fait un clone
6. Ce clone copie les champs déclenche `store_referentiel` qui fait un`find(value)`ce qui ne peut pas marcher :
   - le find attend un id de l'item, et pa sune vraie valeur
   - de toute façon la valeur initiale peut ne pas être dans le référentiel

## Solution (rapide) :
- on n'utilise plus le find

## Pistes d'amélioration:
- chercher intelligemment la valeur lors du rebase
- nettoyer les valeurs lors du rebase
- … ?


Ça devrait corriger aussi des erreurs vues côté instructeur