### PR TITLE
Tech: migre `api_particulier_token` de notre implem custom d'attributs chiffrés vers les encrypted attributes

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -25,7 +25,7 @@ class Procedure < ApplicationRecord
 
   DOSSIERS_COUNT_EXPIRING = 1.hour
 
-  attr_encrypted :api_particulier_token
+  encrypts :api_particulier_token
 
   has_many :revisions, -> { order(:id) }, class_name: 'ProcedureRevision', inverse_of: :procedure
   belongs_to :draft_revision, class_name: 'ProcedureRevision', optional: false

--- a/app/tasks/maintenance/t20250317_migrate_api_particulier_token_to_encrypted_attributes_task.rb
+++ b/app/tasks/maintenance/t20250317_migrate_api_particulier_token_to_encrypted_attributes_task.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20250317MigrateAPIParticulierTokenToEncryptedAttributesTask < MaintenanceTasks::Task
+    # Documentation: migre les API particulier token d'une implémentation custom d'attributs chiffrés
+    # vers les encrypted attributs standard de Rails
+
+    include RunnableOnDeployConcern
+    include StatementsHelpersConcern
+
+    run_on_first_deploy
+
+    def collection
+      Procedure.where.not(encrypted_api_particulier_token: nil)
+    end
+
+    def process(element)
+      old_token = EncryptionService.new.decrypt(element.encrypted_api_particulier_token)
+
+      element.update_columns(api_particulier_token: old_token, encrypted_api_particulier_token: nil)
+    end
+
+    def count
+      collection.count
+    end
+  end
+end

--- a/app/views/administrateurs/jeton_particulier/api_particulier.html.haml
+++ b/app/views/administrateurs/jeton_particulier/api_particulier.html.haml
@@ -3,28 +3,27 @@
                     [@procedure.libelle.truncate_words(10), admin_procedure_path(@procedure)],
                     [Procedure.human_attribute_name(:jeton_api_particulier)]] }
 
-.container
-  .flex
-    = link_to admin_procedure_api_particulier_jeton_path, class: 'card-admin', id: 'add-jeton' do
-      - if @procedure.api_particulier_token.blank?
-        %div
-          %p.fr-badge.fr-badge--info= t('.needs_configuration')
-      - else
-        %div
-          %p.fr-badge.fr-badge--success= t('.already_configured')
-      %div
-        %h3.fr-h6
-          = Procedure.human_attribute_name(:jeton_api_particulier)
-      %p.fr-btn.fr-btn--tertiary= t('views.shared.actions.edit')
+.fr-container
+  %h1.fr-h2= Procedure.human_attribute_name(:jeton_api_particulier)
+
+  .fr-grid-row.fr-grid-row--gutters.fr-pb-6w
+    .fr-col-12.fr-col-md-6
+      .fr-card.fr-card--shadow.fr-my-3w
+        .fr-card__body
+          .fr-card__content
+            %h2.fr-card__title= Procedure.human_attribute_name(:jeton_api_particulier)
+            %p.fr-badge.fr-badge--sm.fr-mb-2w{ class: @procedure.api_particulier_token.blank? ? 'fr-badge--info' : 'fr-badge--success' }
+              = @procedure.api_particulier_token.blank? ? t('.needs_configuration') : t('.already_configured')
+          .fr-card__footer
+            = link_to t('views.shared.actions.edit'), admin_procedure_api_particulier_jeton_path, class: 'fr-btn', id: 'edit-jeton'
 
     - if @procedure.api_particulier_scopes.present?
