### PR TITLE
ETQ usager et admin je suis encore plus prévenu que la démarche et dossiers sont en test

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -157,4 +157,21 @@ module ApplicationHelper
   end
 
   def asterisk = render(EditableChamp::AsteriskMandatoryComponent.new)
+
+  def add_pdf_draft_warning(pdf, dossier)
+    return unless dossier.revision.draft?
+
+    pdf.pad_top(20) do
+      pdf.fill_color "AA3300"
+      pdf.font 'marianne', style: :bold, size: 12 do
+        pdf.text "DÉMARCHE EN TEST"
+      end
+
+      pdf.font 'marianne', size: 10 do
+        pdf.text "Ce dossier est déposé sur une démarche en test par l’administration."
+        pdf.text "Il peut être supprimé à tout moment et sans préavis, même après avoir été accepté."
+      end
+      pdf.fill_color "000000"
+    end
+  end
 end

--- a/app/views/commencer/show.html.haml
+++ b/app/views/commencer/show.html.haml
@@ -2,6 +2,7 @@
 
 .commencer.form
   - if !user_signed_in?
+    = render ProcedureDraftWarningComponent.new(revision: @revision, current_administrateur:, extra_class_names: "fr-mb-2w")
     = render Dsfr::CalloutComponent.new(title: t(".start_procedure"), heading_level: 'h2') do |c|
       - c.with_html_body do
         = render partial: 'shared/france_connect_login', locals: { url: commencer_france_connect_path(path: @procedure.path, prefill_token: @prefilled_dossier&.prefill_token), heading_level: :h3 }
@@ -13,7 +14,6 @@
                 #{Current.application_name}
           %li= link_to t('views.shared.account.already_user'), commencer_sign_in_path(path: @procedure.path, prefill_token: @prefilled_dossier&.prefill_token), class: 'fr-btn fr-btn--secondary'
 
-    = render ProcedureDraftWarningComponent.new(revision: @revision, current_administrateur:, extra_class_names: "fr-mb-2w")
 
   - else
     = render ProcedureDraftWarningComponent.new(revision: @revision, current_administrateur:, extra_class_names: "fr-mb-2w")

--- a/app/views/dossiers/show.pdf.prawn
+++ b/app/views/dossiers/show.pdf.prawn
@@ -328,6 +328,7 @@ prawn_document(page_size: "A4") do |pdf|
 
   pdf.pad_bottom(40) do
     pdf.image DOSSIER_PDF_EXPORT_LOGO_SRC, width: 300, position: :center
+    add_pdf_draft_warning(pdf, @dossier)
   end
 
   format_in_2_columns(pdf, 'Dossier Nº', @dossier.id.to_s)

--- a/app/views/users/dossiers/papertrail.pdf.prawn
+++ b/app/views/users/dossiers/papertrail.pdf.prawn
@@ -36,6 +36,7 @@ prawn_document(margin: [top_margin, right_margin, bottom_margin, left_margin], p
     pdf.pad_top(15) do
       pdf.fill_color grey
       pdf.text t('.receipt'), size: 14, align: :center
+      add_pdf_draft_warning(pdf, @dossier)
     end
   end
 


### PR DESCRIPTION
Suite à https://mattermost.incubateur.net/betagouv/pl/3m6deotmztdkxpim8wiqc6iacw

- Remonte le positionnement du warning sur la page commencer au-dessus de bouton de signup
- Message déjà présent sur la page identité, dossier, merci
- Ajoute le warning sur l'attestation de dépôt et dossier PDF
<img width="1007" alt="Capture d’écran 2025-03-19 à 11 01 47" src="https://github.com/user-attachments/assets/753476b8-b9e5-469f-b503-aa4981c37a87" />
<img width="1007" alt="Capture d’écran 2025-03-19 à 10 49 40" src="https://github.com/user-attachments/assets/f3fecc4f-4026-442c-b8b7-bed405e1f503" />
