### PR TITLE
ETQ instructeur, j'aimerais avoir des stats plus fiables sur l'estimation de la durée de traitement des dossiers par mois

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -928,7 +928,7 @@ en:
         processing_time: "Processing time"
         since_procedure_creation: "since the procedure was created"
         nb_days: "Nb Days"
-        processing_time_graph_description: "Processing time between instruction and final answer (accepted, rejected or closed) for 90% of files."
+        processing_time_graph_description: "Weiweighted mean time between last submission and final answer (accepted, rejected or closed)."
         status_evolution_details: "since the procedure launch"
         status_evolution: "Evolution of file statuses"
         acceptance_rate: "Acceptance rate"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1007,7 +1007,7 @@ fr:
         processing_time: "Temps de traitement"
         since_procedure_creation: "depuis le lancement de la démarche"
         nb_days: "Nb Jours"
-        processing_time_graph_description: "Temps de traitement entre le passage en instruction et la réponse (accepté, refusé, ou classé sans suite) pour 90% des dossiers"
+        processing_time_graph_description: "Moyenne pondérée du temps de traitement entre la dernière date de dépot et la réponse (accepté, refusé, ou classé sans suite)."
         status_evolution_details: "depuis le lancement de la démarche"
         status_evolution: "Avancée des dossiers"
         acceptance_rate: "Taux d’acceptation"

--- a/spec/models/concerns/procedure_stats_concern_spec.rb
+++ b/spec/models/concerns/procedure_stats_concern_spec.rb
@@ -123,8 +123,8 @@ describe ProcedureStatsConcern do
 }
 
       it 'computes a time representative of the dossier instruction delay for each month except current month' do
-        expect(procedure.usual_traitement_time_by_month_in_days['avril 2019']).to eq 60
-        expect(procedure.usual_traitement_time_by_month_in_days['mai 2019']).to eq 4
+        expect(procedure.usual_traitement_time_by_month_in_days['avril 2019']).to eq 54
+        expect(procedure.usual_traitement_time_by_month_in_days['mai 2019']).to eq 3
         expect(procedure.usual_traitement_time_by_month_in_days['juin 2019']).to eq nil
       end
     end


### PR DESCRIPTION
hs: https://secure.helpscout.net/conversation/2852711317/2152697

# probleme

<img width="613" alt="Capture d’écran 2025-04-03 à 10 49 04 AM" src="https://github.com/user-attachments/assets/a377075f-a7ad-4b51-8420-6da04beb5efa" />

sur le mois de février, l'instructrice en charge des stats tombait un delai de traitement moyen de 25 jours, quand nous afffichions 75. wtf ? 

# solution 

Sur l'estimation de la durée du traitement moyen nous faisions un `dataset.percentile(90)` afin d'éliminer les valeurs abérantes (outliers, souvent en fin et début de série : exemple un dossier qui a trainé).

Le problème de cette approche est qu'elle est sensible sur des jeux de données tordus, ex: 
![54b599b1-8ad8-4d23-a477-dd65c7eee0fc-distrib](https://github.com/user-attachments/assets/0194ba2d-5863-4eb5-94e9-f6709d72fc26)

D'autant plus que pour certaines démarches, le jeu de données lié au traitement est bien biaisé 
![87d2eff3-8b67-4c66-b60d-3ec51e950dca-dist](https://github.com/user-attachments/assets/938bc3b5-b297-4d5b-b6ba-0144f0c5f223)

La ligne rouge sur ces graphes est la valeur du 90eme percentile. En l'occurence dans notre cas de bug ±70. C'est ce que nous affichons sur le graph des démarches : https://www.demarches-simplifiees.fr/statistiques/demande-de-rescrit-relatif-a-la-participation-a-l-assurance-chomage
L'instructrice en charge du suivis a fait une moyenne simple qui tombe a 25 jours de delai de traitement. On en est loiiiiinnnnnnnnn.

Avec le winsorized mean, on tombe a 22 qui est bien plus représentatif du jeu de donnée (https://en.wikipedia.org/wiki/Winsorized_mean)