### PR TITLE
Tech: corrige tests système instructeurs qui bagotaient

### DIFF
--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -13,6 +13,7 @@ module SystemHelpers
 
     perform_enqueued_jobs do
       click_on 'Se connecter'
+      expect(page).to have_text("Voir mon profil")
     end
 
     if sign_in_by_link

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -3,17 +3,6 @@
 module SystemHelpers
   include ActiveJob::TestHelper
 
-  def login_admin
-    user = create :user
-    login_as user, scope: :user
-    user
-  end
-
-  def login_instructeur
-    instructeur = create(:instructeur)
-    login_as instructeur, scope: :instructeur
-  end
-
   def sign_in_with(email, password, sign_in_by_link = false)
     fill_in :user_email, with: email
     fill_in :user_password, with: password

--- a/spec/system/instructeurs/batch_operation_spec.rb
+++ b/spec/system/instructeurs/batch_operation_spec.rb
@@ -163,11 +163,11 @@ describe 'BatchOperation a dossier:', js: true do
     end
   end
 
-  def log_in(email, password, check_email: true)
+  def log_in(email, password)
     visit new_user_session_path
     expect(page).to have_current_path(new_user_session_path)
 
-    sign_in_with(email, password, check_email)
+    sign_in_with(email, password)
 
     expect(page).to have_current_path(instructeur_procedures_path)
   end

--- a/spec/system/instructeurs/instruction_spec.rb
+++ b/spec/system/instructeurs/instruction_spec.rb
@@ -217,6 +217,7 @@ describe 'Instructing a dossier:', js: true do
 
     expect {
       page.first(".fr-table .fr-btn").click
+      expect(page).to have_text("Votre demande a été prise en compte")
     }.to have_enqueued_job(ArchiveCreationJob).with(archivable_procedure, an_instance_of(Archive), instructeur)
     expect(Archive.first.month).not_to be_nil
   end

--- a/spec/system/instructeurs/instruction_spec.rb
+++ b/spec/system/instructeurs/instruction_spec.rb
@@ -10,6 +10,12 @@ describe 'Instructing a dossier:', js: true do
 
   let!(:procedure) { create(:procedure, :published, instructeurs: [instructeur], types_de_champ_private: [{ type: 'checkbox', libelle: 'Yes/No', stable_id: 99 }, { libelle: 'Nom', condition: ds_eq(champ_value(99), constant(true)) }]) }
   let!(:dossier) { create(:dossier, :en_construction, :with_entreprise, procedure: procedure) }
+
+  scenario 'A instructeur can signin by email' do
+    log_in(instructeur.email, password, check_email: true)
+    expect(page).to have_current_path(instructeur_procedures_path)
+  end
+
   context 'the instructeur is also a user' do
     scenario 'a instructeur can fill a dossier' do
       visit commencer_path(path: procedure.path)
@@ -126,9 +132,7 @@ describe 'Instructing a dossier:', js: true do
   end
 
   scenario 'A instructeur can request an export' do
-    assert_performed_jobs 1 do
-      log_in(instructeur.email, password)
-    end
+    log_in(instructeur.email, password)
 
     click_on(procedure.libelle, visible: true)
     test_statut_bar(a_suivre: 1, tous_les_dossiers: 1)
@@ -315,7 +319,7 @@ describe 'Instructing a dossier:', js: true do
     end
   end
 
-  def log_in(email, password, check_email: true)
+  def log_in(email, password, check_email: false)
     visit new_user_session_path
     expect(page).to have_current_path(new_user_session_path)
 

--- a/spec/system/instructeurs/instruction_spec.rb
+++ b/spec/system/instructeurs/instruction_spec.rb
@@ -324,10 +324,6 @@ describe 'Instructing a dossier:', js: true do
     expect(page).to have_current_path(instructeur_procedures_path)
   end
 
-  def log_out
-    click_on 'Se déconnecter'
-  end
-
   def ask_confidential_avis(to, introduction)
     fill_in 'avis_emails', with: to
     fill_in 'avis_introduction', with: introduction

--- a/spec/system/sessions/sign_in_spec.rb
+++ b/spec/system/sessions/sign_in_spec.rb
@@ -8,7 +8,7 @@ describe 'Signin in:' do
     visit root_path
     click_on 'Se connecter', match: :first
 
-    sign_in_with user.email, 'invalid-password'
+    try_sign_in_with user.email, 'invalid-password'
     expect(page).to have_content 'Adresse électronique ou mot de passe incorrect.'
     expect(page).to have_field('Adresse électronique', with: user.email)
 
@@ -36,10 +36,10 @@ describe 'Signin in:' do
     visit root_path
     click_on 'Se connecter', match: :first
 
-    5.times { sign_in_with user.email, 'bad password' }
+    5.times { try_sign_in_with user.email, 'bad password' }
     expect(user.reload.access_locked?).to be false
 
-    sign_in_with user.email, 'bad password'
+    try_sign_in_with user.email, 'bad password'
     expect(user.reload.access_locked?).to be true
   end
 
@@ -79,8 +79,15 @@ describe 'Signin in:' do
       visit root_path
       click_on 'Se connecter', match: :first
 
-      sign_in_with user.email, password
+      try_sign_in_with user.email, password
       expect(page).to have_content('Vous devez confirmer votre compte par email.')
     end
+  end
+
+  def try_sign_in_with(email, password)
+    fill_in :user_email, with: email
+    fill_in :user_password, with: password
+
+    click_on 'Se connecter'
   end
 end

--- a/spec/system/users/sign_up_spec.rb
+++ b/spec/system/users/sign_up_spec.rb
@@ -154,7 +154,11 @@ describe 'Signing up:', js: true do
 
     scenario 'they cannot signed in' do
       visit new_user_session_path
-      sign_in_with user_email, user_password
+      fill_in :user_email, with: user_email
+      fill_in :user_password, with: user_password
+
+      click_on 'Se connecter'
+      expect(page).to have_text "Votre compte n’est pas encore activé."
 
       expect(page).to have_current_path new_user_session_path
     end


### PR DESCRIPTION
Le cœur du pb résolu ici est que le clic sur "se connecter" n'attend pas que l'utilisateur soit connecté, c'est qui peut provquer plusieurs types d'erreurs plus loin si ça va trop vite, à commencer par l'helper qui va voir dans la liste des mails envoyés pour cliquer sur le lien.
En conséquence on adapte plusieurs autres tests qui cherchent à manipuler différemment le form de connexion