### PR TITLE
ETQ Admin je veux intégrer l'attestation automatique d'acceptation dans l'export personnalisé ZIP

### DIFF
--- a/app/controllers/instructeurs/export_templates_controller.rb
+++ b/app/controllers/instructeurs/export_templates_controller.rb
@@ -70,6 +70,7 @@ module Instructeurs
           :groupe_instructeur_id,
           dossier_folder: [:enabled, :template],
           export_pdf: [:enabled, :template],
+          attestation: [:enabled, :template],
           pjs: [:stable_id, :enabled, :template],
           exported_columns: []
         )

--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -14,6 +14,11 @@ class ExportJob < ApplicationJob
 
     Sentry.set_tags(procedure: export.procedure.id)
 
+    if Rails.env.development?
+      # Set URL options for ActiveStorage
+      ActiveStorage::Current.url_options = Rails.application.routes.default_url_options
+    end
+
     export.compute_with_safe_stale_for_purge do
       export.compute
     end

--- a/app/models/export_template.rb
+++ b/app/models/export_template.rb
@@ -14,6 +14,7 @@ class ExportTemplate < ApplicationRecord
   attribute :dossier_folder, :export_item
   attribute :export_pdf, :export_item
   attribute :pjs, :export_item, array: true
+  attribute :attestation, :export_item
 
   attribute :exported_columns, :exported_column, array: true
 
@@ -33,9 +34,10 @@ class ExportTemplate < ApplicationRecord
     # TODO: remove default values for tabular export
     dossier_folder = ExportItem.default(prefix: 'dossier')
     export_pdf = ExportItem.default(prefix: 'export')
+    attestation = ExportItem.default(prefix: 'attestation')
     pjs = groupe_instructeur.procedure.exportables_pieces_jointes.map { |tdc| ExportItem.default_pj(tdc) }
 
-    new(name:, kind:, groupe_instructeur:, dossier_folder:, export_pdf:, pjs:)
+    new(name:, kind:, groupe_instructeur:, dossier_folder:, export_pdf:, attestation:, pjs:)
   end
 
   def tabular?
@@ -56,6 +58,8 @@ class ExportTemplate < ApplicationRecord
   def attachment_path(dossier, attachment, index: 0, row_index: nil, champ: nil)
     file_path = if attachment.name == 'pdf_export_for_instructeur'
       export_pdf.path(dossier, attachment:)
+    elsif attachment.record_type == 'Attestation' && attestation&.enabled?
+      attestation.path(dossier, attachment:)
     elsif attachment.record_type == 'Champ' && pj(champ.type_de_champ).enabled?
       pj(champ.type_de_champ).path(dossier, attachment:, index:, row_index:)
     else

--- a/app/models/export_template.rb
+++ b/app/models/export_template.rb
@@ -18,6 +18,8 @@ class ExportTemplate < ApplicationRecord
 
   attribute :exported_columns, :exported_column, array: true
 
+  after_initialize :set_default_export_items
+
   before_validation :ensure_pjs_are_legit
 
   validates_with ExportTemplateValidator
@@ -32,12 +34,11 @@ class ExportTemplate < ApplicationRecord
 
   def self.default(name: nil, kind: 'zip', groupe_instructeur:)
     # TODO: remove default values for tabular export
-    dossier_folder = ExportItem.default(prefix: 'dossier')
-    export_pdf = ExportItem.default(prefix: 'export')
-    attestation = ExportItem.default(prefix: 'attestation')
     pjs = groupe_instructeur.procedure.exportables_pieces_jointes.map { |tdc| ExportItem.default_pj(tdc) }
 
-    new(name:, kind:, groupe_instructeur:, dossier_folder:, export_pdf:, attestation:, pjs:)
+    export_template = new(name:, kind:, groupe_instructeur:, pjs:)
+    export_template.set_default_export_items
+    export_template
   end
 
   def tabular?
