### PR TITLE
ETQ instructeur, l'avancement des actions multiples se met à jour dynamiquement

### DIFF
--- a/app/components/dossiers/batch_alert_component/batch_alert_component.en.yml
+++ b/app/components/dossiers/batch_alert_component/batch_alert_component.en.yml
@@ -110,6 +110,4 @@ en:
   title:
     finish: The bulk action is finished
     in_progress:  A bulk action is processing
-  link_text: Refresh this webpage
-  after_link_text: to check if the process is over.
   context: This bulk action was created by %{mail}, %{time_ago}

--- a/app/components/dossiers/batch_alert_component/batch_alert_component.fr.yml
+++ b/app/components/dossiers/batch_alert_component/batch_alert_component.fr.yml
@@ -110,6 +110,4 @@ fr:
   title:
     finish: L’action de masse est terminée
     in_progress: Une action de masse est en cours
-  link_text: Recharger la page
-  after_link_text: pour voir si l'opération est finie.
   context: Cette opération a été lancée par %{mail}, il y a %{time_ago}

--- a/app/components/dossiers/batch_alert_component/batch_alert_component.html.haml
+++ b/app/components/dossiers/batch_alert_component/batch_alert_component.html.haml
@@ -1,19 +1,16 @@
-.fr-mb-5v
-  - if @batch.finished_at.present?
-    = render Dsfr::AlertComponent.new(title: t(".title.finish"), state: (@batch.errors? ? :warning : :success), heading_level: 'h2', extra_class_names: 'fr-my-2w') do |c|
-      - c.with_body do
-        %p
-          = t(".#{batch.operation}.finish.text_success", count: @batch.total_count, success_count: @batch.success_count)
+%div{ data: !@batch.finished_at? ? { controller: "turbo-poll", turbo_poll_url_value: polling_batch_operation_instructeur_procedure_path(@procedure, batch: @batch), turbo_poll_interval_value: 5_000, turbo_poll_max_checks_value: 12 } : {} }
+  .fr-mb-5v
+    - if @batch.finished_at.present?
+      = render Dsfr::AlertComponent.new(title: t(".title.finish"), state: (@batch.errors? ? :warning : :success), heading_level: 'h2', extra_class_names: 'fr-my-2w') do |c|
+        - c.with_body do
+          %p
+            = t(".#{batch.operation}.finish.text_success", count: @batch.total_count, success_count: @batch.success_count)
 
 
-  - else
-    = render Dsfr::AlertComponent.new(title: t(".title.in_progress"), state: :info, heading_level: 'h2', extra_class_names: 'fr-my-2w') do |c|
-      - c.with_body do
-        %p= t(".#{batch.operation}.in_progress.text_success", count: @batch.total_count, success_count: @batch.success_count)
+    - else
+      = render Dsfr::AlertComponent.new(title: t(".title.in_progress"), state: :info, heading_level: 'h2', extra_class_names: 'fr-my-2w') do |c|
+        - c.with_body do
+          %p= t(".#{batch.operation}.in_progress.text_success", count: @batch.total_count, success_count: @batch.success_count)
 
-        %p
-          = link_to t('.link_text'), procedure_path, data: { action: 'turbo-poll#refresh' }
-          = t('.after_link_text')
-
-        %p.fr-mt-2w
-          %small= t('.context', mail: @batch.instructeur.email, time_ago: time_ago_in_words(@batch.created_at))
+          %p.fr-mt-2w
+            %small= t('.context', mail: @batch.instructeur.email, time_ago: time_ago_in_words(@batch.created_at))

--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -229,6 +229,10 @@ module Instructeurs
       end
     end
 
+    def polling_batch_operation
+      render turbo_stream: turbo_stream.refresh
+    end
+
     def email_notifications
       @procedure = procedure
       @instructeur_procedure = find_or_create_instructeur_procedure(@procedure)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -569,6 +569,7 @@ Rails.application.routes.draw do
         get 'download_export'
         post 'download_export'
         get 'polling_last_export'
+        get 'polling_batch_operation'
         get 'stats'
         get 'exports'
         get 'export_templates'

--- a/spec/system/instructeurs/batch_operation_spec.rb
+++ b/spec/system/instructeurs/batch_operation_spec.rb
@@ -56,7 +56,7 @@ describe 'BatchOperation a dossier:', js: true do
         .from(false).to(true)
 
       # ensure alert updates when jobs are run
-      click_on "Recharger la page"
+      visit instructeur_procedure_path(procedure, statut: 'traites')
       expect(page).to have_content("L’action de masse est terminée")
       expect(page).to have_content("1 dossier a été placé dans « à archiver »")
 


### PR DESCRIPTION
Suite à une discussion avec @marleneklok, on a amélioré l'UX des actions multiples, en rechargeant dynamiquement la page, les compteurs … au fur et à mesure de l'avancée. 
Plutot que de demander à l'utilisateur de recharger manuellement. 

