### PR TITLE
ETQ usager, j'aimerais qu'une recherche par autocomplete sur les adresse soit plus fiable

### DIFF
--- a/app/javascript/components/react-aria/hooks.ts
+++ b/app/javascript/components/react-aria/hooks.ts
@@ -67,7 +67,7 @@ function inputChanged(container: HTMLSpanElement, inputs: HTMLInputElement[]) {
 }
 
 const naturalSort: MatchSorterOptions['baseSort'] = (a, b) => {
-  return a.rankedValue.localeCompare(b.rankedValue, undefined, {
+  return String(a.rankedValue).localeCompare(String(b.rankedValue), undefined, {
     numeric: true,
     sensitivity: 'base'
   });


### PR DESCRIPTION
﻿Problème 👍 

essayer de rechercher par 188 rue saint honoré.

l'API interne de matchSorter transforme les items en rankedItem. Ceux qui ne sont pas rankable sont transformé ainsi  : 
<img width="937" alt="Capture d’écran 2025-03-13 à 3 27 20 PM" src="https://github.com/user-attachments/assets/3a91a27c-ce26-42ac-81d8-d4b388b07eba" />
(cf fin de la liste)

Sauf que derriere on essaie de les ordonner avec ce code : 

```ts
const naturalSort: MatchSorterOptions['baseSort'] = (a, b) => {
  return a.rankedValue.localeCompare(b.rankedValue, undefined, {
    numeric: true,
    sensitivity: 'base'
  });
};
```

Les objet non rankable n'ont pas de `rankedValue`, donc ca plante (silencieusement car on a wrappé le truc dans un catch)