@@ -80,6 +81,13 @@ class ExportTemplate < ApplicationRecord
   def in_export?(exported_column)
     @template_exported_columns ||= exported_columns.map(&:column)
     @template_exported_columns.include?(exported_column.column)
+  end
+
+  def set_default_export_items
+    self.dossier_folder ||= ExportItem.default(prefix: 'dossier')
+    self.export_pdf ||= ExportItem.default(prefix: 'export')
+    self.attestation ||= ExportItem.default(prefix: 'attestation')
+    self.pjs ||= []
   end
 
   private

--- a/app/views/instructeurs/export_templates/_form.html.haml
+++ b/app/views/instructeurs/export_templates/_form.html.haml
@@ -45,6 +45,14 @@
             libelle: ExportTemplate.human_attribute_name(:export_pdf),
             prefix: 'export_template[export_pdf]' }
 
+        - if procedure.attestation_template&.activated?
+          %h3 Attestation d'acceptation au format PDF
+
+          = render partial: 'export_item',
+            locals: { item: export_template.attestation || ExportItem.default(prefix: 'attestation'),
+              libelle: ExportTemplate.human_attribute_name(:attestation),
+              prefix: 'export_template[attestation]' }
+
         - if procedure.exportables_pieces_jointes_for_all_versions.any?
           %h3 Pièces justificatives
 

--- a/app/views/instructeurs/export_templates/_form.html.haml
+++ b/app/views/instructeurs/export_templates/_form.html.haml
@@ -1,14 +1,6 @@
 - procedure = @export_template.procedure
 
 #export_template-edit.fr-my-4w
-  .fr-mb-6w
-    = render Dsfr::AlertComponent.new(state: :info, title: "Nouvel éditeur de modèle d'export", heading_level: 'h3') do |c|
-      - c.with_body do
-        Cette page permet d'éditer un modèle d'export et ainsi personnaliser le contenu des exports (pour l'instant,
-        uniquement au format zip). Ainsi, vous pouvez notamment normaliser le nom des pièces jointes.
-        Essayez-le et donnez-nous votre avis
-        en nous envoyant un email à #{mail_to(CONTACT_EMAIL, subject: "Editeur de modèle d'export")}.
-
   .fr-grid-row.fr-grid-row--gutters
     .fr-col-12.fr-col-md-8.fr-pr-4w
       = form_with model: [:instructeur, procedure, export_template], data: { turbo: 'true', controller: 'autosubmit' } do |f|

--- a/app/views/instructeurs/export_templates/_preview.html.haml
+++ b/app/views/instructeurs/export_templates/_preview.html.haml
@@ -24,6 +24,10 @@
                 %li
                   %span.fr-icon-pdf-2-line
                   #{export_template.export_pdf.path(dossier)}.pdf
+              - if export_template.attestation.enabled? && procedure.attestation_template&.activated?
+                %li
+                  %span.fr-icon-pdf-2-line
+                  #{export_template.attestation.path(dossier)}.pdf
 
               - procedure.exportables_pieces_jointes.each do |tdc|
                 - export_pj = export_template.pj(tdc)

--- a/config/locales/models/export_templates/en.yml
+++ b/config/locales/models/export_templates/en.yml
@@ -11,6 +11,7 @@ en:
         name: "Template's name"
         dossier_folder: "Directory's name for pdf format"
         export_pdf: "File in pdf format"
+        attestation: "Attestation of acceptance"
     errors:
       models:
         export_template:

--- a/config/locales/models/export_templates/fr.yml
+++ b/config/locales/models/export_templates/fr.yml
@@ -11,6 +11,7 @@ fr:
         name: "Nom du modèle"
         dossier_folder: Nom du répertoire
         export_pdf: "Dossier au format pdf"
+        attestation: "Attestation d'acceptation"
     errors:
       models:
         export_template:

