### PR TITLE
ETQ Utilisateur d'un lecteur d'écran, je veux que les blocs répétables soient différenciés

### DIFF
--- a/app/assets/stylesheets/sections.scss
+++ b/app/assets/stylesheets/sections.scss
@@ -24,15 +24,6 @@
     content: counter(h2) '.' counter(h3) '.' counter(h4) '. ';
   }
 
-  .repetition {
-    counter-reset: repetition;
-
-    .block-id::after {
-      counter-increment: repetition;
-      content: counter(repetition);
-    }
-  }
-
   // Repeat block
   .repetition {
     .fr-fieldset,

--- a/app/components/editable_champ/repetition_component/repetition_component.en.yml
+++ b/app/components/editable_champ/repetition_component/repetition_component.en.yml
@@ -1,4 +1,3 @@
 ---
 en:
-  add: "Add an element to « %{libelle} »"
-  add_title: "Add an element to « %{libelle} »"
+  add: "Add another element to « %{libelle} »"

--- a/app/components/editable_champ/repetition_component/repetition_component.fr.yml
+++ b/app/components/editable_champ/repetition_component/repetition_component.fr.yml
@@ -1,4 +1,4 @@
 ---
 fr:
-  add: "Ajouter un élément pour « %{libelle} »"
-  add_title: Ajouter un élément pour « %{libelle} »
+  add: "Ajouter un élément supplémentaire à « %{libelle} »"
+

--- a/app/components/editable_champ/repetition_row_component/repetition_row_component.en.yml
+++ b/app/components/editable_champ/repetition_row_component/repetition_row_component.en.yml
@@ -1,5 +1,3 @@
 ---
 en:
-  delete: Destroy element
-  delete_title: "Destroy element number %{row_number}"
-  delete_label: "Destroy element number %{row_number}"
+  delete: "Destroy %{libelle} %{row_number}"

--- a/app/components/editable_champ/repetition_row_component/repetition_row_component.fr.yml
+++ b/app/components/editable_champ/repetition_row_component/repetition_row_component.fr.yml
@@ -1,5 +1,3 @@
 ---
 fr:
-  delete: Supprimer l’élément
-  delete_title: "Supprimer l’élément n°%{row_number}"
-  delete_label: "Supprimer l’élément numéro %{row_number}"
+  delete: "Supprimer %{libelle} %{row_number}"

--- a/app/components/editable_champ/repetition_row_component/repetition_row_component.html.haml
+++ b/app/components/editable_champ/repetition_row_component/repetition_row_component.html.haml
@@ -1,7 +1,7 @@
 .row{ id: "safe-row-selector-#{row_id}" }
   - if @types_de_champ.size > 1
     %fieldset.fr-mx-0.fr-px-0
-      %legend.block-id.fr-px-0= "#{@type_de_champ.libelle} "
+      %legend.fr-px-0= "#{@type_de_champ.libelle} #{row_number}"
       = render section_component
   - else
     = render section_component

--- a/app/components/editable_champ/repetition_row_component/repetition_row_component.html.haml
+++ b/app/components/editable_champ/repetition_row_component/repetition_row_component.html.haml
@@ -7,5 +7,5 @@
     = render section_component
 
   .flex.row-reverse
-    = render NestedForms::OwnedButtonComponent.new(formaction: champs_repetition_path(@dossier, @type_de_champ.stable_id, row_id:), http_method: :delete, opt: { class: "fr-btn fr-btn--sm fr-btn--tertiary fr-text-action-high--red-marianne utils-repetition-required-destroy-button", title: t(".delete_title", row_number:), "aria-label": t(".delete_label", row_number:)}) do
-      = t(".delete")
+    = render NestedForms::OwnedButtonComponent.new(formaction: champs_repetition_path(@dossier, @type_de_champ.stable_id, row_id:), http_method: :delete, opt: { class: "fr-btn fr-btn--sm fr-btn--tertiary fr-text-action-high--red-marianne utils-repetition-required-destroy-button" }) do
+      = t(".delete", libelle: @type_de_champ.libelle, row_number:)

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -154,7 +154,7 @@ describe 'The user', js: true do
     expect(page).to have_selector(".repetition .row", count: 1)
 
     # adding an element means we can ddestroy last item
-    click_on 'Ajouter un élément pour'
+    click_on 'Ajouter un élément supplémentaire à'
     expect(page).to have_selector(".repetition .row:first-child .utils-repetition-required-destroy-button", count: 1, visible: false)
     expect(page).to have_selector(".repetition .row", count: 2)
     expect(page).to have_selector(".repetition .row:last-child .utils-repetition-required-destroy-button", count: 1, visible: true)
@@ -166,7 +166,7 @@ describe 'The user', js: true do
 
     expect do
       within '.repetition .row:last-child' do
-        click_on 'Supprimer l’élément'
+        click_on 'Supprimer'
       end
       wait_until { page.all(".row").size == 1 }
       # removing a repetition means one child only, thus its button destroy is not visible


### PR DESCRIPTION
- Fix #11461 
- Remplace les attributs `title`et `aria-label` des boutons de suppression d'un bloc par un intitulé pertinent.
 
  
__Après__
![Capture d’écran 2025-03-14 à 14 18 10](https://github.com/user-attachments/assets/2057b64e-aa2b-4bea-b330-295b5e138658)
![Capture d’écran 2025-03-14 à 14 34 38](https://github.com/user-attachments/assets/c0bf46cd-8a71-4764-adc8-71c532040804)


__Avant__
![Capture d’écran 2025-03-14 à 14 18 43](https://github.com/user-attachments/assets/5384ea6d-e56e-49df-9dd5-a5d045d21ecf)
![Capture d’écran 2025-03-14 à 14 19 17](https://github.com/user-attachments/assets/6e4e65d5-de9a-4803-9b92-df0c1c9bd79c)
