### PR TITLE
SVA: Corrige un crash de calcul de date pour un dossier plusieurs fois mentionné incomplet, et toujours incomplet

### DIFF
--- a/app/services/sva_svr_decision_date_calculator_service.rb
+++ b/app/services/sva_svr_decision_date_calculator_service.rb
@@ -55,7 +55,7 @@ class SVASVRDecisionDateCalculatorService
   end
 
   def latest_incomplete_correction_date
-    correction_date dossier.corrections.filter(&:dossier_incomplete?).max_by(&:resolved_at)
+    correction_date dossier.corrections.filter(&:dossier_incomplete?).max_by { _1.resolved_at || Time.current }
   end
 
   def latest_correction_date

--- a/spec/services/sva_svr_decision_date_calculator_service_spec.rb
+++ b/spec/services/sva_svr_decision_date_calculator_service_spec.rb
@@ -101,7 +101,7 @@ describe SVASVRDecisionDateCalculatorService do
             expect(subject).to eq(Date.new(2023, 7, 26))
           end
 
-          context 'when there are multiple corrections' do
+          context 'when there are mixed incorrect and incomplete corrections' do
             let!(:correction2) do
               created_at = Time.zone.local(2023, 5, 30, 18)
               resolved_at = Time.zone.local(2023, 6, 3, 8)
@@ -110,6 +110,19 @@ describe SVASVRDecisionDateCalculatorService do
 
             it 'calculates the date based on SVA rules with all correction delays' do
               expect(subject).to eq(Date.new(2023, 7, 31))
+            end
+          end
+
+          context 'when there are multiple incomplete corrections and last is not yet resolved' do
+            let!(:correction2) do
+              created_at = Time.zone.local(2023, 5, 30, 18)
+              create(:dossier_correction, :incomplete, dossier:, created_at:)
+            end
+
+            before { travel_to Time.zone.local(2023, 6, 5, 8) }
+
+            it 'calculates the date like if resolution is made today' do
+              expect(subject).to eq(Date.new(2023, 8, 6))
             end
           end
         end


### PR DESCRIPTION
situation d'un dossier avec plusieurs corrections de type "dossier incomplet", dont la dernière non corrigée
(un dossier incomplet conduit tjs à une réinitialisation du délai)

https://demarches-simplifiees.sentry.io/issues/6341990755