### PR TITLE
ETQ Usager utilisant un lecteur d'écran, je veux que l'indicateur d'étapes m'indique l'étape courante

### DIFF
--- a/app/assets/stylesheets/status_overview.scss
+++ b/app/assets/stylesheets/status_overview.scss
@@ -4,19 +4,12 @@
   display: inline-block;
   border: 1px solid var(--border-plain-grey);
   border-radius: 3px;
+  padding: 0 1.5rem;
 
   li {
     display: inline-block;
     padding-top: $default-spacer;
     padding-bottom: $default-spacer;
-
-    &:first-child {
-      padding-left: 20px;
-    }
-
-    &:last-child {
-      padding-right: 20px;
-    }
 
     &.active {
       font-weight: bold;

--- a/app/assets/stylesheets/status_overview.scss
+++ b/app/assets/stylesheets/status_overview.scss
@@ -11,11 +11,11 @@
     padding-top: $default-spacer;
     padding-bottom: $default-spacer;
 
-    &.active {
+    &[aria-current='true'] {
       font-weight: bold;
     }
 
-    &.active ~ li {
+    &:not([aria-current='true']) {
       color: var(--text-mention-grey);
     }
 

--- a/app/assets/stylesheets/status_overview.scss
+++ b/app/assets/stylesheets/status_overview.scss
@@ -1,9 +1,8 @@
-@import 'colors';
 @import 'constants';
 
 .status-timeline {
   display: inline-block;
-  border: 1px solid #808080;
+  border: 1px solid var(--border-plain-grey);
   border-radius: 3px;
 
   li {
@@ -24,7 +23,7 @@
     }
 
     &.active ~ li {
-      color: $dark-grey;
+      color: var(--text-mention-grey);
     }
 
     // Arrows

--- a/app/views/users/dossiers/show/_status_overview.html.haml
+++ b/app/views/users/dossiers/show/_status_overview.html.haml
@@ -4,16 +4,16 @@
       .fr-col-md-8.text-center
         %ol.status-timeline.fr-mb-4w
           - if dossier.brouillon?
-            %li.brouillon{ class: dossier.brouillon? ? 'active' : nil }
+            %li.brouillon{ 'aria-current': dossier.brouillon? ? 'true' : nil }
               = t('views.users.dossiers.show.status_overview.status_draft')
-          %li.en-construction{ class: dossier.en_construction? ? 'active' : nil }
+          %li.en-construction{ 'aria-current': dossier.en_construction? ? 'true' : nil }
             = t('views.users.dossiers.show.status_overview.status_in_progress')
 
             - if dossier.pending_correction.present?
               = "(#{Dossier.human_attribute_name("pending_correction.for_user")})"
-          %li.en-instruction{ class: dossier.en_instruction? ? 'active' : nil }
+          %li.en-instruction{ 'aria-current': dossier.en_instruction? ? 'true' : nil }
             = t('views.users.dossiers.show.status_overview.status_review')
-          %li.termine{ class: dossier.termine? ? 'active' : nil }
+          %li.termine{ 'aria-current': dossier.termine? ? 'true' : nil }
             = t('views.users.dossiers.show.status_overview.status_completed')
 
   - if dossier.en_construction?

--- a/app/views/users/dossiers/show/_status_overview.html.haml
+++ b/app/views/users/dossiers/show/_status_overview.html.haml
@@ -2,7 +2,7 @@
   - if !dossier.termine?
     .fr-grid-row.fr-grid-row--center
       .fr-col-md-8.text-center
-        %ul.status-timeline.fr-mb-4w
+        %ol.status-timeline.fr-mb-4w
           - if dossier.brouillon?
             %li.brouillon{ class: dossier.brouillon? ? 'active' : nil }
               = t('views.users.dossiers.show.status_overview.status_draft')

--- a/spec/views/users/dossiers/show/_status_overview.html.haml_spec.rb
+++ b/spec/views/users/dossiers/show/_status_overview.html.haml_spec.rb
@@ -19,10 +19,11 @@ describe 'users/dossiers/show/_status_overview', type: :view do
     end
 
     def item_selector(selector)
-      item_selector = ".status-timeline #{selector}"
-      item_selector += '.active' if @active == true
-      item_selector += ':not(.active)' if @active == false
-      item_selector
+      if @active
+        "#{selector}[aria-current=true]"
+      else
+        "#{selector}:not([aria-current=true])"
+      end
     end
   end
 


### PR DESCRIPTION
- Remplacement de la classe `active` par un attribut `aria-current="true"`
- Transformation de la liste en liste numérotée
- Suppression du code obsolète

__Après__
<img width="728" alt="" src="https://github.com/user-attachments/assets/0b8e5546-e346-41f8-b00d-0f2cfec883bb" />

__Avant__
<img width="581" alt="" src="https://github.com/user-attachments/assets/892a1097-986c-43a0-b9e9-b0b8ce281f9b" />

