### PR TITLE
ETQ usager j'ai plus de détails sur ma liste de dossiers si l'établissement est une enseigne d'apres l'API entreprise

### DIFF
--- a/app/helpers/etablissement_helper.rb
+++ b/app/helpers/etablissement_helper.rb
@@ -49,7 +49,7 @@ module EtablissementHelper
 
   def raison_sociale_or_name(etablissement)
     etablissement.association_titre.presence ||
-      etablissement.enseigne.presence ||
+      etablissement.enseigne.present? ? "#{etablissement.enseigne} - #{etablissement.localite}" : nil ||
       etablissement.entreprise_raison_sociale.presence ||
       "#{etablissement.entreprise_nom} #{etablissement.entreprise_prenom}"
   end

--- a/spec/helpers/etablissement_helper_spec.rb
+++ b/spec/helpers/etablissement_helper_spec.rb
@@ -50,8 +50,8 @@ RSpec.describe EtablissementHelper, type: :helper do
 
     context 'when etablissement is not the siege and enseigne exist' do
       let(:enseigne) { "mon enseigne" }
-      it 'display enseigne' do
-        expect(subject).to eq(enseigne)
+      it 'display enseigne and localité' do
+        expect(subject).to eq("mon enseigne - BOIS COLOMBES")
       end
     end
 


### PR DESCRIPTION
closes #11327 

On rajoute l'info de la localité lorsque l'etablissement est une enseigne selon l'API entreprise.
Par exemple pour les mairies on a désormais la commune qui s'affiche.

**APRES**
<img width="1017" alt="Capture d’écran 2025-03-31 à 14 47 01" src="https://github.com/user-attachments/assets/845a413f-86bc-48a6-9b9c-03ccba02b052" />

**AVANT**
<img width="1003" alt="Capture d’écran 2025-03-31 à 14 47 38" src="https://github.com/user-attachments/assets/35722f63-b168-4197-864e-9dc07a7e27e0" />
