### PR TITLE
[ETQ admin] je n'ai plus d'exemple pour les champs dates pour ne pas porter à confusion avec les dates limites

### DIFF
--- a/config/locales/models/champs/date_champ/en.yml
+++ b/config/locales/models/champs/date_champ/en.yml
@@ -3,4 +3,4 @@ en:
     attributes:
       champs/date_champ:
         hints:
-          value: "Expected format: mm/dd/yyyy. Example: 01/15/2022"
+          value: "Expected format: mm/dd/yyyy."

--- a/config/locales/models/champs/date_champ/fr.yml
+++ b/config/locales/models/champs/date_champ/fr.yml
@@ -3,4 +3,4 @@ fr:
     attributes:
       champs/date_champ:
         hints:
-          value: "Format attendu : JJ/MM/AAAA. Exemple : 15/01/2022"
+          value: "Format attendu : JJ/MM/AAAA."

--- a/config/locales/models/champs/datetime_champ/en.yml
+++ b/config/locales/models/champs/datetime_champ/en.yml
@@ -3,4 +3,4 @@ en:
     attributes:
       champs/datetime_champ:
           hints:
-            value: "Expected format: mm/dd/yyyy hh:mm. Example: 01/15/2022 12:00"
+            value: "Expected format: mm/dd/yyyy hh:mm."

--- a/config/locales/models/champs/datetime_champ/fr.yml
+++ b/config/locales/models/champs/datetime_champ/fr.yml
@@ -3,4 +3,4 @@ fr:
     attributes:
       champs/datetime_champ:
           hints:
-            value: "Format attendu : JJ/MM/AAAA HH:MM. Exemple : 15/01/2022 12:00"
+            value: "Format attendu : JJ/MM/AAAA HH:MM."


### PR DESCRIPTION
Maintenant qu'on a ajouté des limitations sur le champ date, la date d'exemple peut porter à confusion.
Le format est suffisant. Et si l'admin veut rajouter un exemple plus parlant, il peut l'ajouter manuellement.

**APRES**
<img width="447" alt="Capture d’écran 2025-04-07 à 16 03 26" src="https://github.com/user-attachments/assets/595565a0-9ce3-4da4-9b93-5f5824014b50" />

**AVANT**
<img width="429" alt="Capture d’écran 2025-04-07 à 16 03 51" src="https://github.com/user-attachments/assets/18cb3e1c-dc8b-432b-93c1-757649854bf5" />
