### PR TITLE
ETQ Instructeur utilisant un lecteur d'écran, en arrivant depuis un lien externe sur la page de création de compte, je ne veux pas d'autofocus forcé

### DIFF
--- a/app/components/instructeurs/activate_account_form_component/activate_account_form_component.en.yml
+++ b/app/components/instructeurs/activate_account_form_component/activate_account_form_component.en.yml
@@ -1,6 +1,6 @@
 ---
 en:
-  title: Create your account for %{application_name}
-  activate: Activate your account %{email}
+  title: Create an account for %{application_name}
+  activate: Create an account with the e-mail address %{email}
   email_disabled: Instructor email address not changeable
-  submit: Choose password
+  submit: Create an account

--- a/app/components/instructeurs/activate_account_form_component/activate_account_form_component.fr.yml
+++ b/app/components/instructeurs/activate_account_form_component/activate_account_form_component.fr.yml
@@ -1,7 +1,7 @@
 ---
 fr:
   title: Création de compte sur %{application_name}
-  activate: Se créer un compte pour %{email} en choissant un mot de passe
+  activate: Se créer un compte avec l'adresse électronique %{email}
   email_disabled: Adresse instructeur non modifiable
-  submit: Définir le mot de passe
+  submit: Créer un compte
 

--- a/app/components/instructeurs/activate_account_form_component/activate_account_form_component.html.haml
+++ b/app/components/instructeurs/activate_account_form_component/activate_account_form_component.html.haml
@@ -16,8 +16,7 @@
 
       .fr-fieldset__element
         = render Dsfr::InputComponent.new(form: f, attribute: :password, input_type: :password_field,
-          opts: { autofocus: 'true',
-            autocomplete: 'new-password',
+          opts: { autocomplete: 'new-password',
             data: { controller: 'turbo-input', turbo_input_url_value: show_password_complexity_path },
             aria: {describedby: 'password_hint'}})
 

--- a/app/components/instructeurs/activate_account_form_component/activate_account_form_component.html.haml
+++ b/app/components/instructeurs/activate_account_form_component/activate_account_form_component.html.haml
@@ -6,7 +6,7 @@
     %fieldset.fr-mb-0.fr-fieldset{ aria: { labelledby: 'activate-account-legend' } }
 
       %legend.fr-fieldset__legend#activate-account-legend
-        %h2.fr-h6.fr-mb-0= t('.activate', email: user.email)
+        %h2.fr-h6= t('.activate', email: user.email)
 
       .fr-fieldset__element
         %p= t('asterisk_html', scope: [:utils])

--- a/spec/system/instructeurs/instructeur_creation_spec.rb
+++ b/spec/system/instructeurs/instructeur_creation_spec.rb
@@ -25,7 +25,7 @@ describe 'As an instructeur', js: true do
     visit "users/activate?#{token_params}"
     fill_in :user_password, with: SECURE_PASSWORD
 
-    click_button 'Définir le mot de passe'
+    click_button 'Créer un compte'
 
     expect(page).to have_content 'Mot de passe enregistré'
   end

--- a/spec/system/routing/rules_full_scenario_spec.rb
+++ b/spec/system/routing/rules_full_scenario_spec.rb
@@ -323,7 +323,7 @@ describe 'The routing with rules', js: true do
 
     visit "users/activate?#{token_params}"
     fill_in :user_password, with: password
-    click_button 'Définir le mot de passe'
+    click_button 'Créer un compte'
 
     expect(page).to have_text('Mot de passe enregistré')
   end


### PR DESCRIPTION
- Homogénéisation de la page de création de compte instructeur avec la page de création de compte usager
- Suppression de l'autofocus forcé (l'instructeur arrive sur la page depuis un lien externe : il n'est pas forcément familier avec la structure des pages).

__Après__
<img width="855" alt="" src="https://github.com/user-attachments/assets/aff81fd8-ccdb-4d96-901c-da81d1bd619b" />

__Avant__
<img width="842" alt="" src="https://github.com/user-attachments/assets/c5c682ad-0ac0-491e-b882-b42b60965ce0" />
