### PR TITLE
Tech: corrige 2 tests instables

### DIFF
--- a/spec/system/instructeurs/procedure_filters_spec.rb
+++ b/spec/system/instructeurs/procedure_filters_spec.rb
@@ -52,6 +52,10 @@ describe "procedure filters" do
   end
 
   scenario "should add be able to add and remove custom type_de_champ column", js: true do
+    # Hack to force filters combo to be above the menu so Enregistrer button
+    # is clickable. (by default height is 2000+ for playwright driver)
+    Capybara.page.current_window.resize_to(1440, 900)
+
     add_column(type_de_champ.libelle)
     within ".dossiers-table" do
       expect(page).to have_button(type_de_champ.libelle)

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -635,7 +635,8 @@ describe 'The user', js: true do
       allow_any_instance_of(Users::DossiersController).to receive(:update).and_raise("Server is busy")
       fill_in('texte obligatoire', with: 'a valid user input')
       blur
-      expect(page).to have_text('Attention : Impossible d’enregistrer le brouillon.')
+      expect(page).to have_css('.autosave-state-failed')
+      expect(page).to have_button('Réessayer')
       # Test that retrying after a failure works
       allow_any_instance_of(Users::DossiersController).to receive(:update).and_call_original
       click_on 'Réessayer'


### PR DESCRIPTION
## Procedure filters
hack pour corriger un test instable à cause de la position du combobox de filtres
Par défaut le driver playwright a une hauteur de 2000+ px, ce qui fait que le combo des filtres se positionne vers le bas, et masque le bouton de validation. Ce pb est nettement plus fréquent avec les maj  sur rails 7.1 pour une raison que j'ignore.

Solution: On réduit la hauteur de la page pour que le combo se positionne au-dessus et laisse le bouton cliquable.

Idéalement faudrait revoir ce menu. qui est aussi dû au fait que le combo prend garde le focus et s'ouvre même après une première sélection

## Brouillon retry
L'assertion `have_text("Attention…")` était tjs true car le texte est déjà dans le DOM (et considéré visible par capybara). Donc si l'exécution va très vite, le stub appellait l'update original avant même que le blur en JS ait eu le temps de lancer la requête précédente censer échouer et provoquer l'affichage du bouton Réessayer.