### PR TITLE
Tech: retire le feature flag attestation v2

### DIFF
--- a/app/components/procedure/card/attestation_component.rb
+++ b/app/components/procedure/card/attestation_component.rb
@@ -8,7 +8,11 @@ class Procedure::Card::AttestationComponent < ApplicationComponent
   private
 
   def edit_attestation_path
-    helpers.edit_admin_procedure_attestation_template_v2_path(@procedure)
+    if @procedure.attestation_template&.version == 1
+      helpers.edit_admin_procedure_attestation_template_path(@procedure)
+    else
+      helpers.edit_admin_procedure_attestation_template_v2_path(@procedure)
+    end
   end
 
   def error_messages

--- a/app/controllers/administrateurs/attestation_template_v2s_controller.rb
+++ b/app/controllers/administrateurs/attestation_template_v2s_controller.rb
@@ -3,7 +3,6 @@
 module Administrateurs
   class AttestationTemplateV2sController < AdministrateurController
     before_action :retrieve_procedure
-    before_action :ensure_feature_active
     before_action :retrieve_attestation_template
     before_action :preload_revisions, only: [:edit, :update, :create]
 
@@ -109,10 +108,6 @@ module Administrateurs
     end
 
     private
-
-    def ensure_feature_active
-      redirect_to root_path if !@procedure.feature_enabled?(:attestation_v2)
-    end
 
     def retrieve_attestation_template
       v2s = @procedure.attestation_templates_v2

--- a/app/views/administrateurs/attestation_template_v2s/edit.html.haml
+++ b/app/views/administrateurs/attestation_template_v2s/edit.html.haml
@@ -128,7 +128,7 @@
             = link_to("créez-vous un dossier", new_dossier_path(procedure_id: @procedure, brouillon: true), **external_link_attributes)
             et acceptez-le : l’aperçu l’utilisera.
 
-  - if @procedure.feature_enabled?(:attestation_v2) && @attestation_template.draft?
+  - if @attestation_template.draft?
     - content_for(:sticky_header) do
       = render partial: "sticky_header"
 

--- a/app/views/administrateurs/attestation_templates/edit.html.haml
+++ b/app/views/administrateurs/attestation_templates/edit.html.haml
@@ -6,12 +6,11 @@
                     ['Attestation']] }
 
 .fr-container
-  - if @procedure.feature_enabled?(:attestation_v2)
-    .fr-mb-6w
-      = render Dsfr::AlertComponent.new(state: :info, title: "Nouvel éditeur d’attestation", heading_level: 'h3') do |c|
-        - c.with_body do
-          Cette page concerne l’attestation actuellement délivrée aux usagers.
-          = link_to("Suivez ce lien pour tester le nouvel éditeur d’attestation", edit_admin_procedure_attestation_template_v2_path(@procedure))
+  .fr-mb-6w
+    = render Dsfr::AlertComponent.new(state: :info, title: "Nouvel éditeur d’attestation disponible", heading_level: 'h3') do |c|
+      - c.with_body do
+        Cette page concerne l’attestation actuellement délivrée aux usagers.
+        = link_to("Suivez ce lien pour passer au nouvel éditeur d’attestation", edit_admin_procedure_attestation_template_v2_path(@procedure))
 
   .procedure-form#attestation-template-edit
     .procedure-form__columns

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -21,7 +21,6 @@ end
 features = [
   :administrateur_web_hook,
   :api_particulier,
-  :attestation_v2,
   :blocking_pending_correction,
   :cojo_type_de_champ,
   :dossier_pdf_vide,

--- a/spec/controllers/administrateurs/attestation_template_v2s_controller_spec.rb
+++ b/spec/controllers/administrateurs/attestation_template_v2s_controller_spec.rb
@@ -28,7 +28,6 @@ describe Administrateurs::AttestationTemplateV2sController, type: :controller do
 
   before do
     sign_in(admin.user)
-    Flipper.enable(:attestation_v2)
   end
 
   describe 'GET #show' do

--- a/spec/system/administrateurs/procedure_attestation_template_spec.rb
+++ b/spec/system/administrateurs/procedure_attestation_template_spec.rb
@@ -9,14 +9,14 @@ describe 'As an administrateur, I want to manage the procedure’s attestation',
 
   before do
     login_as(administrateur.user, scope: :user)
-    Flipper.enable(:attestation_v2) # fully enabled on prod, pending removal in code
 
     response = Typhoeus::Response.new(code: 200, body: 'Hello world')
     Typhoeus.stub(WEASYPRINT_URL).and_return(response)
   end
 
-  def find_attestation_card(with_nested_selector: nil)
-    attestation_path = edit_admin_procedure_attestation_template_v2_path(procedure)
+  def find_attestation_card(v2: true, with_nested_selector: nil)
+    attestation_path = v2 ? edit_admin_procedure_attestation_template_v2_path(procedure)
+                          : edit_admin_procedure_attestation_template_path(procedure)
 
     full_selector = [
       "a[href=\"#{attestation_path}\"]",
@@ -35,14 +35,9 @@ describe 'As an administrateur, I want to manage the procedure’s attestation',
     scenario do
       visit admin_procedure_path(procedure)
 
-      within find_attestation_card do
+      within find_attestation_card(v2: false) do
         expect(page).to have_content('Activée')
         click
-      end
-
-      within('.fr-alert--info') do
-        expect(page).to have_content("Nouvel éditeur d’attestation")
-        click_on 'cliquez ici'
       end
 
       fill_in "Titre de l’attestation", with: 'BOOM'
@@ -59,7 +54,7 @@ describe 'As an administrateur, I want to manage the procedure’s attestation',
       # check attestation is now disabled
       visit admin_procedure_path(procedure)
 
-      find_attestation_card(with_nested_selector: ".fr-badge")
+      find_attestation_card(v2: false, with_nested_selector: ".fr-badge")
       expect(page).to have_content('Désactivée')
     end
   end


### PR DESCRIPTION
c'est activé depuis longtemps pour tout le monde

J'ai aussi changé le lien de la tuile pour pointer vers la v1 si c'est celle là qui est active, car c'était confusant pour certains admins de de tomber sur une v2 vierge alors qu'ils ont activé la v1.