### PR TITLE
 ETQ usager, je veux pouvoir télécharger l'attestation d'un dossier supprimé

### DIFF
--- a/app/assets/stylesheets/flex.scss
+++ b/app/assets/stylesheets/flex.scss
@@ -43,6 +43,12 @@
     flex-direction: column;
   }
 
+  @media (min-width: $two-columns-breakpoint) {
+    &.row-lg {
+      flex-direction: row;
+    }
+  }
+
   &.row-reverse {
     flex-direction: row-reverse;
   }

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -538,7 +538,9 @@ module Users
         Dossier.visible_by_user.or(Dossier.for_procedure_preview).or(Dossier.for_editing_fork)
       elsif action_name == 'restore'
         Dossier.hidden_by_user.or(Dossier.hidden_by_not_modified_for_a_long_time)
-      elsif action_name == 'extend_conservation_and_restore' || (action_name == 'show' && request.format.pdf?)
+      elsif action_name == 'extend_conservation_and_restore' ||
+            (action_name == 'show' && request.format.pdf?) ||
+            action_name == 'attestation'
         Dossier.visible_by_user.or(Dossier.hidden_by_expired)
       else
         Dossier.visible_by_user

--- a/app/views/users/dossiers/_dossiers_list.html.haml
+++ b/app/views/users/dossiers/_dossiers_list.html.haml
@@ -122,7 +122,9 @@
 
 
             - else
-              = render(partial: 'users/dossiers/show/download_dossier', locals: { dossier: dossier })
+              .flex.justify-end.flex-gap-2.column.row-lg.align-end
+                = render(partial: 'users/dossiers/show/download_dossier', locals: { dossier: dossier })
+                = render(partial: 'users/dossiers/show/download_attestation', locals: { dossier: dossier })
 
   = paginate dossiers, views_prefix: 'shared'
 

--- a/app/views/users/dossiers/show/_download_attestation.html.haml
+++ b/app/views/users/dossiers/show/_download_attestation.html.haml
@@ -1,0 +1,2 @@
+- if dossier && dossier.attestation.present?
+  = link_to "#{t('views.users.dossiers.merci.download_attestation')} (PDF)", attestation_dossier_path(dossier), download: "Attestation", target: "_blank", rel: "noopener", class: 'fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-download-line'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -449,6 +449,7 @@ en:
           dossier_edit_l3: and
           dossier_edit_l4: talk with an instructor.
           download_dossier: Download your file
+          download_attestation: Download your attestation
           acces_dossier: Access your file
           submit_dossier: Submit an other file
           jdma_l1: Help us improve this service!

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -456,6 +456,7 @@ fr:
           dossier_edit_l3: et
           dossier_edit_l4: échanger avec un instructeur.
           download_dossier: Télécharger mon dossier
+          download_attestation: Télécharger mon attestation
           acces_dossier: Accéder à votre dossier
           submit_dossier: Déposer un autre dossier
           jdma_l1: Aidez-nous à améliorer ce service !

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -133,6 +133,17 @@ describe Users::DossiersController, type: :controller do
         get :attestation, params: { id: dossier.id }
         expect(response.location).to match '/rails/active_storage/disk/'
       end
+
+      context 'when the dossier is expired by automatic' do
+        before do
+          dossier.hide_and_keep_track!(:automatic, :expired)
+        end
+
+        it 'redirects to attestation pdf' do
+          get :attestation, params: { id: dossier.id }
+          expect(response.location).to match '/rails/active_storage/disk/'
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #11500 
Ajoute le bouton pour télécharger une attestation depuis la corbeille

<img width="1189" alt="image" src="https://github.com/user-attachments/assets/35e16562-60a8-4508-b027-d79937fc1667" />
