### PR TITLE
Tech: permet le décodage d'attributs chiffrés avant rails 7.1

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -115,6 +115,8 @@ module TPS
 
     config.active_record.encryption.primary_key = Rails.application.secrets.active_record_encryption.fetch(:primary_key)
     config.active_record.encryption.key_derivation_salt = Rails.application.secrets.active_record_encryption.fetch(:key_derivation_salt)
+    config.active_record.encryption.support_sha1_for_non_deterministic_encryption = true # supports for encrypted attributes encoded in SHA1, before rails 7.1
+
     config.active_record.partial_inserts = false
 
     config.exceptions_app = self.routes


### PR DESCRIPTION
Rails 7.1 chiffre et déchiffre par défaut avec un hash digest  SHA256, contre SHA1 auparavant.

Or, nous avons des attributs qui ont été chiffrés en rails 6 ou 7.0 : 
- OTP pour les super admins
- tokens de `RdvConnection`
- Token API particulier

On doit donc activer la lecture de digests en SHA1 et on discutera d'un probablement rechiffrement plus tard.
