### PR TITLE
[fix] Le compteur de sélection de dossiers des actions multiples fonctionnent aussi sur de la sélection multi-pages

### DIFF
--- a/app/components/dossiers/batch_select_more_component/batch_select_more_component.fr.yml
+++ b/app/components/dossiers/batch_select_more_component/batch_select_more_component.fr.yml
@@ -1,7 +1,7 @@
 fr:
   pagination_files_selected_html: Les <span id='dynamic_number'>n</span> dossiers de cette page sont sélectionnés.
-  select_all: "Sélectionner tous les %{dossiers_count} dossiers."
+  select_all: "Sélectionner la totalité des %{dossiers_count} dossiers."
   select_all_limit: "Sélectionner les %{limit} premiers dossiers sur les %{dossiers_count}"
-  selected_all: "Tous les %{dossiers_count} dossiers sont sélectionnés."
+  selected_all: "%{dossiers_count} dossiers sont sélectionnés."
   selected_all_limit: "%{limit} dossiers sont sélectionnés."
   delete_selection: "Effacer la sélection"

--- a/app/components/dossiers/batch_select_more_component/batch_select_more_component.html.haml
+++ b/app/components/dossiers/batch_select_more_component/batch_select_more_component.html.haml
@@ -1,15 +1,15 @@
 %tr#js_batch_select_more.hidden
-  %td.fr-py-2w.fr-cell--center.fr-background-alt--blue-france{ colspan: 100 }
+  %td.fr-py-2w.fr-background-alt--blue-france{ colspan: 100 }
     #not_selected
       %p{ role: "status" }
         = t('.pagination_files_selected_html')
-        %button#js_select_more.fr-btn.fr-btn--sm.fr-btn--tertiary-no-outline{ data: not_selected_button_data }
+        %button#js_select_more.fr-btn.fr-btn--sm.fr-btn--tertiary{ data: not_selected_button_data }
           = not_selected_text
 
     #selected.hidden
       %p{ role: "status" }
         = selected_text
-        %button#js_delete_selection.fr-btn.fr-btn--sm.fr-btn--tertiary-no-outline{ data: selected_button_data }
+        %button#js_delete_selection.fr-btn.fr-btn--sm.fr-btn--tertiary{ data: selected_button_data }
           = t(".delete_selection")
 
       = hidden_field_tag :"batch_operation[dossier_ids][]", "", form: dom_id(BatchOperation.new), id: dom_id(BatchOperation.new, "input_multiple_ids")

--- a/app/javascript/controllers/batch_operation_controller.ts
+++ b/app/javascript/controllers/batch_operation_controller.ts
@@ -65,6 +65,8 @@ export class BatchOperationController extends ApplicationController {
     if (button) {
       button.focus();
     }
+
+    this.updateCheckboxCount();
   }
 
   onSubmitInstruction(event: { srcElement: HTMLInputElement }) {
@@ -157,17 +159,26 @@ export class BatchOperationController extends ApplicationController {
   updateCheckboxCount() {
     if (!this.checkboxCountTarget) return;
 
-    const checkedCount = this.inputTargets.filter(
-      (input) => input.checked
-    ).length;
+    // Use hidden input value if present
+    const hiddenInput = document.querySelector<HTMLInputElement>(
+      '#input_multiple_ids_batch_operation'
+    );
 
-    const label = `${checkedCount} dossier${checkedCount > 1 ? 's' : ''} sélectionné${checkedCount > 1 ? 's' : ''}`;
+    let count = 0;
 
+    if (hiddenInput && hiddenInput.value.trim() !== '') {
+      const ids = hiddenInput.value.split(',').filter((id) => id.trim() !== '');
+      count = ids.length;
+    } else {
+      // fallback to visible checked checkboxes
+      count = this.inputTargets.filter((input) => input.checked).length;
+    }
+
+    const label = `${count} dossier${count > 1 ? 's' : ''} sélectionné${count > 1 ? 's' : ''}`;
     this.checkboxCountTarget.textContent = label;
 
     const classList = this.checkboxCountTarget.classList;
-
-    if (checkedCount > 0) {
+    if (count > 0) {
       classList.add('text-high-blue', 'font-weight-bold');
     } else {
       classList.remove('text-high-blue', 'font-weight-bold');

--- a/spec/system/instructeurs/batch_operation_spec.rb
+++ b/spec/system/instructeurs/batch_operation_spec.rb
@@ -101,10 +101,10 @@ describe 'BatchOperation a dossier:', js: true do
       # click on check_all make the notice appear
       find("##{dom_id(BatchOperation.new, :checkbox_all)}").check
       expect(page).to have_selector('#js_batch_select_more')
-      expect(page).to have_content('Les 2 dossiers de cette page sont sélectionnés. Sélectionner tous les 3 dossiers.')
+      expect(page).to have_content('Les 2 dossiers de cette page sont sélectionnés. Sélectionner la totalité des 3 dossiers.')
 
       # click on selection link fill checkbox value with dossier_ids
-      click_on("Sélectionner tous les 3 dossiers")
+      click_on("Sélectionner la totalité des 3 dossiers")
       expect(page).to have_content('3 dossiers sont sélectionnés. Effacer la sélection ')
       expect(find_field("batch_operation[dossier_ids][]", type: :hidden).value).to eq "#{dossier_3.id},#{dossier_2.id},#{dossier_1.id}"
 
@@ -116,7 +116,7 @@ describe 'BatchOperation a dossier:', js: true do
 
       # click on check_all + notice link and submit
       find("##{dom_id(BatchOperation.new, :checkbox_all)}").check
-      click_on("Sélectionner tous les 3 dossiers")
+      click_on("Sélectionner la totalité des 3 dossiers")
 
       accept_alert do
         click_on "Suivre les dossiers"


### PR DESCRIPTION
lié à la PR #11594

J'avais oublié le cas de figure où on pouvait sélectionner des dossiers sur plusieurs pages.

<img width="1409" alt="Capture d’écran 2025-04-17 à 17 57 06" src="https://github.com/user-attachments/assets/9f52424a-8573-417c-988b-119dbe467a25" />

