### PR TITLE
[UX] ETQ instructeur mes actions multiples sont mieux présentées

### DIFF
--- a/app/assets/stylesheets/02_utils.scss
+++ b/app/assets/stylesheets/02_utils.scss
@@ -90,6 +90,10 @@
   }
 }
 
+.text-high-blue {
+  color: var(--text-action-high-blue-france);
+}
+
 .relative {
   position: relative;
 }

--- a/app/assets/stylesheets/dossiers_table.scss
+++ b/app/assets/stylesheets/dossiers_table.scss
@@ -20,7 +20,8 @@
 
   .follow-col {
     .fr-btn {
-      margin-bottom: 0;
+      margin-bottom: 2px;
+      margin-top: 2px;
     }
   }
 }

--- a/app/assets/stylesheets/dsfr.scss
+++ b/app/assets/stylesheets/dsfr.scss
@@ -58,8 +58,8 @@ input[type='radio'] {
 }
 
 // dans le DSFR il est possible d'avoir un bouton seulement avec une icone mais j'ai du surcharger ici pour eviter d'avoir des marges de l'icone. Je n'ai pas bien compris pourquoi
-.fr-btns-group--sm.fr-btns-group--icon-right
-  .fr-btn[class*=' fr-icon-'].icon-only::after {
+.fr-btns-group--sm.fr-btns-group--icon-left
+  .fr-btn[class*=' fr-icon-'].icon-only::before {
   margin-left: 0;
   margin-right: 0;
 }

--- a/app/components/dossiers/batch_operation_component/batch_operation_component.html.haml
+++ b/app/components/dossiers/batch_operation_component/batch_operation_component.html.haml
@@ -1,25 +1,28 @@
-.batch-operation.fr-ml-auto.flex
-  - if available_operations[:options].count.between?(1,3)
-    = form_for(BatchOperation.new, url: instructeur_batch_operations_path(procedure_id: procedure.id), method: :post, html: { class: 'form', id: dom_id(BatchOperation.new) }, data: { turbo: true, turbo_confirm: t('.operations.confirm') }) do |form|
-      - available_operations[:options].each do |opt|
-        = render Dossiers::BatchOperationInlineButtonsComponent.new(opt:, icons:, form:)
+.fr-background-alt--blue-france.fr-p-2w.fr-mb-n2w
+  .batch-operation.flex.align-center
+    %span.fr-mr-1w{ data: { batch_operation_target: 'checkboxCount' } }
+      0 dossier sélectionné
+    - if available_operations[:options].count.between?(1,3)
+      = form_for(BatchOperation.new, url: instructeur_batch_operations_path(procedure_id: procedure.id), method: :post, html: { class: 'form', id: dom_id(BatchOperation.new) }, data: { turbo: true, turbo_confirm: t('.operations.confirm') }) do |form|
+        - available_operations[:options].each do |opt|
+          = render Dossiers::BatchOperationInlineButtonsComponent.new(opt:, icons:, form:)
 
-  - else
-    = form_for(BatchOperation.new, url: instructeur_batch_operations_path(procedure_id: procedure.id), method: :post, html: { class: 'form flex', id: dom_id(BatchOperation.new) }, data: { turbo: true, turbo_confirm: t('.operations.confirm') }) do |form|
-      - available_operations[:options][0,2].each do |opt|
-        = render Dossiers::BatchOperationInlineButtonsComponent.new(opt:, icons:, form:)
+    - else
+      = form_for(BatchOperation.new, url: instructeur_batch_operations_path(procedure_id: procedure.id), method: :post, html: { class: 'form flex', id: dom_id(BatchOperation.new) }, data: { turbo: true, turbo_confirm: t('.operations.confirm') }) do |form|
+        - available_operations[:options][0,2].each do |opt|
+          = render Dossiers::BatchOperationInlineButtonsComponent.new(opt:, icons:, form:)
 
-      .dropdown{ data: { controller: 'menu-button', popover: 'true' } }
-        -# Dropdown button title
-        %button#batch_operation_others.fr-btn.fr-btn--sm.fr-btn--secondary.fr-ml-1w.dropdown-button{ disabled: true, data: { menu_button_target: 'button', batch_operation_target: 'dropdown' } }
-          = t('.operations.other')
-          %span.fr-ml-2v{ 'aria-hidden': 'true' }
+        .dropdown{ data: { controller: 'menu-button', popover: 'true' } }
+          -# Dropdown button title
+          %button#batch_operation_others.fr-btn.fr-btn--sm.fr-btn--secondary.fr-ml-1w.dropdown-button{ disabled: true, data: { menu_button_target: 'button', batch_operation_target: 'dropdown' } }
+            = t('.operations.other')
+            %span.fr-ml-2v{ 'aria-hidden': 'true' }
 
-        #state-menu.dropdown-content.fade-in-down{ data: { menu_button_target: 'menu' }, "aria-labelledby" => "batch_operation_others" }
-          %ul.dropdown-items
-            - available_operations[:options][2, available_operations[:options].count].each do |opt|
-              %li
-                = form.button opt[:label], class: 'dropdown-items-link ', disabled: true, name: "#{form.object_name}[operation]", value: opt[:operation], data: { operation: opt[:operation] } do
-                  %span{ class: icons[opt[:operation].to_sym] }
-                  .dropdown-description
-                    %h4= opt[:label]
+          #state-menu.dropdown-content.fade-in-down{ data: { menu_button_target: 'menu' }, "aria-labelledby" => "batch_operation_others" }
+            %ul.dropdown-items
+              - available_operations[:options][2, available_operations[:options].count].each do |opt|
+                %li
+                  = form.button opt[:label], class: 'dropdown-items-link ', disabled: true, name: "#{form.object_name}[operation]", value: opt[:operation], data: { operation: opt[:operation] } do
+                    %span{ class: icons[opt[:operation].to_sym] }
+                    .dropdown-description
+                      %h4= opt[:label]

--- a/app/components/instructeurs/filter_buttons_component.rb
+++ b/app/components/instructeurs/filter_buttons_component.rb
@@ -27,7 +27,7 @@ class Instructeurs::FilterButtonsComponent < ApplicationComponent
         hidden_field_tag('filters[]', ''),    # to ensure the filters is not empty
         *other_hidden_fields(filter),         # other filters to keep
         hidden_field_tag('statut', @statut),  # collection to set
-        button_tag(button_content(filter), class: 'fr-tag fr-tag--dismiss fr-my-1w')
+        button_tag(button_content(filter), class: 'fr-tag fr-tag--dismiss fr-my-1w fr-tag--sm')
       ])
     end
   end

