### PR TITLE
Tech: le direct upload doit utiliser le même csrf token que celui de l'ApplicationController

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
 
   MAINTENANCE_MESSAGE = 'Le site est actuellement en maintenance. Il sera à nouveau disponible dans un court instant.'
 
-  protect_from_forgery with: :exception, store: :cookie
+  protect_from_forgery with: :exception, store: :cookie # define same store in config/initializers/active_storage.rb
 
   before_action :set_sentry_user
   before_action :redirect_if_untrusted

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -32,6 +32,11 @@ Rails.application.reloader.to_prepare do
   class ActiveStorage::BaseJob
     include ActiveJob::RetryOnTransientErrors
   end
+
+  class ActiveStorage::BaseController
+    # same store as ApplicationController
+    protect_from_forgery with: :exception, store: :cookie
+  end
 end
 
 # When an OpenStack service is initialized it makes a request to fetch


### PR DESCRIPTION
Etant donné que notre JS renvoie le token trouvé dans l'HTML, qui correspond à celui généré par `ApplicationController` on doit utiliser le même store partout.
