### PR TITLE
Tech (notif plus de PJ): pas d'erreur si le champ n'est plus attaché à la révision

### DIFF
--- a/app/tasks/maintenance/t20250418send_notification_to_users_having_lost_pjs_task.rb
+++ b/app/tasks/maintenance/t20250418send_notification_to_users_having_lost_pjs_task.rb
@@ -91,10 +91,15 @@ module Maintenance
 
         html = "#{dossier_link} (#{dossier_display_state(dossier.state, lower: true)}) - #{dossier.procedure.libelle} : "
 
-        html += if champs.size == 1
-          champs.first.libelle
+        if champs.size == 1
+          begin
+            html += champs.first.libelle
+          rescue
+            # Ignore error like Type De Champ 3990816 not found in Revision 168536
+            html = "#{dossier_link} (#{dossier_display_state(dossier.state, lower: true)}) - #{dossier.procedure.libelle}"
+          end
         else
-          to_html_list(safe_champs_libelles(champs))
+          html += to_html_list(safe_champs_libelles(champs))
         end
 
         html


### PR DESCRIPTION
dans le cas d'un seul PJ  dans le dossier. On redéfinit l'html pour enlever les `:` censés introduire la liste des PJ