### PR TITLE
ETQ Instructeur, je ne veux pas avoir le téléchargement de PJ qui plante aux heures de pointe

### DIFF
--- a/app/lib/active_storage/downloadable_file.rb
+++ b/app/lib/active_storage/downloadable_file.rb
@@ -19,13 +19,15 @@ class ActiveStorage::DownloadableFile
       return files
     end
 
+    cached_client = self.client
+
     files.filter do |file, _filename|
       if file.is_a?(ActiveStorage::FakeAttachment)
         true
       else
         service = file.blob.service
         begin
-          client.head_object(service.container, file.blob.key)
+          cached_client.head_object(service.container, file.blob.key)
           true
         rescue Fog::OpenStack::Storage::NotFound
           false


### PR DESCRIPTION
Erreur sur sentry : https://demarches-simplifiees.sentry.io/issues/6385259422/?project=1429550&query=procedure%3A51214&referrer=issue-stream&sort=date&stream_index=0

Cette pr permet d'éviter pour un dossier avec 15pjs d'initialiser 15 fois le client openstack.
Cela devrait supprimer dans un premier temps les erreurs.
Mais ce n'est pas suffisant, le problème reviendra lorsqu'on aura plus de charge. 
On va continuer de fouiller la possibilité de mettre en cache ce token avec Sim.