--- a/db/migrate/20250403154944_add_attestation_to_export_templates.rb
+++ b/db/migrate/20250403154944_add_attestation_to_export_templates.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAttestationToExportTemplates < ActiveRecord::Migration[7.1]
+  def change
+    add_column :export_templates, :attestation, :jsonb, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -625,6 +625,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_15_214140) do
   end
 
   create_table "export_templates", force: :cascade do |t|
+    t.jsonb "attestation"
     t.jsonb "content", default: {}
     t.datetime "created_at", null: false
     t.jsonb "dossier_folder", null: false

--- a/spec/controllers/api/v2/graphql_controller_n+1_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_n+1_spec.rb
@@ -24,7 +24,7 @@ describe API::V2::GraphqlController do
   end
 
   MIN_QUERY_COUNT = 47
-  MAX_QUERY_COUNT = 57
+  MAX_QUERY_COUNT = 58
 
   describe 'demarche.dossiers' do
     let(:operation_name) { 'getDemarche' }

--- a/spec/controllers/instructeurs/export_templates_controller_spec.rb
+++ b/spec/controllers/instructeurs/export_templates_controller_spec.rb
@@ -20,6 +20,7 @@ describe Instructeurs::ExportTemplatesController, type: :controller do
       groupe_instructeur_id:,
       export_pdf:,
       dossier_folder: item_params(text: "DOSSIER_"),
+      attestation: item_params(text: "attestation"),
       pjs: [pj_item_params(stable_id: 3, text: "avis-commission-"), pj_item_params(stable_id: 666, text: "evil-hack")]
     }
   end
@@ -109,6 +110,7 @@ describe Instructeurs::ExportTemplatesController, type: :controller do
           groupe_instructeur_id: groupe_instructeur.id,
           export_pdf: item_params(text: "export"),
           dossier_folder: item_params(text: "dossier"),
+          attestation: item_params(text: "attestation"),
           exported_columns:
         }
       end
@@ -198,6 +200,7 @@ describe Instructeurs::ExportTemplatesController, type: :controller do
           groupe_instructeur_id: groupe_instructeur.id,
           export_pdf: item_params(text: "export"),
           dossier_folder: item_params(text: "dossier"),
+          attestation: item_params(text: "attestation"),
           exported_columns:
         }
       end

--- a/spec/models/export_template_spec.rb
+++ b/spec/models/export_template_spec.rb
@@ -59,6 +59,15 @@ describe ExportTemplate do
         expect(export_template.attachment_path(dossier, attachment, champ: champ_pj)).to eq("dossier-#{dossier.id}/justif-#{dossier.id}-01.png")
       end
     end
+
+    context 'for attestation' do
+      let!(:attestation) { create(:attestation, dossier:) }
+      let(:attachment) { ActiveStorage::Attachment.new(name: 'Attestation', record: attestation, blob: ActiveStorage::Blob.new(filename: "attestation.pdf")) }
+
+      it 'returns attestation and custom name for attestation' do
+        expect(export_template.attachment_path(dossier, attachment)).to eq("dossier-#{dossier.id}/attestation-#{dossier.id}.pdf")
+      end
+    end
   end
 
   describe '#tags and #pj_tags' do

--- a/spec/services/pieces_justificatives_service_spec.rb
+++ b/spec/services/pieces_justificatives_service_spec.rb
@@ -222,7 +222,7 @@ describe PiecesJustificativesService do
         context 'with export_template' do
           let(:export_template) { default_export_template }
 
-          it { expect(subject).to be_empty }
+          it { expect(subject).to match_array(dossier.attestation.pdf.attachment) }
         end
       end
 


### PR DESCRIPTION
Si la démarche a l'attestation d'acceptation de configurée, on ajoute la possibilité de configurer l'export de l'attestation en PDF dans les Modèles d'export.
<img width="1231" alt="image" src="https://github.com/user-attachments/assets/2d3e4554-1ea1-4f6b-b362-6270882e4b8c" />

