### PR TITLE
ETQ usager je suis guidé quand une liste a plus de 200 options

### DIFF
--- a/app/assets/stylesheets/dsfr.scss
+++ b/app/assets/stylesheets/dsfr.scss
@@ -143,6 +143,11 @@ input[type='radio'] {
 .fr-badge--lowercase {
   text-transform: lowercase;
 }
+// We use the DSFR badge design to highlight a warning in the combobox
+// but as it is a two sentences warning, we want to keep the original case
+.fr-badge--no-text-transform {
+  text-transform: none;
+}
 
 // Caption is bold, but all-procedures table use fr-tag in caption
 .fr-table caption .fr-tag {

--- a/app/components/editable_champ/drop_down_list_component/drop_down_list_component.en.yml
+++ b/app/components/editable_champ/drop_down_list_component/drop_down_list_component.en.yml
@@ -1,0 +1,3 @@
+---
+en:
+  exceed_options_threshold_hint: Begin typing your choice and select it from the proposed list.

--- a/app/components/editable_champ/drop_down_list_component/drop_down_list_component.fr.yml
+++ b/app/components/editable_champ/drop_down_list_component/drop_down_list_component.fr.yml
@@ -1,0 +1,3 @@
+---
+fr:
+  exceed_options_threshold_hint: Commencez à saisir votre choix puis sélectionnez-le dans la liste proposée.

--- a/app/components/editable_champ/drop_down_list_component/drop_down_list_component.html.haml
+++ b/app/components/editable_champ/drop_down_list_component/drop_down_list_component.html.haml
@@ -1,3 +1,6 @@
+- if @champ.exceed_options_threshold?
+  .fr-hint-text.fr-mt-0
+    = t('.exceed_options_threshold_hint')
 - if @champ.render_as_radios?
   .fr-fieldset__content
     - items.each do |value, option_id|

--- a/app/components/editable_champ/multiple_drop_down_list_component/multiple_drop_down_list_component.en.yml
+++ b/app/components/editable_champ/multiple_drop_down_list_component/multiple_drop_down_list_component.en.yml
@@ -1,3 +1,4 @@
 ---
 en:
   prompt: "Select"
+  exceed_options_threshold_hint: "Start typing your choice and select it from the proposed list."

--- a/app/components/editable_champ/multiple_drop_down_list_component/multiple_drop_down_list_component.fr.yml
+++ b/app/components/editable_champ/multiple_drop_down_list_component/multiple_drop_down_list_component.fr.yml
@@ -1,3 +1,4 @@
 ---
 fr:
   prompt: "Sélectionner"
+  exceed_options_threshold_hint: "Commencez à saisir votre choix puis sélectionnez-le dans la liste proposée."

--- a/app/components/editable_champ/multiple_drop_down_list_component/multiple_drop_down_list_component.html.haml
+++ b/app/components/editable_champ/multiple_drop_down_list_component/multiple_drop_down_list_component.html.haml
@@ -8,5 +8,8 @@
             = b.text
 
 - else
+  - if @champ.exceed_options_threshold?
+    .fr-hint-text.fr-mt-0
+      = t('.exceed_options_threshold_hint')
   %react-fragment
     = render ReactComponent.new "ComboBox/MultiComboBox", **react_props

--- a/app/javascript/components/ComboBox.tsx
+++ b/app/javascript/components/ComboBox.tsx
@@ -149,7 +149,8 @@ export function SingleComboBox({
     maxItemsDisplay
   });
 
-  const showAlert = (defaultItems?.length ?? 0) > 200;
+  const showAlert =
+    (defaultItems?.length ?? 0) > 200 && comboBoxProps.items.length >= 200;
 
   return (
     <>
@@ -229,7 +230,8 @@ export function MultiComboBox(maybeProps: MultiComboBoxProps) {
   });
   const formResetRef = useOnFormReset(onReset);
 
-  const showAlert = (defaultItems?.length ?? 0) > 200;
+  const showAlert =
+    (defaultItems?.length ?? 0) > 200 && comboBoxProps.items.length >= 200;
 
   return (
     <div className={`fr-ds-combobox__multiple ${className ? className : ''}`}>

--- a/app/javascript/components/ComboBox.tsx
+++ b/app/javascript/components/ComboBox.tsx
@@ -346,7 +346,11 @@ export function RemoteComboBox({
         {...comboBoxProps}
         {...props}
       >
-        {(item) => <ComboBoxItem id={item.value}>{item.label}</ComboBoxItem>}
+        {(item) => (
+          <ComboBoxItem key={item.value} id={item.value}>
+            {item.label}
+          </ComboBoxItem>
+        )}
       </ComboBox>
       {children || name ? (
         <span ref={ref}>

--- a/app/javascript/components/ComboBox.tsx
+++ b/app/javascript/components/ComboBox.tsx
@@ -44,11 +44,13 @@ export function ComboBox({
   isLoading,
   isOpen,
   placeholder,
+  alertMessage,
   ...props
 }: ComboBoxProps & {
   inputRef?: RefObject<HTMLInputElement | null>;
   isOpen?: boolean;
   placeholder?: string;
+  alertMessage?: boolean;
 }) {
   return (
     <AriaComboBox
@@ -94,7 +96,23 @@ export function ComboBox({
         UNSTABLE_portalContainer={getPortal()!}
         isOpen={isOpen}
       >
-        <ListBox className="fr-menu__list">{children}</ListBox>
+        <ListBox className="fr-menu__list">
+          {typeof children === 'function'
+            ? Array.from(props.items ?? []).map((item) => children(item))
+            : children}
+          {alertMessage && (
+            <ListBoxItem
+              id="combo-alert-message"
+              textValue="alert"
+              aria-disabled={true}
+              isDisabled={true}
+              className="fr-menu__item fr-badge fr-badge--info fr-badge--no-text-transform width-100"
+            >
+              Toutes les options ne sont pas affichées. Commencez à saisir votre
+              choix puis sélectionnez-le dans la liste proposée.
+            </ListBoxItem>
+          )}
+        </ListBox>
       </Popover>
     </AriaComboBox>
   );
@@ -131,15 +149,22 @@ export function SingleComboBox({
     maxItemsDisplay
   });
 
+  const showAlert = (defaultItems?.length ?? 0) > 200;
+
   return (
     <>
       <ComboBox
         menuTrigger="focus"
         placeholder={placeholder}
+        alertMessage={showAlert}
         {...comboBoxProps}
         {...props}
       >
-        {(item) => <ComboBoxItem id={item.value}>{item.label}</ComboBoxItem>}
+        {(item) => (
+          <ComboBoxItem key={item.value} id={item.value}>
+            {item.label}
+          </ComboBoxItem>
+        )}
       </ComboBox>
       {children || name ? (
         <span ref={ref}>

--- a/app/javascript/components/ComboBox.tsx
+++ b/app/javascript/components/ComboBox.tsx
@@ -229,6 +229,8 @@ export function MultiComboBox(maybeProps: MultiComboBoxProps) {
   });
   const formResetRef = useOnFormReset(onReset);
 
+  const showAlert = (defaultItems?.length ?? 0) > 200;
+
   return (
     <div className={`fr-ds-combobox__multiple ${className ? className : ''}`}>
       {selectedItems.length > 0 ? (
@@ -252,10 +254,15 @@ export function MultiComboBox(maybeProps: MultiComboBoxProps) {
         allowsCustomValue={allowsCustomValue}
         inputRef={inputRef}
         menuTrigger="focus"
+        alertMessage={showAlert}
         {...comboBoxProps}
         {...props}
       >
-        {(item) => <ComboBoxItem id={item.value}>{item.label}</ComboBoxItem>}
+        {(item) => (
+          <ComboBoxItem key={item.value} id={item.value}>
+            {item.label}
+          </ComboBoxItem>
+        )}
       </ComboBox>
       {name ? (
         <span ref={ref}>

--- a/app/models/champs/drop_down_list_champ.rb
+++ b/app/models/champs/drop_down_list_champ.rb
@@ -5,7 +5,7 @@ class Champs::DropDownListChamp < Champ
   THRESHOLD_NB_OPTIONS_AS_RADIO = 5
   THRESHOLD_NB_OPTIONS_AS_AUTOCOMPLETE = 20
   OTHER = '__other__'
-  delegate :options_without_empty_value_when_mandatory, to: :type_de_champ
+  delegate :options_without_empty_value_when_mandatory, :exceed_options_threshold?, to: :type_de_champ
   validate :validate_value_is_in_options, if: -> { validate_champ_value? && !(value.blank? || drop_down_other?) }
   before_save :store_referentiel, if: :drop_down_advanced?
 

--- a/app/models/champs/multiple_drop_down_list_champ.rb
+++ b/app/models/champs/multiple_drop_down_list_champ.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Champs::MultipleDropDownListChamp < Champ
+  delegate :exceed_options_threshold?, to: :type_de_champ
   validate :values_are_in_options, if: -> { value.present? && validate_champ_value? }
 
   THRESHOLD_NB_OPTIONS_AS_CHECKBOX = 5

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -460,7 +460,7 @@ class TypeDeChamp < ApplicationRecord
   end
 
   def exceed_options_threshold?
-    drop_down_list? && drop_down_options.size > 200
+    (drop_down_list? || multiple_drop_down_list?) && drop_down_options.size > 200
   end
 
   def header_section_level_value

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -459,6 +459,10 @@ class TypeDeChamp < ApplicationRecord
     self.drop_down_options = text.to_s.lines.map(&:strip).reject(&:empty?)
   end
 
+  def exceed_options_threshold?
+    drop_down_list? && drop_down_options.size > 200
+  end
+
   def header_section_level_value
     if header_section_level.presence
       header_section_level.to_i

--- a/config/locales/models/champs/multiple_drop_down_list/en.yml
+++ b/config/locales/models/champs/multiple_drop_down_list/en.yml
@@ -3,4 +3,4 @@ en:
     attributes:
       champs/multiple_drop_down_list_champ:
         hints:
-          value: "Select one or more options."
+          value: "You can select one or more options."

--- a/config/locales/models/champs/multiple_drop_down_list/fr.yml
+++ b/config/locales/models/champs/multiple_drop_down_list/fr.yml
@@ -3,4 +3,4 @@ fr:
     attributes:
       champs/multiple_drop_down_list_champ:
         hints:
-          value: "Sélectionnez un ou plusieurs choix."
+          value: "Vous pouvez sélectionner un ou plusieurs choix."


### PR DESCRIPTION
Voir #11452

- Si un champ choix simple (manuel ou avec référentiel) ou un champ choix multiple a plus de 200 options, on affiche un texte d'aide avant le champ et dans la combobox à la suite des 200 options.

AVANT

<img width="1288" alt="Capture d’écran 2025-04-07 à 17 44 17" src="https://github.com/user-attachments/assets/67208c14-dd82-48ae-8c71-284030c5dac7" />

APRÈS

<img width="1288" alt="Capture d’écran 2025-04-07 à 17 43 43" src="https://github.com/user-attachments/assets/8a4d2555-1b60-42e0-a436-0578bf3af0af" />
