### PR TITLE
ETQ instructeur, corrige une erreur sur la liste des démarches

### DIFF
--- a/app/tasks/maintenance/t20250320_fix_instructeurs_procedures_without_position_task.rb
+++ b/app/tasks/maintenance/t20250320_fix_instructeurs_procedures_without_position_task.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20250320FixInstructeursProceduresWithoutPositionTask < MaintenanceTasks::Task
+    # Documentation: backfill l'attribut `position` d'InstructeurProcedure qui ont été créés avec une valeur nil
+
+    include RunnableOnDeployConcern
+    include StatementsHelpersConcern
+
+    run_on_first_deploy
+
+    def collection
+      InstructeursProcedure.where(position: nil)
+    end
+
+    def process(element)
+      element.update(position: 99)
+    end
+  end
+end

--- a/db/migrate/20250320153834_alter_instructeurs_procedures_default_position.rb
+++ b/db/migrate/20250320153834_alter_instructeurs_procedures_default_position.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AlterInstructeursProceduresDefaultPosition < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :instructeurs_procedures, :position, 99
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_03_17_104348) do
+ActiveRecord::Schema[7.0].define(version: 2025_03_20_153834) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_stat_statements"
@@ -830,7 +830,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_17_104348) do
     t.datetime "created_at", null: false
     t.bigint "instructeur_id", null: false
     t.bigint "last_revision_seen_id"
-    t.integer "position"
+    t.integer "position", default: 99
     t.bigint "procedure_id", null: false
     t.datetime "updated_at", null: false
     t.index ["instructeur_id", "procedure_id"], name: "index_instructeurs_procedures_on_instructeur_and_procedure", unique: true

--- a/spec/controllers/instructeurs/procedures_controller_spec.rb
+++ b/spec/controllers/instructeurs/procedures_controller_spec.rb
@@ -1182,6 +1182,7 @@ describe Instructeurs::ProceduresController, type: :controller do
 
       it 'updates the last_revision_seen_id in instructeur_procedure' do
         expect(assigns(:instructeur_procedure).last_revision_seen_id).to eq(revision.id)
+        expect(assigns(:instructeur_procedure).position).to eq(99)
       end
     end
 

--- a/spec/tasks/maintenance/t20250320_fix_instructeurs_procedures_without_position_task_spec.rb
+++ b/spec/tasks/maintenance/t20250320_fix_instructeurs_procedures_without_position_task_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe T20250320FixInstructeursProceduresWithoutPositionTask do
+    describe "#process" do
+      subject(:process) { described_class.process(element) }
+
+      let(:element) { create(:instructeurs_procedure, position: nil) }
+
+      it "updates the instructeur_procedure position to 0" do
+        expect { process }.to change { element.reload.position }.from(nil).to(99)
+      end
+    end
+
+    describe "#collection" do
+      subject { described_class.new.collection }
+
+      before do
+        create_list(:instructeurs_procedure, 2, position: nil)
+        create(:instructeurs_procedure, position: 1)
+        create(:instructeurs_procedure, position: 2)
+      end
+
+      it "returns only instructeur_procedures with nil position" do
+        expect(subject.count).to eq(2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://demarches-simplifiees.sentry.io/issues/6431375934/

Depuis https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11496 on créé des `instructeurs_procedure` sans position par défaut à 99 pour être en tête de démarches.


Dans une future PR on pourra changer le schema pour empêcher la valeur null au niveau de la base. 

Et refacto à venir pour ne plus faire de `find_or_create_by` à chaque page, soit en adaptant le code pour que ça marche sans, soit en crééant les records dès l'assignation des instructeurs