### PR TITLE
ETQ Usager, je veux que l'exemple d'IBAN soit correct et que le contenu ne déborde pas sur les terminaux de faible largeur

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -119,6 +119,7 @@
 
   .editable-champ {
     position: relative;
+    max-width: calc(100% - 1.5rem); // Prevent overflow on 320px wide viewports
 
     .updated-at {
       font-size: 0.875rem;

--- a/config/locales/models/champs/iban_champ/fr.yml
+++ b/config/locales/models/champs/iban_champ/fr.yml
@@ -5,7 +5,7 @@ fr:
         champs/iban_champ:
           attributes:
             value:
-              invalid_iban: 'est invalide. Saisissez un numéro IBAN valide. Exemple (France) : 500 001 234 56789'
+              invalid_iban: 'est invalide. Saisissez un numéro IBAN valide. Exemple (France) : FR76 1234 1234 1234 1234 1234 123'
     attributes:
       champs/iban_champ:
         hints:

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -197,13 +197,13 @@ describe 'The user', js: true do
     fill_in('IBAN', with: 'FR')
     wait_until { champ_value_for('IBAN') == 'FR' }
 
-    expect(page).not_to have_content 'est invalide. Saisissez un numéro IBAN valide. Exemple (France) : 500 001 234 56789'
+    expect(page).not_to have_content 'est invalide. Saisissez un numéro IBAN valide. Exemple (France) : FR76 1234 1234 1234 1234 1234 123'
     blur
-    expect(page).to have_content 'est invalide. Saisissez un numéro IBAN valide. Exemple (France) : 500 001 234 56789'
+    expect(page).to have_content 'est invalide. Saisissez un numéro IBAN valide. Exemple (France) : FR76 1234 1234 1234 1234 1234 123'
 
     fill_in('IBAN', with: 'FR7630006000011234567890189')
     wait_until { champ_value_for('IBAN') == 'FR76 3000 6000 0112 3456 7890 189' }
-    expect(page).not_to have_content 'est invalide. Saisissez un numéro IBAN valide. Exemple (France) : 500 001 234 56789'
+    expect(page).not_to have_content 'est invalide. Saisissez un numéro IBAN valide. Exemple (France) : FR76 1234 1234 1234 1234 1234 123'
 
     # Check an incomplete dossier cannot be submitted when mandatory fields are missing
     click_on 'Déposer le dossier'


### PR DESCRIPTION
# IBAN : Corrige l'exemple erroné
__Après__
![Capture d’écran 2025-04-14 à 17 15 23](https://github.com/user-attachments/assets/112e00e6-8cbd-4a1e-a844-5de4b6f9b73c)

__Avant__
![Capture d’écran 2025-04-14 à 17 14 54](https://github.com/user-attachments/assets/dfdea2aa-dd0e-4d14-8f75-11bedf150c33)


# Évite le débordement du contenu sur les terminaux de 320px de large
__Après__
![Capture d’écran 2025-04-14 à 17 06 29](https://github.com/user-attachments/assets/1917c327-f214-4a9b-b212-504a827618e5)

__Avant__
![Capture d’écran 2025-04-14 à 17 06 18](https://github.com/user-attachments/assets/f3a11f1e-f743-4433-a1ae-bca5604ad650)
