### PR TITLE
Tech: renforce la sécu des email qu'on encode dans les urls

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -134,8 +134,8 @@ class ApplicationController < ActionController::Base
     "window.location.href='#{path}'"
   end
 
-  def message_verifier
-    @message_verifier ||= ActiveSupport::MessageVerifier.new(Rails.application.secret_key_base)
+  def message_encryptor_service
+    @message_encryptor_service ||= MessageEncryptorService.new
   end
 
   protected
@@ -307,7 +307,7 @@ class ApplicationController < ActionController::Base
       end
 
       send_login_token_or_bufferize(current_instructeur)
-      signed_email = message_verifier.generate(current_instructeur.email, purpose: :reset_link, expires_in: 1.hour)
+      signed_email = message_encryptor_service.encrypt_and_sign(current_instructeur.email, purpose: :reset_link, expires_in: 1.hour)
       redirect_to link_sent_path(email: signed_email)
     end
   end

--- a/app/controllers/manager/administrateur_confirmations_controller.rb
+++ b/app/controllers/manager/administrateur_confirmations_controller.rb
@@ -36,15 +36,15 @@ module Manager
     def decrypt_params
       @inviter_id = decrypted_params[:inviter_id]
       @invited_email = decrypted_params[:email]
-    rescue ActiveSupport::MessageVerifier::InvalidSignature, ArgumentError
+    rescue ActiveSupport::MessageEncryptor::InvalidMessage
       flash[:error] = "Le lien que vous avez utilisé est invalide. Veuillez contacter la personne qui vous l'a envoyé."
       redirect_to manager_procedure_path(@procedure)
     end
 
     def decrypted_params
-      @decrypted_params ||= ActiveSupport::MessageVerifier.new(
-        Rails.application.key_generator.generate_key("confirm_adding_administrateur")
-      ).verify(Base64.urlsafe_decode64(params[:q])).symbolize_keys
+      @decrypted_params ||= message_encryptor_service
+        .decrypt_and_verify(params[:q], purpose: :confirm_adding_administrateur)
+        .symbolize_keys
     end
 
     def set_procedure

--- a/app/controllers/manager/application_controller.rb
+++ b/app/controllers/manager/application_controller.rb
@@ -12,6 +12,10 @@ module Manager
       }
     end
 
+    def message_encryptor_service
+      @message_encryptor_service ||= MessageEncryptorService.new
+    end
+
     protected
 
     def authenticate_super_admin!

--- a/app/controllers/manager/confirmation_urls_controller.rb
+++ b/app/controllers/manager/confirmation_urls_controller.rb
@@ -40,9 +40,7 @@ module Manager
     end
 
     def encrypt(parameters)
-      key = Rails.application.key_generator.generate_key("confirm_adding_administrateur")
-      verifier = ActiveSupport::MessageVerifier.new(key)
-      Base64.urlsafe_encode64(verifier.generate(parameters))
+      message_encryptor_service.encrypt_and_sign(parameters, purpose: :confirm_adding_administrateur)
     end
   end
 end

--- a/app/controllers/recoveries_controller.rb
+++ b/app/controllers/recoveries_controller.rb
@@ -22,13 +22,13 @@ class RecoveriesController < ApplicationController
   def post_identification
     # cipher previous_user email
     # to avoid leaks in the url
-    ciphered_email = cipher(previous_email)
+    ciphered_email = message_encryptor_service.encrypt_and_sign(previous_email, purpose: :agent_files_recovery, expires_in: 1.hour)
 
     redirect_to selection_recovery_path(ciphered_email:)
   end
 
   def selection
-    @previous_email = uncipher(params[:ciphered_email])
+    @previous_email = message_encryptor_service.decrypt_and_verify(params[:ciphered_email], purpose: :agent_files_recovery) rescue nil
 
     previous_user = User.find_by(email: @previous_email)
 
@@ -61,9 +61,6 @@ class RecoveriesController < ApplicationController
   def siret = current_instructeur.last_pro_connect_information.siret
   def previous_email = params[:previous_email]
   def procedure_ids = params[:procedure_ids].map(&:to_i)
-
-  def cipher(email) = message_verifier.generate(email, purpose: :agent_files_recovery, expires_in: 1.hour)
-  def uncipher(email) = message_verifier.verified(email, purpose: :agent_files_recovery) rescue nil
 
   def structure_name
     # we know that the structure exists because

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -29,7 +29,7 @@ class Users::PasswordsController < Devise::PasswordsController
   # end
 
   def reset_link_sent
-    @email = message_verifier.verify(params[:email], purpose: :reset_password) rescue nil
+    @email = message_encryptor_service.decrypt_and_verify(params[:email], purpose: :reset_password) rescue nil
   end
 
   protected
@@ -40,7 +40,7 @@ class Users::PasswordsController < Devise::PasswordsController
 
   def after_sending_reset_password_instructions_path_for(resource_name)
     flash.discard(:notice)
-    signed_email = message_verifier.generate(resource.email, purpose: :reset_password, expires_in: 1.hour)
+    signed_email = message_encryptor_service.encrypt_and_sign(resource.email, purpose: :reset_password, expires_in: 1.hour)
     users_password_reset_link_sent_path(email: signed_email)
   end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -30,12 +30,12 @@ class Users::SessionsController < Devise::SessionsController
       flash[:notice] = "Nous venons de vous renvoyer un nouveau lien de connexion sécurisée à #{Current.application_name}"
     end
 
