### PR TITLE
ETQ Usager, sur une démarche avec routage les informations de contact ne sont pas les bonnes 

### DIFF
--- a/app/components/procedure/service_list_contact_component.rb
+++ b/app/components/procedure/service_list_contact_component.rb
@@ -1,10 +1,16 @@
 # frozen_string_literal: true
 
 class Procedure::ServiceListContactComponent < ApplicationComponent
-  attr_reader :service, :dossier
+  attr_reader :dossier, :faq_link, :contact_link, :email, :telephone, :telephone_url, :other_contact_info, :horaires
 
-  def initialize(service:, dossier:)
-    @service = service
+  def initialize(service_or_contact_information:, dossier:)
     @dossier = dossier
+    @faq_link = service_or_contact_information.respond_to?(:faq_link) ? service_or_contact_information.faq_link : nil
+    @contact_link = service_or_contact_information.respond_to?(:contact_link) ? service_or_contact_information.contact_link : nil
+    @email = service_or_contact_information.email
+    @telephone = service_or_contact_information.telephone
+    @telephone_url = service_or_contact_information.telephone_url
+    @other_contact_info = service_or_contact_information.respond_to?(:other_contact_info) ? service_or_contact_information.other_contact_info : nil
+    @horaires = service_or_contact_information.horaires
   end
 end

--- a/app/components/procedure/service_list_contact_component/service_list_contact_component.html.haml
+++ b/app/components/procedure/service_list_contact_component/service_list_contact_component.html.haml
@@ -1,9 +1,9 @@
-- if service.faq_link.present?
+- if faq_link.present?
   %li.fr-mb-1w
-    = link_to t('.faq_link'), service.faq_link , title: helpers.new_tab_suffix(t('.faq_link')), class: 'fr-link fr-link--sm', **helpers.external_link_attributes
-- if service.contact_link.present?
+    = link_to t('.faq_link'), faq_link , title: helpers.new_tab_suffix(t('.faq_link')), class: 'fr-link fr-link--sm', **helpers.external_link_attributes
+- if contact_link.present?
   %li.fr-mb-2w
-    = link_to t('.contact_link'), service.contact_link, title: helpers.new_tab_suffix(t('.contact_link')), class: 'fr-link fr-link--sm', **helpers.external_link_attributes
+    = link_to t('.contact_link'), contact_link, title: helpers.new_tab_suffix(t('.contact_link')), class: 'fr-link fr-link--sm', **helpers.external_link_attributes
 
 %li.border-left-dark
   %dl
@@ -15,29 +15,29 @@
         %dd
           = link_to t('.contact_instructeur'), messagerie_dossier_path(dossier)
 
-    - if service.email.present?
+    - if email.present?
       .flex.fr-mb-2v
         %dt.fr-mr-2v
           %span.fr-icon-mail-line.fr-icon--sm{ "aria-hidden": "true" }
           %span.visually-hidden= t('layouts.mailers.service_footer.by_email')
         %dd
-          = link_to service.email, "mailto:#{service.email}"
+          = link_to email, "mailto:#{email}"
     .flex.fr-mb-2v
       %dt.fr-mr-2v
         %span.fr-icon-phone-line.fr-icon--sm{ "aria-hidden": "true" }
         %span.visually-hidden= t('layouts.mailers.service_footer.by_phone')
       %dd
-        = link_to service.telephone, service.telephone_url
+        = link_to telephone, telephone_url
     .flex.fr-mb-2v
       %dt.fr-mr-2v
         %span.fr-icon-time-line.fr-icon--sm{ "aria-hidden": "true" }
         %span.visually-hidden= t('layouts.mailers.service_footer.schedule')
       %dd
-        = service.horaires
+        = horaires
 
-    - if service.other_contact_info.present?
+    - if other_contact_info.present?
       .flex.fr-mb-2v
         %dt.fr-mr-2v
           %span.fr-fi-info-line.fr-icon--sm{ "aria-hidden": "true" }
         %dd
-          = service.other_contact_info
+          = other_contact_info

