### PR TITLE
ETQ instructeur, fix notification et affichage de la galerie lorsque la dernière PJ a été retirée

### DIFF
--- a/app/views/instructeurs/dossiers/_header_bottom.html.haml
+++ b/app/views/instructeurs/dossiers/_header_bottom.html.haml
@@ -7,7 +7,7 @@
         instructeur_dossier_path(dossier.procedure, params[:statut], dossier),
         notification: notifications_summary[:demande])
 
-      - if gallery_attachments.present?
+      - if gallery_attachments.present? || notifications_summary[:pieces_jointes]
         = dynamic_tab_item(t('views.instructeurs.dossiers.tab_steps.attachments'),
           pieces_jointes_instructeur_dossier_path(dossier.procedure, dossier, statut: params[:statut]),
           notification: notifications_summary[:pieces_jointes])

--- a/app/views/instructeurs/dossiers/pieces_jointes.html.haml
+++ b/app/views/instructeurs/dossiers/pieces_jointes.html.haml
@@ -3,6 +3,11 @@
 = render partial: "header", locals: { dossier: @dossier, gallery_attachments: @gallery_attachments, procedure_presentation: @procedure_presentation }
 
 .fr-container
+  - if @gallery_attachments.blank?
+    = render Dsfr::AlertComponent.new(state: :info, extra_class_names: "fr-my-6w") do |c|
+      - c.with_body do
+        %p Ce dossier ne comporte pas ou plus de pièce jointe.
+
   .gallery.gallery-pieces-jointes{ "data-controller": "lightbox" }
     - @gallery_attachments.each do |attachment|
       = render Attachment::GalleryItemComponent.new(attachment:, seen_at: @pieces_jointes_seen_at)


### PR DESCRIPTION
Fix le cas où la dernière pièce jointe a été supprimée (y compris titre d'identité une fois le dossier instruit) : cela met à jour `last_champ_piece_jointe_updated_at` , ce qui déclenche la notification mais l'instructeur a besoin d'aller sur l'onglet pour constater qu'il n'y a plus de PJ et retirer la notification.

https://secure.helpscout.net/conversation/2889440950/2161712?viewId=1653799