### PR TITLE
ETQ tech -  je ne veux pas recevoir des données issues de traductions automatiques

### DIFF
--- a/app/components/dossiers/individual_form_component/individual_form_component.html.haml
+++ b/app/components/dossiers/individual_form_component/individual_form_component.html.haml
@@ -37,12 +37,12 @@
 
           .fr-fieldset__element
             .fr-radio-group
-              = individual.radio_button :gender, Individual::GENDER_FEMALE, required: true, id: "identite_champ_radio_#{Individual::GENDER_FEMALE}"
+              = individual.radio_button :gender, Individual::GENDER_FEMALE, required: true, id: "identite_champ_radio_#{Individual::GENDER_FEMALE}", translate: "no"
               %label.fr-label{ for: "identite_champ_radio_#{Individual::GENDER_FEMALE}" }
                 = Individual.human_attribute_name('gender.female')
           .fr-fieldset__element
             .fr-radio-group
-              = individual.radio_button :gender, Individual::GENDER_MALE, required: true, id: "identite_champ_radio_#{Individual::GENDER_MALE}"
+              = individual.radio_button :gender, Individual::GENDER_MALE, required: true, id: "identite_champ_radio_#{Individual::GENDER_MALE}", translate: "no"
               %label.fr-label{ for: "identite_champ_radio_#{Individual::GENDER_MALE}" }
                 = Individual.human_attribute_name('gender.male')
       .fr-fieldset__element.fr-mb-0
@@ -72,7 +72,7 @@
         - Individual.notification_methods.each do |method, _|
           .fr-fieldset__element
             .fr-radio-group
-              = individual.radio_button :notification_method, method, required: true, id: "notification_method_#{method}", "data-action" => "for-tiers#toggleEmailInput", "data-for-tiers-target" => "notificationMethod"
+              = individual.radio_button :notification_method, method, required: true, id: "notification_method_#{method}", "data-action" => "for-tiers#toggleEmailInput", "data-for-tiers-target" => "notificationMethod", translate: "no"
               %label.fr-label{ for: "notification_method_#{method}" }
                 = t("activerecord.attributes.individual.notification_methods.#{method}")
 

--- a/app/components/editable_champ/civilite_component/civilite_component.html.haml
+++ b/app/components/editable_champ/civilite_component/civilite_component.html.haml
@@ -1,11 +1,11 @@
 
 .fr-fieldset__element.fr-fieldset__element--inline
   .fr-radio-group
-    = @form.radio_button :value, Individual::GENDER_FEMALE, id: @champ.female_input_id
+    = @form.radio_button :value, Individual::GENDER_FEMALE, id: @champ.female_input_id, translate: "no"
     %label.fr-label{ for: @champ.female_input_id }
       = Individual.human_attribute_name('gender.female')
 .fr-fieldset__element.fr-fieldset__element--inline
   .fr-radio-group
-    = @form.radio_button :value, Individual::GENDER_MALE, id: @champ.male_input_id
+    = @form.radio_button :value, Individual::GENDER_MALE, id: @champ.male_input_id, translate: "no"
     %label.fr-label{ for: @champ.male_input_id }
       = Individual.human_attribute_name('gender.male')

--- a/app/components/editable_champ/drop_down_list_component/drop_down_list_component.html.haml
+++ b/app/components/editable_champ/drop_down_list_component/drop_down_list_component.html.haml
@@ -2,7 +2,7 @@
   .fr-fieldset__content
     - items.each do |value, option_id|
       .fr-radio-group
-        = @form.radio_button :value, option_id, id: @champ.radio_id(option_id)
+        = @form.radio_button :value, option_id, id: @champ.radio_id(option_id), translate: 'no'
         %label.fr-label{ for: @champ.radio_id(option_id) }
           = value
 
@@ -22,7 +22,8 @@
     { required: @champ.required?,
     id: @champ.input_id,
     class: select_class_names,
-    aria: { describedby: select_aria_describedby } }
+    aria: { describedby: select_aria_describedby },
+    translate: 'no' }
 
 - if @champ.drop_down_other?
   %div{ class: other_element_class_names }

--- a/app/components/editable_champ/linked_drop_down_list_component/linked_drop_down_list_component.html.haml
+++ b/app/components/editable_champ/linked_drop_down_list_component/linked_drop_down_list_component.html.haml
@@ -2,7 +2,7 @@
   .fr-select-group
     = render EditableChamp::ChampLabelComponent.new form: @form, champ: @champ, seen_at: @seen_at
 
-    = @form.select :primary_value, @champ.primary_options, {}, required: @champ.required?, class: 'fr-select fr-mb-3v', id: @champ.input_id, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }
+    = @form.select :primary_value, @champ.primary_options, {}, required: @champ.required?, class: 'fr-select fr-mb-3v', id: @champ.input_id, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, translate: 'no'
 
 - if @champ.has_secondary_options_for_primary?
   .secondary
@@ -13,6 +13,6 @@
         - if @champ.drop_down_secondary_description.present?
           .fr-hint-text{ id: "#{@champ.describedby_id}-secondary" }
             = render SimpleFormatComponent.new(@champ.drop_down_secondary_description, allow_a: true)
-        = @form.select :secondary_value, @champ.secondary_options[@champ.primary_value], {}, required: @champ.required?, class: 'fr-select', id: "#{@champ.input_id}-secondary", aria: { describedby: "#{@champ.describedby_id}-secondary" }
+        = @form.select :secondary_value, @champ.secondary_options[@champ.primary_value], {}, required: @champ.required?, class: 'fr-select', id: "#{@champ.input_id}-secondary", aria: { describedby: "#{@champ.describedby_id}-secondary" }, translate: 'no'
 - else
   = @form.hidden_field :secondary_value, value: ''

--- a/app/components/editable_champ/multiple_drop_down_list_component/multiple_drop_down_list_component.html.haml
+++ b/app/components/editable_champ/multiple_drop_down_list_component/multiple_drop_down_list_component.html.haml
@@ -3,7 +3,7 @@
     - capture do
       .fr-fieldset__element
         .fr-checkbox-group
-          = b.check_box(checked: @champ.selected_options.include?(b.value), id: @champ.checkbox_id(b.value), class: 'fr-checkbox-group__checkbox')
+          = b.check_box(checked: @champ.selected_options.include?(b.value), id: @champ.checkbox_id(b.value), class: 'fr-checkbox-group__checkbox', translate: 'no')
           %label.fr-label{ for: @champ.checkbox_id(b.value) }
             = b.text
 

--- a/app/javascript/components/ComboBox.tsx
+++ b/app/javascript/components/ComboBox.tsx
@@ -72,6 +72,7 @@ export function ComboBox({
           ref={inputRef}
           aria-busy={isLoading}
           placeholder={placeholder || undefined}
+          translate="no"
         />
         <Button
           aria-haspopup="false"


### PR DESCRIPTION
Pb : les traducteurs automatiques de navigateur peuvent avoir pour effet de traduire la value d'un input ou d'un select, ce qui conduit à stocker en base des données qui ne sont pas valides.

Première solution : bloquer la traduction sur les input et select an ajoutant un attribut translate: 'no' :
- page identité (civilité + notification) ;
- champ civilité ;
- champ adresse & co ;
- choix simple ;
- choix multiple ;
- menus liés.
