### PR TITLE
ETQ usager, corrige l'affichage de la première ligne de répétition lorsque l'ensemble du bloc est conditionné

### DIFF
--- a/app/controllers/concerns/turbo_champs_concern.rb
+++ b/app/controllers/concerns/turbo_champs_concern.rb
@@ -9,7 +9,7 @@ module TurboChampsConcern
     to_update = champs.filter { _1.public_id.in?(params.keys) }
       .filter { _1.refresh_after_update? || _1.user_buffer_changes? }
 
-    to_show, to_hide = champs.filter(&:conditional?)
+    to_show, to_hide = champs.filter { it.conditional? || it.child? }
       .partition(&:visible?)
       .map { champs_to_one_selector(_1 - to_update) }
 

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -3,7 +3,7 @@
 describe Users::DossiersController, type: :controller do
   include ActiveSupport::Testing::TimeHelpers
 
-  let(:user) { create(:user) }
+  let(:user) { users(:default_user) }
 
   describe 'before_actions' do
     it 'are present' do
@@ -78,7 +78,6 @@ describe Users::DossiersController, type: :controller do
   end
 
   describe '#ensure_ownership_or_invitation!' do
-    let(:user) { create(:user) }
     let(:asked_dossier) { create(:dossier) }
     let(:ensure_authorized) { :ensure_ownership_or_invitation! }
 

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -427,12 +427,13 @@ describe 'The user', js: true do
     context 'with a repetition' do
       let(:stable_id) { 999 }
       let(:condition) { greater_than_eq(champ_value(stable_id), constant(18)) }
+      let(:repetition_mandatory) { false }
       let(:procedure) do
         create(:procedure, :published, :for_individual,
           types_de_champ_public: [
             { type: :integer_number, libelle: 'UNIQ_LABEL', mandatory: false, stable_id: },
             {
-              type: :repetition, libelle: 'repetition', condition:, children: [
+              type: :repetition, libelle: 'repetition', mandatory: repetition_mandatory, condition:, children: [
                 { type: :text, libelle: 'nom', mandatory: true }
               ]
             }
@@ -446,6 +447,21 @@ describe 'The user', js: true do
         fill_in('UNIQ_LABEL', with: 10)
         click_on 'Déposer le dossier'
         expect(page).to have_current_path(merci_dossier_path(user_dossier))
+      end
+
+      context 'condition for a mandatory repetition' do
+        let(:repetition_mandatory) { true }
+
+        scenario 'default rows is visible when condition is satisfied' do
+          log_in(user, procedure)
+          fill_individual
+
+          fill_in('UNIQ_LABEL', with: 20)
+
+          fill_in('nom', with: "got it")
+          click_on 'Déposer le dossier'
+          expect(page).to have_current_path(merci_dossier_path(user_dossier))
+        end
       end
     end
 


### PR DESCRIPTION
https://mattermost.incubateur.net/betagouv/pl/js99z3ot4jgp8rwr9yce1pt94o

Depuis que [la visibilité d'un child dépend de celle du parent](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11513), on doit gérer le hide/show des children ici

Closes [#11532](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/11532)