--- a/app/components/procedure/one_groupe_management_component/one_groupe_management_component.html.haml
+++ b/app/components/procedure/one_groupe_management_component/one_groupe_management_component.html.haml
@@ -36,7 +36,7 @@
 
   %h2.fr-h3#dossiers-affectes Dossiers affectés
   .card
-    .flex.justify-between.align-center.fr-btns-group--sm.fr-btns-group--icon-right
+    .flex.justify-between.align-center.fr-btns-group--sm.fr-btns-group--icon-left
       %span.fr-icon.fr-icon-folder-2-line.fr-mr-2w
         = t('.number_of_files', count: @groupe_instructeur.dossiers.visible_by_administration.size)
       - if !@groupe_instructeur.can_delete?

--- a/app/javascript/controllers/batch_operation_controller.ts
+++ b/app/javascript/controllers/batch_operation_controller.ts
@@ -3,14 +3,16 @@ import { disable, enable, show, hide } from '@utils';
 import invariant from 'tiny-invariant';
 
 export class BatchOperationController extends ApplicationController {
-  static targets = ['menu', 'input', 'dropdown'];
+  static targets = ['menu', 'input', 'dropdown', 'checkboxCount'];
 
   declare readonly menuTargets: HTMLButtonElement[];
   declare readonly inputTargets: HTMLInputElement[];
   declare readonly dropdownTargets: HTMLButtonElement[];
+  declare readonly checkboxCountTarget: HTMLElement;
 
   onCheckOne() {
     this.toggleSubmitButtonWhenNeeded();
+    this.updateCheckboxCount();
     deleteSelection();
   }
 
@@ -23,6 +25,7 @@ export class BatchOperationController extends ApplicationController {
     });
 
     this.toggleSubmitButtonWhenNeeded();
