### PR TITLE
Test: fix flaky tests

### DIFF
--- a/spec/controllers/api/v2/graphql_controller_n+1_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_n+1_spec.rb
@@ -38,6 +38,8 @@ describe API::V2::GraphqlController do
       query_count = 0
 
       dossier
+      # Execute the query first time to ensure shared queries are never counted in the query counter
+      post :execute, params: { queryId: query_id, variables: variables, operationName: operation_name }.compact, as: :json
       ActiveSupport::Notifications.subscribed(lambda { |*_args| query_count += 1 }, "sql.active_record") { subject }
 
       expect(gql_errors).to be_nil

--- a/spec/controllers/experts/avis_controller_spec.rb
+++ b/spec/controllers/experts/avis_controller_spec.rb
@@ -72,8 +72,8 @@ describe Experts::AvisController, type: :controller do
 
           it do
             expect(response).to have_http_status(:success)
-            expect(assigns(:avis_a_donner)).to match([avis_without_answer, oldest_avis_without_answer])
-            expect(assigns(:avis_donnes)).to match([avis_with_answer])
+            expect(assigns(:avis_a_donner)).to match_array([avis_without_answer, oldest_avis_without_answer])
+            expect(assigns(:avis_donnes)).to match_array([avis_with_answer])
             expect(assigns(:statut)).to eq('a-donner')
           end
         end


### PR DESCRIPTION
- comparaison d'arrays
- check N+1 de l'API : suivant le seed, d'autres tests jouent des queries qui sont "partageables" entre les appels à l'API. Pour contourner ça, on exécute 1 fois la requête à la main avant de la rejouer pour ne compter que celles propre à l'appel de l'API.
