### PR TITLE
ETQ usager, je souhaite ne pas avoir de lien pour recréer un dossier si : la demarche qui remplace celle de mon dossier a été supprimée

### DIFF
--- a/app/helpers/procedure_helper.rb
+++ b/app/helpers/procedure_helper.rb
@@ -70,4 +70,11 @@ module ProcedureHelper
     end
     admin_procedures_path(statut:)
   end
+
+  def can_recreate_a_dossier_from_a_procedure?(procedure)
+    procedure.closing_reason_internal_procedure? &&
+    procedure.replaced_by_procedure.present? &&
+    !procedure.replaced_by_procedure.discarded? &&
+    procedure.replaced_by_procedure.path.present? # TODO: to remove when all path are added, cf: https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11453
+  end
 end

--- a/app/views/users/dossiers/_dossiers_list.html.haml
+++ b/app/views/users/dossiers/_dossiers_list.html.haml
@@ -62,15 +62,15 @@
         = render Dsfr::AlertComponent.new(state: :info, size: :sm, extra_class_names: "fr-mb-2w") do |c|
           - c.with_body do
             %p
-              - if dossier.brouillon? && dossier.procedure.closing_reason_internal_procedure? && dossier.procedure.replaced_by_procedure.present?
+              - if dossier.brouillon? && can_recreate_a_dossier_from_a_procedure?(dossier.procedure)
                 = t('views.users.dossiers.dossiers_list.procedure_closed.brouillon.internal_procedure_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.procedure'), commencer_path(dossier.procedure.replaced_by_procedure.path), **external_link_attributes, title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_new_procedure'))).html_safe)
               - elsif dossier.brouillon?
                 = t('views.users.dossiers.dossiers_list.procedure_closed.brouillon.other_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.more_details'), closing_details_path(dossier.procedure.path), **external_link_attributes, title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_closing_details'))).html_safe)
-              - elsif dossier.en_construction_ou_instruction? && dossier.procedure.closing_reason_internal_procedure? && dossier.procedure.replaced_by_procedure.present?
+              - elsif dossier.en_construction_ou_instruction? && can_recreate_a_dossier_from_a_procedure?(dossier.procedure)
                 = t('views.users.dossiers.dossiers_list.procedure_closed.en_cours.internal_procedure_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.procedure'), commencer_path(dossier.procedure.replaced_by_procedure.path), **external_link_attributes, title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_new_procedure'))).html_safe)
-              - elsif dossier.en_construction_ou_instruction?
+              - elsif dossier.en_construction_ou_instruction? && !dossier.procedure.replaced_by_procedure.present?
                 = t('views.users.dossiers.dossiers_list.procedure_closed.en_cours.other_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.more_details'), closing_details_path(dossier.procedure.path), **external_link_attributes, title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_closing_details'))).html_safe)
-              - elsif dossier.termine? && dossier.procedure.closing_reason_internal_procedure? && dossier.procedure.replaced_by_procedure.present?
+              - elsif dossier.termine? && can_recreate_a_dossier_from_a_procedure?(dossier.procedure)
                 = t('views.users.dossiers.dossiers_list.procedure_closed.termine.internal_procedure_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.this_procedure'), commencer_path(dossier.procedure.replaced_by_procedure.path), **external_link_attributes, title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_new_procedure'))).html_safe)
               - elsif dossier.termine?
                 = t('views.users.dossiers.dossiers_list.procedure_closed.termine.other_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.more_details'), closing_details_path(dossier.procedure.path), **external_link_attributes, title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_closing_details'))).html_safe)

--- a/spec/views/users/dossiers/_dossier_list.html.haml_spec
+++ b/spec/views/users/dossiers/_dossier_list.html.haml_spec
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+describe 'users/dossiers/dossiers_list', type: :view do
+  let(:user) { dossier.user }
+
+  subject do
+    @rdvs_for_dossiers = []
+    render 'users/dossiers/dossiers_list', dossiers: [dossier], current_user: user
+  end
+  before do
+    [:paginate, :page_entries_info].map { allow(view).to receive(it).and_return("") }
+  end
+  context 'when procedure is not published and not path (sentry#6394294155)' do
+    let(:discarded_procedure) { create(:procedure, :discarded) }
+    let(:replaced_procedure) { create(:procedure, :closed, closing_reason: :internal_procedure, replaced_by_procedure: discarded_procedure) }
+    let(:dossier) { create(:dossier, :en_construction, procedure: replaced_procedure) }
+
+    it "renders successfully" do
+      expect(subject).not_to have_link(commencer_path(replaced_procedure.path))
+      expect(subject).not_to have_link(commencer_path(discarded_procedure.path))
+    end
+  end
+end


### PR DESCRIPTION
un mini correctif / amelioration de code extrait de https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11471. en gros, on pouvait proposer a l'usager de re-creer un dossier si la demarche d'un dossier est close