+    this.updateCheckboxCount();
 
     const pagination = document.querySelector(
       '.fr-table__footer .fr-pagination'
@@ -100,6 +103,7 @@ export class BatchOperationController extends ApplicationController {
     emptyCheckboxes();
     deleteSelection();
     this.toggleSubmitButtonWhenNeeded();
+    this.updateCheckboxCount();
   }
 
   toggleSubmitButtonWhenNeeded() {
@@ -147,6 +151,26 @@ export class BatchOperationController extends ApplicationController {
       buttons.forEach((button) => switchButton(button, false));
 
       this.dropdownTargets.forEach((e) => disable(e));
+    }
+  }
+
+  updateCheckboxCount() {
+    if (!this.checkboxCountTarget) return;
+
+    const checkedCount = this.inputTargets.filter(
+      (input) => input.checked
+    ).length;
+
+    const label = `${checkedCount} dossier${checkedCount > 1 ? 's' : ''} sélectionné${checkedCount > 1 ? 's' : ''}`;
+
+    this.checkboxCountTarget.textContent = label;
+
+    const classList = this.checkboxCountTarget.classList;
+
+    if (checkedCount > 0) {
+      classList.add('text-high-blue', 'font-weight-bold');
+    } else {
+      classList.remove('text-high-blue', 'font-weight-bold');
     }
   }
 }

--- a/app/views/administrateurs/procedures/_procedures_list.html.haml
+++ b/app/views/administrateurs/procedures/_procedures_list.html.haml
@@ -71,7 +71,7 @@
             = t('draft', scope: [:layouts, :breadcrumb])
 
     .flex.justify-end
-      %ul.fr-btns-group.fr-btns-group--sm.fr-btns-group--inline.fr-btns-group--icon-right
+      %ul.fr-btns-group.fr-btns-group--sm.fr-btns-group--inline.fr-btns-group--icon-left
         - unless procedure.discarded?
           %li
             = link_to admin_procedure_path(procedure), class: 'fr-btn fr-icon-draft-line fr-btn--tertiary' do

--- a/app/views/instructeurs/dossiers/_header_actions.html.haml
+++ b/app/views/instructeurs/dossiers/_header_actions.html.haml
@@ -1,5 +1,5 @@
 .flex.justify-end.fr-mb-1w
-  %ul.fr-btns-group.fr-btns-group--sm.fr-btns-group--inline-md.fr-btns-group--icon-right
+  %ul.fr-btns-group.fr-btns-group--sm.fr-btns-group--inline-md.fr-btns-group--icon-left
     = render partial: "instructeurs/procedures/dossier_actions",
       locals: { procedure_id: dossier.procedure.id,
                 dossier_id: dossier.id,

--- a/app/views/instructeurs/procedures/_dossiers_filter_dropdown.html.haml
+++ b/app/views/instructeurs/procedures/_dossiers_filter_dropdown.html.haml
@@ -1,4 +1,4 @@
-= render Dropdown::MenuComponent.new(wrapper: :div, button_options: { class: ['fr-btn--secondary', 'fr-btn--sm', 'fr-mr-1w', 'fr-mb-2w'] }, menu_options: { id: 'filter-menu', class:['left-aligned'] }) do |menu|
+= render Dropdown::MenuComponent.new(wrapper: :div, button_options: { class: ['fr-btn--secondary', 'fr-btn--sm'] }, menu_options: { id: 'filter-menu', class:['left-aligned'] }) do |menu|
   - menu.with_button_inner_html do
     = t('views.instructeurs.dossiers.filters.title')
 

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -25,13 +25,28 @@
         has_termine_notifications: @has_termine_notifications }
 
   .fr-container--fluid.fr-mx-4w.overflow-y-visible
-    .flex.align-center
+    .flex
       - if @filtered_sorted_paginated_ids.present? || @current_filters.count > 0
         = render partial: "dossiers_filter_dropdown", locals: { procedure: @procedure, statut: @statut, procedure_presentation: @procedure_presentation }
-        = render Dossiers::NotifiedToggleComponent.new(procedure_presentation: @procedure_presentation) if @statut != 'a-suivre'
 