--- a/app/models/concerns/tags_substitution_concern.rb
+++ b/app/models/concerns/tags_substitution_concern.rb
@@ -242,7 +242,7 @@ module TagsSubstitutionConcern
     id: 'dossier_contact_information_name',
     libelle: 'nom du service instructeur',
     description: 'Le nom du service qui traite le dossier (celui des informations de contact du groupe instructeur s’il existe, sinon celui de la démarche)',
-    lambda: -> (d) { d.service&.nom || '' },
+    lambda: -> (d) { d.service_or_contact_information&.nom || '' },
     available_for_states: Dossier::SOUMIS
   }
 

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -1008,7 +1008,7 @@ class Dossier < ApplicationRecord
     )
   end
 
-  def service
+  def service_or_contact_information
     if procedure.routing_enabled?
       groupe_instructeur&.contact_information || procedure.service
     else

--- a/app/views/dossier_mailer/notify_new_answer.html.haml
+++ b/app/views/dossier_mailer/notify_new_answer.html.haml
@@ -20,4 +20,4 @@
 = render 'layouts/mailers/signature', service: @service
 
 - content_for :footer do
-  = render 'layouts/mailers/service_footer', service: @service, dossier: @dossier
+  = render 'layouts/mailers/service_footer', dossier: @dossier

--- a/app/views/dossier_mailer/notify_new_draft.html.haml
+++ b/app/views/dossier_mailer/notify_new_draft.html.haml
@@ -13,4 +13,4 @@
 = render 'layouts/mailers/signature'
 
 - content_for :footer do
-  = render 'layouts/mailers/service_footer', service: @service, dossier: @dossier
+  = render 'layouts/mailers/service_footer', dossier: @dossier

--- a/app/views/dossier_mailer/notify_pending_correction.html.haml
+++ b/app/views/dossier_mailer/notify_pending_correction.html.haml
@@ -13,4 +13,4 @@
 = render 'layouts/mailers/signature', service: @service
 
 - content_for :footer do
-  = render 'layouts/mailers/service_footer', service: @service, dossier: @dossier
+  = render 'layouts/mailers/service_footer', dossier: @dossier

--- a/app/views/layouts/mailers/_service_footer.html.haml
+++ b/app/views/layouts/mailers/_service_footer.html.haml
@@ -5,16 +5,16 @@
     = succeed '.' do
       = link_to t('.file_messagerie'), messagerie_dossier_url(dossier), target: '_blank', rel: 'noopener'
 
-- service = dossier&.service || dossier.procedure.service
-- if service.present?
+- service_or_contact_information = dossier.service_or_contact_information || dossier.procedure.service
+- if service_or_contact_information.present?
   %table{ width: "100%", border: "0", cellspacing: "0", cellpadding: "0", style: "cursor:auto;color:#55575d;font-family:Helvetica, Arial, sans-serif;font-size:11px;line-height:22px;text-align:left;" }
     %tr
       %td{ width: "50%", valign: "top" }
         %p
           %strong
             = t('.procedure_management')
-          = service.nom
-          = service.adresse
+          = service_or_contact_information.nom
+          = service_or_contact_information.adresse
         %p
           = t('.email_sent_to')
           %br
@@ -28,8 +28,8 @@
             = link_to t('.by_messagerie'), messagerie_dossier_url(dossier), target: '_blank', rel: 'noopener'
           - else
             = t('.by_email')
-            = link_to service.email, "mailto:#{service.email}"
-          - if service.telephone_url.present?
+            = link_to service_or_contact_information.email, "mailto:#{service_or_contact_information.email}"
+          - if service_or_contact_information.telephone_url.present?
             %br= t('.by_phone')
-            = link_to service.telephone, service.telephone_url
-          %br= "#{t('.schedule')} #{ formatted_horaires(service.horaires) }"
+            = link_to service_or_contact_information.telephone, service_or_contact_information.telephone_url
+          %br= "#{t('.schedule')} #{ formatted_horaires(service_or_contact_information.horaires) }"

