### PR TITLE
ETQ Expert, je veux que la page de création de compte soit plus accessible

### DIFF
--- a/app/components/instructeurs/activate_account_form_component/activate_account_form_component.html.haml
+++ b/app/components/instructeurs/activate_account_form_component/activate_account_form_component.html.haml
@@ -9,7 +9,7 @@
         %h2.fr-h6.fr-mb-0= t('.activate', email: user.email)
 
       .fr-fieldset__element
-        %p.fr-text--sm= t('utils.mandatory_champs')
+        %p= t('asterisk_html', scope: [:utils])
 
       .fr-fieldset__element
         = render Dsfr::InputComponent.new(form: f, attribute: :email, input_type: :email_field, opts: { disabled: :disabled, class: 'fr-input-group--disabled' })

--- a/app/views/experts/avis/sign_up.html.haml
+++ b/app/views/experts/avis/sign_up.html.haml
@@ -10,7 +10,7 @@
             %p= t('asterisk_html', scope: [:utils])
 
           .fr-fieldset__element
-            = render Dsfr::InputComponent.new(form: f, attribute: :email, input_type: :email_field, opts: { disabled: true, autocomplete: 'email' })
+            = render Dsfr::InputComponent.new(form: f, attribute: :email, input_type: :email_field, opts: { disabled: true })
 
           .fr-fieldset__element
             = render Dsfr::InputComponent.new(form: f, attribute: :password, input_type: :password_field,

--- a/app/views/experts/avis/sign_up.html.haml
+++ b/app/views/experts/avis/sign_up.html.haml
@@ -14,8 +14,7 @@
 
           .fr-fieldset__element
             = render Dsfr::InputComponent.new(form: f, attribute: :password, input_type: :password_field,
-              opts: { autofocus: 'true',
-              autocomplete: 'new-password',
+              opts: { autocomplete: 'new-password',
               data: { controller: 'turbo-input', turbo_input_url_value: show_password_complexity_path },
               aria: {describedby: 'password_hint'}})
 

--- a/app/views/experts/avis/sign_up.html.haml
+++ b/app/views/experts/avis/sign_up.html.haml
@@ -7,7 +7,7 @@
           = t('views.registrations.new.title', name: Current.application_name)
         %fieldset.fr-mb-0.fr-fieldset{ aria: { labelledby: 'create-account-legend' } }
           .fr-fieldset__element
-            %p.fr-text--sm= t('utils.mandatory_champs')
+            %p= t('asterisk_html', scope: [:utils])
 
           .fr-fieldset__element
             = render Dsfr::InputComponent.new(form: f, attribute: :email, input_type: :email_field, opts: { disabled: true, autocomplete: 'email' })

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,7 +51,6 @@ en:
     deconnexion: "Log out"
     pj: "Attachments"
     asterisk_html: "Fields marked by an asterisk ( <svg aria-label='required' class='icon mandatory' height='10' role='img' viewBox='0 0 1200 1200' width='10' xml:space='preserve' xmlns='http://www.w3.org/2000/svg'><desc>required</desc><path d='M489.838 29.354v443.603L68.032 335.894 0 545.285l421.829 137.086-260.743 358.876 178.219 129.398L600.048 811.84l260.673 358.806 178.146-129.398-260.766-358.783L1200 545.379l-68.032-209.403-421.899 137.07V29.443H489.84l-.002-.089z'></path></svg> ) are mandatory."
-    mandatory_champs: All fields are mandatory.
     no_mandatory: (optional)
     send_mail: Send message
     new_tab: New tab

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -42,7 +42,6 @@ fr:
     deconnexion: "Déconnexion"
     pj: "Pièces jointes"
     asterisk_html: "Les champs suivis d’un astérisque ( <svg aria-label='obligatoire' class='icon mandatory' height='10' role='img' viewBox='0 0 1200 1200' width='10' xml:space='preserve' xmlns='http://www.w3.org/2000/svg'><desc>obligatoire</desc><path d='M489.838 29.354v443.603L68.032 335.894 0 545.285l421.829 137.086-260.743 358.876 178.219 129.398L600.048 811.84l260.673 358.806 178.146-129.398-260.766-358.783L1200 545.379l-68.032-209.403-421.899 137.07V29.443H489.84l-.002-.089z'></path></svg> ) sont obligatoires."
-    mandatory_champs: Tous les champs sont obligatoires.
     no_mandatory: (facultatif)
     send_mail: Envoyer le message
     new_tab: "Nouvel onglet"


### PR DESCRIPTION
# Mise à jour de la phrase indiquant les champs obligatoires
__Après__
![Capture d’écran 2025-04-25 à 14 46 06](https://github.com/user-attachments/assets/877596e8-3e85-41ce-874d-b5697fcacbb7)

__Avant__
![Capture d’écran 2025-04-25 à 14 47 10](https://github.com/user-attachments/assets/b1beab24-5209-44fe-8938-7547ec61399b)


# Suppression d'un attribut `autocomplete` inutile
__Après__
![Capture d’écran 2025-04-25 à 14 46 42](https://github.com/user-attachments/assets/8cc4fe3c-13ce-4e78-bdfc-b55f96986dcf)

__Avant__
![Capture d’écran 2025-04-25 à 14 47 05](https://github.com/user-attachments/assets/9347b872-a08a-46b5-8de4-09c3c62183a0)

# Suppression d'un attribut `autofocus` non souhaité
__Après__
![Capture d’écran 2025-04-25 à 15 16 50](https://github.com/user-attachments/assets/d6227d8a-7e79-41bc-aa05-064a1e87527b)

__Avant__
![Capture d’écran 2025-04-25 à 15 16 02](https://github.com/user-attachments/assets/33c6c6b3-4381-43bf-a1e0-99759c35c7bf)