-    signed_email = message_verifier.generate(current_instructeur.email, purpose: :reset_link, expires_in: 1.hour)
+    signed_email = message_encryptor_service.encrypt_and_sign(current_instructeur.email, purpose: :reset_link, expires_in: 1.hour)
     redirect_to link_sent_path(email: signed_email)
   end
 
   def link_sent
-    email = message_verifier.verify(params[:email], purpose: :reset_link) rescue nil
+    email = message_encryptor_service.decrypt_and_verify(params[:email], purpose: :reset_link) rescue nil
 
     if StrictEmailValidator::REGEXP.match?(email)
       @email = email

--- a/app/services/message_encryptor_service.rb
+++ b/app/services/message_encryptor_service.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class MessageEncryptorService
+  delegate :encrypt_and_sign, to: :@encryptor
+
+  def initialize
+    len = ActiveSupport::MessageEncryptor.key_len
+    key = Rails.application.secret_key_base[0, len]
+    @encryptor = ActiveSupport::MessageEncryptor.new(key, url_safe: true)
+
+    # Verifier pendant la transition verifier => encryptor
+    @verifier = ActiveSupport::MessageVerifier.new(Rails.application.secret_key_base)
+  end
+
+  # Let controllers handle errors like they want
+  def decrypt_and_verify(message, purpose: nil)
+    @encryptor.decrypt_and_verify(message, purpose:)
+  rescue ActiveSupport::MessageEncryptor::InvalidMessage => original_error
+    # Ce n'est pas un message chiffré, on essaie juste de le décoder s'il avait été simplement signé
+    begin
+      @verifier.verify(message, purpose:)
+    rescue ActiveSupport::MessageVerifier::InvalidSignature
+      raise original_error
+    end
+  end
+end

--- a/spec/controllers/manager/administrateur_confirmations_controller_spec.rb
+++ b/spec/controllers/manager/administrateur_confirmations_controller_spec.rb
@@ -159,8 +159,6 @@ RSpec.describe Manager::AdministrateurConfirmationsController, type: :controller
   private
 
   def encrypt(parameters)
-    key = Rails.application.key_generator.generate_key("confirm_adding_administrateur")
-    verifier = ActiveSupport::MessageVerifier.new(key)
-    Base64.urlsafe_encode64(verifier.generate(parameters))
+    controller.message_encryptor_service.encrypt_and_sign(parameters, purpose: :confirm_adding_administrateur)
   end
 end

--- a/spec/controllers/manager/confirmation_urls_controller_spec.rb
+++ b/spec/controllers/manager/confirmation_urls_controller_spec.rb
@@ -28,11 +28,9 @@ describe Manager::ConfirmationUrlsController, type: :controller do
     it { expect(response.body).to match(/Veuillez partager ce lien/) }
 
     it "shows the confirmation url with encrypted parameters" do
-      expect(response.body).to include(
-        new_manager_procedure_administrateur_confirmation_url(
-          procedure,
-          q: encrypt({ email: invited_administrateur.email, inviter_id: inviter_super_admin.id })
-        )
+      path_base = new_manager_procedure_administrateur_confirmation_path(procedure)
+      expect(response.body).to match(
+        %r{#{Regexp.escape(path_base)}\?q=\S{30,}}m
       )
     end
 
@@ -63,13 +61,5 @@ describe Manager::ConfirmationUrlsController, type: :controller do
         it { expect(response).to redirect_to(manager_procedure_path(procedure)) }
       end
     end
-  end
-
-  private
-
-  def encrypt(parameters)
-    key = Rails.application.key_generator.generate_key("confirm_adding_administrateur")
-    verifier = ActiveSupport::MessageVerifier.new(key)
-    Base64.urlsafe_encode64(verifier.generate(parameters))
   end
 end

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -58,7 +58,17 @@ describe Users::PasswordsController, type: :controller do
     let(:email) { 'test@example.com' }
 
     it 'displays the page' do
-      signed_email = controller.message_verifier.generate(email, purpose: :reset_password)
+      crypted_email = controller.message_encryptor_service.encrypt_and_sign(email, purpose: :reset_password)
+
+      get 'reset_link_sent', params: { email: crypted_email }
+
+      expect(response).to have_http_status(:ok)
+      expect(response).to render_template('reset_link_sent')
+      expect(assigns(:email)).to eq email
+    end
+
+    it 'when message was only signed, displays the page' do
+      signed_email = ActiveSupport::MessageVerifier.new(Rails.application.secret_key_base).generate(email, purpose: :reset_password)
 
       get 'reset_link_sent', params: { email: signed_email }
 

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -271,7 +271,7 @@ describe Users::SessionsController, type: :controller do
 
     before { get :link_sent, params: { email: signed_email } }
 
-    let(:signed_email) { controller.message_verifier.generate(link_email, purpose: :reset_link) }
+    let(:signed_email) { controller.message_encryptor_service.encrypt_and_sign(link_email, purpose: :reset_link) }
 
     context 'when the email is legit' do
       let(:link_email) { 'a@a.com' }


### PR DESCRIPTION
A plusieurs endroits on encode des emails dans les urls pour éviter qu'elles se retrouvent indexées sur internet. Sauf qu'elles ne sont que base64 encodées (et signées) donc pas dur de retrouver des emails si quelqu'un met la main sur ces urls.

Les messages générés sont url safe, donc inutile de les base64 encoder encode derrière.


Cette PR refacto la logique en chiffrant réellement les params (tout en gérant la transition le temps du déploiement.)

J'en ai profité pour réutiliser le même service pour les parties du manager qui chiffrent/signent des params.