### PR TITLE
ETQ usager - optimisation du menu « Aide (et contact) » et du footer

### DIFF
--- a/app/assets/stylesheets/02_utils.scss
+++ b/app/assets/stylesheets/02_utils.scss
@@ -173,8 +173,13 @@
   padding-left: $default-padding;
 }
 
-.border-left-1px {
+.border-left-light {
   border-left: 1px solid var(--border-default-grey);
+  padding-left: $default-padding;
+}
+
+.border-left-dark {
+  border-left: 1px solid var(--border-plain-grey);
   padding-left: $default-padding;
 }
 

--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -253,7 +253,7 @@ ul.dropdown-items {
   @media (min-width: 62em) {
     font-size: 0.875rem;
     padding: 0;
-    width: 360px;
+    width: 450px;
   }
 }
 
@@ -261,7 +261,7 @@ ul.dropdown-items {
   padding: 0.75rem 1rem;
 
   @media (min-width: 62em) {
-    padding-right: 1rem;
+    padding-right: 2.5rem;
     padding-left: 1rem;
   }
 }

--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -257,7 +257,7 @@ ul.dropdown-items {
   }
 }
 
-.help-content.fr-menu ul.fr-menu__list li {
+.help-content.fr-menu ul.fr-menu__list > li {
   padding: 0.75rem 1rem;
 
   @media (min-width: 62em) {
@@ -266,7 +266,7 @@ ul.dropdown-items {
   }
 }
 
-.help-content.fr-menu ul.fr-menu__list li:not(:last-child) {
+.help-content.fr-menu ul.fr-menu__list > li:not(:last-child) {
   @media (min-width: 62em) {
     border-bottom: 1px solid $border-grey;
   }

--- a/app/assets/stylesheets/procedure_champs_editor.scss
+++ b/app/assets/stylesheets/procedure_champs_editor.scss
@@ -72,10 +72,6 @@
       }
     }
 
-    .vertical-border {
-      border-left: 1px solid;
-    }
-
     legend {
       text-transform: uppercase;
       padding: 0;

--- a/app/components/procedure/service_list_contact_component.rb
+++ b/app/components/procedure/service_list_contact_component.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Procedure::ServiceListContactComponent < ApplicationComponent
+  attr_reader :service, :dossier
+
+  def initialize(service:, dossier:)
+    @service = service
+    @dossier = dossier
+  end
+end

--- a/app/components/procedure/service_list_contact_component/service_list_contact_component.en.yml
+++ b/app/components/procedure/service_list_contact_component/service_list_contact_component.en.yml
@@ -1,0 +1,4 @@
+en:
+  contact_instructeur: Send a message directly to the instructor.
+  faq_link: Consult the online help
+  contact_link: Consult the administration contact page

--- a/app/components/procedure/service_list_contact_component/service_list_contact_component.fr.yml
+++ b/app/components/procedure/service_list_contact_component/service_list_contact_component.fr.yml
@@ -1,0 +1,4 @@
+fr:
+  contact_instructeur: Envoyez directement un message à l’instructeur.
+  faq_link: Consultez l'aide en ligne
+  contact_link: Consultez la page de contact de l'administration

--- a/app/components/procedure/service_list_contact_component/service_list_contact_component.html.haml
+++ b/app/components/procedure/service_list_contact_component/service_list_contact_component.html.haml
@@ -1,0 +1,43 @@
+%li.fr-mb-1w
+  - if service.faq_link.present?
+    = link_to t('.faq_link'), service.faq_link , title: helpers.new_tab_suffix(t('.faq_link')), class: 'fr-link fr-link--sm', **helpers.external_link_attributes
+%li.fr-mb-2w
+  - if service.contact_link.present?
+    = link_to t('.contact_link'), service.contact_link, title: helpers.new_tab_suffix(t('.contact_link')), class: 'fr-link fr-link--sm', **helpers.external_link_attributes
+
+%li.border-left-dark
+  %dl
+    - if dossier.present? && dossier&.messagerie_available?
+      .flex.fr-mb-2v
+        %dt.fr-mr-2v
+          %span.fr-icon-message-2-line.fr-icon--sm{ "aria-hidden": "true" }
+          %span.visually-hidden= t('layouts.mailers.service_footer.by_email')
+        %dd
+          = link_to t('.contact_instructeur'), messagerie_dossier_path(dossier)
+
+    - if service.email.present?
+      .flex.fr-mb-2v
+        %dt.fr-mr-2v
+          %span.fr-icon-mail-line.fr-icon--sm{ "aria-hidden": "true" }
+          %span.visually-hidden= t('layouts.mailers.service_footer.by_email')
+        %dd
+          = link_to service.email, "mailto:#{service.email}"
+    .flex.fr-mb-2v
+      %dt.fr-mr-2v
+        %span.fr-icon-phone-line.fr-icon--sm{ "aria-hidden": "true" }
+        %span.visually-hidden= t('layouts.mailers.service_footer.by_phone')
+      %dd
+        = link_to service.telephone, service.telephone_url
+    .flex.fr-mb-2v
+      %dt.fr-mr-2v
+        %span.fr-icon-time-line.fr-icon--sm{ "aria-hidden": "true" }
+        %span.visually-hidden= t('layouts.mailers.service_footer.schedule')
+      %dd
+        = service.horaires
+
+    - if service.other_contact_info.present?
+      .flex.fr-mb-2v
+        %dt.fr-mr-2v
+          %span.fr-icon-information-line.fr-icon--sm{ "aria-hidden": "true" }
+        %dd
+          = service.other_contact_info

--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
@@ -55,7 +55,7 @@
                 = render Attachment::EditComponent.new(**notice_explicative_options)
 
             - if type_de_champ.integer_number? || type_de_champ.decimal_number?
-              .vertical-border.fr-pl-2w.fr-mt-2w
+              .border-left-dark.fr-mt-2w
                 .cell
                   %legend.fake-label
                     Format accepté
@@ -84,7 +84,7 @@
                           = form.number_field :max_number, class: "fr-input", id: dom_id(type_de_champ, :max_number)
 
             - if type_de_champ.date? || type_de_champ.datetime?
-              .vertical-border.fr-pl-2w.fr-mt-2w
+              .border-left-dark.fr-mt-2w
                 .cell
                   %legend.fake-label
                     Format accepté
@@ -136,7 +136,7 @@
                       = form.radio_button :drop_down_mode, 'advanced', id: dom_id(type_de_champ, :advanced)
                       = form.label :drop_down_mode_advanced, t('.drop_down_list.labels.advanced'), for: dom_id(type_de_champ, :advanced), class: 'fr-label'
 
-            .flex.column.justify-start.flex-grow.vertical-border.fr-pl-2w.fr-my-1w
+            .flex.column.justify-start.flex-grow.border-left-dark.fr-my-1w
               = render TypesDeChampEditor::ChampDropDownSimpleComponent.new(type_de_champ:, form:, procedure:)
               = render TypesDeChampEditor::ChampDropDownAdvancedComponent.new(type_de_champ:, form:, procedure:)
 

--- a/app/components/types_de_champ_editor/champ_formatted_advanced_component/champ_formatted_advanced_component.html.haml
+++ b/app/components/types_de_champ_editor/champ_formatted_advanced_component/champ_formatted_advanced_component.html.haml
@@ -1,4 +1,4 @@
-.formatted_mode_advanced.flex.column.justify-start.flex-grow.width-66.vertical-border.fr-pl-2w.fr-mb-4w
+.formatted_mode_advanced.flex.column.justify-start.flex-grow.width-66.border-left-dark.fr-mb-4w
   .cell
     .fr-input-group
       = form.label :expression_reguliere, for: dom_id(type_de_champ, :expression_reguliere), class: "fr-md-1w" do

--- a/app/components/types_de_champ_editor/champ_formatted_simple_component/champ_formatted_simple_component.html.haml
+++ b/app/components/types_de_champ_editor/champ_formatted_simple_component/champ_formatted_simple_component.html.haml
@@ -1,4 +1,4 @@
-.formatted_mode_simple.flex.column.justify-start.flex-grow.width-66.vertical-border.fr-pl-2w.fr-mb-4w
+.formatted_mode_simple.flex.column.justify-start.flex-grow.width-66.border-left-dark.fr-mb-4w
   .cell
     %fieldset.fr-fieldset{ aria_labelledby: 'checkboxes-inline-legend' }
       .fr-fieldset__element.fr-mb-0

--- a/app/controllers/administrateurs/services_controller.rb
+++ b/app/controllers/administrateurs/services_controller.rb
@@ -103,7 +103,7 @@ module Administrateurs
     private
 
     def service_params
-      params.require(:service).permit(:nom, :organisme, :type_organisme, :email, :telephone, :horaires, :adresse, :siret)
+      params.require(:service).permit(:nom, :organisme, :type_organisme, :email, :telephone, :horaires, :adresse, :siret, :faq_link, :contact_link, :other_contact_info)
     end
 
     def service

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -26,11 +26,18 @@ class Service < ApplicationRecord
   validates :siret, siret_format: true
   validates :siret, comparison: { other_than: SIRET_TEST, message: "n'est pas valide" }, on: :update
   validates :type_organisme, presence: { message: 'doit être renseigné' }, allow_nil: false
-  validates :email, presence: { message: 'doit être renseigné' }, allow_nil: false
   validates :telephone, phone: { possible: true, allow_blank: true }
   validates :horaires, presence: { message: 'doivent être renseignés' }, allow_nil: false
   validates :adresse, presence: { message: 'doit être renseignée' }, allow_nil: false
   validates :administrateur, presence: { message: 'doit être renseigné' }, allow_nil: false
+  validate :at_least_one_contact
+
+  def at_least_one_contact
+    if email.blank? && contact_link.blank?
+      errors.add(:email, :at_least_one_contact)
+      errors.add(:contact_link, :at_least_one_contact)
+    end
+  end
 
   def pretty_nom
     "#{nom}, #{organisme}"

--- a/app/views/administrateurs/services/_form.html.haml
+++ b/app/views/administrateurs/services/_form.html.haml
@@ -44,10 +44,19 @@
       %br
       Ces informations de contact seront visibles par les utilisateurs de la démarche, affichées dans le menu « Aide », ainsi qu’en pied de page lors du dépôt d’un dossier. En cas d’informations invalides, #{Current.application_name} se réserve le droit de suspendre la publication de la démarche.
 
-  = render Dsfr::InputComponent.new(form: f, attribute: :email, input_type: :email_field)
+  = render Dsfr::InputComponent.new(form: f, attribute: :faq_link, input_type: :text_field, required: false)
+  .fr-input-group
+    = f.label :contact_link, class: "fr-label" do
+      Veuillez renseigner au moins un des deux champs de contact ci-dessous
+      = render EditableChamp::AsteriskMandatoryComponent.new
+    .border-left-dark.fr-mt-1w
+      = render Dsfr::InputComponent.new(form: f, attribute: :contact_link, input_type: :text_field, required: false)
+      = render Dsfr::InputComponent.new(form: f, attribute: :email, input_type: :email_field, required: false, opts: {class: 'fr-mb-3w'})
+
   = render Dsfr::InputComponent.new(form: f, attribute: :telephone, input_type: :telephone_field)
   = render Dsfr::InputComponent.new(form: f, attribute: :horaires, input_type: :text_area)
   = render Dsfr::InputComponent.new(form: f, attribute: :adresse, input_type: :text_area)
+  = render Dsfr::InputComponent.new(form: f, attribute: :other_contact_info, input_type: :text_area, required: false)
 
   - if local_assigns[:procedure].present?
     = hidden_field_tag :procedure_id, procedure.id

--- a/app/views/instructeurs/dossiers/_header_actions.html.haml
+++ b/app/views/instructeurs/dossiers/_header_actions.html.haml
@@ -17,5 +17,5 @@
 
     %li.instruction-button
       = render Instructeurs::InstructionMenuComponent.new(dossier:)
-  .border-left-1px.fr-ml-2w.fr-mb-1v
+  .border-left-light.fr-ml-2w.fr-mb-1v
   = render partial: 'instructeurs/dossiers/print_and_export_actions', locals: { dossier: }

--- a/app/views/shared/dossiers/_update_contact_information.html.haml
+++ b/app/views/shared/dossiers/_update_contact_information.html.haml
@@ -6,23 +6,13 @@
       %span{ lang: :fr }= service.pretty_nom
       %div{ lang: :fr }
         = render SimpleFormatComponent.new(service.adresse, class_names_map: {paragraph: 'fr-footer__content-desc'})
-  %h3.fr-footer__top-cat= I18n.t('users.procedure_footer.contact.header')
-  %ul.fr-footer__top-list
-    - if dossier.present? && dossier.messagerie_available?
-      %li
-        = link_to I18n.t('users.procedure_footer.contact.in_app_mail.link'), messagerie_dossier_path(dossier), class: 'fr-footer__link'
-    - elsif service.present?
-      %li
-        %span.fr-footer__top-link
-          = I18n.t('users.procedure_footer.contact.email.link')
-        = link_to service.email, "mailto:#{service.email}", class: "fr-footer__link"
-
-      - if service.telephone.present?
-        %li
-          %span.fr-footer__top-link
-            = I18n.t('users.procedure_footer.contact.phone.label')
-          = link_to I18n.t('users.procedure_footer.contact.phone.link', service_telephone: service.telephone), service.telephone_url, class: 'fr-footer__link'
-
-      - if service.horaires.present?
-        %li
-          = "#{I18n.t('users.procedure_footer.contact.schedule.prefix')}#{formatted_horaires(service.horaires)}"
+  %h3.fr-footer__top-cat
+    - if dossier.present? && dossier.depose_at.present?
+      = I18n.t('help_dropdown.help_filled_dossier')
+    - elsif dossier.present?
+      = I18n.t('help_dropdown.help_brouillon_title')
+    - else
+      = I18n.t('help_dropdown.procedure_title')
+  - if procedure.service.present?
+    %ul.fr-footer__top-list
+      = render Procedure::ServiceListContactComponent.new(service: procedure.service, dossier: dossier)

--- a/app/views/shared/help/_help_dropdown_dossier.html.haml
+++ b/app/views/shared/help/_help_dropdown_dossier.html.haml
@@ -6,15 +6,10 @@
     #help-menu.help-content.fr-collapse.fr-menu
       - title = dossier.brouillon? ? t("help_dropdown.help_brouillon_title") : t("help_dropdown.help_filled_dossier")
       %ul.fr-menu__list
-
-        - if dossier.messagerie_available?
-          %li.flex
-            = render partial: 'shared/help/dropdown_items/messagerie_item', locals: { dossier: dossier, title: title }
-
-        - elsif dossier.procedure.service.present?
+        - if dossier.procedure.service.present?
           %li.flex
             = render partial: 'shared/help/dropdown_items/service_item',
-              locals: { service: dossier.procedure.service, title: title }
+              locals: { service: dossier.procedure.service, title:, dossier: }
 
         %li.flex
           = render partial: 'shared/help/dropdown_items/faq_item'

--- a/app/views/shared/help/_help_dropdown_instructeur.html.haml
+++ b/app/views/shared/help/_help_dropdown_instructeur.html.haml
@@ -7,5 +7,5 @@
       %ul.fr-menu__list
         %li.flex
           = render partial: 'shared/help/dropdown_items/faq_item'
-        %li
+        %li.flex
           = render partial: 'shared/help/dropdown_items/email_item'

--- a/app/views/shared/help/_help_dropdown_procedure.html.haml
+++ b/app/views/shared/help/_help_dropdown_procedure.html.haml
@@ -7,6 +7,6 @@
       %ul.fr-menu__list
         - if procedure.service.present?
           %li.flex
-            = render partial: 'shared/help/dropdown_items/service_item', locals: { service: procedure.service, title: t('help_dropdown.procedure_title') }
+            = render partial: 'shared/help/dropdown_items/service_item', locals: { service: procedure.service, title: t('help_dropdown.procedure_title'), dossier: nil }
         %li.flex
           = render partial: 'shared/help/dropdown_items/faq_item'

--- a/app/views/shared/help/dropdown_items/_email_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_email_item.html.haml
@@ -1,5 +1,5 @@
-= mail_to CONTACT_EMAIL, class: 'flex' do
-  %span.fr-icon-mail-fill.fr-text-action-high--blue-france{ "aria-hidden": "true" }
-  .fr-pl-1w
-    %h1= t('help_dropdown.technical_contact_title')
+%span.fr-icon-mail-fill.fr-text-action-high--blue-france{ "aria-hidden": "true" }
+.fr-pl-1w
+  %h1= t('help_dropdown.technical_contact_title')
+  = mail_to CONTACT_EMAIL do
     %p= t('help_dropdown.technical_contact_description', contact_email: CONTACT_EMAIL)

--- a/app/views/shared/help/dropdown_items/_faq_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_faq_item.html.haml
@@ -1,4 +1,5 @@
-%span.fr-icon-question-fill.fr-text-action-high--blue-france{ "aria-hidden": "true" }
+= image_tag('favicons/96x96.png', height: '24px', "aria-hidden": true)
 .fr-pl-1w
-  %h1= t('help_dropdown.problem_title')
-  = link_to t('help_dropdown.problem_description'), t("links.common.faq.url"), title: new_tab_suffix(t('help_dropdown.problem_description')), **external_link_attributes
+  %h1= t('help_dropdown.problem_title', app_name: APPLICATION_NAME)
+  = t('help_dropdown.problem_description')
+  = link_to t('help_dropdown.problem_url_title'), t("links.common.faq.url"), title: new_tab_suffix(t('help_dropdown.problem_url_title')), class: 'fr-link fr-link--sm', **external_link_attributes

--- a/app/views/shared/help/dropdown_items/_messagerie_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_messagerie_item.html.haml
@@ -1,4 +1,0 @@
-%span.fr-icon-mail-fill.fr-text-action-high--blue-france{ "aria-hidden": "true" }
-.fr-pl-1w
-  %h1= title
-  = link_to t('help_dropdown.contact_instructeur'), messagerie_dossier_path(dossier)

--- a/app/views/shared/help/dropdown_items/_service_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_service_item.html.haml
@@ -1,23 +1,46 @@
-%span.fr-icon-user-fill.fr-text-action-high--blue-france{ "aria-hidden": "true" }
+%span.fr-icon-question-fill.fr-text-action-high--blue-france{ "aria-hidden": "true" }
 .fr-pl-1w
   %h1= title
-  %p.fr-mb-1w= t('help_dropdown.contact_administration')
-  %dl
-    .flex.fr-mb-1v
-      %dt.fr-mr-1v
-        %span.fr-icon-mail-fill.fr-icon--sm{ "aria-hidden": "true" }
-        %span.visually-hidden= t('layouts.mailers.service_footer.by_email')
-      %dd
-        = link_to service.email, "mailto:#{service.email}"
-    .flex.fr-mb-1v
-      %dt.fr-mr-1v
-        %span.fr-icon-phone-fill.fr-icon--sm{ "aria-hidden": "true" }
-        %span.visually-hidden= t('layouts.mailers.service_footer.by_phone')
-      %dd
-        = link_to service.telephone, service.telephone_url
-    .flex
-      %dt.fr-mr-1v
-        %span.fr-icon-time-fill.fr-icon--sm{ "aria-hidden": "true" }
-        %span.visually-hidden= t('layouts.mailers.service_footer.schedule')
-      %dd
-        = service.horaires
+  %p.fr-mb-1w
+    - if service.faq_link.present?
+      = link_to t('help_dropdown.faq_link'), service.faq_link , title: new_tab_suffix(t('help_dropdown.faq_link')), class: 'fr-link fr-link--sm', **external_link_attributes
+  %p.fr-mb-2w
+    - if service.contact_link.present?
+      = link_to t('help_dropdown.contact_link'), service.contact_link, title: new_tab_suffix(t('help_dropdown.contact_link')), class: 'fr-link fr-link--sm', **external_link_attributes
+
+  .fr-background-alt--grey.fr-p-2w
+    %dl
+      - if dossier&.messagerie_available?
+        .flex.fr-mb-2v
+          %dt.fr-mr-2v
+            %span.fr-icon-message-2-line.fr-icon--sm{ "aria-hidden": "true" }
+            %span.visually-hidden= t('layouts.mailers.service_footer.by_email')
+          %dd
+            = link_to t('help_dropdown.contact_instructeur'), messagerie_dossier_path(dossier)
+
+      - if service.email.present?
+        .flex.fr-mb-2v
+          %dt.fr-mr-2v
+            %span.fr-icon-mail-line.fr-icon--sm{ "aria-hidden": "true" }
+            %span.visually-hidden= t('layouts.mailers.service_footer.by_email')
+          %dd
+            = link_to service.email, "mailto:#{service.email}"
+      .flex.fr-mb-2v
+        %dt.fr-mr-2v
+          %span.fr-icon-phone-line.fr-icon--sm{ "aria-hidden": "true" }
+          %span.visually-hidden= t('layouts.mailers.service_footer.by_phone')
+        %dd
+          = link_to service.telephone, service.telephone_url
+      .flex.fr-mb-2v
+        %dt.fr-mr-2v
+          %span.fr-icon-time-line.fr-icon--sm{ "aria-hidden": "true" }
+          %span.visually-hidden= t('layouts.mailers.service_footer.schedule')
+        %dd
+          = service.horaires
+
+      - if service.other_contact_info.present?
+        .flex.fr-mb-2v
+          %dt.fr-mr-2v
+            %span.fr-icon-information-line.fr-icon--sm{ "aria-hidden": "true" }
+          %dd
+            = service.other_contact_info

--- a/app/views/shared/help/dropdown_items/_service_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_service_item.html.haml
@@ -1,46 +1,5 @@
 %span.fr-icon-question-fill.fr-text-action-high--blue-france{ "aria-hidden": "true" }
 .fr-pl-1w
   %h1= title
-  %p.fr-mb-1w
-    - if service.faq_link.present?
-      = link_to t('help_dropdown.faq_link'), service.faq_link , title: new_tab_suffix(t('help_dropdown.faq_link')), class: 'fr-link fr-link--sm', **external_link_attributes
-  %p.fr-mb-2w
-    - if service.contact_link.present?
-      = link_to t('help_dropdown.contact_link'), service.contact_link, title: new_tab_suffix(t('help_dropdown.contact_link')), class: 'fr-link fr-link--sm', **external_link_attributes
-
-  .fr-background-alt--grey.fr-p-2w
-    %dl
-      - if dossier&.messagerie_available?
-        .flex.fr-mb-2v
-          %dt.fr-mr-2v
-            %span.fr-icon-message-2-line.fr-icon--sm{ "aria-hidden": "true" }
-            %span.visually-hidden= t('layouts.mailers.service_footer.by_email')
-          %dd
-            = link_to t('help_dropdown.contact_instructeur'), messagerie_dossier_path(dossier)
-
-      - if service.email.present?
-        .flex.fr-mb-2v
-          %dt.fr-mr-2v
-            %span.fr-icon-mail-line.fr-icon--sm{ "aria-hidden": "true" }
-            %span.visually-hidden= t('layouts.mailers.service_footer.by_email')
-          %dd
-            = link_to service.email, "mailto:#{service.email}"
-      .flex.fr-mb-2v
-        %dt.fr-mr-2v
-          %span.fr-icon-phone-line.fr-icon--sm{ "aria-hidden": "true" }
-          %span.visually-hidden= t('layouts.mailers.service_footer.by_phone')
-        %dd
-          = link_to service.telephone, service.telephone_url
-      .flex.fr-mb-2v
-        %dt.fr-mr-2v
-          %span.fr-icon-time-line.fr-icon--sm{ "aria-hidden": "true" }
-          %span.visually-hidden= t('layouts.mailers.service_footer.schedule')
-        %dd
-          = service.horaires
-
-      - if service.other_contact_info.present?
-        .flex.fr-mb-2v
-          %dt.fr-mr-2v
-            %span.fr-icon-information-line.fr-icon--sm{ "aria-hidden": "true" }
-          %dd
-            = service.other_contact_info
+  %ul
+    = render Procedure::ServiceListContactComponent.new(service: service, dossier: dossier)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,14 +35,16 @@ en:
   help: 'Help'
   help_dropdown:
     procedure_title: "Do you have a question about this procedure?"
-    problem_title: A problem with the website?
-    problem_description: Find your answer in the online help.
+    problem_title: A problem with the website %{app_name}?
+    problem_description: Find your answer in the
+    problem_url_title: FAQ
     technical_contact_title: Technical contact
     technical_contact_description: Send us a message to %{contact_email}.
-    contact_administration: "Contact the administration directly:"
     help_brouillon_title: "Need help filling out your file?"
     help_filled_dossier: "A question about your file?"
     contact_instructeur: Send a message directly to the instructor.
+    faq_link: Consult the online help
+    contact_link: Consult the administration contact page
   utils:
     'yes': 'Yes'
     'no': 'No'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,9 +42,6 @@ en:
     technical_contact_description: Send us a message to %{contact_email}.
     help_brouillon_title: "Need help filling out your file?"
     help_filled_dossier: "A question about your file?"
-    contact_instructeur: Send a message directly to the instructor.
-    faq_link: Consult the online help
-    contact_link: Consult the administration contact page
   utils:
     'yes': 'Yes'
     'no': 'No'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -32,9 +32,6 @@ fr:
     technical_contact_description: Envoyez nous un message à %{contact_email}.
     help_brouillon_title: "Besoin d’aide pour remplir votre dossier ?"
     help_filled_dossier: "Une question sur votre dossier ?"
-    contact_instructeur: Envoyez directement un message à l’instructeur.
-    faq_link: Consultez l'aide en ligne
-    contact_link: Consultez la page de contact de l'administration
   utils:
     'yes': Oui
     'no': Non

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -25,14 +25,16 @@ fr:
   help: 'Aide'
   help_dropdown:
     procedure_title: "Une question sur cette démarche ?"
-    problem_title: Un problème avec le site ?
-    problem_description: Trouvez votre réponse dans l’aide en ligne.
+    problem_title: Un problème avec le site %{app_name} ?
+    problem_description: Trouvez votre réponse dans la
+    problem_url_title: FAQ
     technical_contact_title: Contact technique
     technical_contact_description: Envoyez nous un message à %{contact_email}.
-    contact_administration: "Contactez directement l’administration :"
     help_brouillon_title: "Besoin d’aide pour remplir votre dossier ?"
     help_filled_dossier: "Une question sur votre dossier ?"
     contact_instructeur: Envoyez directement un message à l’instructeur.
+    faq_link: Consultez l'aide en ligne
+    contact_link: Consultez la page de contact de l'administration
   utils:
     'yes': Oui
     'no': Non

--- a/config/locales/models/service/en.yml
+++ b/config/locales/models/service/en.yml
@@ -12,9 +12,14 @@ en:
     errors:
       models:
         service:
+          at_least_one_contact: Please fill in at least one of the two contact fields
           attributes:
             siret:
               format: 'SIRET number %{message}'
               length: 'must contain exactly 14 digits'
               checksum: 'is invalid'
               not_prefillable: 'Unable to pre-fill information for this SIRET, please fill it manually'
+            contact_link:
+              format: ""
+            email:
+              format: "%{message}"

--- a/config/locales/models/service/fr.yml
+++ b/config/locales/models/service/fr.yml
@@ -10,6 +10,9 @@ fr:
         email: 'Adresse électronique de contact'
         telephone: 'Téléphone'
         nom: Nom du service
+        faq_link: Lien vers une page d'aide ou FAQ
+        contact_link: Lien vers une page ou formulaire de contact
+        other_contact_info: Précisions
         organisme: Organisme(s)
         hints:
           nom: |
@@ -18,6 +21,12 @@ fr:
           organisme: |
             Indiquez les organismes depuis l’échelon territorial jusqu’au ministère séparés par une virgule.
             Exemple : mairie de Mours, préfecture de l'Oise, ministère de la Culture
+          faq_link: |
+            Indiquez l'url d'une page présentant des contenus d'aide et/ou questions-réponses permettant d'orienter les usagers.
+            Exemple : https://www.mairie-de-mours.fr/faq
+          contact_link: |
+            Indiquez l'url d'une page présentant vos coordonnées et/ou un formulaire de contact en ligne.
+            Exemple : https://www.mairie-de-mours.fr/contact
           email: |
             Indiquez une adresse électronique valide qui permettra de recevoir et de répondre aux questions des usagers.
             Exemple : contact@mairie-de-mours.fr
@@ -27,8 +36,9 @@ fr:
             Exemple : Du lundi au vendredi de 9h30 à 17h30, le samedi de 9h30 à 12h.
           adresse: |
             Indiquez l’adresse à laquelle un usager peut vous contacter, par exemple s’il n’est pas en capacité de compléter son formulaire en ligne.
+          other_contact_info: |
+            Autres indications éventuelles que vous souhaitez fournir aux usagers concernant les modalités de contact du service.
       contact_information: *service
-
     errors:
       models:
         service:
@@ -38,6 +48,10 @@ fr:
               length: 'doit comporter exactement 14 chiffres. Exemple : 500 001 234 56789'
               checksum: 'comporte une erreur de saisie. Corrigez-la.'
               not_prefillable: 'Impossible de préremplir les informations pour ce SIRET, veuillez les saisir manuellement'
+            contact_link:
+              at_least_one_contact: Veuillez renseigner au moins un des deux champs de contact
+            email:
+              at_least_one_contact: Veuillez renseigner au moins un des deux champs de contact
   type_organisme:
     administration_centrale: 'Administration centrale'
     association: 'Association'

--- a/config/locales/models/service/fr.yml
+++ b/config/locales/models/service/fr.yml
@@ -42,6 +42,7 @@ fr:
     errors:
       models:
         service:
+          at_least_one_contact: Veuillez renseigner au moins un des deux champs de contact
           attributes:
             siret:
               format: 'Le numéro SIRET %{message}'
@@ -49,9 +50,11 @@ fr:
               checksum: 'comporte une erreur de saisie. Corrigez-la.'
               not_prefillable: 'Impossible de préremplir les informations pour ce SIRET, veuillez les saisir manuellement'
             contact_link:
-              at_least_one_contact: Veuillez renseigner au moins un des deux champs de contact
+              format: ""
             email:
-              at_least_one_contact: Veuillez renseigner au moins un des deux champs de contact
+              format: "%{message}"
+
+
   type_organisme:
     administration_centrale: 'Administration centrale'
     association: 'Association'

--- a/config/locales/views/users/procedure_footer/en.yml
+++ b/config/locales/views/users/procedure_footer/en.yml
@@ -4,15 +4,6 @@ en:
       managed_by:
         header: 'This procedure is managed by'
       contact:
-        header: 'Ask a question about the procedure'
-        in_app_mail:
-          link: "Direclty via the chat"
-        email:
-          link: "Directly by email: "
-        phone:
-          label: 'By phone: '
-        schedule:
-          prefix: 'Hours: '
         stats:
           link: "See the procedure's stats"
       legals:

--- a/config/locales/views/users/procedure_footer/fr.yml
+++ b/config/locales/views/users/procedure_footer/fr.yml
@@ -4,16 +4,6 @@ fr:
       managed_by:
         header: 'Cette démarche est gérée par'
       contact:
-        header: 'Poser une question sur la démarche'
-        in_app_mail:
-          link: "Directement par la messagerie"
-        email:
-          link: "Directement par courriel :"
-        phone:
-          label: 'Par téléphone au : '
-          link: '%{service_telephone}'
-        schedule:
-          prefix: "Horaires d’ouverture : "
         stats:
           link: "Voir les statistiques de la démarche"
       legals:

--- a/db/migrate/20250401133421_add_more_contact_infos_to_services.rb
+++ b/db/migrate/20250401133421_add_more_contact_infos_to_services.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddMoreContactInfosToServices < ActiveRecord::Migration[7.0]
+  def change
+    add_column :services, :faq_link, :string
+    add_column :services, :contact_link, :string
+    add_column :services, :other_contact_info, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_03_20_153834) do
+ActiveRecord::Schema[7.0].define(version: 2025_04_01_133421) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_stat_statements"
@@ -1171,15 +1171,18 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_20_153834) do
   create_table "services", force: :cascade do |t|
     t.bigint "administrateur_id"
     t.text "adresse"
+    t.string "contact_link"
     t.datetime "created_at", precision: nil, null: false
     t.string "departement"
     t.string "email"
     t.jsonb "etablissement_infos", default: {}
     t.decimal "etablissement_lat", precision: 10, scale: 6
     t.decimal "etablissement_lng", precision: 10, scale: 6
+    t.string "faq_link"
     t.text "horaires"
     t.string "nom", null: false
     t.string "organisme"
+    t.text "other_contact_info"
     t.string "siret"
     t.string "telephone"
     t.string "type_organisme", null: false

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -56,6 +56,32 @@ describe Service, type: :model do
       end
     end
 
+    describe "email and contact_link" do
+      it 'should be valid if only email is present' do
+        subject.email = 'super@email.com'
+        subject.contact_link = nil
+        expect(subject).to be_valid
+      end
+
+      it 'should be valid if only contact_link is present' do
+        subject.email = nil
+        subject.contact_link = 'www.test.fr/faq'
+        expect(subject).to be_valid
+      end
+
+      it 'should be valid if email and contact_link are present' do
+        subject.email = 'super@email.com'
+        subject.contact_link = 'www.test.fr/faq'
+        expect(subject).to be_valid
+      end
+
+      it 'should be invalid if none are present' do
+        subject.email = nil
+        subject.contact_link = nil
+        expect(subject).not_to be_valid
+      end
+    end
+
     context 'when a first service exists' do
       before { Service.create(params) }
 


### PR DESCRIPTION
closes #11246 #11257 #11245

<img width="443" alt="Capture d’écran 2025-04-03 à 19 17 30" src="https://github.com/user-attachments/assets/ed0aa4b6-5a3e-4245-a000-7a5c8051cc82" />
<img width="537" alt="Capture d’écran 2025-04-03 à 19 17 40" src="https://github.com/user-attachments/assets/459157af-5648-4203-a202-15fdb78fc3fc" />

<img width="1268" alt="Capture d’écran 2025-04-07 à 15 21 15" src="https://github.com/user-attachments/assets/3c2f0d1d-da97-4f34-a031-b5a552509bb2" />
![Uploading Capture d’écran 2025-04-07 à 15.21.23.png…]()
