### PR TITLE
etq-admin : pas d'archive proposé pour le mois en cours

### DIFF
--- a/app/controllers/administrateurs/archives_controller.rb
+++ b/app/controllers/administrateurs/archives_controller.rb
@@ -10,7 +10,12 @@ module Administrateurs
     def index
       @exports = Export.ante_chronological.by_key(all_groupe_instructeurs.map(&:id))
       @average_dossier_weight = @procedure.average_dossier_weight
-      @count_dossiers_termines_by_month = @procedure.dossiers.visible_by_administration.processed_by_month(all_groupe_instructeurs).count
+      @count_dossiers_termines_by_month = @procedure
+        .dossiers
+        .visible_by_administration
+        .where(processed_at: ...Date.current.beginning_of_month)
+        .processed_by_month(all_groupe_instructeurs)
+        .count
       @archives = Archive.for_groupe_instructeur(all_groupe_instructeurs).to_a
     end
 

--- a/spec/controllers/administrateurs/archives_controller_spec.rb
+++ b/spec/controllers/administrateurs/archives_controller_spec.rb
@@ -28,7 +28,7 @@ describe Administrateurs::ArchivesController, type: :controller do
       end
 
       it 'counts only dossiers visible by administration' do
-        travel_to Date.new(2025, 1, 29)
+        travel_to Date.new(2025, 2, 01)
         create(:dossier, :accepte, procedure:, hidden_by_expired_at: nil)
         create(:dossier, :accepte, :hidden_by_expired, procedure:)
         create(:dossier, :accepte, :hidden_by_user, procedure:)
@@ -36,6 +36,14 @@ describe Administrateurs::ArchivesController, type: :controller do
 
         subject
         expect(assigns(:count_dossiers_termines_by_month)).to eq({ Date.new(2025, 1, 1) => 2 })
+      end
+
+      it 'does not suggest an archive for the current month' do
+        travel_to Date.new(2025, 2, 15)
+        create(:dossier, :accepte, procedure:, processed_at: Date.new(2025, 2, 10))
+
+        subject
+        expect(assigns(:count_dossiers_termines_by_month)).to eq({})
       end
     end
 

--- a/spec/system/administrateurs/procedure_archive_and_export_spec.rb
+++ b/spec/system/administrateurs/procedure_archive_and_export_spec.rb
@@ -15,7 +15,7 @@ describe 'Creating a new procedure', js: true do
       path: 'libelle-de-la-procedure')
   end
   let!(:dossiers) do
-    create(:dossier, :accepte, procedure: procedure)
+    create(:dossier, :accepte, procedure: procedure, processed_at: 1.month.ago.to_date)
   end
 
   before { login_as administrateur.user, scope: :user }


### PR DESCRIPTION
Actuellement, on propose une liste mensuelle d'archives jusqu'au dernier mois où au moins un dossier a été traité durant celui-ci. Ceci est également valable pour le mois en cours.

Le problème : si un admin génère une archive pour le mois en cours, compte tenu que l'on ne permet pas de régénérer un fichier d'archive instantannément, tout les dossiers qui se verront traités durant la disponibilité de cette archive ne seront pas intégrés au fichier.

Solution (simple) ici : ne pas proposer de fichier d'archive mensuel pour le mois en cours.