### PR TITLE
Tâche pour mise à jour de la date de fermeture d'une démarche

### DIFF
--- a/app/tasks/maintenance/t20250314update_procedure_closed_at_task.rb
+++ b/app/tasks/maintenance/t20250314update_procedure_closed_at_task.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20250314updateProcedureClosedAtTask < MaintenanceTasks::Task
+    # Documentation: cette tâche modifie la date de clôture d'une procédure.
+    # Elle peut être utilisée en cas d'erreur de l'administrateur.
+    # Le format de la date de clôture (closing_date) doit être "YYYY-MM-DD".
+
+    include RunnableOnDeployConcern
+    include StatementsHelpersConcern
+
+    attribute :procedure_id, :string
+    validates :procedure_id, presence: true
+    attribute :closing_date, :string
+    validates :closing_date, presence: true
+
+    def collection
+      [Procedure.find(procedure_id)]
+    end
+
+    def process(procedure)
+      closed_at = Time.zone.parse(closing_date)
+      procedure.update!(closed_at: closed_at)
+    end
+  end
+end

--- a/spec/tasks/maintenance/t20250314update_procedure_closed_at_task_spec.rb
+++ b/spec/tasks/maintenance/t20250314update_procedure_closed_at_task_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe T20250314updateProcedureClosedAtTask do
+    describe "#process" do
+      let(:closed_procedure) { create(:procedure, closed_at: Time.zone.parse('2025-02-25')) }
+
+      setup do
+        @task = T20250314updateProcedureClosedAtTask.new
+        @task.procedure_id = closed_procedure.id
+        @task.closing_date = '2025-02-27'
+      end
+
+      it "updates the procedure closed_at attribute" do
+        expect { @task.process(closed_procedure) }.to change { closed_procedure.reload.closed_at }.from(Time.zone.parse('2025-02-25')).to(Time.zone.parse('2025-02-27'))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Maintenance task pour corriger la date de fermeture d'une procédure.
Utile pour des raisons juridiques si recours
Voir https://secure.helpscout.net/conversation/2868785806/2156585?