### PR TITLE
ETQ instructeur, je veux retrouver le raccourci "Copier le lien de la démarche dans le presse-papiers"

### DIFF
--- a/app/views/instructeurs/procedures/_list.html.haml
+++ b/app/views/instructeurs/procedures/_list.html.haml
@@ -79,6 +79,7 @@
       .fr-hidden.fr-unhidden-lg
         %h3.font-weight-normal.fr-link.fr-mx-2w
           = link_to procedure_libelle_with_number(p), instructeur_procedure_path(p)
+          = render Dsfr::CopyButtonComponent.new(text: commencer_url(p.path), title: t('instructeurs.dossiers.header.banner.copy_link_button'))
         = procedure_badge(p)
 
     .flex.align-center.fr-hidden-lg.fr-mb-2w


### PR DESCRIPTION
#11470 

Version B pour garder l'existant mais si il faut faire la version A dites moi. 

<img width="1089" alt="image" src="https://github.com/user-attachments/assets/074ebd0e-998a-4712-b1b9-79de7005ad0c" />
