### PR TITLE
ETQ instructeur, corrige un crash du tableau lorsque la colonne "dépôt pour un tiers" est affichée

### DIFF
--- a/app/components/instructeurs/cell_component.rb
+++ b/app/components/instructeurs/cell_component.rb
@@ -44,7 +44,7 @@ class Instructeurs::CellComponent < ApplicationComponent
   def format(raw_value, type)
     case @column.type
     when :boolean
-      if @column.tdc_type == 'checkbox'
+      if @column.type_de_champ? && @column.tdc_type == 'checkbox'
         raw_value ? I18n.t('activerecord.attributes.type_de_champ.type_champs.checkbox_true') : ''
       else
         raw_value ? I18n.t('utils.yes') : I18n.t('utils.no')

--- a/spec/components/instructeurs/cell_component_spec.rb
+++ b/spec/components/instructeurs/cell_component_spec.rb
@@ -4,7 +4,7 @@ describe Instructeurs::CellComponent do
   let(:component) { described_class.new(dossier:, column:) }
 
   describe '#call' do
-    let(:procedure) { create(:procedure, types_de_champ_public:) }
+    let(:procedure) { create(:procedure, :for_individual, types_de_champ_public:) }
     let(:dossier) { create(:dossier, procedure:) }
     let(:types_de_champ_public) { {} }
 
@@ -17,12 +17,9 @@ describe Instructeurs::CellComponent do
       it { is_expected.to eq(user.email) }
 
       context 'when the dossier is for tiers' do
-        before do
-          dossier.update(for_tiers: true)
-          dossier.create_individual(prenom: 'prenom', nom: 'nom')
-        end
+        let(:dossier) { create(:dossier, :for_tiers_with_notification, procedure:) }
 
-        it { is_expected.to eq("#{user.email} agit pour prenom nom") }
+        it { is_expected.to eq("#{user.email} agit pour Xavier Julien") }
       end
     end
 
@@ -55,6 +52,13 @@ describe Instructeurs::CellComponent do
       let(:column) { dossier.procedure.find_column(label: 'yes_no') }
 
       before { dossier.champs.first.update(value: 'true') }
+
+      it { is_expected.to eq('Oui') }
+    end
+
+    context 'for a boolean column on dossier' do
+      let(:column) { dossier.procedure.find_column(label: "Dépôt pour un tiers") }
+      let(:dossier) { build(:dossier, :for_tiers_with_notification, procedure:) }
 
       it { is_expected.to eq('Oui') }
     end


### PR DESCRIPTION
https://demarches-simplifiees.sentry.io/issues/6359421895/
https://secure.helpscout.net/conversation/2872701075/2157352