### PR TITLE
Correctif : ETQ admin je peux importer un fichier csv au format iso 8859

### DIFF
--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -343,7 +343,7 @@ module Administrateurs
         flash[:alert] = "Importation impossible : le poids du fichier est supérieur à #{number_to_human_size(CSV_MAX_SIZE)}"
 
       else
-        csv_content = SmarterCSV.process(csv_file, strings_as_keys: true, convert_values_to_numeric: false)
+        csv_content = SmarterCSV.process(csv_file, strings_as_keys: true, convert_values_to_numeric: false, force_utf8: true)
 
         if csv_content.first.has_key?("groupe") && csv_content.first.has_key?("email")
           groupes_emails = csv_content.map { |r| r.to_h.slice('groupe', 'email') }

--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -148,7 +148,7 @@ module Administrateurs
         type_de_champ = draft.find_and_ensure_exclusive_use(params[:stable_id])
 
         begin
-          csv_to_code = SmarterCSV.process(referentiel_file, strings_as_keys: true, keep_original_headers: true, convert_values_to_numeric: false)
+          csv_to_code = SmarterCSV.process(referentiel_file, strings_as_keys: true, keep_original_headers: true, convert_values_to_numeric: false, force_utf8: true)
         rescue CSV::MalformedCSVError
           return flash[:alert] = "Importation impossible : le fichier est mal formaté"
         end

--- a/app/controllers/manager/procedures_controller.rb
+++ b/app/controllers/manager/procedures_controller.rb
@@ -157,7 +157,7 @@ module Manager
         flash[:alert] = "Importation impossible : le poids du fichier est supérieur à #{number_to_human_size(CSV_MAX_SIZE)}"
 
       else
-        procedure_tags = SmarterCSV.process(tags_csv_file, strings_as_keys: true, convert_values_to_numeric: false)
+        procedure_tags = SmarterCSV.process(tags_csv_file, strings_as_keys: true, convert_values_to_numeric: false, force_utf8: true)
           .map { |r| r.to_h.slice('demarche', 'tag') }
 
         invalid_ids = []

--- a/spec/fixtures/files/groupe_iso_8859.csv
+++ b/spec/fixtures/files/groupe_iso_8859.csv
@@ -1,0 +1,5 @@
+Email,Groupe
+kara@beta.gouv.fr,Marne
+camilya@beta.gouv.fr,Loire
+philippe@beta.gouv.fr,Marne
+sim@beta.gouv.fr,Loire

--- a/spec/fixtures/files/groupe_iso_8859_invalid_characters.csv
+++ b/spec/fixtures/files/groupe_iso_8859_invalid_characters.csv
@@ -1,0 +1,5 @@
+Email,Groupe
+kara@beta.gouv.fr,Auvergne-Rhône-Alpes
+camilya@beta.gouv.fr,Vendée
+philippe@beta.gouv.fr,Auvergne-Rhône-Alpes
+sim@beta.gouv.fr,Vendée


### PR DESCRIPTION
Cf https://secure.helpscout.net/conversation/2901354195/2166684 , un cas d'imports d'instructeurs qui échouent à cause de l'encodage du fichier (iso 8859 au lieu de utf8 + présence de caractères invalides).
Les caractères invalides sont remplacés par une string vide.

Pour gérer ce cas, j'ajoute une option à la méthode de SmarterCsv pour forcer la conversion en utf8.

Voir la [doc](https://github.com/tilo/smarter_csv/blob/main/docs/options.md)