-      = link_to admin_procedure_api_particulier_sources_path, class: 'card-admin' do
-        - if @procedure.api_particulier_token.blank?
-          %div
-            %p.fr-badge.fr-badge--info= t('.needs_configuration')
-        - else
-          %div
-            %p.fr-badge.fr-badge--success= t('.already_configured')
-        %div
-          %p.card-admin-title= t('administrateurs.sources_particulier.show.data_sources')
-        %p.fr-btn.fr-btn--tertiary= t('views.shared.actions.edit')
+      .fr-col-12.fr-col-md-6
+        .fr-card.fr-card--shadow.fr-my-3w
+          .fr-card__body
+            .fr-card__content
+              %h2.fr-card__title= t('administrateurs.sources_particulier.show.data_sources')
+              %p.fr-badge.fr-badge--sm.fr-mb-2w{ class: @procedure.api_particulier_token.blank? ? 'fr-badge--info' : 'fr-badge--success' }
+                = @procedure.api_particulier_token.blank? ? t('.needs_configuration') : t('.already_configured')
+            .fr-card__footer
+              = link_to t('views.shared.actions.edit'), admin_procedure_api_particulier_sources_path, class: 'fr-btn'

--- a/db/migrate/20250317104348_add_api_particulier_token_to_procedures.rb
+++ b/db/migrate/20250317104348_add_api_particulier_token_to_procedures.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAPIParticulierTokenToProcedures < ActiveRecord::Migration[7.0]
+  def change
+    add_column :procedures, :api_particulier_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_03_03_153311) do
+ActiveRecord::Schema[7.0].define(version: 2025_03_17_104348) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_stat_statements"
@@ -986,6 +986,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_03_153311) do
     t.datetime "api_entreprise_token_expires_at", precision: nil
     t.text "api_particulier_scopes", default: [], array: true
     t.jsonb "api_particulier_sources", default: {}
+    t.string "api_particulier_token"
     t.boolean "ask_birthday", default: false, null: false
     t.date "auto_archive_on"
     t.string "cadre_juridique"

--- a/spec/system/api_particulier/api_particulier_spec.rb
+++ b/spec/system/api_particulier/api_particulier_spec.rb
@@ -62,7 +62,7 @@ describe 'fetch API Particulier Data', js: true do
       find('#api-particulier').click
       expect(page).to have_current_path(admin_procedure_api_particulier_path(procedure))
 
-      find('#add-jeton').click
+      find('#edit-jeton').click
       expect(page).to have_current_path(admin_procedure_api_particulier_jeton_path(procedure))
 
       fill_in 'procedure_api_particulier_token', with: expected_token

--- a/spec/tasks/maintenance/t20250317_migrate_api_particulier_token_to_encrypted_attributes_task_spec.rb
+++ b/spec/tasks/maintenance/t20250317_migrate_api_particulier_token_to_encrypted_attributes_task_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe T20250317MigrateAPIParticulierTokenToEncryptedAttributesTask do
+    describe "#process" do
+      subject(:task) { described_class.new }
+
+      context "when procedure has encrypted_api_particulier_token" do
+        let(:api_token) { "abc123-test-token-456xyz" }
+        let(:procedure) { create(:procedure) }
+
+        before do
+          encrypted_value = EncryptionService.new.encrypt(api_token)
+          procedure.update_column(:encrypted_api_particulier_token, encrypted_value)
+
+          procedure.reload
+        end
+
+        it "migrates the token to the new encrypted attribute" do
+          expect(procedure.encrypted_api_particulier_token).to be_present
+
+          expect(EncryptionService.new.decrypt(procedure.encrypted_api_particulier_token)).to eq(api_token)
+
+          task.process(procedure)
+          procedure.reload
+
+          expect(procedure.api_particulier_token).to eq(api_token)
+          expect(procedure.encrypted_api_particulier_token).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Motivations:
- moins de code à maintenir
- avec rails 7.1 il aurait fallu un changement pour que les tests continuent de marcher

Dans une future PR, on supprimera `EncryptionService` et l'ancienne colonne.

PI: 2 démarches ont ce token, 1 close en 2022 et 1 brouillon jamais publié


J'ai aussi amélioré le layout de la page avant/après

<img width="1230" alt="Capture d’écran 2025-03-17 à 12 37 30" src="https://github.com/user-attachments/assets/ec17aa56-3521-47c9-ad52-f14254bfd996" />

<img width="1267" alt="Capture d’écran 2025-03-17 à 12 39 30" src="https://github.com/user-attachments/assets/d3e3677b-8fa4-43b3-a1bb-cd6fc51c14ce" />

