### PR TITLE
Fix task failing when a procedure is invalid

### DIFF
--- a/app/tasks/maintenance/t20250313_fix_missing_procedure_paths_for_discarded_procedures_task.rb
+++ b/app/tasks/maintenance/t20250313_fix_missing_procedure_paths_for_discarded_procedures_task.rb
@@ -13,7 +13,7 @@ module Maintenance
 
     def process(element)
       element.ensure_path_exists
-      element.save!
+      element.save(validate: false)
     end
   end
 end

--- a/spec/tasks/maintenance/t20250313_fix_missing_procedure_paths_for_discarded_procedures_task_spec.rb
+++ b/spec/tasks/maintenance/t20250313_fix_missing_procedure_paths_for_discarded_procedures_task_spec.rb
@@ -28,6 +28,19 @@ module Maintenance
       it "adds a procedure_path to the discarded procedure" do
         expect { process }.to change { discarded_procedure.procedure_paths.count }.from(0).to(1)
       end
+
+      context "when the procedure is invalid" do
+        subject(:process) { described_class.process(element) }
+        let(:element) {
+          discarded_procedure.update_column(:libelle, nil) # make it invalid
+          discarded_procedure
+        }
+
+        it "adds a procedure_path to the invalid discarded procedure" do
+          expect(element).not_to be_valid
+          expect { process }.to change { discarded_procedure.procedure_paths.count }.from(0).to(1)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Corrige https://www.demarches-simplifiees.fr/manager/maintenance_tasks/tasks/Maintenance::T20250313FixMissingProcedurePathsForDiscardedProceduresTask