### PR TITLE
ETQ administrateur j'ai une nouvelle interface pour la page d'ajout de groupes d'instructeurs 

### DIFF
--- a/app/components/dsfr/sidemenu_component.rb
+++ b/app/components/dsfr/sidemenu_component.rb
@@ -2,10 +2,6 @@
 
 class Dsfr::SidemenuComponent < ApplicationComponent
   renders_many :links, "LinkComponent"
-  attr_reader :sticky
-  def initialize(sticky: false)
-    @sticky = sticky
-  end
 
   class LinkComponent < ApplicationComponent
     attr_reader :name, :url, :icon

--- a/app/components/dsfr/sidemenu_component/sidemenu_component.html.haml
+++ b/app/components/dsfr/sidemenu_component/sidemenu_component.html.haml
@@ -1,5 +1,5 @@
 
-%nav.fr-sidemenu{ class: sticky ? 'sticky' : '', "aria-labelledby" => "fr-sidemenu-title" }
+%nav.fr-sidemenu.fr-sidemenu--sticky{ "aria-labelledby" => "fr-sidemenu-title" }
   .fr-sidemenu__inner
     %button.fr-sidemenu__btn{ "aria-controls" => "fr-sidemenu-wrapper", "aria-expanded" => "false", hidden: "" }= t('.btn_collapse_text')
     #fr-sidemenu-wrapper.fr-collapse

--- a/app/components/procedure/groupe_instructeur_menu_component.rb
+++ b/app/components/procedure/groupe_instructeur_menu_component.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
 class Procedure::GroupeInstructeurMenuComponent < ApplicationComponent
-  attr_reader :sticky
-  def initialize(procedure:, sticky: false)
+  def initialize(procedure:)
     @procedure = procedure
-    @sticky = sticky
   end
 
   private

--- a/app/components/procedure/groupe_instructeur_menu_component/groupe_instructeur_menu_component.html.haml
+++ b/app/components/procedure/groupe_instructeur_menu_component/groupe_instructeur_menu_component.html.haml
@@ -4,6 +4,6 @@
       .fr-mb-2w.fr-ml-2w
         = link_to admin_procedure_groupe_instructeurs_path, class: 'fr-link fr-icon-arrow-left-line fr-link--icon-left' do
           Revenir à la liste
-      = render(Dsfr::SidemenuComponent.new(sticky:)) do |component|
+      = render(Dsfr::SidemenuComponent.new) do |component|
         - component.with_links(links)
     .fr-col= content

--- a/app/components/procedure/groupes_ajout_component/groupes_ajout_component.html.haml
+++ b/app/components/procedure/groupes_ajout_component/groupes_ajout_component.html.haml
@@ -1,11 +1,16 @@
-- content_for(:title, 'Ajout de groupes')
-%h1 Ajout de groupes d'instructeurs
+- content_for(:title, 'Ajouter un groupe d’instructeurs')
+%h1.fr-h2 Ajouter un groupe d’instructeurs
 
-%section
-  = form_for :groupe_instructeur,
-    method: :post do |f|
+= form_for :groupe_instructeur,
+  method: :post do |f|
+  .card
     = f.label :label, class: 'fr-label fr-mb-1w' do
       = t('.add_a_group.title')
     .flex.justify-between.align-baseline.fr-mb-1w
       = f.text_field :label, required: true, class: 'fr-input', placeholder: 'Entrer un nom de groupe'
-      = f.button t('.button.add_group'), class: "fr-btn fr-btn fr-btn--secondary fr-btn--icon-right fr-icon-add-line ml-2"
+
+  %ul.fr-btns-group.fr-btns-group--inline-sm
+    %li
+      = link_to 'Annuler', admin_procedure_groupe_instructeurs_path, class: 'fr-btn fr-btn--secondary'
+    %li
+      = f.button t('.button.add_group'), class: "fr-btn fr-btn--secondary ml-2"

--- a/app/views/administrateurs/groupe_instructeurs/ajout.html.haml
+++ b/app/views/administrateurs/groupe_instructeurs/ajout.html.haml
@@ -4,5 +4,13 @@
                     [(@procedure.groupe_instructeurs.many? ? 'Groupes' : 'Instructeurs'), admin_procedure_groupe_instructeurs_path(@procedure)],
                     ['Ajout']] }
 
-= render Procedure::InstructeursMenuComponent.new(procedure: @procedure) do
-  = render Procedure::GroupesAjoutComponent.new(procedure: @procedure, groupe_instructeurs: @groupes_instructeurs)
+.container
+  .fr-grid-row
+    .fr-col.fr-col-12.fr-col-md-3
+      .fr-container
+        %ul.fr-btns-group.fr-btns-group--inline-md.fr-ml-0.fr-sidemenu__inner
+          %li
+            = link_to options_admin_procedure_groupe_instructeurs_path, class: 'fr-link fr-icon-arrow-left-line fr-link--icon-left fr-mb-2w fr-mr-2w' do
+              Revenir à la liste
+    .fr-col
+      = render Procedure::GroupesAjoutComponent.new(procedure: @procedure, groupe_instructeurs: @groupes_instructeurs)

--- a/app/views/administrateurs/groupe_instructeurs/show.html.haml
+++ b/app/views/administrateurs/groupe_instructeurs/show.html.haml
@@ -4,7 +4,7 @@
                     ['Groupes d’instructeurs', admin_procedure_groupe_instructeurs_path(@procedure)],
                     [@groupe_instructeur.label]] }
 
-= render Procedure::GroupeInstructeurMenuComponent.new(procedure: @procedure, sticky: true) do
+= render Procedure::GroupeInstructeurMenuComponent.new(procedure: @procedure) do
   = render Procedure::OneGroupeManagementComponent.new(revision: @procedure.active_revision, groupe_instructeur: @groupe_instructeur)
 
   = render partial: 'shared/groupe_instructeurs/instructeurs',


### PR DESCRIPTION
Cf une partie de https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/10766

Quelques changements d'UI dans la page Ajout d'un groupe d'instructeurs

AVANT
<img width="1280" alt="Capture d’écran 2025-03-14 à 16 18 48" src="https://github.com/user-attachments/assets/cf85847b-fabc-47f8-bca1-8834dc908b1e" />


APRÈS

<img width="1280" alt="Capture d’écran 2025-03-17 à 11 21 29" src="https://github.com/user-attachments/assets/f4168de6-e0cc-4fa8-a903-561bdb3375c8" />

