### PR TITLE
[bug design] Retire la barre de scroll horizontal sur les onglets

### DIFF
--- a/app/assets/stylesheets/dsfr.scss
+++ b/app/assets/stylesheets/dsfr.scss
@@ -190,7 +190,10 @@ input[type='radio'] {
 // Improve tabs alignment because we are not displaying the border around the page content
 .fr-tabs__list {
   padding-left: 0;
-  margin-left: -4px;
+}
+
+.fr-tabs__list li:first-child .fr-tabs__tab {
+  margin-left: 0;
 }
 
 .fr-header__tools .fr-btns-group .fr-btn {


### PR DESCRIPTION
bug introduit avec #11581 
J'ai été un peu vite au moment de l'alignement des tabs, j'ai pas visé les bons margins et ça faisait apparaitre une barre de scroll horizontal au niveau des onglets.

