### PR TITLE
ETQ  administrateur, lorsque je configure un champ de type référentiel avancé, je suis averti que les endpoints sont validé en .gouv.fr, sinon on autorise ça a la main

### DIFF
--- a/app/components/referentiels/new_form_component.rb
+++ b/app/components/referentiels/new_form_component.rb
@@ -17,7 +17,7 @@ class Referentiels::NewFormComponent < ApplicationComponent
   end
 
   def form_url
-    if @referentiel.persisted?
+    if @referentiel.persisted? && @referentiel.valid?
       admin_procedure_referentiel_path(@procedure, @type_de_champ.stable_id, @referentiel)
     else
       admin_procedure_referentiels_path(@procedure, @type_de_champ.stable_id)

--- a/app/components/referentiels/new_form_component/new_form_component.html.haml
+++ b/app/components/referentiels/new_form_component/new_form_component.html.haml
@@ -2,12 +2,21 @@
   = form.hidden_field :referentiel_id, value: params[:referentiel_id]
   %div
     = render Dsfr::RadioButtonListComponent.new(form:, target: :type,
-      buttons: [ { label: 'À partir d’une URL', value: 'Referentiels::APIReferentiel', hint: 'Connectez un champ à une API', data: {controller: 'autosubmit'} } ,
+      buttons: [ { label: 'À partir d’une URL', value: 'Referentiels::APIReferentiel', hint: 'Connectez un champ à une API', data: { controller: 'autosubmit' } } ,
         { label: 'À partir d’un fichier CSV', value: 'Referentiels::CsvReferentiel', hint: 'Connectez un champ à un CSV', disabled: true }]) do ||
       Comment interroger votre référentiel ?
 
     - if @referentiel.type == 'Referentiels::APIReferentiel'
-      = render Dsfr::InputComponent.new(form:, attribute: :url)
+      = render Dsfr::InputComponent.new(form:, attribute: :url, opts: { data: { controller: 'autosubmit' } })
+      - if @referentiel.url.blank? || @referentiel.errors.where(:url).present?
+        = render Dsfr::AlertComponent.new(state: :warning, title: nil, size: :sm, heading_level: :p, extra_class_names:'') do |c|
+          - c.with_body do
+            %p
+              %strong
+                %span.fr-text--bold= "Pour des raisons de cyber/sécuritées, seuls les endpoints terminant .gouv.fr seront automatiquement autorisées (pas les .beta.gouv.fr). Les autres endpoints seront soumis à une vérification manuelle de notre part, merci de nous en faire la demande par mail à "
+                = mail_to CONTACT_EMAIL, CONTACT_EMAIL, class: 'fr-link'
+                = "."
+
     - elsif @referentiel.type == 'Referentiels::CsvReferentiel'
       .fr-input-group
         = form.label :piece_justificative_template, class: 'fr-label', for: dom_id(@type_de_champ, :piece_justificative_template) do

--- a/app/components/referentiels/new_form_component/new_form_component.html.haml
+++ b/app/components/referentiels/new_form_component/new_form_component.html.haml
@@ -7,15 +7,20 @@
       Comment interroger votre référentiel ?
 
     - if @referentiel.type == 'Referentiels::APIReferentiel'
-      = render Dsfr::InputComponent.new(form:, attribute: :url, opts: { data: { controller: 'autosubmit' } })
-      - if @referentiel.url.blank? || @referentiel.errors.where(:url).present?
-        = render Dsfr::AlertComponent.new(state: :warning, title: nil, size: :sm, heading_level: :p, extra_class_names:'') do |c|
-          - c.with_body do
-            %p
-              %strong
-                %span.fr-text--bold= "Pour des raisons de cyber/sécuritées, seuls les endpoints terminant .gouv.fr seront automatiquement autorisées (pas les .beta.gouv.fr). Les autres endpoints seront soumis à une vérification manuelle de notre part, merci de nous en faire la demande par mail à "
-                = mail_to CONTACT_EMAIL, CONTACT_EMAIL, class: 'fr-link'
-                = "."
+      = render Dsfr::InputComponent.new(form:, attribute: :url, opts: { data: { controller: 'autosubmit' } }) do |c|
+        - c.with_describedby do
+          - if @referentiel.url.blank? || @referentiel.errors.where(:url).present?
+            = render Dsfr::AlertComponent.new(state: :warning, title: nil, size: :sm, heading_level: :p, extra_class_names:'') do |c|
+              - c.with_body do
+                %p
+                  Pour des raisons de sécurité,
+                  %strong seuls les domaines se terminant par .gouv.fr sont automatiquement autorisés
+                  (à l’exception de .beta.gouv.fr). Les autres domaines sont soumis à une validation manuelle de notre part, merci de nous en faire la demande par mail à "
+                  = mail_to CONTACT_EMAIL, CONTACT_EMAIL, class: 'fr-link'
+                  = "."
+          - else
+            .fr-mt-1w.fr-message.fr-message--info Attention si vous appelez une API qui renvoie de la donnée personnelle, vous devez en informer votre DPO.
+
 
     - elsif @referentiel.type == 'Referentiels::CsvReferentiel'
       .fr-input-group

--- a/app/controllers/administrateurs/referentiels_controller.rb
+++ b/app/controllers/administrateurs/referentiels_controller.rb
@@ -21,6 +21,7 @@ module Administrateurs
       if referentiel.configured? && referentiel.update(referentiel_params)
         redirect_to mapping_type_de_champ_admin_procedure_referentiel_path(@procedure, @type_de_champ.stable_id, referentiel)
       else
+        referentiel.validate
         component = Referentiels::NewFormComponent.new(referentiel:, type_de_champ: @type_de_champ, procedure: @procedure)
         render turbo_stream: turbo_stream.replace(component.id, component)
       end

--- a/app/models/referentiels/api_referentiel.rb
+++ b/app/models/referentiels/api_referentiel.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 class Referentiels::APIReferentiel < Referentiel
-  validates :mode, inclusion: { in: ['exact_match', 'autocomplete'] }, allow_blank: true, allow_nil: true
+  enum :mode, {
+    exact_match: 'exact_match',
+    autocomplete: 'autocomplete'
+  }
+  validates :mode, inclusion: { in: modes.values }, allow_blank: true, allow_nil: true
+  validate :url_in_whitelist?
 
   before_save :name_as_url
 
@@ -30,5 +35,20 @@ class Referentiels::APIReferentiel < Referentiel
 
   def name_as_url
     self.name = url
+  end
+
+  def url_in_whitelist?
+    return if url.blank?
+
+    uri = Addressable::URI.parse(url)
+
+    return if uri.host && uri.host.match?(/\A(?:.*\.)?gouv\.fr\z/) && !uri.host.match?(/\A(?:.*\.)?beta\.gouv\.fr\z/)
+
+    whitelist = ENV.fetch('API_WHITELIST', '').split(',')
+    if whitelist.none? { |whitelisted_url| uri.host && whitelisted_url.include?(uri.host) }
+      errors.add(:url, "L'URL doit être dans la liste blanche")
+    end
+  rescue URI::InvalidURIError
+    errors.add(:url, "L'URL est invalide")
   end
 end

--- a/config/env.example
+++ b/config/env.example
@@ -149,3 +149,4 @@ STRICT_EMAIL_VALIDATION_STARTS_ON="2024-02-19"
 # Weasyprint endpoint generating attestations v2
 # See https://github.com/demarches-simplifiees/weasyprint_server
 WEASYPRINT_URL="http://127.0.0.1:5000/pdf"
+

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -295,4 +295,4 @@ RDV_SERVICE_PUBLIC_URL=https://demo.rdv.anct.gouv.fr
 PURGE_LATER_DELAY_IN_DAY="7"
 
 # A list of url separated by commma allowed by your front|back,end
-API_WHITELIST=""
+ALLOWED_API_DOMAINS_FROM_FRONTEND=""

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -293,3 +293,6 @@ RDV_SERVICE_PUBLIC_URL=https://demo.rdv.anct.gouv.fr
 
 # allows to soft delete blobs 7 days after their purge_later call
 PURGE_LATER_DELAY_IN_DAY="7"
+
+# A list of url separated by commma allowed by your front|back,end
+API_WHITELIST=""

--- a/spec/components/referentiels/mapping_form_component_spec.rb
+++ b/spec/components/referentiels/mapping_form_component_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Referentiels::MappingFormComponent, type: :component do
   let(:whitelist) { %w[https://rnb-api.beta.gouv.fr] }
   before do
     allow(ENV).to receive(:fetch).and_call_original
-    allow(ENV).to receive(:fetch).with('API_WHITELIST', '').and_return(whitelist.join(','))
+    allow(ENV).to receive(:fetch).with('ALLOWED_API_DOMAINS_FROM_FRONTEND', '').and_return(whitelist.join(','))
   end
   describe 'render' do
     delegate :url_helpers, to: :routes

--- a/spec/components/referentiels/mapping_form_component_spec.rb
+++ b/spec/components/referentiels/mapping_form_component_spec.rb
@@ -3,10 +3,14 @@
 RSpec.describe Referentiels::MappingFormComponent, type: :component do
   let(:component) { described_class.new(referentiel:, type_de_champ:, procedure:) }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
-  let(:types_de_champ_public) { [{ type: :referentiel }] }
+  let(:types_de_champ_public) { [{ type: :referentiel, referentiel: }] }
   let(:type_de_champ) { procedure.draft_revision.types_de_champ_public.first }
-  let(:referentiel) { create(:api_referentiel, :configured) }
-
+  let(:referentiel) { create(:api_referentiel, :configured, url: whitelist.first) }
+  let(:whitelist) { %w[https://rnb-api.beta.gouv.fr] }
+  before do
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with('API_WHITELIST', '').and_return(whitelist.join(','))
+  end
   describe 'render' do
     delegate :url_helpers, to: :routes
     delegate :routes, to: :application
@@ -25,7 +29,7 @@ RSpec.describe Referentiels::MappingFormComponent, type: :component do
     end
 
     context 'when referentiel is properly configured' do
-      let(:referentiel) { create(:api_referentiel, :with_last_response, :configured) }
+      let(:referentiel) { create(:api_referentiel, :with_last_response, :configured, url: whitelist.first) }
 
       it 'table' do
         # thead

--- a/spec/components/referentiels/new_form_component_spec.rb
+++ b/spec/components/referentiels/new_form_component_spec.rb
@@ -10,8 +10,10 @@ RSpec.describe Referentiels::NewFormComponent, type: :component do
     let(:procedure) { create(:procedure, types_de_champ_public:) }
     let(:types_de_champ_public) { [{ type: :referentiel }] }
     let(:type_de_champ) { procedure.draft_revision.types_de_champ_public.first }
-
+    let(:whitelist) { %w[https://rnb-api.beta.gouv.fr] }
     before do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with('API_WHITELIST', '').and_return(whitelist.join(','))
       Flipper.enable_actor(:referentiel_type_de_champ, procedure)
       render_inline(component)
     end
@@ -62,7 +64,7 @@ RSpec.describe Referentiels::NewFormComponent, type: :component do
     end
 
     context 'when referentiel was persisted' do
-      let(:referentiel) { create(:api_referentiel, types_de_champ: [type_de_champ], url: "https://rnb.api") }
+      let(:referentiel) { create(:api_referentiel, types_de_champ: [type_de_champ], url: "https://rnb-api.beta.gouv.fr") }
       it 'render form to update' do
         expect(page).to have_css('form[method=post]')
         expect(page).to have_css('input[name=_method][value=patch]')

--- a/spec/components/referentiels/new_form_component_spec.rb
+++ b/spec/components/referentiels/new_form_component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Referentiels::NewFormComponent, type: :component do
     let(:whitelist) { %w[https://rnb-api.beta.gouv.fr] }
     before do
       allow(ENV).to receive(:fetch).and_call_original
-      allow(ENV).to receive(:fetch).with('API_WHITELIST', '').and_return(whitelist.join(','))
+      allow(ENV).to receive(:fetch).with('ALLOWED_API_DOMAINS_FROM_FRONTEND', '').and_return(whitelist.join(','))
       Flipper.enable_actor(:referentiel_type_de_champ, procedure)
       render_inline(component)
     end

--- a/spec/components/types_de_champ_editor/info_referentiel_component_spec.rb
+++ b/spec/components/types_de_champ_editor/info_referentiel_component_spec.rb
@@ -9,7 +9,7 @@ describe TypesDeChampEditor::InfoReferentielComponent, type: :component do
 
     before do
       allow(ENV).to receive(:fetch).and_call_original
-      allow(ENV).to receive(:fetch).with('API_WHITELIST', '').and_return(whitelist.join(','))
+      allow(ENV).to receive(:fetch).with('ALLOWED_API_DOMAINS_FROM_FRONTEND', '').and_return(whitelist.join(','))
       referentiel
       type_de_champ
       Flipper.enable_actor(:referentiel_type_de_champ, procedure)

--- a/spec/components/types_de_champ_editor/info_referentiel_component_spec.rb
+++ b/spec/components/types_de_champ_editor/info_referentiel_component_spec.rb
@@ -5,8 +5,11 @@ describe TypesDeChampEditor::InfoReferentielComponent, type: :component do
     let(:component) { described_class.new(procedure:, type_de_champ:) }
     let(:types_de_champ_public) { [{ type: :referentiel }] }
     let(:type_de_champ) { procedure.draft_revision.types_de_champ_public.first }
+    let(:whitelist) { %w[https://rnb-api.beta.gouv.fr] }
 
     before do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with('API_WHITELIST', '').and_return(whitelist.join(','))
       referentiel
       type_de_champ
       Flipper.enable_actor(:referentiel_type_de_champ, procedure)
@@ -16,7 +19,7 @@ describe TypesDeChampEditor::InfoReferentielComponent, type: :component do
     context "draft_procedure" do
       let(:procedure) { create(:procedure, types_de_champ_public:) }
       context 'having referentiel' do
-        let(:referentiel) { create(:api_referentiel, types_de_champ: [type_de_champ], url: "https://rnb.api") }
+        let(:referentiel) { create(:api_referentiel, types_de_champ: [type_de_champ], url: "https://rnb-api.beta.gouv.fr") }
 
         it "allows to edit referentiel" do
           expect(page).to have_link("Configurer le champ", href: Rails.application.routes.url_helpers.edit_admin_procedure_referentiel_path(procedure, type_de_champ.stable_id, referentiel.id))
@@ -35,7 +38,7 @@ describe TypesDeChampEditor::InfoReferentielComponent, type: :component do
       let(:procedure) { create(:procedure, :published, types_de_champ_public:) }
 
       context "having referentiel" do
-        let(:referentiel) { create(:api_referentiel, types_de_champ: [type_de_champ], url: "https://rnb.api") }
+        let(:referentiel) { create(:api_referentiel, types_de_champ: [type_de_champ], url: "https://rnb-api.beta.gouv.fr") }
 
         it "does not allow to edit existing referentiel" do
           expect(page).to have_link("Configurer le champ", href: Rails.application.routes.url_helpers.new_admin_procedure_referentiel_path(procedure, type_de_champ.stable_id, referentiel_id: referentiel.id))

--- a/spec/controllers/administrateurs/referentiels_controller_spec.rb
+++ b/spec/controllers/administrateurs/referentiels_controller_spec.rb
@@ -5,7 +5,7 @@ describe Administrateurs::ReferentielsController, type: :controller do
   before do
     sign_in(procedure.administrateurs.first.user)
     allow(ENV).to receive(:fetch).and_call_original
-    allow(ENV).to receive(:fetch).with('API_WHITELIST', '').and_return(whitelist.join(','))
+    allow(ENV).to receive(:fetch).with('ALLOWED_API_DOMAINS_FROM_FRONTEND', '').and_return(whitelist.join(','))
   end
 
   let(:stable_id) { 123 }

--- a/spec/models/referentiel_spec.rb
+++ b/spec/models/referentiel_spec.rb
@@ -9,9 +9,10 @@ describe Referentiel do
       end
 
       describe 'APIReferentiel' do
-        let(:whitelist) { %w[example.com allowed.com] }
+        let(:whitelist) { %w[https://example.com https://allowed.com] }
         before do
-          allow(ENV).to receive(:fetch).with('API_WHITELIST', '').and_return(whitelist.join(','))
+          allow(ENV).to receive(:fetch).and_call_original
+          allow(ENV).to receive(:fetch).with('ALLOWED_API_DOMAINS_FROM_FRONTEND', '').and_return(whitelist.join(','))
         end
         it 'validates presentater as exact_match/autocomplete or nil' do
           expect(build(:api_referentiel, mode: 'exact_match').tap(&:validate).errors.map(&:attribute)).not_to include(:mode)
@@ -50,7 +51,7 @@ describe Referentiel do
 
             it 'adds an error' do
               referentiel.validate
-              expect(referentiel.errors[:url]).to include("L'URL doit être dans la liste blanche")
+              expect(referentiel.errors[:url]).to include("L'URL doit être autorisée par notre équipe, veuillez nous contacter")
             end
           end
 
@@ -59,7 +60,7 @@ describe Referentiel do
 
             it 'adds an invalid URL error' do
               referentiel.validate
-              expect(referentiel.errors[:url]).to include("L'URL doit être dans la liste blanche")
+              expect(referentiel.errors[:url]).to include("L'URL est invalide")
             end
           end
 
@@ -73,7 +74,7 @@ describe Referentiel do
           end
 
           context 'when the URL ends with .gouv.fr' do
-            let(:url) { "https://api.service.gouv.fr/resource" }
+            let(:url) { "https://ministere.gouv.fr/resource" }
 
             it 'does not add an error' do
               referentiel.validate
@@ -86,7 +87,7 @@ describe Referentiel do
 
             it 'adds an error' do
               referentiel.validate
-              expect(referentiel.errors[:url]).to include("L'URL doit être dans la liste blanche")
+              expect(referentiel.errors[:url]).to include("L'URL doit être autorisée par notre équipe, veuillez nous contacter")
             end
           end
         end

--- a/spec/models/referentiel_spec.rb
+++ b/spec/models/referentiel_spec.rb
@@ -9,22 +9,84 @@ describe Referentiel do
       end
 
       describe 'APIReferentiel' do
+        let(:whitelist) { %w[example.com allowed.com] }
+        before do
+          allow(ENV).to receive(:fetch).with('API_WHITELIST', '').and_return(whitelist.join(','))
+        end
         it 'validates presentater as exact_match/autocomplete or nil' do
           expect(build(:api_referentiel, mode: 'exact_match').tap(&:validate).errors.map(&:attribute)).not_to include(:mode)
           expect(build(:api_referentiel, mode: 'autocomplete').tap(&:validate).errors.map(&:attribute)).not_to include(:mode)
           expect(build(:api_referentiel, mode: nil).tap(&:validate).errors.map(&:attribute)).not_to include(:mode)
-          expect(build(:api_referentiel, mode: 'wrong').tap(&:validate).errors.map(&:attribute)).to include(:mode)
         end
 
         describe 'configured?' do
           context 'when adapter is url' do
             it 'tests url params' do
-              referentiel = build(:api_referentiel)
+              referentiel = build(:api_referentiel, url: whitelist)
               expect(referentiel).to receive(:mode).and_return(double(present?: true))
               expect(referentiel).to receive(:url).and_return(double(present?: true))
               expect(referentiel).to receive(:test_data).and_return(double(present?: true))
 
               expect(referentiel.configured?).to eq(true)
+            end
+          end
+        end
+
+        describe 'url_in_whitelist?' do
+          let(:referentiel) { build(:api_referentiel, url:) }
+          let(:whitelist) { %w[https://example.com https://allowed.com] }
+
+          context 'when the URL is in the whitelist' do
+            let(:url) { whitelist.first }
+
+            it 'does not add an error' do
+              referentiel.validate
+              expect(referentiel.errors[:url]).to be_empty
+            end
+          end
+
+          context 'when the URL is not in the whitelist' do
+            let(:url) { "https://api.untrusted.com/resource" }
+
+            it 'adds an error' do
+              referentiel.validate
+              expect(referentiel.errors[:url]).to include("L'URL doit être dans la liste blanche")
+            end
+          end
+
+          context 'when the URL is invalid' do
+            let(:url) { "invalid_url" }
+
+            it 'adds an invalid URL error' do
+              referentiel.validate
+              expect(referentiel.errors[:url]).to include("L'URL doit être dans la liste blanche")
+            end
+          end
+
+          context 'when the URL is blank' do
+            let(:url) { nil }
+
+            it 'does not add an error' do
+              referentiel.validate
+              expect(referentiel.errors[:url]).to be_empty
+            end
+          end
+
+          context 'when the URL ends with .gouv.fr' do
+            let(:url) { "https://api.service.gouv.fr/resource" }
+
+            it 'does not add an error' do
+              referentiel.validate
+              expect(referentiel.errors[:url]).to be_empty
+            end
+          end
+
+          context 'when the URL ends with .beta.gouv.fr' do
+            let(:url) { "https://api.beta.gouv.fr/resource" }
+
+            it 'adds an error' do
+              referentiel.validate
+              expect(referentiel.errors[:url]).to include("L'URL doit être dans la liste blanche")
             end
           end
         end


### PR DESCRIPTION
# probleme

ETQ DS/RSSI, je souhaite contraindre les domaines appelable par l'app a des domaines de confiance

# solution

petit warning par défaut
<img width="1028" alt="Capture d’écran 2025-04-11 à 4 32 28 PM" src="https://github.com/user-attachments/assets/b516fd44-f3de-472a-ae51-dc52f75d4738" />

on garde le warning en cas d'url ni dans la whitelist, ni terminant en .gouv.fr
<img width="1031" alt="Capture d’écran 2025-04-11 à 4 32 41 PM" src="https://github.com/user-attachments/assets/a6319b70-acf0-4c14-a700-5de9fd5d6fda" />

en cas d'url valide, on s'assure de communiquer aux admins qu'il doivent en informer leurs DPO
<img width="1025" alt="Capture d’écran 2025-04-24 à 3 56 46 PM" src="https://github.com/user-attachments/assets/3a226167-af73-4dde-a0de-ebf1ffd06b4a" />


ENV VAR !
API_WHITELIST="" (liste des urls autorisées a être appelées par nos fronts/back)