### PR TITLE
ETQ Usager utilisant un lecteur d'écran, je veux que la hiérarchie de la page de résumé soit correcte 

### DIFF
--- a/app/assets/stylesheets/status_overview.scss
+++ b/app/assets/stylesheets/status_overview.scss
@@ -39,28 +39,8 @@
 }
 
 .status-explanation {
-  p {
-    margin-bottom: $default-padding;
-  }
-
-  .decision {
-    font-size: 1.2em;
-    margin-top: $default-padding * 3;
-    margin-bottom: $default-padding * 3;
-  }
-
-  .icon {
-    margin-right: $default-spacer;
-  }
-
-  h3 {
-    font-weight: bold;
-    margin-bottom: $default-spacer;
-  }
-
   blockquote {
     quotes: '« ' ' »' '‘' '’';
-    margin-bottom: $default-padding * 3;
   }
 
   blockquote::before {
@@ -69,9 +49,5 @@
 
   blockquote::after {
     content: close-quote;
-  }
-
-  .action {
-    margin-bottom: $default-padding * 3;
   }
 }

--- a/app/components/dossiers/en_construction_not_submitted_component/en_construction_not_submitted_component.html.haml
+++ b/app/components/dossiers/en_construction_not_submitted_component/en_construction_not_submitted_component.html.haml
@@ -1,4 +1,4 @@
-= render Dsfr::CalloutComponent.new(title: t(".title"), icon: "fr-fi-information-line") do |c|
+= render Dsfr::CalloutComponent.new(title: t(".title"), icon: "fr-fi-information-line", heading_level: 'h2') do |c|
   - c.with_body do
     = t(".body")
 

--- a/app/components/dossiers/message_component.rb
+++ b/app/components/dossiers/message_component.rb
@@ -1,15 +1,19 @@
 # frozen_string_literal: true
 
 class Dossiers::MessageComponent < ApplicationComponent
-  def initialize(commentaire:, connected_user:, messagerie_seen_at: nil, show_reply_button: false, groupe_gestionnaire: nil)
+  def initialize(commentaire:, connected_user:, messagerie_seen_at: nil, show_reply_button: false, groupe_gestionnaire: nil, heading_level: 'h2')
     @commentaire = commentaire
     @connected_user = connected_user
     @messagerie_seen_at = messagerie_seen_at
     @show_reply_button = show_reply_button
     @groupe_gestionnaire = groupe_gestionnaire
+    @heading_level = heading_level
   end
 
   attr_reader :commentaire, :connected_user, :messagerie_seen_at, :groupe_gestionnaire
+  def heading_level
+    @heading_level
+  end
 
   def correction_badge
     return if groupe_gestionnaire || commentaire.dossier_correction.nil?

--- a/app/components/dossiers/message_component/message_component.html.haml
+++ b/app/components/dossiers/message_component/message_component.html.haml
@@ -1,7 +1,8 @@
 = icon
 
 .width-100
-  %h2.fr-h6
+
+  = tag.send(heading_level, class: 'fr-h6') do
     %span.mail
       = commentaire_issuer
     - if commentaire_from_guest?

--- a/app/views/shared/dossiers/_messagerie.html.haml
+++ b/app/views/shared/dossiers/_messagerie.html.haml
@@ -2,7 +2,7 @@
   %ul.messages-list{ data: { controller: 'scroll-to' } }
     - dossier.preloaded_commentaires.each do |commentaire|
       %li.message.fr-background-alt--grey{ class: commentaire_is_from_me_class(commentaire, connected_user), id: dom_id(commentaire) }
-        = render Dossiers::MessageComponent.new(commentaire: commentaire, connected_user: connected_user, messagerie_seen_at: messagerie_seen_at, show_reply_button: show_reply_button(commentaire, connected_user))
+        = render Dossiers::MessageComponent.new(commentaire: commentaire, connected_user: connected_user, messagerie_seen_at: messagerie_seen_at, show_reply_button: show_reply_button(commentaire, connected_user), heading_level: 'h2')
 
   - if dossier.messagerie_available?
     = render partial: "shared/dossiers/messages/form", locals: { commentaire: new_commentaire, form_url: form_url, dossier: dossier }

--- a/app/views/users/dossiers/show/_header.html.haml
+++ b/app/views/users/dossiers/show/_header.html.haml
@@ -4,10 +4,11 @@
       = dossier.procedure.libelle
       = status_badge_user(dossier, 'super')
       = pending_correction_badge(:for_user) if dossier.pending_correction?
-    %h2
-      = t('views.users.dossiers.show.header.dossier_number_html', dossier_id: dossier.id)
-      - if dossier.depose_at.present?
-        = t('views.users.dossiers.show.header.submit_date', date_du_dossier: I18n.l(dossier.depose_at))
+      %br
+      %span.fr-h2
+        = t('views.users.dossiers.show.header.dossier_number_html', dossier_id: dossier.id)
+        - if dossier.depose_at.present?
+          = t('views.users.dossiers.show.header.submit_date', date_du_dossier: I18n.l(dossier.depose_at))
 
     = render(partial: 'users/dossiers/expiration_banner', locals: {dossier: dossier})
 

--- a/app/views/users/dossiers/show/_latest_message.html.haml
+++ b/app/views/users/dossiers/show/_latest_message.html.haml
@@ -4,7 +4,7 @@
     %h2.fr-h5= t('views.users.dossiers.show.latest_message.latest_message')
 
     .message.fr-background-alt--grey
-      = render Dossiers::MessageComponent.new(commentaire: latest_message, connected_user: current_user)
+      = render Dossiers::MessageComponent.new(commentaire: latest_message, connected_user: current_user, heading_level: 'h3')
 
     = link_to messagerie_dossier_url(dossier, anchor: 'new_commentaire'), class: 'fr-btn fr-btn--icon-left fr-icon-discuss-line' do
       = commentaire_answer_action(latest_message, current_user)

--- a/app/views/users/dossiers/show/_latest_message.html.haml
+++ b/app/views/users/dossiers/show/_latest_message.html.haml
@@ -1,7 +1,7 @@
 - latest_message = dossier.commentaires.last
 - if latest_message.present?
   .latest-message-section
-    %h3.tab-title= t('views.users.dossiers.show.latest_message.latest_message')
+    %h2.fr-h5= t('views.users.dossiers.show.latest_message.latest_message')
 
     .message.fr-background-alt--grey
       = render Dossiers::MessageComponent.new(commentaire: latest_message, connected_user: current_user)

--- a/app/views/users/dossiers/show/_status_overview.html.haml
+++ b/app/views/users/dossiers/show/_status_overview.html.haml
@@ -60,7 +60,7 @@
 
         - elsif dossier.accepte?
           .accepte
-            %p.decision{ role: 'status' }
+            %p.fr-my-6w.fr-text--lead{ role: 'status' }
               = dsfr_icon('fr-icon-checkbox-circle-fill fr-text-default--success')
               = t('views.users.dossiers.show.status_overview.acceptee_html')
 
@@ -78,7 +78,7 @@
 
         - elsif dossier.refuse?
           .refuse
-            %p.decision{ role: 'status' }
+            %p.fr-my-6w.fr-text--lead{ role: 'status' }
               = dsfr_icon('fr-icon-close-circle-fill fr-text-default--error')
               = t('views.users.dossiers.show.status_overview.refuse_html')
 
@@ -92,7 +92,7 @@
 
         - elsif dossier.sans_suite?
           .sans-suite
-            %p.decision{ role: 'status' }
+            %p.fr-my-6w.fr-text--lead{ role: 'status' }
               = dsfr_icon('fr-icon-intermediate-circle-fill')
               = t('views.users.dossiers.show.status_overview.sans_suite_html')
 


### PR DESCRIPTION
__Après__
<img width="1673" alt="" src="https://github.com/user-attachments/assets/a732c5c2-86dd-4c18-a557-c7f07edfe578" />
<img width="1741" alt="Capture d’écran 2025-05-23 à 15 12 49" src="https://github.com/user-attachments/assets/e934c02b-ce71-485b-b996-b22457db518a" />


__Avant__
![Capture d’écran 2025-04-28 à 16 51 08](https://github.com/user-attachments/assets/a1d030e4-a8e0-45fc-9b17-c4759d242c78)
