### PR TITLE
ETQ tech - je veux corriger les gender invalides en base

### DIFF
--- a/app/tasks/maintenance/t20250318_fix_individual_gender_task.rb
+++ b/app/tasks/maintenance/t20250318_fix_individual_gender_task.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20250318FixIndividualGenderTask < MaintenanceTasks::Task
+    # Documentation: cette tâche corrige la valeur du gender dans la table
+    # Individual, notamment dans les cas où l'utilisateur a fait traduire la
+    # page par son navigateur.
+
+    include RunnableOnDeployConcern
+    include StatementsHelpersConcern
+
+    # Uncomment only if this task MUST run imperatively on its first deployment.
+    # If possible, leave commented for manual execution later.
+    # run_on_first_deploy
+
+    GENDER = {
+      "Mr." => 'M.',
+      "Господин." => 'M.',
+      "السيد." => 'M.',
+      "Г-жо." => 'Mme',
+      "Bayan." => 'Mme',
+      "Госпожа." => 'Mme',
+      "Sra." => 'Mme',
+      "السيدة." => 'Mme',
+      "م." => 'M.',
+      "Mrs." => 'Mme'
+    }
+
+    def collection
+      Individual.where.not(gender: ['M.', 'Mme'])
+    end
+
+    def process(element)
+      element.update!(gender: GENDER.fetch(element.gender, 'Mme'))
+    end
+
+    def count
+      collection.count
+    end
+  end
+end

--- a/spec/tasks/maintenance/t20250318_fix_individual_gender_task_spec.rb
+++ b/spec/tasks/maintenance/t20250318_fix_individual_gender_task_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe T20250318FixIndividualGenderTask do
+    describe '#collection' do
+      subject(:collection) { described_class.collection }
+
+      context 'valid gender' do
+        let(:individual) { create(:individual) }
+
+        it do
+          expect(collection).not_to include(individual)
+        end
+      end
+
+      context 'invalid gender' do
+        let(:individual) { create(:individual, gender: "traduction") }
+
+        it do
+          expect(collection).to include(individual)
+        end
+      end
+    end
+
+    describe "#process" do
+      subject(:process) { described_class.process(individual) }
+
+      context 'know invalid gender' do
+        let(:individual) { create(:individual, gender: described_class::GENDER.keys.first) }
+
+        it do
+          subject
+          expect(individual.reload.gender).to eq(described_class::GENDER.values.first)
+        end
+      end
+
+      context 'unknow invalid gender' do
+        let(:individual) { create(:individual, gender: "traduction") }
+
+        it do
+          subject
+          expect(individual.reload.gender).to eq('Mme')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Dans page d'identité du dossier, il s'avère qu'en raison des traductions générées par les navigateurs, on en vient à stocker la version traduite du genre/civilité en base, ce qui rend invalide le dossier et bloque ainsi toute action par les instructeurs.

Cette tâche vise à sélectionner tous les cas concernés (depuis la table Individual) et d'associer arbitrairement la valeur 'Mme'