### PR TITLE
ETQ instructeur, je vois la date de mise à la corbeille par l'usager d'un dossier en construction plutôt que celle de la suppression effective

### DIFF
--- a/app/models/deleted_dossier.rb
+++ b/app/models/deleted_dossier.rb
@@ -29,6 +29,12 @@ class DeletedDossier < ApplicationRecord
   def self.create_from_dossier(dossier, reason)
     return if !dossier.log_operations?
 
+    deleted_at = if dossier.hidden_by_user_at && dossier.en_construction?
+      dossier.hidden_by_user_at
+    else
+      Time.current
+    end
+
     # We have some bad data because of partially deleted dossiers in the past.
     # For now use find_or_create_by! to avoid errors.
     create_with(
@@ -39,7 +45,7 @@ class DeletedDossier < ApplicationRecord
       procedure: dossier.procedure,
       state: dossier.state,
       depose_at: dossier.depose_at,
-      deleted_at: Time.zone.now
+      deleted_at:
     ).create_or_find_by!(dossier_id: dossier.id)
   end
 

--- a/spec/jobs/cron/discarded_dossiers_deletion_job_spec.rb
+++ b/spec/jobs/cron/discarded_dossiers_deletion_job_spec.rb
@@ -74,6 +74,19 @@ RSpec.describe Cron::DiscardedDossiersDeletionJob, type: :job do
         context 'hidden long ago' do
           let(:hidden_at) { 1.week.ago - 1.hour }
           include_examples "does delete"
+
+          it "uses relevant deleted_at depending on user hidden it and state" do
+            subject
+
+            if state == :en_construction
+              expect(DeletedDossier.find_by(dossier_id: dossier.id).deleted_at).to be_within(1.second).of(dossier.hidden_by_user_at)
+            else
+              expect(DeletedDossier.find_by(dossier_id: dossier.id).deleted_at).to be_within(1.second).of(Time.current)
+            end
+
+            # dossier not hidden:
+            expect(DeletedDossier.find_by(dossier_id: dossier_2.id).deleted_at).to be_within(1.second).of(Time.current)
+          end
         end
       end
     end


### PR DESCRIPTION
Autrement ça perturbe les instructeurs ne voir des suppressions au milieu de la nuit, et quand ils interrogent les usagers les dates/heures ne coincident pas avec l'action de l'usager
Sachant qu'on a les created_at qui correspond à la suppression effective