### PR TITLE
ETQ instructeur, le bouton `Enregistrer` est visible après avoir personnalisé une colonne à afficher

### DIFF
--- a/app/components/instructeurs/column_picker_component/column_picker_component.html.haml
+++ b/app/components/instructeurs/column_picker_component/column_picker_component.html.haml
@@ -1,5 +1,5 @@
 = form_with model: [:instructeur, @procedure_presentation], class: 'dropdown-form large columns-form' do
   %react-fragment
-    = render ReactComponent.new "ComboBox/MultiComboBox", items: @displayable_columns_for_select, selected_keys: @displayable_columns_selected, name: 'displayed_columns[]', 'aria-label': 'Colonne à afficher', value_separator: false
+    = render ReactComponent.new "ComboBox/MultiComboBox", items: @displayable_columns_for_select, selected_keys: @displayable_columns_selected, name: 'displayed_columns[]', 'aria-label': 'Colonne à afficher', focus_on_select: dom_id(@procedure_presentation, "submit"), value_separator: false
 
-  = submit_tag t('.save'), class: 'fr-btn fr-btn--secondary'
+  = submit_tag t('.save'), id: dom_id(@procedure_presentation, "submit"), class: 'fr-btn fr-btn--secondary'

--- a/app/javascript/components/ComboBox.tsx
+++ b/app/javascript/components/ComboBox.tsx
@@ -172,6 +172,7 @@ export function MultiComboBox(maybeProps: MultiComboBoxProps) {
     valueSeparator,
     className,
     maxItemsDisplay,
+    focusOnSelect,
     ...props
   } = useMemo(() => s.create(maybeProps, MultiComboBoxProps), [maybeProps]);
 
@@ -187,13 +188,18 @@ export function MultiComboBox(maybeProps: MultiComboBoxProps) {
   } = useMultiList({
     defaultItems,
     defaultSelectedKeys,
-    onChange: dispatch,
     formValue,
     allowsCustomValue,
     valueSeparator,
     maxItemsDisplay,
     focusInput: () => {
       inputRef.current?.focus();
+    },
+    onChange: () => {
+      dispatch();
+      if (focusOnSelect) {
+        document.getElementById(focusOnSelect)?.focus();
+      }
     }
   });
   const formResetRef = useOnFormReset(onReset);

--- a/app/javascript/components/react-aria/props.ts
+++ b/app/javascript/components/react-aria/props.ts
@@ -56,7 +56,8 @@ export const MultiComboBoxProps = s.assign(
       selectedKeys: s.array(s.string()),
       allowsCustomValue: s.boolean(),
       valueSeparator: s.union([s.string(), s.literal(false)]),
-      maxItemsDisplay: s.number()
+      maxItemsDisplay: s.number(),
+      focusOnSelect: s.string()
     })
   )
 );


### PR DESCRIPTION
Actuellement le combo reste ouvert et cache le bouton Enregistrer qui se trouve en dessous. Il faut cliquer ailleurs sur la page, ce qui ferme le combo , et ensuite cliquer sur le bouton Enregistrer.
Aussi cela provoque des flaky tests car le bouton est caché (parfois non , ça dépend de la taille de la fenêtre et du driver playwright)

Cette PR règle les 2 pb en fermant le combo une fois une colonne choisie en mettant le focus sur le button, (ce qui devrait aussi améliorer l'accessibilité). Il est tjs possible de sélectionner plusieurs colonnes d'un coup en remettant le focus sur l'input pour re-ouvrir le combo.

C'est pas un cas général du multi combobox car ici: 
- on est dans un dropdown
- il y a un button enregistrer, qui sert aussi à la suppression des colonnes

https://github.com/user-attachments/assets/98bdbfbb-65c8-4256-9c56-4048fdf0c138


