### PR TITLE
ETQ Super Admin, j ai une page dossier moins chargé et une page procédure qui se charge plus vite

### DIFF
--- a/app/controllers/manager/procedures_controller.rb
+++ b/app/controllers/manager/procedures_controller.rb
@@ -184,6 +184,14 @@ module Manager
 
     private
 
+    def find_resource(param)
+      procedure = super
+
+      procedure.preload_draft_and_published_revisions
+
+      procedure
+    end
+
     def procedure
       @procedure ||= Procedure.with_discarded.find(params[:id])
     end

--- a/app/views/manager/dossiers/show.html.erb
+++ b/app/views/manager/dossiers/show.html.erb
@@ -61,9 +61,26 @@ as well as a link to its edit page.
           ) %>
           </dt>
 
-          <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
-              ><%= render_field attribute, page: page %></dd>
-        <% end %>
+            <% if attribute.name == 'procedure' %>
+              <%- procedure = attribute.data %>
+              <dd class="attribute-data attribute-data--<%=attribute.html_class%>">
+                <%= link_to(
+                  procedure.libelle + " (#{procedure.id})",
+                  manager_procedure_path(procedure)
+                ) %>
+              </dd>
+
+              <dt class="attribute-label" id="procedure">
+                lien procedure
+              </dt>
+              <dd class="attribute-data attribute-data--<%=attribute.html_class%>">
+                <%= link_to(commencer_path(procedure.canonical_path), commencer_path(procedure.canonical_path)) %>
+              </dd>
+            <% else %>
+              <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
+                  ><%= render_field attribute, page: page %></dd>
+            <% end %>
+          <% end %>
       </fieldset>
     <% end %>
   </dl>


### PR DESCRIPTION
on affiche plus tous le detail d'une procédure dans le détail d'un dossier mais uniquement l'id, le lien vers le detail et le canonical_path

![Screenshot 2025-04-11 at 17-19-58 Détails Dossier #15288350 - Tps](https://github.com/user-attachments/assets/05f8a1c0-6113-485e-acfb-df368eb36dd8)

dans le cas fond vert, on passe de 800 queries a 20.

dans la page procedure, on preload les revision, dans le cas fonds vert on passe de > 1000 a 70