### PR TITLE
[UI routage] etq admin l'interface de filtrage des groupes a été mise à jour 

### DIFF
--- a/app/components/conditions/routing_rules_component/routing_rules_component.html.haml
+++ b/app/components/conditions/routing_rules_component/routing_rules_component.html.haml
@@ -5,7 +5,9 @@
     class: 'form width-100' do
     .conditionnel.width-100
       .flex
-        - if @groupe_instructeur.invalid_rule?
+        - if @groupe_instructeur.routing_rule.nil?
+          %p.fr-mb-1w.fr-badge.fr-badge--warning.fr-badge--sm aucune règle
+        - elsif @groupe_instructeur.invalid_rule?
           %p.fr-mb-1w.fr-badge.fr-badge--warning.fr-badge--sm règle invalide
         - elsif @groupe_instructeur.non_unique_rule?
           %p.fr-mb-1w.fr-badge.fr-badge--warning.fr-badge--sm règle déjà attribuée à #{@groupe_instructeur.groups_with_same_rule}

--- a/app/components/procedure/groupes_management_component/groupes_management_component.html.haml
+++ b/app/components/procedure/groupes_management_component/groupes_management_component.html.haml
@@ -36,13 +36,15 @@
                 %td.fr-cell--multiline{ scope: 'col' }
                   = link_to admin_procedure_groupe_instructeur_path(@procedure, gi), class: 'fr-link' do
                     %span= gi.label
-                  - if gi.closed
-                    %p.fr-badge.fr-badge--info.fr-badge--sm.fr-ml-1w inactif
-                  - elsif gi.invalid_rule?
-                    %p.fr-badge.fr-badge--warning.fr-badge--sm.fr-ml-1w règle invalide
-                  - elsif gi.non_unique_rule?
-                    %p.fr-badge.fr-badge--warning.fr-badge--sm.fr-ml-1w règle déjà attribuée à #{gi.groups_with_same_rule}
                   %p= gi.routing_rule&.to_s(@procedure.active_revision.types_de_champ)
+                  - if gi.closed
+                    %p.fr-badge.fr-badge--info.fr-badge--sm.fr-mt-1w inactif
+                  - elsif gi.routing_rule.nil?
+                    %p.fr-badge.fr-badge--warning.fr-badge--sm.fr-mt-1w aucune règle
+                  - elsif gi.invalid_rule?
+                    %p.fr-badge.fr-badge--warning.fr-badge--sm.fr-mt-1w règle invalide
+                  - elsif gi.non_unique_rule?
+                    %p.fr-badge.fr-badge--warning.fr-badge--sm.fr-mt-1w règle déjà attribuée à #{gi.groups_with_same_rule}
 
                 %td{ scope: 'col' }
                   %span.fr-mr-1w

--- a/app/components/procedure/groupes_search_component/groupes_search_component.fr.yml
+++ b/app/components/procedure/groupes_search_component/groupes_search_component.fr.yml
@@ -1,5 +1,5 @@
 ---
 fr:
-  to_configure_filter:
-    one: "Filtrer %{count} groupe à configurer"
-    other: "Filtrer les %{count} groupes à configurer"
+  to_configure_filter_html:
+    one: "<span>Afficher seulement le groupe avec alerte sur la règle de routage </ span><strong>(%{count})</strong>"
+    other: "<span>Afficher seulement les groupes avec alerte sur la règle de routage </ span><strong>(%{count})</strong>"

--- a/app/components/procedure/groupes_search_component/groupes_search_component.html.haml
+++ b/app/components/procedure/groupes_search_component/groupes_search_component.html.haml
@@ -1,20 +1,15 @@
 = form_with(url: admin_procedure_groupe_instructeurs_path(@procedure),
   method: :get) do
-  #header-search.fr-search-bar.fr-mb-3w.fr-p-2w.fr-background-alt--grey{ role: "search" }
-    = label_tag :q, 'Rechercher un groupe (par nom)', class: 'sr-only'
-    = text_field_tag :q, @query, class: 'fr-input', type: 'search', autocomplete: 'off', placeholder: 'Rechercher un groupe (par nom)'
-    %button.fr-btn{ title: "Rechercher" } Rechercher
+  .header-search-container.fr-background-alt--grey.fr-mb-3w.fr-p-2w
+    #header-search.fr-search-bar.fr-mb-2w{ role: "search" }
+      = label_tag :q, 'Rechercher un groupe (par nom)', class: 'sr-only'
+      = text_field_tag :q, @query, class: 'fr-input', type: 'search', autocomplete: 'off', placeholder: 'Rechercher un groupe (par nom)'
+      %button.fr-btn{ title: "Rechercher" } Rechercher
+    - if show_to_configure?
+      .fr-toggle
+        = check_box_tag :filter, '1', @to_configure_filter, class: 'fr-toggle__input', data: { controller: 'autosubmit' }
+        = label_tag :filter, t('.to_configure_filter_html', count: @to_configure_count), class: 'fr-toggle__label'
   - if @query.present?
     = link_to "Réinitialiser la recherche",
       admin_procedure_groupe_instructeurs_path(@procedure),
       class: 'fr-link'
-  - if show_to_configure?
-    .flex.align-baseline
-      %ul.fr-btns-group.fr-btns-group--sm
-        %li.fr-checkbox-group.fr-ml-1w.fr-py-1w
-          .title.font-weight-bold.fr-mb-1w
-            %span.fr-icon-filter-fill.fr-icon--sm.fr-mr-1w{ 'aria-hidden': 'true' }
-              Filtre
-
-          = check_box_tag :filter, '1', @to_configure_filter, data: { controller: 'autosubmit' }
-          = label_tag :filter, t('.to_configure_filter', count: @to_configure_count)

--- a/spec/components/procedures/one_group_management_component_spec.rb
+++ b/spec/components/procedures/one_group_management_component_spec.rb
@@ -25,7 +25,7 @@ describe Procedure::OneGroupeManagementComponent, type: :component do
         procedure.reload
         subject
       end
-      it { expect(page).to have_text('règle invalide') }
+      it { expect(page).to have_text('aucune règle') }
     end
   end
 end

--- a/spec/system/routing/rules_full_scenario_spec.rb
+++ b/spec/system/routing/rules_full_scenario_spec.rb
@@ -53,7 +53,7 @@ describe 'The routing with rules', js: true do
     click_on 'Continuer'
 
     expect(page).to have_text('Gestion des groupes')
-    expect(page).to have_text('règle invalide')
+    expect(page).to have_text('aucune règle')
 
     # close modal
     expect(page).to have_selector("#routing-mode-modal", visible: true)


### PR DESCRIPTION
Voir une partie de https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/10766


- Mise à jour de l'UI du composant permettant de filtrer sur les groupes avec alerte sur la règle de routage (on remplace la checkbox par un toggle)

- On affiche le badge "Aucune règle" plutôt que "règle invalide" si le groupe instructeur n'a pas de règle de routage
- On fait un retour à la ligne pour afficher le badge

AVANT
<img width="1280" alt="Capture d’écran 2025-03-25 à 10 41 58" src="https://github.com/user-attachments/assets/ad8927c1-c7d5-4543-9617-8804c9db91a7" />



APRÈS
<img width="1280" alt="Capture d’écran 2025-03-25 à 11 04 17" src="https://github.com/user-attachments/assets/44caf1b8-12ba-4968-8160-1bdb1d6df21a" />


