### PR TITLE
[UI] ETQ instructeur, je retrouve plus facilement mon champ pour sélectionner une démarche

### DIFF
--- a/app/assets/stylesheets/dsfr.scss
+++ b/app/assets/stylesheets/dsfr.scss
@@ -191,3 +191,10 @@ input[type='radio'] {
 .fr-header__tools .fr-btns-group .fr-btn {
   margin-bottom: 0;
 }
+
+// We increase from 3rem the max-width to avoid truncating hint in header search
+@media (min-width: 62em) {
+  .fr-header__tools .fr-header__search {
+    max-width: 27rem;
+  }
+}

--- a/app/assets/stylesheets/dsfr.scss
+++ b/app/assets/stylesheets/dsfr.scss
@@ -182,6 +182,12 @@ input[type='radio'] {
   margin-top: 0.5rem;
 }
 
+// Improve tabs alignment because we are not displaying the border around the page content
+.fr-tabs__list {
+  padding-left: 0;
+  margin-left: -4px;
+}
+
 .fr-header__tools .fr-btns-group .fr-btn {
   margin-bottom: 0;
 }

--- a/app/views/instructeurs/procedures/index.html.haml
+++ b/app/views/instructeurs/procedures/index.html.haml
@@ -5,8 +5,9 @@
     .flex.fr-mb-2v
       %h1.fr-h3.fr-mb-0 Démarches
       = render Instructeurs::TabsExplanationsComponent.new
-      = render SelectProcedureDropDownListComponent.new(procedures: @procedures, action_path: url_for([:select_procedure, :instructeur, :procedures]))
+
     = render partial: 'instructeurs/procedures/synthese', locals: { procedures: @procedures, all_dossiers_counts: @all_dossiers_counts }
+    = render SelectProcedureDropDownListComponent.new(procedures: @procedures, action_path: url_for([:select_procedure, :instructeur, :procedures]), form_class: 'width-66 fr-mb-3w')
 
     %nav.fr-tabs{ role: 'navigation', 'aria-label': t('views.users.dossiers.secondary_menu') }
       %ul.fr-tabs__list{ role: 'tablist' }
@@ -26,7 +27,7 @@
 
   - if collection.present?
     = render Instructeurs::WarningBannerComponent.new(draft: @statut == "brouillons", single_procedure: false)
-    .fr-container.flex.justify-between.fr-mb-6w
+    .flex.justify-between.fr-mb-3w
       %h2.fr-h6.fr-m-0
         = page_entries_info collection
       - if (@statut == "en-cours" && @all_procedures_en_cours.size > 1)

--- a/app/views/users/dossiers/index.html.haml
+++ b/app/views/users/dossiers/index.html.haml
@@ -5,12 +5,12 @@
 
 .dossiers-headers.sub-header
   .fr-container
-    %h1.page-title.fr-h2= t('views.users.dossiers.index.dossiers')
+    %h1.fr-h3= t('views.users.dossiers.index.dossiers')
 
     - if current_user.dossiers.count > 2 || current_user.dossiers_invites.count > 2  || @procedures_for_select.size > 1
       .fr-grid-row.fr-grid-row--gutters
         - if current_user.dossiers.count > 2 || current_user.dossiers_invites.count > 2
-          .fr-col.fr-mb-5w
+          .fr-col
             #search-2.fr-search-bar
               = form_tag dossiers_path, method: :get, :role => "search", class: "width-100" do
                 = hidden_field_tag :procedure_id, params[:procedure_id]
@@ -20,7 +20,7 @@
                   %button.fr-btn.fr-btn--sm
                     = t('views.users.dossiers.search.label')
         - if @procedures_for_select.size > 1
-          .fr-col.fr-mb-5w
+          .fr-col
             = render Dossiers::UserProcedureFilterComponent.new(procedures_for_select: @procedures_for_select)
 
     - if @search_terms.blank?

--- a/config/locales/views/users/header/fr.yml
+++ b/config/locales/views/users/header/fr.yml
@@ -22,5 +22,5 @@ fr:
             other: "Conserver %{count} mois supplémentaires"
         callout:
           first_brouillon_recently_updated_title: Vous avez déjà commencé à remplir un dossier
-          first_brouillon_recently_updated_text: Il y a %{time_ago} vous avez commencé à remplir un dossier sur la démarche « %{libelle} ».
+          first_brouillon_recently_updated_text: Il y a %{time_ago} vous avez commencé à remplir un dossier sur la démarche « %{libelle} ».
           first_brouillon_recently_updated_button: Continuer à remplir


### PR DESCRIPTION
Lors d'un point UX, Colin a soulevé que les 2 barres de recherche étaient trop proches l'une de l'autre : celle de la navigation et celle de l'acces direct à la demarche.
Avec Marlène, on propose de la déplacer au même endroit que pour la page des admins.

On en a également profité pour aligner les onglets et faire qq corrections d'espacements.

**APRES**
<img width="1259" alt="Capture d’écran 2025-04-14 à 15 31 52" src="https://github.com/user-attachments/assets/90cdba2f-b171-414d-b286-8187aa14375e" />
**AVANT**
<img width="1258" alt="Capture d’écran 2025-04-14 à 15 32 10" src="https://github.com/user-attachments/assets/1bfc08ff-0d59-4e1a-a911-6554af746a60" />