--- a/app/views/layouts/mailers/_service_footer.html.haml
+++ b/app/views/layouts/mailers/_service_footer.html.haml
@@ -29,6 +29,8 @@
           - elsif service_or_contact_information.email.present?
             = t('.by_email')
             = link_to service_or_contact_information.email, "mailto:#{service_or_contact_information.email}"
+          - elsif service_or_contact_information.respond_to?(:contact_link) && service_or_contact_information.contact_link.present?
+            = link_to t('.by_contact_link'), service_or_contact_information.contact_link, target: '_blank', rel: 'noopener'
           - if service_or_contact_information.telephone_url.present?
             %br= t('.by_phone')
             = link_to service_or_contact_information.telephone, service_or_contact_information.telephone_url

--- a/app/views/layouts/mailers/_service_footer.html.haml
+++ b/app/views/layouts/mailers/_service_footer.html.haml
@@ -5,7 +5,7 @@
     = succeed '.' do
       = link_to t('.file_messagerie'), messagerie_dossier_url(dossier), target: '_blank', rel: 'noopener'
 
-- service_or_contact_information = dossier.service_or_contact_information || dossier.procedure.service
+- service_or_contact_information = dossier.service_or_contact_information
 - if service_or_contact_information.present?
   %table{ width: "100%", border: "0", cellspacing: "0", cellpadding: "0", style: "cursor:auto;color:#55575d;font-family:Helvetica, Arial, sans-serif;font-size:11px;line-height:22px;text-align:left;" }
     %tr
@@ -26,7 +26,7 @@
           %br
           - if dossier.present? && dossier.messagerie_available?
             = link_to t('.by_messagerie'), messagerie_dossier_url(dossier), target: '_blank', rel: 'noopener'
-          - else
+          - elsif service_or_contact_information.email.present?
             = t('.by_email')
             = link_to service_or_contact_information.email, "mailto:#{service_or_contact_information.email}"
           - if service_or_contact_information.telephone_url.present?

--- a/app/views/notification_mailer/send_notification.html.haml
+++ b/app/views/notification_mailer/send_notification.html.haml
@@ -13,4 +13,4 @@
   = render 'layouts/mailers/jdma'
 
 - content_for :footer do
-  = render 'layouts/mailers/service_footer', service: @service, dossier: @dossier
+  = render 'layouts/mailers/service_footer', dossier: @dossier

--- a/app/views/shared/dossiers/_update_contact_information.html.haml
+++ b/app/views/shared/dossiers/_update_contact_information.html.haml
@@ -13,6 +13,6 @@
       = I18n.t('help_dropdown.help_brouillon_title')
     - else
       = I18n.t('help_dropdown.procedure_title')
-  - if procedure.service.present?
+  - if service.present?
     %ul.fr-footer__top-list
-      = render Procedure::ServiceListContactComponent.new(service: procedure.service, dossier: dossier)
+      = render Procedure::ServiceListContactComponent.new(service_or_contact_information: service, dossier: dossier)

--- a/app/views/shared/dossiers/_update_contact_information.html.haml
+++ b/app/views/shared/dossiers/_update_contact_information.html.haml
@@ -1,11 +1,11 @@
 #contact_information
-  - service = dossier&.service || procedure.service
-  - if service.present?
+  - service_or_contact_information = dossier&.service_or_contact_information || procedure.service
+  - if service_or_contact_information.present?
     %h3.fr-footer__top-cat= I18n.t('users.procedure_footer.managed_by.header')
     .fr-footer__top-link.fr-pb-3w
-      %span{ lang: :fr }= service.pretty_nom
+      %span{ lang: :fr }= service_or_contact_information.pretty_nom
       %div{ lang: :fr }
-        = render SimpleFormatComponent.new(service.adresse, class_names_map: {paragraph: 'fr-footer__content-desc'})
+        = render SimpleFormatComponent.new(service_or_contact_information.adresse, class_names_map: {paragraph: 'fr-footer__content-desc'})
   %h3.fr-footer__top-cat
     - if dossier.present? && dossier.depose_at.present?
       = I18n.t('help_dropdown.help_filled_dossier')
