### PR TITLE
ETQ Admin, je veux pouvoir me connecter à RDV

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -4,6 +4,8 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider :rdv_service_public, ENV["RDV_SERVICE_PUBLIC_OAUTH_APP_ID"], ENV["RDV_SERVICE_PUBLIC_OAUTH_APP_SECRET"],
            scope: "write", base_url: ENV["RDV_SERVICE_PUBLIC_URL"]
 
+  ActionController::Base.config.csrf_token_storage_strategy = ActionController::RequestForgeryProtection::CookieStore.new(:csrf_token)
+
   # on_failure do |env|
   #   Sentry.capture_exception(env["omniauth.error"])
 


### PR DESCRIPTION
Fixes #11573

Il y a un bout de code dans la lib `omniauth-rails_csrf_protection` qui se charge de récupérer la config sur `ActionController::Base` (cela permet notamment de récupérer la stratégie de stockage pour les token csrf) https://github.com/cookpad/omniauth-rails_csrf_protection/blob/f0f5f84dae091fa3f4410840b331e771b3e0f28b/lib/omniauth/rails_csrf_protection/token_verifier.rb#L19

Cette PR permet de définir globalement la stratégie de stockage pour les token csrf