### PR TITLE
ETQ Operateur, je veux avoir acces aux nouveautés de DS même si je n'ai pas de compte

### DIFF
--- a/app/controllers/release_notes_controller.rb
+++ b/app/controllers/release_notes_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class ReleaseNotesController < ApplicationController
-  before_action :ensure_access_allowed!
   after_action :touch_default_categories_seen_at
 
   def index
@@ -32,14 +31,5 @@ class ReleaseNotesController < ApplicationController
     return if current_user.announces_seen_at&.after?(@announces.max_by(&:released_on).released_on)
 
     current_user.touch(:announces_seen_at)
-  end
-
-  def ensure_access_allowed!
-    return if administrateur_signed_in?
-    return if instructeur_signed_in?
-    return if expert_signed_in?
-
-    flash[:alert] = t('release_notes.index.forbidden')
-    redirect_to root_path
   end
 end

--- a/config/locales/release_notes.en.yml
+++ b/config/locales/release_notes.en.yml
@@ -3,7 +3,6 @@ en:
   release_notes:
     index:
       title: What’s new on %{app_name} ? 🚀
-      forbidden: You are not authorized to view the News page.
       no_content: No announcement here.
     page:
       previous_page: Previous announcements

--- a/config/locales/release_notes.fr.yml
+++ b/config/locales/release_notes.fr.yml
@@ -3,7 +3,6 @@ fr:
   release_notes:
     index:
       title: Quoi de neuf sur %{app_name} ? 🚀
-      forbidden: Vous n’êtes pas autorisé(e) à consulter la page des Nouveautés.
       no_content: Aucune nouveauté annoncée de ce côté là.
     page:
       previous_page: Annonces précédentes

--- a/spec/controllers/release_notes_controller_spec.rb
+++ b/spec/controllers/release_notes_controller_spec.rb
@@ -37,19 +37,6 @@ RSpec.describe ReleaseNotesController, type: :controller do
       end
     end
 
-    describe 'acl' do
-      before { subject }
-      context 'user is normal' do
-        let(:user) { create(:user) }
-
-        it { is_expected.to be_redirection }
-      end
-
-      context 'no user' do
-        it { is_expected.to be_redirection }
-      end
-    end
-
     describe 'touch user announces_seen_at' do
       let(:user) { create(:user, administrateur: build(:administrateur)) }
 


### PR DESCRIPTION
Les opérateurs des autres instances aimeraient avoir accès à notre page nouveauté pour les communiquer facilement à leurs utilisateurs.

Cette pr enlève donc les restriction d'accès sur `/release_notes`, considérant que les informations qui s'y trouvent ne sont pas confidentielles.

Il reste un problème plus compliqué : ou mettre le lien vers cette page sachant que l'on a déjà un lien `nouveautés` dans le footer qui pointe vers les releases github. Je laisse ce point ouvert pour un second temps.