@@ -13,6 +13,6 @@
       = I18n.t('help_dropdown.help_brouillon_title')
     - else
       = I18n.t('help_dropdown.procedure_title')
-  - if service.present?
+  - if service_or_contact_information.present?
     %ul.fr-footer__top-list
-      = render Procedure::ServiceListContactComponent.new(service_or_contact_information: service, dossier: dossier)
+      = render Procedure::ServiceListContactComponent.new(service_or_contact_information: service_or_contact_information, dossier: dossier)

--- a/app/views/shared/help/_help_dropdown_dossier.html.haml
+++ b/app/views/shared/help/_help_dropdown_dossier.html.haml
@@ -1,15 +1,16 @@
-.fr-translate.fr-nav
-  .fr-nav__item
-    %button.help-btn.fr-translate__btn.fr-btn{ "aria-controls" => "help-menu", "aria-expanded" => "false" }
-      = t('help')
+#help_dropdown_dossier
+  .fr-translate.fr-nav
+    .fr-nav__item
+      %button.help-btn.fr-translate__btn.fr-btn{ "aria-controls" => "help-menu", "aria-expanded" => "false" }
+        = t('help')
 
-    #help-menu.help-content.fr-collapse.fr-menu
-      - title = dossier.brouillon? ? t("help_dropdown.help_brouillon_title") : t("help_dropdown.help_filled_dossier")
-      %ul.fr-menu__list
-        - if dossier.service_or_contact_information.present?
+      #help-menu.help-content.fr-collapse.fr-menu
+        - title = dossier.brouillon? ? t("help_dropdown.help_brouillon_title") : t("help_dropdown.help_filled_dossier")
+        %ul.fr-menu__list
+          - if dossier.service_or_contact_information.present?
+            %li.flex
+              = render partial: 'shared/help/dropdown_items/service_item',
+                locals: { service: dossier.service_or_contact_information, title:, dossier: }
+
           %li.flex
-            = render partial: 'shared/help/dropdown_items/service_item',
-              locals: { service: dossier.service_or_contact_information, title:, dossier: }
-
-        %li.flex
-          = render partial: 'shared/help/dropdown_items/faq_item'
+            = render partial: 'shared/help/dropdown_items/faq_item'

--- a/app/views/shared/help/_help_dropdown_dossier.html.haml
+++ b/app/views/shared/help/_help_dropdown_dossier.html.haml
@@ -6,10 +6,10 @@
     #help-menu.help-content.fr-collapse.fr-menu
       - title = dossier.brouillon? ? t("help_dropdown.help_brouillon_title") : t("help_dropdown.help_filled_dossier")
       %ul.fr-menu__list
-        - if dossier.procedure.service.present?
+        - if dossier.service_or_contact_information.present?
           %li.flex
             = render partial: 'shared/help/dropdown_items/service_item',
-              locals: { service: dossier.procedure.service, title:, dossier: }
+              locals: { service: dossier.service_or_contact_information, title:, dossier: }
 
         %li.flex
           = render partial: 'shared/help/dropdown_items/faq_item'

--- a/app/views/shared/help/dropdown_items/_service_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_service_item.html.haml
@@ -3,4 +3,4 @@
   %h1.fr-mb-1v
     = title
   %ul
-    = render Procedure::ServiceListContactComponent.new(service: service, dossier: dossier)
+    = render Procedure::ServiceListContactComponent.new(service_or_contact_information: service, dossier: dossier)

