### PR TITLE
Typo in publiccode.yml name

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -3,7 +3,7 @@
 # More info at https://github.com/italia/publiccode.yml
 
 publiccodeYmlVersion: '0.2'
-name: Démarches Simplifiéees
+name: Démarches Simplifiées
 url: 'https://github.com/demarches-simplifiees/demarches-simplifiees.fr'
 landingURL: 'https://www.demarches-simplifiees.fr/'
 roadmap: 'https://github.com/demarches-simplifiees/demarches-simplifiees.fr/wiki/Feuille-de-route'


### PR DESCRIPTION
I randomly spotted the typo [here](https://interoperable-europe.ec.europa.eu/eu-oss-catalogue/solutions/demarches-simplifieees).
Have a good day!