-        .fr-ml-auto
-          - if @dossiers_count > 0
+    - if @filtered_sorted_paginated_ids.present? || @current_filters.count > 0
+      = render Instructeurs::FilterButtonsComponent.new(filters: @current_filters, procedure_presentation: @procedure_presentation, statut: @statut)
+
+    - batch_operation_component = Dossiers::BatchOperationComponent.new(statut: @statut, procedure: @procedure)
+
+    - if @batch_operations.present?
+      - @batch_operations.each do |batch_operation|
+        = render Dossiers::BatchAlertComponent.new(batch: batch_operation, procedure: @procedure)
+
+    - if @dossiers_count > 0
+      %div{ data: batch_operation_component.render? ? { controller: 'batch-operation' } : {} }
+        .flex.align-center.fr-mt-2w
+          %span.fr-h6.fr-mb-0.fr-mr-2w
+            = page_entries_info @filtered_sorted_paginated_ids
+
+          = render Dossiers::NotifiedToggleComponent.new(procedure_presentation: @procedure_presentation) if @statut != 'a-suivre'
+
+          .fr-ml-auto
             %ul.fr-btns-group.fr-btns-group--right.fr-btns-group--sm.fr-btns-group--inline-md.fr-btns-group--icon-left
               = render Dossiers::ExportDropdownComponent.new(wrapper: :li, procedure: @procedure, export_templates: current_instructeur.export_templates_for(@procedure), statut: @statut, count: @dossiers_count, archived_count: @archived_dossiers_count,
                 class_btn: 'fr-btn--secondary fr-icon-download-line', export_url: method(:download_export_instructeur_procedure_path))
@@ -42,21 +57,8 @@
                 - menu.with_form do
                   = render Instructeurs::ColumnPickerComponent.new(procedure: @procedure, procedure_presentation: @procedure_presentation)
 
-    - if @filtered_sorted_paginated_ids.present? || @current_filters.count > 0
-      = render Instructeurs::FilterButtonsComponent.new(filters: @current_filters, procedure_presentation: @procedure_presentation, statut: @statut)
 
-      - batch_operation_component = Dossiers::BatchOperationComponent.new(statut: @statut, procedure: @procedure)
-
-      - if @batch_operations.present?
-        - @batch_operations.each do |batch_operation|
-          = render Dossiers::BatchAlertComponent.new(batch: batch_operation, procedure: @procedure)
-
-      %div{ data: batch_operation_component.render? ? { controller: 'batch-operation' } : {} }
-        .flex.align-center.fr-mt-2w
-          %span.fr-h6.fr-mb-0.fr-mr-2w
-            = page_entries_info @filtered_sorted_paginated_ids
-
-          = render batch_operation_component
+        = render batch_operation_component
 
         .fr-table.fr-table--bordered
           .fr-table__wrapper

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -135,7 +135,7 @@
                               = link_to_if dossier.hidden_by_administration_at.blank?, render(Instructeurs::SVASVRDecisionBadgeComponent.new(dossier:, procedure: @procedure)), path
 
                         %td.follow-col
-                          %ul.fr-btns-group.fr-btns-group--sm.fr-btns-group--inline.fr-btns-group--icon-right
+                          %ul.fr-btns-group.fr-btns-group--sm.fr-btns-group--inline.fr-btns-group--icon-left
                             = render partial: 'instructeurs/procedures/dossier_actions', locals: { procedure_id: @procedure.id,
                                         dossier_id: dossier.id,
                                         state: dossier.state,

--- a/app/views/recherche/index.html.haml
+++ b/app/views/recherche/index.html.haml
@@ -90,7 +90,7 @@
 
                     - else
                       %td.follow-col
-                        %ul.fr-btns-group.fr-btns-group--sm.fr-btns-group--inline-lg.fr-btns-group--icon-right
+                        %ul.fr-btns-group.fr-btns-group--sm.fr-btns-group--inline-lg.fr-btns-group--icon-left
                           = render partial: "instructeurs/procedures/dossier_actions",
                                                                   locals: { procedure_id: procedure_id,
                                                                             dossier_id: dossier.id,


### PR DESCRIPTION
Réorganisation de l'UI afin de préparer la suite pour les nouvelles actiosn multiples : 
- on ajoute un compteur dynamiques pour les dossiers sélectionnés
- on délimite bien l'espace dédié aux actions multiples
- j'en ai profité pour harmoniser tous les boutons avec un icone - avec l'icone à gauche

**APRES**
<img width="1403" alt="Capture d’écran 2025-04-17 à 09 43 49" src="https://github.com/user-attachments/assets/3826e1c4-3730-4a7a-a05c-4e0961b594b9" />

---

**AVANT**
<img width="1404" alt="Capture d’écran 2025-04-17 à 09 44 29" src="https://github.com/user-attachments/assets/df0186e5-26d4-40fa-a196-4c191bad1b15" />