### PR TITLE
feat(turbo): enable refresh action

### DIFF
--- a/app/helpers/turbo_stream_helper.rb
+++ b/app/helpers/turbo_stream_helper.rb
@@ -48,6 +48,10 @@ module TurboStreamHelper
       turbo_stream_action_tag :disable, targets:, delay:
     end
 
+    def refresh
+      turbo_stream_action_tag :refresh
+    end
+
     def dispatch(type, detail = nil)
       content = detail.present? ? tag.script(cdata_section(detail.to_json), type: 'application/json') : nil
       action_all :append, 'head', tag.dispatch_event(content, type:)

--- a/bun.lock
+++ b/bun.lock
@@ -3,9 +3,9 @@
   "workspaces": {
     "": {
       "dependencies": {
-        "@coldwired/actions": "^0.16.1",
+        "@coldwired/actions": "^0.17.1",
         "@coldwired/react": "^0.16.1",
-        "@coldwired/turbo-stream": "^0.16.0",
+        "@coldwired/turbo-stream": "^0.17.1",
         "@coldwired/utils": "^0.16.1",
         "@formatjs/intl-listformat": "^7.7.11",
         "@frsource/autoresize-textarea": "^2.0.142",
@@ -22,7 +22,7 @@
         "@rails/activestorage": "^7.2.201",
         "@rails/ujs": "^7.1.3-4",
         "@reach/slider": "^0.17.0",
-        "@sentry/browser": "^9.12.0",
+        "@sentry/browser": "9.12.0",
         "@tiptap/core": "^2.2.4",
         "@tiptap/extension-bold": "^2.2.4",
         "@tiptap/extension-bullet-list": "^2.2.4",
@@ -163,11 +163,11 @@
 
     "@codemirror/view": ["@codemirror/view@6.26.1", "", { "dependencies": { "@codemirror/state": "^6.4.0", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-wLw0t3R9AwOSQThdZ5Onw8QQtem5asE7+bPlnzc57eubPqiuJKIzwjMZ+C42vQett+iva+J8VgFV4RYWDBh5FA=="],
 
-    "@coldwired/actions": ["@coldwired/actions@0.16.1", "", { "dependencies": { "@coldwired/utils": "^0.16.1", "morphdom": "^2.7.4" } }, "sha512-BRZFl0ETYpS6yPR0j5hfB5i/A2a7xY3rrKUDSiT0h72lhzSyY8h5WcJdvfAXyNxViI+hH5Ic9c9vdG1uNqsXsw=="],
+    "@coldwired/actions": ["@coldwired/actions@0.17.1", "", { "dependencies": { "@coldwired/utils": "^0.16.1", "morphdom": "^2.7.4" } }, "sha512-dlRB7jH+rTmTIpBTIz3ssIxwLb+Q6QwTViApItaKM38dinYXeCGCWFdhQyeXDElN+ENC3c7dVOYrVNRkHp39WA=="],
 
     "@coldwired/react": ["@coldwired/react@0.16.1", "", { "dependencies": { "@coldwired/utils": "^0.16.1" }, "peerDependencies": { "react": "^19.0.0", "react-dom": "^19.0.0" } }, "sha512-473agIHc1Yp/+iT4W3XS6Dp4mV806NUWjErBItQnQazJvEwlGM3+icvPGdxbPN5RyH1t+ECSmfh/1A6GxX0bWQ=="],
 
-    "@coldwired/turbo-stream": ["@coldwired/turbo-stream@0.16.0", "", { "dependencies": { "@coldwired/actions": "^0.16.0", "@coldwired/utils": "^0.16.0", "tiny-invariant": "^1.3.2" } }, "sha512-J9Pq781nz4lrTGpsuP31N0Y8rrbldtve2pFSJnYx35vBJAiX8fgFsaB/0a0nicAntxYsumwfig8QJ6AfpHwtjQ=="],
+    "@coldwired/turbo-stream": ["@coldwired/turbo-stream@0.17.1", "", { "dependencies": { "@coldwired/actions": "^0.17.1", "@coldwired/utils": "^0.16.0", "tiny-invariant": "^1.3.2" } }, "sha512-gz7+YLv6yJIYViVDCf4Bd8NQnkL9TrBEa2Rh/jQq3+tz3Ayba8/cF0ZyB3Lxjujo0KSmn2jqzMol6nKJ/f5X3Q=="],
 
     "@coldwired/utils": ["@coldwired/utils@0.16.1", "", {}, "sha512-1rAcm4ekYjgtaZzAmxDfbwYdlvj0umR/bddee5u+QKip6vMyjMXoK+cU8E/MFTJDG8omX/pzXf04WZptx7vY4A=="],
 
@@ -2064,10 +2064,6 @@
     "@babel/traverse/@babel/template": ["@babel/template@7.27.0", "", { "dependencies": { "@babel/code-frame": "^7.26.2", "@babel/parser": "^7.27.0", "@babel/types": "^7.27.0" } }, "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA=="],
 
     "@babel/traverse/globals": ["globals@11.12.0", "", {}, "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="],
-
-    "@coldwired/turbo-stream/@coldwired/actions": ["@coldwired/actions@0.16.0", "", { "dependencies": { "@coldwired/utils": "^0.16.0", "morphdom": "^2.7.4" } }, "sha512-8B4Jb4a17fPPJqVz6x/spak7bTgWlwWvt1I4bW6obLjLoxvqRIbaqnQ93CSL0qtRbRSLy8/mxZTstVC1oje7xQ=="],
-
-    "@coldwired/turbo-stream/@coldwired/utils": ["@coldwired/utils@0.16.0", "", {}, "sha512-7eTPyyKELJ3dJ3sXR/TZucZdbWcRjyGxVYD14d5pz+5lVNWBiqvNZeXQYxTmX35884Y83EzDDP6j52y9bmQaDw=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "type": "module",
   "dependencies": {
-    "@coldwired/actions": "^0.16.1",
+    "@coldwired/actions": "^0.17.1",
     "@coldwired/react": "^0.16.1",
-    "@coldwired/turbo-stream": "^0.16.0",
+    "@coldwired/turbo-stream": "^0.17.1",
     "@coldwired/utils": "^0.16.1",
     "@formatjs/intl-listformat": "^7.7.11",
     "@frsource/autoresize-textarea": "^2.0.142",


### PR DESCRIPTION
Attention, si vous faites un `turbo_stream.refresh` dans un template "turbo stream", les turbo streams du layout qui affichent le flash seront aussi exécutés. Ce n'est pas ce qu'on veut, car le flash sera rendu aussi lors du refresh. Je ne suis pas sûr si cela pose problème. À tester. Et pour éviter ce comportement, vous pouvez appeler `turbo_stream.refresh` directement depuis le `controller`.