### PR TITLE
correctif: ETQ tech, j'aimerais savoir qui requete l'API et avoir des logs fiables

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -98,14 +98,6 @@ class ApplicationController < ActionController::Base
     current_expert.present?
   end
 
-  # calling current_user in a before_action will trigger the warden authentication (devise behavior)
-  # which is not what we want in a before_action of a sign_in action (current_user should be nil before explicit sign_in)
-  # so we need to override current_user to avoid this
-  # https://github.com/heartcombo/devise/issues/5602#issuecomment-1876164084
-  def current_user
-    super if warden.authenticated?(scope: :user)
-  end
-
   def current_account
     {
       gestionnaire: current_gestionnaire,

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -121,4 +121,12 @@ class Users::SessionsController < Devise::SessionsController
     flash[:alert] = "La connexion des agents passe à présent systématiquement par AgentConnect"
     redirect_to agent_connect_path(force_agent_connect: true)
   end
+
+  # calling current_user in a before_action will trigger the warden authentication (devise behavior)
+  # which is not what we want in a before_action of a sign_in action (current_user should be nil before explicit sign_in)
+  # so we need to override current_user to avoid this
+  # https://github.com/heartcombo/devise/issues/5602#issuecomment-1876164084
+  def current_user
+    super if warden.authenticated?(scope: :user)
+  end
 end

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -128,6 +128,18 @@ describe API::V2::GraphqlController do
     end
 
     describe "token authentication" do
+      describe 'logging' do
+        it "generates correct LogRage payload" do
+          @rs = nil
+          expect(controller).to receive(:request_logs).and_wrap_original do |m, *args|
+            @rs = m.call(*args)
+          end
+          gql_data
+          expect(@rs[:user_id]).to eq(admin.user.id)
+          expect(@rs[:user_roles]).to eq("User, Instructeur, Administrateur")
+        end
+      end
+
       it {
         expect(gql_errors).to eq(nil)
         expect(gql_data).not_to be_nil


### PR DESCRIPTION
# problème 

depuis le 20/12/2024, on a plus les user_id dans les logs de notre api graphql. pas pratique pr debugger.

# solution 

c'etait notre surchage du current_user pr un prob de warden. cf: https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11156 en théorie on reste sur le même périmetre fonctionnelle pr l'override (`POST /users/sign_in`), sans aller deborder sur le reste de l'app et perdre nos info de logging (utile pr debugger)