### PR TITLE
wip - ETQ instructeur, j'aimerais avoir des stats plus fiables sur l'estimation de la durée de traitement des dossiers par mois

### DIFF
--- a/app/models/concerns/procedure_stats_concern.rb
+++ b/app/models/concerns/procedure_stats_concern.rb
@@ -77,10 +77,21 @@ module ProcedureStatsConcern
     traitement_times(first_processed_at..last_considered_processed_at)
       .group_by { |t| t[:processed_at].beginning_of_month }
       .transform_values { |month| month.map { |h| h[:processed_at] - h[:depose_at] } }
-      .transform_values { |traitement_times_for_month| traitement_times_for_month.percentile(USUAL_TRAITEMENT_TIME_PERCENTILE).ceil }
+      .transform_values { |traitement_times_for_month| winsorized_mean.traitement_times_for_month(traitement_times_for_month).ceil }
       .transform_values { |seconds| seconds == 0 ? nil : seconds }
       .transform_values { |seconds| convert_seconds_in_days(seconds) }
       .transform_keys { |month| pretty_month(month) }
+  end
+
+  # The winsorized mean is a useful estimator because by retaining the outliers without taking them too literally, it is less sensitive to observations at the extremes than the straightforward mean, and will still generate a reasonable estimate of central tendency or mean for almost all statistical models. In this regard it is referred to as a robust estimator.
+  def winsorized_mean(data, lower_perc = 5, upper_perc = 95)
+    data_points = data.sort
+    lower_bound_percentile = data_points.percentile(lower_perc)
+    upper_bound_percentile = data_points.percentile(upper_perc)
+
+    winsorized_data = data_points.map { |data_point| data_point < lower_bound_percentile ? lower_bound_percentile : (data_point > upper_bound_percentile ? upper_bound_percentile : data_point) }
+
+    winsorized_data.sum.to_f / winsorized_data.size
   end
 
   def usual_traitement_time_for_recent_dossiers(nb_days)
@@ -90,7 +101,7 @@ module ProcedureStatsConcern
     traitement_time =
       traitement_times((now - nb_days.days)..now)
         .map { |times| times[:processed_at] - times[:depose_at] }
-        .sort
+        .sor t
     if traitement_time.size >= clusters_count
       traitement_time.each_slice((traitement_time.size.to_f / clusters_count.to_f).ceil)
         .map { _1.percentile(USUAL_TRAITEMENT_TIME_PERCENTILE) }


### PR DESCRIPTION
hs: https://secure.helpscout.net/conversation/2852711317/2152697

# probleme

<img width="613" alt="Capture d’écran 2025-04-03 à 10 49 04 AM" src="https://github.com/user-attachments/assets/a377075f-a7ad-4b51-8420-6da04beb5efa" />
l'instructrice en charge des stats tombe sur 25, nous sur 75. wtf ? 

# solution 

Sur l'estimation de la durée du traitement moyen nous faisions un `dataset.percentile(90)` afin d'éliminer les valeurs abérantes (outliers, souvent en fin et début de série : exemple un dossier qui a trainé).

Le problème de cette approche est qu'elle est sensible sur des jeux de données tordus, ex: 
![54b599b1-8ad8-4d23-a477-dd65c7eee0fc-distrib](https://github.com/user-attachments/assets/0194ba2d-5863-4eb5-94e9-f6709d72fc26)

D'autant plus que pour certaines démarches, le jeu de données lié au traitement est bien biaisé 
![87d2eff3-8b67-4c66-b60d-3ec51e950dca-dist](https://github.com/user-attachments/assets/938bc3b5-b297-4d5b-b6ba-0144f0c5f223)

La ligne rouge sur ces graphes est la valeur du 90eme percentile. En l'occurence dans notre cas de bug ±70. C'est ce que nous affichons sur le graph des démarches : https://www.demarches-simplifiees.fr/statistiques/demande-de-rescrit-relatif-a-la-participation-a-l-assurance-chomage
L'instructrice en charge du suivis a fait une simple moyenne simple qui tombe a 25 jours de delai de traitement. On en est loiiiiinnnnnnnnn.

Avec le winsorized mean, on tombe a 22 qui est bien plus représentatif du jeu de donnée (https://en.wikipedia.org/wiki/Winsorized_mean)