--- a/app/views/users/dossiers/papertrail.pdf.prawn
+++ b/app/views/users/dossiers/papertrail.pdf.prawn
@@ -88,7 +88,9 @@ prawn_document(margin: [top_margin, right_margin, bottom_margin, left_margin], p
       pdf.pad_top(7) do
         pdf.text "#{Service.model_name.human} : " + [service_or_contact_information.nom, service_or_contact_information.organisme].join(", "), size: 10, character_spacing: -0.2, align: :justify
         pdf.text "#{Service.human_attribute_name(:adresse)} : #{service_or_contact_information.adresse}", size: 10, character_spacing: -0.2, align: :justify
-        pdf.text "#{Service.human_attribute_name(:email)} : #{service_or_contact_information.email}", size: 10, character_spacing: -0.2, align: :justify
+        if service_or_contact_information.email.present?
+          pdf.text "#{Service.human_attribute_name(:email)} : #{service_or_contact_information.email}", size: 10, character_spacing: -0.2, align: :justify
+        end
         if service_or_contact_information.telephone.present?
           pdf.text "#{Service.human_attribute_name(:telephone)} : #{service_or_contact_information.telephone}", size: 10, character_spacing: -0.2, align: :justify
         end

--- a/app/views/users/dossiers/papertrail.pdf.prawn
+++ b/app/views/users/dossiers/papertrail.pdf.prawn
@@ -79,18 +79,18 @@ prawn_document(margin: [top_margin, right_margin, bottom_margin, left_margin], p
       pdf.text t('.dossier_state') + ' : ' + papertrail_dossier_state(@dossier), size: 10, character_spacing: -0.2, align: :justify
     end
 
-    service = @dossier.service
-    if service.present?
+    service_or_contact_information = @dossier.service_or_contact_information
+    if service_or_contact_information.present?
       pdf.fill_color black
       pdf.pad_top(30) { pdf.text t('.administrative_service'), size: 14, character_spacing: -0.2, align: :justify }
 
       pdf.fill_color grey
       pdf.pad_top(7) do
-        pdf.text "#{Service.model_name.human} : " + [service.nom, service.organisme].join(", "), size: 10, character_spacing: -0.2, align: :justify
-        pdf.text "#{Service.human_attribute_name(:adresse)} : #{service.adresse}", size: 10, character_spacing: -0.2, align: :justify
-        pdf.text "#{Service.human_attribute_name(:email)} : #{service.email}", size: 10, character_spacing: -0.2, align: :justify
-        if service.telephone.present?
-          pdf.text "#{Service.human_attribute_name(:telephone)} : #{service.telephone}", size: 10, character_spacing: -0.2, align: :justify
+        pdf.text "#{Service.model_name.human} : " + [service_or_contact_information.nom, service_or_contact_information.organisme].join(", "), size: 10, character_spacing: -0.2, align: :justify
+        pdf.text "#{Service.human_attribute_name(:adresse)} : #{service_or_contact_information.adresse}", size: 10, character_spacing: -0.2, align: :justify
+        pdf.text "#{Service.human_attribute_name(:email)} : #{service_or_contact_information.email}", size: 10, character_spacing: -0.2, align: :justify
+        if service_or_contact_information.telephone.present?
+          pdf.text "#{Service.human_attribute_name(:telephone)} : #{service_or_contact_information.telephone}", size: 10, character_spacing: -0.2, align: :justify
         end
       end
     end

--- a/app/views/users/dossiers/update.turbo_stream.haml
+++ b/app/views/users/dossiers/update.turbo_stream.haml
@@ -5,3 +5,4 @@
 
 - if @update_contact_information
   = turbo_stream.update "contact_information", partial: 'shared/dossiers/update_contact_information', locals: { dossier: @dossier, procedure: @dossier.procedure }
+  = turbo_stream.update "help_dropdown_dossier", partial: 'shared/help/help_dropdown_dossier', locals: { dossier: @dossier }

--- a/config/locales/views/layouts/mailers/en.yml
+++ b/config/locales/views/layouts/mailers/en.yml
@@ -9,6 +9,7 @@ en:
         ask_question: "Ask a question about your file:"
         email_sent_to: "This email has been sent to :"
         by_messagerie: By messaging
+        by_contact_link: By contact page
         by_email: "By email :"
         by_phone: "By phone :"
         schedule: "Schedule :"

--- a/config/locales/views/layouts/mailers/fr.yml
+++ b/config/locales/views/layouts/mailers/fr.yml
@@ -10,6 +10,7 @@ fr:
         ask_question: "Poser une question sur votre dossier :"
         email_sent_to: "Cet email a été envoyé à l'adresse :"
         by_messagerie: Par la messagerie
+        by_contact_link: Par la page de contact
         by_email: "Par email :"
         by_phone: "Par téléphone :"
         schedule: "Horaires :"

--- a/spec/components/procedure/service_list_contact_component_spec.rb
+++ b/spec/components/procedure/service_list_contact_component_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+RSpec.describe Procedure::ServiceListContactComponent, type: :component do
+  let(:dossier) { create(:dossier) }
+
+  describe 'rendering with different service types' do
+    subject { render_inline(described_class.new(service_or_contact_information: service_or_contact_information, dossier: dossier)) }
+
+    context 'when using a Service object' do
+      let(:service_or_contact_information) do
+        create(:service,
+          email: 'service@example.com',
+          telephone: '0123456789',
+          horaires: 'Du lundi au vendredi de 9h à 17h',
+          faq_link: 'https://example.com/faq',
+          contact_link: 'https://example.com/contact',
+          other_contact_info: 'Fermé les jours fériés')
+      end
+
+      it 'renders contact information correctly' do
+        expect(subject).to have_link(href: 'https://example.com/faq')
+        expect(subject).to have_link(href: 'https://example.com/contact')
+        expect(subject).to have_link('service@example.com', href: 'mailto:service@example.com')
+        expect(subject).to have_link('0123456789')
+        expect(subject).to have_text('Du lundi au vendredi de 9h à 17h')
+        expect(subject).to have_text('Fermé les jours fériés')
+      end
+    end
+
+    context 'when using a ContactInformation object' do
+      let(:service_or_contact_information) do
+        create(:contact_information,
+          email: 'contact@example.com',
+          telephone: '0876543210',
+          horaires: 'Du mardi au samedi de 10h à 18h')
+      end
+
+      it 'renders contact information correctly' do
+        expect(subject).to have_link('contact@example.com', href: 'mailto:contact@example.com')
+        expect(subject).to have_link('0876543210')
+        expect(subject).to have_text('Du mardi au samedi de 10h à 18h')
+        expect(subject).not_to have_text('other_contact_info')
+      end
+    end
+
+    context 'when dossier has messagerie available' do
+      let(:service_or_contact_information) { create(:service) }
+
+      before do
+        allow(dossier).to receive(:messagerie_available?).and_return(true)
+      end
+
+      it 'renders the contact instructeur link' do
+        expect(subject).to have_link("Envoyez directement un message à l’instructeur")
+      end
+    end
+  end
+end

--- a/spec/system/routing/rules_full_scenario_spec.rb
+++ b/spec/system/routing/rules_full_scenario_spec.rb
@@ -291,7 +291,7 @@ describe 'The routing with rules', js: true do
     wait_for_autosave
 
     expect(dossier.reload.groupe_instructeur_id).not_to be_nil
-    expect(page).to have_text(dossier.service.nom)
+    expect(page).to have_text(dossier.service_or_contact_information.nom)
     expect(page).not_to have_text(procedure.service.nom)
 
     click_on 'Déposer le dossier'


### PR DESCRIPTION
Closes #11641

Dans une démarche avec routage on affiche les informations de contact du groupe d'instructeur auquel est routé le dossier.

Dans le footer
<img width="513" alt="Capture d’écran 2025-05-13 à 09 46 33" src="https://github.com/user-attachments/assets/82feb162-1001-4c0e-8bce-c8eac48955d8" />

<img width="390" alt="Capture d’écran 2025-05-13 à 09 46 49" src="https://github.com/user-attachments/assets/5fcf0abb-57fe-49ca-b93d-f298caad8c35" />

Dans la dropdown d'aide du header
<img width="984" alt="Capture d’écran 2025-05-13 à 11 48 01" src="https://github.com/user-attachments/assets/e1f02b80-bf09-470d-85e8-6c619b1ea34a" />
