### PR TITLE
ETQ admin, je peux décider des paramètres à conserver lorsque je clone une démarche

### DIFF
--- a/app/components/procedure/card/instructeurs_component/instructeurs_component.html.haml
+++ b/app/components/procedure/card/instructeurs_component/instructeurs_component.html.haml
@@ -1,7 +1,9 @@
 .fr-col-6.fr-col-md-4.fr-col-lg-3
   = link_to admin_procedure_groupe_instructeurs_path(@procedure), id: 'groupe-instructeurs', class: 'fr-tile fr-enlarge-link' do
     .fr-tile__body.flex.column.align-center.justify-between
-      - if @procedure.routing_enabled? || @procedure.instructeurs.present?
+      - if @procedure.routing_enabled? && @procedure.groupe_instructeurs.any? { _1.routing_to_configure?}
+        %p.fr-badge.fr-badge--warning À faire
+      - elsif @procedure.instructeurs.present?
         %p.fr-badge.fr-badge--success Validé
       - else
         %p.fr-badge.fr-badge--warning À faire

--- a/app/components/procedure/results_component/results_component.html.haml
+++ b/app/components/procedure/results_component/results_component.html.haml
@@ -12,7 +12,7 @@
                 = procedure.libelle
               %td.flex
                 = link_to('Consulter', apercu_admin_procedure_path(id: procedure.id), target: "_blank", rel: "noopener", class: 'button small')
-                = link_to('Cloner', admin_procedure_clone_path(procedure.id, from_new_from_existing: true), 'data-method' => :put, class: 'button small primary')
+                = link_to('Cloner', admin_procedure_clone_settings_path(procedure.id, from_new_from_existing: true), 'data-method' => :get, class: 'button small primary')
                 = link_to('Contacter', "mailto:#{procedure.administrateurs.map(&:email) * ","}", class: 'button small')
     - else
       %p.mt-2 aucun résultat

--- a/app/controllers/administrateurs/mail_templates_controller.rb
+++ b/app/controllers/administrateurs/mail_templates_controller.rb
@@ -7,7 +7,7 @@ module Administrateurs
     before_action :preload_revisions
 
     def index
-      @mail_templates = mail_templates
+      @mail_templates = @procedure.mail_templates
       @mail_templates.each(&:validate)
     end
 
@@ -52,19 +52,8 @@ module Administrateurs
 
     private
 
-    def mail_templates
-      [
-        @procedure.passer_en_construction_email_template,
-        @procedure.passer_en_instruction_email_template,
-        @procedure.accepter_email_template,
-        @procedure.refuser_email_template,
-        @procedure.classer_sans_suite_email_template,
-        @procedure.repasser_en_instruction_email_template
-      ]
-    end
-
     def find_mail_template_by_slug(slug)
-      mail_templates.find { |template| template.class.const_get(:SLUG) == slug }
+      @procedure.mail_templates.find { |template| template.class.const_get(:SLUG) == slug }
     end
 
     def update_params

--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -142,6 +142,7 @@ module Administrateurs
       @procedure = Procedure.find(params[:procedure_id])
       @cloned_from_library = cloned_from_library?
       @is_same_admin = current_administrateur.owns?(@procedure)
+      @updated_mail_templates = @procedure.mail_templates.any? { _1.updated_at.present? }
     end
 
     def clone

--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -138,6 +138,9 @@ module Administrateurs
       end
     end
 
+    def clone_settings
+    end
+
     def clone
       procedure = Procedure.find(params[:procedure_id])
       new_procedure = procedure.clone(current_administrateur, cloned_from_library?)

--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -139,6 +139,8 @@ module Administrateurs
     end
 
     def clone_settings
+      @procedure = Procedure.find(params[:procedure_id])
+      @cloned_from_library = cloned_from_library?
     end
 
     def clone

--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -688,7 +688,8 @@ module Administrateurs
         :api_entreprise_token,
         :mail_templates,
         :sva_svr,
-        :avis
+        :avis,
+        :labels
       )
       {
         clone_champs: options[:champs] == '1',
@@ -706,6 +707,7 @@ module Administrateurs
         clone_mail_templates: options[:mail_templates] == '1',
         clone_sva_svr: options[:sva_svr] == '1',
         clone_avis: options[:avis] == '1',
+        clone_labels: options[:labels] == '1',
         clone_libelle: params.fetch(:procedure)[:libelle],
         cloned_from_library: params[:from_new_from_existing]
       }

--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -141,14 +141,15 @@ module Administrateurs
     def clone_settings
       @procedure = Procedure.find(params[:procedure_id])
       @cloned_from_library = cloned_from_library?
+      @is_same_admin = current_administrateur.owns?(@procedure)
     end
 
     def clone
       procedure = Procedure.find(params[:procedure_id])
-      new_procedure = procedure.clone(current_administrateur, cloned_from_library?)
+      new_procedure = procedure.clone(options: clone_options_from_params, admin: current_administrateur)
 
       if new_procedure.valid?
-        flash.notice = 'Démarche clonée. Pensez à vérifier la présentation et choisir le service à laquelle cette démarche est associée.'
+        flash.notice = 'Démarche clonée. Pensez à vérifier les paramètres avant publication.'
         redirect_to admin_procedure_path(id: new_procedure.id)
       else
         if cloned_from_library?
@@ -412,7 +413,7 @@ module Administrateurs
         flash.alert = "Envoi vers #{params[:email_admin]} impossible : cet administrateur n’existe pas"
       else
         procedure = current_administrateur.procedures.find(params[:procedure_id])
-        procedure.clone(admin, false)
+        procedure.clone(admin:)
         redirect_to admin_procedure_path(params[:procedure_id])
         flash.notice = "La démarche a correctement été clonée vers le nouvel administrateur."
       end
@@ -667,6 +668,46 @@ module Administrateurs
 
     def allow_decision_access_params
       params.require(:experts_procedure).permit(:allow_decision_access)
+    end
+
+    def clone_options_from_params
+      options = params.dig(:procedure, :clone_options).permit(
+        :champs,
+        :annotations,
+        :administrateurs,
+        :instructeurs,
+        :attestation_template,
+        :libelle,
+        :zones,
+        :service,
+        :ineligibilite,
+        :monavis_embed,
+        :dossier_submitted_message,
+        :accuse_lecture,
+        :api_entreprise_token,
+        :mail_templates,
+        :sva_svr,
+        :avis
+      )
+      {
+        clone_champs: options[:champs] == '1',
+        clone_annotations: options[:annotations] == '1',
+        clone_administrateurs: options[:administrateurs] == '1',
+        clone_instructeurs: options[:instructeurs] == '1',
+        clone_attestation_template: options[:attestation_template] == '1',
+        clone_zones: options[:zones] == '1',
+        clone_service: options[:service] == '1',
+        clone_ineligibilite: options[:ineligibilite] == '1',
+        clone_monavis_embed: options[:monavis_embed] == '1',
+        clone_dossier_submitted_message: options[:dossier_submitted_message] == '1',
+        clone_accuse_lecture: options[:accuse_lecture] == '1',
+        clone_api_entreprise_token: options[:api_entreprise_token] == '1',
+        clone_mail_templates: options[:mail_templates] == '1',
+        clone_sva_svr: options[:sva_svr] == '1',
+        clone_avis: options[:avis] == '1',
+        clone_libelle: params.fetch(:procedure)[:libelle],
+        cloned_from_library: params[:from_new_from_existing]
+      }
     end
 
     def cloned_from_library?

--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -143,10 +143,21 @@ module Administrateurs
       @cloned_from_library = cloned_from_library?
       @is_same_admin = current_administrateur.owns?(@procedure)
       @updated_mail_templates = @procedure.mail_templates.any? { _1.updated_at.present? }
+
+      if @procedure.hidden_as_template? && !@is_same_admin
+        flash.alert = "Cette démarche n’est pas clonable"
+        redirect_to admin_procedures_path
+      end
     end
 
     def clone
       procedure = Procedure.find(params[:procedure_id])
+
+      if procedure.hidden_as_template? && !current_administrateur.owns?(procedure)
+        flash.alert = "Cette démarche n’est pas clonable"
+        redirect_to admin_procedures_path and return
+      end
+
       new_procedure = procedure.clone(options: clone_options_from_params, admin: current_administrateur)
 
       if new_procedure.valid?

--- a/app/graphql/mutations/demarche_cloner.rb
+++ b/app/graphql/mutations/demarche_cloner.rb
@@ -15,7 +15,7 @@ module Mutations
       demarche = Procedure.find_by(id: demarche_number)
 
       if demarche.present? && (demarche.opendata? || context.authorized_demarche?(demarche))
-        cloned_demarche = demarche.clone(context.current_administrateur, false)
+        cloned_demarche = demarche.clone(admin: context.current_administrateur)
         cloned_demarche.update!(libelle: title) if title.present?
 
         { demarche: cloned_demarche.draft_revision }

--- a/app/models/concerns/procedure_clone_concern.rb
+++ b/app/models/concerns/procedure_clone_concern.rb
@@ -32,6 +32,7 @@ module ProcedureCloneConcern
 
     procedure.draft_revision.revision_types_de_champ.public_only.each(&:destroy) if !options[:clone_champs]
     procedure.draft_revision.revision_types_de_champ.private_only.each(&:destroy) if !options[:clone_annotations]
+    procedure.labels = [] if !options[:clone_labels]
 
     if !same_admin?(admin) || options[:cloned_from_library]
       procedure.draft_revision.types_de_champ_public.each { |tdc| tdc.options&.delete(:old_pj) }
@@ -110,7 +111,8 @@ module ProcedureCloneConcern
       clone_monavis_embed: true,
       clone_dossier_submitted_message: true,
       clone_accuse_lecture: true,
-      clone_mail_templates: true
+      clone_mail_templates: true,
+      clone_labels: true
     }
   end
 

--- a/app/models/concerns/procedure_clone_concern.rb
+++ b/app/models/concerns/procedure_clone_concern.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+module ProcedureCloneConcern
+  extend ActiveSupport::Concern
+
+  NEW_MAX_DUREE_CONSERVATION = Expired::DEFAULT_DOSSIER_RENTENTION_IN_MONTH
+
+  def clone(options: nil, admin:)
+    options = default_options if options.nil?
+
+    populate_champ_stable_ids
+
+    procedure = self.deep_clone(include: cloneable_associations(options, admin)) do |original, kopy|
+      ClonePiecesJustificativesService.clone_attachments(original, kopy)
+    end
+
+    procedure = initialize_clone_defaults(procedure, admin)
+
+    procedure = apply_clone_options(procedure, options, admin)
+
+    if !procedure.valid?
+      procedure.errors.attribute_names.each do |attribute|
+        next if [:notice, :deliberation, :logo].exclude?(attribute)
+        procedure.public_send("#{attribute}=", nil)
+      end
+    end
+
+    transaction do
+      procedure.save!
+      move_new_children_to_new_parent_coordinate(procedure.draft_revision)
+    end
+
+    procedure.draft_revision.revision_types_de_champ.public_only.each(&:destroy) if !options[:clone_champs]
+    procedure.draft_revision.revision_types_de_champ.private_only.each(&:destroy) if !options[:clone_annotations]
+
+    if !same_admin?(admin) || options[:cloned_from_library]
+      procedure.draft_revision.types_de_champ_public.each { |tdc| tdc.options&.delete(:old_pj) }
+    end
+
+    new_defaut_groupe = procedure.groupe_instructeurs
+      .find_by(label: defaut_groupe_instructeur.label) || procedure.groupe_instructeurs.first
+    procedure.update!(defaut_groupe_instructeur: new_defaut_groupe)
+
+    procedure.defaut_groupe_instructeur.instructeurs = [admin.instructeur] if !options[:clone_instructeurs] || !same_admin?(admin)
+
+    Flipper.features.each do |feature|
+      next if feature.enabled? # don't clone features globally enabled
+      next unless feature_enabled?(feature.key)
+
+      Flipper.enable(feature.key, procedure)
+    end
+
+    procedure
+  end
+
+  private
+
+  def populate_champ_stable_ids
+    TypeDeChamp
+      .joins(:revisions)
+      .where(procedure_revisions: { procedure_id: id }, stable_id: nil)
+      .find_each do |type_de_champ|
+        type_de_champ.update_column(:stable_id, type_de_champ.id)
+      end
+  end
+
+  def same_admin?(admin)
+    @same_admin ||= admin.owns?(self)
+  end
+
+  def initialize_clone_defaults(procedure, admin)
+    procedure.claim_path!(admin, SecureRandom.uuid)
+    procedure.aasm_state = :brouillon
+    procedure.closed_at = nil
+    procedure.unpublished_at = nil
+    procedure.published_at = nil
+    procedure.auto_archive_on = nil
+    procedure.lien_notice = nil
+    procedure.duree_conservation_etendue_par_ds = false
+    if procedure.duree_conservation_dossiers_dans_ds > NEW_MAX_DUREE_CONSERVATION
+      procedure.duree_conservation_dossiers_dans_ds = NEW_MAX_DUREE_CONSERVATION
+      procedure.max_duree_conservation_dossiers_dans_ds = NEW_MAX_DUREE_CONSERVATION
+    end
+    procedure.estimated_dossiers_count = 0
+    procedure.published_revision = nil
+    procedure.draft_revision.procedure = procedure
+    procedure.ask_birthday = false # see issue #4242
+    procedure.parent_procedure = self
+    procedure.canonical_procedure = nil
+    procedure.replaced_by_procedure = nil
+    procedure.closing_reason = nil
+    procedure.closing_details = nil
+    procedure.closing_notification_brouillon = false
+    procedure.closing_notification_en_cours = false
+    procedure.template = false
+    procedure.labels = labels.map(&:dup)
+    procedure.routing_alert = false
+    procedure
+  end
+
+  def default_options
+    {
+      clone_administrateurs: true,
+      clone_instructeurs: true,
+      clone_champs: true,
+      clone_annotations: true,
+      clone_attestation_template: true,
+      clone_zones: true,
+      clone_ineligibilite: true,
+      clone_monavis_embed: true,
+      clone_dossier_submitted_message: true,
+      clone_accuse_lecture: true,
+      clone_mail_templates: true
+    }
+  end
+
+  def apply_clone_options(procedure, options, admin)
+    procedure.cloned_from_library = options[:cloned_from_library]
+    procedure.service = nil if !options[:clone_service] || !same_admin?(admin)
+    procedure.libelle = options[:clone_libelle] if options[:clone_libelle].present?
+    procedure.monavis_embed = nil if !options[:clone_monavis_embed]
+    procedure.accuse_lecture = false if !options[:clone_accuse_lecture]
+    procedure.experts_require_administrateur_invitation = false if !options[:clone_avis]
+    procedure.api_entreprise_token = nil if !options[:clone_api_entreprise_token] || !same_admin?(admin)
+    procedure.sva_svr = {} if !options[:clone_sva_svr]
+
+    if !options[:clone_instructeurs] || !same_admin?(admin)
+      procedure.routing_enabled = false
+      procedure.instructeurs_self_management_enabled = false
+    end
+
+    if options[:clone_dossier_submitted_message]
+      procedure.draft_revision.dossier_submitted_message = active_revision.dossier_submitted_message.dup
+    else
+      procedure.draft_revision.dossier_submitted_message = nil
+    end
+
+    if !options[:clone_administrateurs] || !same_admin?(admin)
+      procedure.administrateurs = [admin]
+    else
+      procedure.administrateurs = administrateurs
+    end
+
+    if !options[:clone_ineligibilite]
+      procedure.draft_revision.ineligibilite_rules = nil
+      procedure.draft_revision.ineligibilite_enabled = false
+      procedure.draft_revision.ineligibilite_message = nil
+    end
+
+    if options[:clone_mail_templates]
+      procedure.initiated_mail = initiated_mail&.dup
+      procedure.received_mail = received_mail&.dup
+      procedure.closed_mail = closed_mail&.dup
+      procedure.refused_mail = refused_mail&.dup
+      procedure.re_instructed_mail = re_instructed_mail&.dup
+      procedure.without_continuation_mail = without_continuation_mail&.dup
+    end
+
+    if !same_admin?(admin)
+      procedure.encrypted_api_particulier_token = nil
+      procedure.opendata = true
+      procedure.api_particulier_scopes = []
+    end
+
+    procedure
+  end
+
+  def cloneable_associations(options, admin)
+    associations = {
+      draft_revision: {
+        revision_types_de_champ: [:type_de_champ],
+        dossier_submitted_message: []
+      }
+    }
+
+    if options[:clone_attestation_template]
+      associations[:attestation_template] = []
+    end
+
+    if options[:clone_zones]
+      associations[:zones] = []
+    end
+
+    if options[:clone_avis] && same_admin?(admin)
+      associations[:experts_procedures] = :expert
+    end
+
+    if options[:clone_instructeurs] && same_admin?(admin)
+      associations[:groupe_instructeurs] = [:instructeurs, :contact_information]
+    end
+
+    associations
+  end
+end

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -753,6 +753,17 @@ class Procedure < ApplicationRecord
     monavis_embed.gsub('nd_source=button', "nd_source=#{source}").gsub('<a ', '<a target="_blank" rel="noopener noreferrer" ')
   end
 
+  def mail_templates
+    [
+      self.passer_en_construction_email_template,
+      self.passer_en_instruction_email_template,
+      self.accepter_email_template,
+      self.refuser_email_template,
+      self.classer_sans_suite_email_template,
+      self.repasser_en_instruction_email_template
+    ]
+  end
+
   private
 
   def stable_ids_used_by_routing_rules

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -9,6 +9,7 @@ class Procedure < ApplicationRecord
   include ProcedureChorusConcern
   include ProcedurePublishConcern
   include ProcedurePathConcern
+  include ProcedureCloneConcern
   include PiecesJointesListConcern
   include ColumnsConcern
 
@@ -18,7 +19,6 @@ class Procedure < ApplicationRecord
   default_scope -> { kept }
 
   OLD_MAX_DUREE_CONSERVATION = 36
-  NEW_MAX_DUREE_CONSERVATION = Expired::DEFAULT_DOSSIER_RENTENTION_IN_MONTH
 
   MIN_WEIGHT = 350000
 
@@ -419,99 +419,6 @@ class Procedure < ApplicationRecord
     publiees.find(id)
   end
 
-  def clone(admin, from_library)
-    is_different_admin = !admin.owns?(self)
-
-    populate_champ_stable_ids
-    include_list = {
-      attestation_template: [],
-      draft_revision: {
-        revision_types_de_champ: [:type_de_champ],
-        dossier_submitted_message: []
-      }
-    }
-    include_list[:groupe_instructeurs] = [:instructeurs, :contact_information] if !is_different_admin
-    procedure = self.deep_clone(include: include_list) do |original, kopy|
-      ClonePiecesJustificativesService.clone_attachments(original, kopy)
-    end
-    procedure.claim_path!(admin, SecureRandom.uuid)
-    procedure.aasm_state = :brouillon
-    procedure.closed_at = nil
-    procedure.unpublished_at = nil
-    procedure.published_at = nil
-    procedure.auto_archive_on = nil
-    procedure.lien_notice = nil
-    procedure.duree_conservation_etendue_par_ds = false
-    if procedure.duree_conservation_dossiers_dans_ds > NEW_MAX_DUREE_CONSERVATION
-      procedure.duree_conservation_dossiers_dans_ds = NEW_MAX_DUREE_CONSERVATION
-      procedure.max_duree_conservation_dossiers_dans_ds = NEW_MAX_DUREE_CONSERVATION
-    end
-    procedure.estimated_dossiers_count = 0
-    procedure.published_revision = nil
-    procedure.draft_revision.procedure = procedure
-
-    if is_different_admin
-      procedure.administrateurs = [admin]
-      procedure.api_entreprise_token = nil
-      procedure.encrypted_api_particulier_token = nil
-      procedure.opendata = true
-      procedure.api_particulier_scopes = []
-      procedure.routing_enabled = false
-    else
-      procedure.administrateurs = administrateurs
-    end
-
-    procedure.initiated_mail = initiated_mail&.dup
-    procedure.received_mail = received_mail&.dup
-    procedure.closed_mail = closed_mail&.dup
-    procedure.refused_mail = refused_mail&.dup
-    procedure.without_continuation_mail = without_continuation_mail&.dup
-    procedure.re_instructed_mail = re_instructed_mail&.dup
-    procedure.ask_birthday = false # see issue #4242
-
-    procedure.cloned_from_library = from_library
-    procedure.parent_procedure = self
-    procedure.canonical_procedure = nil
-    procedure.replaced_by_procedure = nil
-    procedure.service = nil
-    procedure.closing_reason = nil
-    procedure.closing_details = nil
-    procedure.closing_notification_brouillon = false
-    procedure.closing_notification_en_cours = false
-    procedure.template = false
-    procedure.monavis_embed = nil
-    procedure.labels = labels.map(&:dup)
-
-    if !procedure.valid?
-      procedure.errors.attribute_names.each do |attribute|
-        next if [:notice, :deliberation, :logo].exclude?(attribute)
-        procedure.public_send("#{attribute}=", nil)
-      end
-    end
-
-    transaction do
-      procedure.save!
-      move_new_children_to_new_parent_coordinate(procedure.draft_revision)
-    end
-
-    if is_different_admin || from_library
-      procedure.draft_revision.types_de_champ_public.each { |tdc| tdc.options&.delete(:old_pj) }
-    end
-
-    new_defaut_groupe = procedure.groupe_instructeurs
-      .find_by(label: defaut_groupe_instructeur.label) || procedure.groupe_instructeurs.first
-    procedure.update!(defaut_groupe_instructeur: new_defaut_groupe)
-
-    Flipper.features.each do |feature|
-      next if feature.enabled? # don't clone features globally enabled
-      next unless feature_enabled?(feature.key)
-
-      Flipper.enable(feature.key, procedure)
-    end
-
-    procedure
-  end
-
   def whitelisted?
     whitelisted_at.present?
   end
@@ -594,15 +501,6 @@ class Procedure < ApplicationRecord
         :extraneous_tag
       end
     end
-  end
-
-  def populate_champ_stable_ids
-    TypeDeChamp
-      .joins(:revisions)
-      .where(procedure_revisions: { procedure_id: id }, stable_id: nil)
-      .find_each do |type_de_champ|
-        type_de_champ.update_column(:stable_id, type_de_champ.id)
-      end
   end
 
   def missing_steps

--- a/app/views/administrateurs/procedures/_detail.html.haml
+++ b/app/views/administrateurs/procedures/_detail.html.haml
@@ -26,7 +26,7 @@
   %td= l(procedure.published_at, format: :message_date_without_time) if procedure.published_at
   %td
     = link_to('Consulter', apercu_admin_procedure_path(procedure.id), target: "_blank", class: 'fr-btn fr-btn--tertiary fr-btn--sm fr-mb-1w',  title: new_tab_suffix('Aperçu de la démarche'))
-    = link_to('Cloner', admin_procedure_clone_path(procedure.id, from_new_from_existing: true), 'data-method' => :put, class: 'fr-btn fr-btn--tertiary fr-btn--sm')
+    = link_to('Cloner', admin_procedure_clone_settings_path(procedure.id, from_new_from_existing: true), 'data-method' => :get, class: 'fr-btn fr-btn--tertiary fr-btn--sm')
 
 
 - if show_detail

--- a/app/views/administrateurs/procedures/_procedures_list.html.haml
+++ b/app/views/administrateurs/procedures/_procedures_list.html.haml
@@ -90,7 +90,7 @@
 
           - if !procedure.discarded?
             - menu.with_item do
-              = link_to(admin_procedure_clone_path(procedure.id), role: 'menuitem', class: 'clone-btn', data: { method: :put }) do
+              = link_to(admin_procedure_clone_settings_path(procedure.id), role: 'menuitem', class: 'clone-btn', data: { method: :get }) do
                 = dsfr_icon('fr-icon-file-copy-line')
                 .dropdown-description
                   %h4= t('administrateurs.dropdown_actions.to_clone')

--- a/app/views/administrateurs/procedures/clone_settings.html.haml
+++ b/app/views/administrateurs/procedures/clone_settings.html.haml
@@ -158,6 +158,15 @@
               .fr-hint-text
                 = t('administrateurs.procedures.clone.accuse_lecture_hint')
 
+      - if @procedure.labels.present?
+        .fr-fieldset__element
+          .fr-checkbox-group
+            = f.check_box 'clone_options[labels]', checked: true
+            = f.label 'clone_options[labels]', class: "fr-label" do
+              = t('administrateurs.procedures.clone.labels')
+              .fr-hint-text
+                = t('administrateurs.procedures.clone.labels_count', count: @procedure.labels.count)
+
     .fixed-footer
       .fr-container
         %ul.fr-btns-group.fr-btns-group--inline-md.fr-ml-0

--- a/app/views/administrateurs/procedures/clone_settings.html.haml
+++ b/app/views/administrateurs/procedures/clone_settings.html.haml
@@ -7,7 +7,7 @@
     = t('administrateurs.procedures.clone.title')
     = "« #{@procedure.libelle} » (N° #{@procedure.id})"
 
-  = form_with(model: [@procedure], url: admin_procedure_clone_path(@procedure, from_new_from_existing: params[:from_new_from_existing]), method: :put) do |f|
+  = form_with(model: @procedure, url: admin_procedure_clone_path(@procedure, from_new_from_existing: params[:from_new_from_existing]), method: :post) do |f|
     %h2.fr-h5.fr-mb-1w
       = t('administrateurs.procedures.clone.rename_title')
     = render Dsfr::InputComponent.new(form: f, attribute: :libelle, input_type: :text_field, opts: {})

--- a/app/views/administrateurs/procedures/clone_settings.html.haml
+++ b/app/views/administrateurs/procedures/clone_settings.html.haml
@@ -93,13 +93,14 @@
               .fr-hint-text
                 = t('administrateurs.procedures.clone.avis_hint')
 
-      .fr-fieldset__element
-        .fr-checkbox-group
-          = f.check_box 'clone_options[mail_templates]', checked: true
-          = f.label 'clone_options[mail_templates]', class: "fr-label" do
-            = t('administrateurs.procedures.clone.mail_templates')
-            .fr-hint-text
-              = t('administrateurs.procedures.clone.mail_templates_hint')
+      - if @updated_mail_templates
+        .fr-fieldset__element
+          .fr-checkbox-group
+            = f.check_box 'clone_options[mail_templates]', checked: true
+            = f.label 'clone_options[mail_templates]', class: "fr-label" do
+              = t('administrateurs.procedures.clone.mail_templates')
+              .fr-hint-text
+                = t('administrateurs.procedures.clone.mail_templates_hint')
 
       - if @procedure.active_revision.types_de_champ_private.present?
         .fr-fieldset__element

--- a/app/views/administrateurs/procedures/clone_settings.html.haml
+++ b/app/views/administrateurs/procedures/clone_settings.html.haml
@@ -1,0 +1,166 @@
+= render partial: 'administrateurs/breadcrumbs',
+  locals: { steps: [['Démarches', admin_procedures_back_path(@procedure)],
+                    ["Cloner la démarche « #{@procedure.libelle.truncate_words(10)} » (N° #{@procedure.id})"]] }
+
+.fr-container
+  %h1
+    = t('administrateurs.procedures.clone.title')
+    = "« #{@procedure.libelle} » (N° #{@procedure.id})"
+
+  = form_with(model: [@procedure], url: admin_procedure_clone_path(@procedure, from_new_from_existing: params[:from_new_from_existing]), method: :put) do |f|
+    %h2.fr-h5.fr-mb-1w
+      = t('administrateurs.procedures.clone.rename_title')
+    = render Dsfr::InputComponent.new(form: f, attribute: :libelle, input_type: :text_field, opts: {})
+
+    %h2.fr-h5.fr-mb-2w
+      = t('administrateurs.procedures.clone.configurate_title')
+
+    %p.fr-alert.fr-alert--info.fr-alert--sm.fr-mb-3w
+      = t('administrateurs.procedures.clone.info')
+
+    %fieldset.fr-fieldset{ id: "clone-options-checkboxes", aria: { labelledby: "clone-options-checkboxes" } }
+      - if @procedure.zones.present?
+        .fr-fieldset__element
+          .fr-checkbox-group
+            = f.check_box 'clone_options[zones]', checked: true
+            = f.label 'clone_options[zones]', class: "fr-label" do
+              = t('administrateurs.procedures.clone.zones')
+              .fr-hint-text
+                = @procedure.zones.map(&:label).join(' | ')
+
+      - if @procedure.active_revision.types_de_champ_public.present?
+        .fr-fieldset__element
+          .fr-checkbox-group
+            = f.check_box 'clone_options[champs]', checked: true
+            = f.label 'clone_options[champs]', class: "fr-label" do
+              = t('administrateurs.procedures.clone.types_de_champ_public')
+              .fr-hint-text
+                = t('administrateurs.procedures.clone.types_de_champ_count', count: @procedure.active_revision.types_de_champ_public.count)
+
+      - if @procedure.active_revision.ineligibilite_enabled?
+        .fr-fieldset__element
+          .fr-checkbox-group
+            = f.check_box 'clone_options[ineligibilite]', checked: true
+            = f.label 'clone_options[ineligibilite]', class: "fr-label" do
+              = t('administrateurs.procedures.clone.ineligibilite')
+              .fr-hint-text
+                = t('administrateurs.procedures.clone.ineligibilite_hint')
+
+      - if @is_same_admin
+        - if @procedure.service.present?
+          .fr-fieldset__element
+            .fr-checkbox-group
+              = f.check_box 'clone_options[service]', checked: false
+              = f.label 'clone_options[service]', class: "fr-label" do
+                = t('administrateurs.procedures.clone.service')
+                .fr-hint-text
+                  = @procedure.service&.nom
+
+        .fr-fieldset__element
+          .fr-checkbox-group
+            = f.check_box 'clone_options[administrateurs]', checked: true
+            = f.label 'clone_options[administrateurs]', class: "fr-label" do
+              = t('administrateurs.procedures.clone.administrateurs')
+              .fr-hint-text
+                = t('administrateurs.procedures.clone.administrateurs_count', count: @procedure.administrateurs.count)
+
+        - if @procedure.instructeurs.any?
+          .fr-fieldset__element
+            .fr-checkbox-group
+              = f.check_box 'clone_options[instructeurs]', checked: false
+              = f.label 'clone_options[instructeurs]', class: "fr-label" do
+                = t('administrateurs.procedures.clone.instructeurs')
+                .fr-hint-text
+                  = t('administrateurs.procedures.clone.instructeurs_count', count: @procedure.instructeurs.count)
+                  = t("administrateurs.procedures.clone.instructeurs_self_management.#{@procedure.instructeurs_self_management?.to_s}")
+                  = t("administrateurs.procedures.clone.routing_enabled.#{@procedure.routing_enabled?.to_s}")
+
+      - if @procedure.attestation_template&.activated?
+        .fr-fieldset__element
+          .fr-checkbox-group
+            = f.check_box 'clone_options[attestation_template]', checked: true
+            = f.label 'clone_options[attestation_template]', class: "fr-label" do
+              = t('administrateurs.procedures.clone.attestation_template')
+              .fr-hint-text
+                = t('administrateurs.procedures.clone.attestation_template_hint')
+
+      - if @procedure.experts_require_administrateur_invitation
+        .fr-fieldset__element
+          .fr-checkbox-group
+            = f.check_box 'clone_options[avis]', checked: true
+            = f.label 'clone_options[avis]', class: "fr-label" do
+              = t('administrateurs.procedures.clone.avis')
+              .fr-hint-text
+                = t('administrateurs.procedures.clone.avis_hint')
+
+      .fr-fieldset__element
+        .fr-checkbox-group
+          = f.check_box 'clone_options[mail_templates]', checked: true
+          = f.label 'clone_options[mail_templates]', class: "fr-label" do
+            = t('administrateurs.procedures.clone.mail_templates')
+            .fr-hint-text
+              = t('administrateurs.procedures.clone.mail_templates_hint')
+
+      - if @procedure.active_revision.types_de_champ_private.present?
+        .fr-fieldset__element
+          .fr-checkbox-group
+            = f.check_box 'clone_options[annotations]', checked: true
+            = f.label 'clone_options[annotations]', class: "fr-label" do
+              = t('administrateurs.procedures.clone.types_de_champ_private')
+              .fr-hint-text
+                = t('administrateurs.procedures.clone.types_de_champ_count', count: @procedure.active_revision.types_de_champ_private.count)
+
+      - if @is_same_admin && @procedure.api_entreprise_token.present?
+        .fr-fieldset__element
+          .fr-checkbox-group
+            = f.check_box 'clone_options[api_entreprise_token]', checked: true
+            = f.label 'clone_options[api_entreprise_token]', class: "fr-label" do
+              = t('administrateurs.procedures.clone.api_entreprise_token')
+              .fr-hint-text
+                = t('administrateurs.procedures.clone.api_entreprise_token_hint')
+
+      - if @procedure.sva_svr_enabled?
+        .fr-fieldset__element
+          .fr-checkbox-group
+            = f.check_box 'clone_options[sva_svr]', checked: true
+            = f.label 'clone_options[sva_svr]', class: "fr-label" do
+              = t('administrateurs.procedures.clone.sva_svr')
+              .fr-hint-text
+                = t("administrateurs.procedures.clone.sva_svr_hint.#{@procedure.sva_svr_decision.to_s}")
+                = t('administrateurs.procedures.clone.sva_svr_period', period: @procedure.sva_svr_configuration.period)
+                = t("administrateurs.procedures.clone.sva_svr_unit_labels.#{@procedure.sva_svr_configuration.unit}")
+
+      - if @is_same_admin && @procedure.monavis_embed?
+        .fr-fieldset__element
+          .fr-checkbox-group
+            = f.check_box 'clone_options[monavis_embed]', checked: true
+            = f.label 'clone_options[monavis_embed]', class: "fr-label" do
+              = t('administrateurs.procedures.clone.monavis_embed')
+              .fr-hint-text
+                = t('administrateurs.procedures.clone.monavis_embed_hint', code: @procedure.monavis_embed)
+
+      - if @procedure.active_revision.dossier_submitted_message.present?
+        .fr-fieldset__element
+          .fr-checkbox-group
+            = f.check_box 'clone_options[dossier_submitted_message]', checked: true
+            = f.label 'clone_options[dossier_submitted_message]', class: "fr-label" do
+              = t('administrateurs.procedures.clone.dossier_submitted_message')
+              .fr-hint-text
+                = t('administrateurs.procedures.clone.dossier_submitted_message_hint', message: @procedure.active_revision.dossier_submitted_message&.message_on_submit_by_usager)
+
+      - if @procedure.accuse_lecture?
+        .fr-fieldset__element
+          .fr-checkbox-group
+            = f.check_box 'clone_options[accuse_lecture]', checked: true
+            = f.label 'clone_options[accuse_lecture]', class: "fr-label" do
+              = t('administrateurs.procedures.clone.accuse_lecture')
+              .fr-hint-text
+                = t('administrateurs.procedures.clone.accuse_lecture_hint')
+
+    .fixed-footer
+      .fr-container
+        %ul.fr-btns-group.fr-btns-group--inline-md.fr-ml-0
+          %li
+            = link_to t('administrateurs.procedures.clone.actions.cancel'), params[:from_new_from_existing] ? all_admin_procedures_path(zone_ids: :admin_default) : admin_procedure_path(@procedure), class: 'fr-btn fr-btn--secondary fr-ml-0'
+          %li
+            = f.submit t('administrateurs.procedures.clone.actions.clone'), class: 'fr-btn', data: { disable_with: t('administrateurs.procedures.clone.actions.disable_with') }

--- a/app/views/administrateurs/procedures/show.html.haml
+++ b/app/views/administrateurs/procedures/show.html.haml
@@ -7,12 +7,16 @@
   %ul.fr-btns-group.fr-btns-group--inline-sm.fr-btns-group--icon-left
     - if @procedure.validate(:publication)
       - if !@procedure.brouillon?
+        = link_to 'Cloner', admin_procedure_clone_settings_path(@procedure), class: 'fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-file-copy-line', id: "clone-procedure"
         = link_to 'Télécharger', admin_procedure_archives_path(@procedure), class: 'fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-download-line', id: "archive-procedure"
 
         = link_to 'PDF', commencer_dossier_vide_for_revision_path(@procedure.active_revision), target: "_blank", rel: "noopener", class: 'fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-printer-line', id: "pdf-procedure"
 
       - if @procedure.brouillon? || @procedure.draft_changed?
         = link_to 'Tester la démarche', commencer_url(@procedure.path, test: true), target: :blank, rel: :noopener, class: 'fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-flashlight-line'
+
+      - if @procedure.brouillon?
+        = link_to 'Cloner', admin_procedure_clone_settings_path(@procedure), class: 'fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-file-copy-line', id: "clone-procedure"
 
       - if @procedure.publiee? || @procedure.brouillon?
         = link_to 'Envoyer une copie', admin_procedure_transfert_path(@procedure), class: 'fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-send-plane-line'

--- a/config/locales/views/administrateurs/procedures/en.yml
+++ b/config/locales/views/administrateurs/procedures/en.yml
@@ -134,6 +134,10 @@ en:
           days: days
         avis: External opinions
         avis_hint: Enabled - External opinions management with predefined list
+        labels: Labels
+        labels_count:
+          one: "%{count} label"
+          other: "%{count} labels"
         actions:
           clone: Clone the procedure
           cancel: Cancel

--- a/config/locales/views/administrateurs/procedures/en.yml
+++ b/config/locales/views/administrateurs/procedures/en.yml
@@ -81,3 +81,60 @@ en:
         intro_html: Changes made will only be visible <strong>after the next publication</strong>
         see_changes: View changes
         publish_changes: Publish changes
+      clone:
+        title: Clone a procedure
+        info: All procedure parameters will remain modifiable after cloning.
+        rename_title: Rename your procedure
+        configurate_title: Choose the procedure parameters you want to keep when cloning
+        types_de_champ_public: Form fields
+        types_de_champ_private: Private annotations
+        types_de_champ_count:
+          zero: No field
+          one: "%{count} field"
+          other: "%{count} fields"
+        administrateurs: Administrators
+        administrateurs_count:
+          one: "%{count} administrator"
+          other: "%{count} administrators"
+        instructeurs: Instructors
+        instructeurs_count:
+          zero: No instructor
+          one: "%{count} instructor"
+          other: "%{count} instructors"
+        attestation_template: Certificate of acceptance of the file
+        attestation_template_hint: Activated
+        zones: Zones
+        service: Service
+        instructeurs_self_management:
+          true: "- Self-management activated"
+          false: "- Self-management deactivated"
+        routing_enabled:
+          true: "- Routing activated"
+          false: "- Routing deactivated"
+        ineligibilite: Ineligibility of files
+        ineligibilite_hint: Enabled
+        monavis_embed: MonAvis button
+        monavis_embed_hint: "Code generated on MonAvis website : %{code}"
+        dossier_submitted_message: End of submission
+        dossier_submitted_message_hint: "(Custom message) %{message}"
+        accuse_lecture: Acknowledgment of receipt of the decision
+        accuse_lecture_hint: Enabled
+        api_entreprise_token: API company token
+        api_entreprise_token_hint: Configured token
+        mail_templates: Email configuration
+        mail_templates_hint: Content of the automatic emails
+        sva_svr: Silence is Worth Agreement or Rejection
+        sva_svr_hint:
+          sva: SVA enabled
+          svr: SVR enabled
+        sva_svr_period: "- After %{period}"
+        sva_svr_unit_labels:
+          months: months
+          weeks: weeks
+          days: days
+        avis: External opinions
+        avis_hint: Enabled - External opinions management with predefined list
+        actions:
+          clone: Clone the procedure
+          cancel: Cancel
+          disable_with: Cloning in progress

--- a/config/locales/views/administrateurs/procedures/fr.yml
+++ b/config/locales/views/administrateurs/procedures/fr.yml
@@ -81,3 +81,60 @@ fr:
         intro_html: Les modifications effectuées ne seront visibles <strong>qu'à la prochaine publication</strong>
         see_changes: Voir les modifications
         publish_changes: Publier les modifications
+      clone:
+        title: Cloner la démarche
+        info: L’ensemble des paramètres de la démarche resteront modifiables après clonage.
+        rename_title: Renommez votre démarche
+        configurate_title: Choisissez les paramètres de la démarche que vous souhaitez conserver lors du clonage
+        types_de_champ_public: Champs du formulaire
+        types_de_champ_private: Annotations privées
+        types_de_champ_count:
+          zero: Aucun champ
+          one: "%{count} champ"
+          other: "%{count} champs"
+        administrateurs: Administrateurs
+        administrateurs_count:
+          one: "%{count} administrateur"
+          other: "%{count} administrateurs"
+        instructeurs: Instructeurs
+        instructeurs_count:
+          zero: Aucun instructeur
+          one: "%{count} instructeur"
+          other: "%{count} instructeurs"
+        attestation_template: Attestation d’acceptation du dossier
+        attestation_template_hint: Activée
+        zones: Zones
+        service: Service
+        instructeurs_self_management:
+          true: "- Autogestion activée"
+          false: "- Autogestion désactivée"
+        routing_enabled:
+          true: "- Routage activé"
+          false: "- Routage désactivé"
+        ineligibilite: Inéligibilité des dossiers
+        ineligibilite_hint: Activée
+        monavis_embed: Bouton « MonAvis »
+        monavis_embed_hint: "Code généré sur le site MonAvis : %{code}"
+        dossier_submitted_message: Fin de dépôt
+        dossier_submitted_message_hint: "(Message personnalisé) %{message}"
+        accuse_lecture: Accusé de lecture de la décision
+        accuse_lecture_hint: Activé
+        api_entreprise_token: Jeton API entreprise
+        api_entreprise_token_hint: Jeton configuré
+        mail_templates: Configuration des emails
+        mail_templates_hint: Contenu des emails automatiques
+        sva_svr: Silence Vaut Accord ou Rejet
+        sva_svr_hint:
+          sva: SVA activé
+          svr: SVR activé
+        sva_svr_period: "- Après %{period}"
+        sva_svr_unit_labels:
+          months: mois
+          weeks: semaines
+          days: jours
+        avis: Avis externes
+        avis_hint: Activé - Gestions des experts avec liste prédéfinie
+        actions:
+          clone: Cloner la démarche
+          cancel: Annuler
+          disable_with: Clonage en cours

--- a/config/locales/views/administrateurs/procedures/fr.yml
+++ b/config/locales/views/administrateurs/procedures/fr.yml
@@ -133,7 +133,11 @@ fr:
           weeks: semaines
           days: jours
         avis: Avis externes
-        avis_hint: Activé - Gestions des experts avec liste prédéfinie
+        avis_hint: Activé - Gestion des experts avec liste prédéfinie
+        labels: Labels
+        labels_count:
+          one: "%{count} label"
+          other: "%{count} labels"
         actions:
           clone: Cloner la démarche
           cancel: Annuler

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -690,6 +690,7 @@ Rails.application.routes.draw do
 
       patch :update_defaut_groupe_instructeur, controller: 'routing_rules', as: :update_defaut_groupe_instructeur
 
+      get 'clone_settings'
       put 'clone'
       put 'archive'
       get 'publication' => 'procedures#publication', as: :publication

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -691,7 +691,7 @@ Rails.application.routes.draw do
       patch :update_defaut_groupe_instructeur, controller: 'routing_rules', as: :update_defaut_groupe_instructeur
 
       get 'clone_settings'
-      put 'clone'
+      post 'clone'
       put 'archive'
       get 'publication' => 'procedures#publication', as: :publication
       post 'check_path' => 'procedures#check_path', as: :check_path

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -731,6 +731,7 @@ describe Administrateurs::ProceduresController, type: :controller do
         :with_service,
         :routee,
         :with_dossier_submitted_message,
+        :with_labels,
         :sva,
         monavis_embed:,
         administrateurs: [admin, administrateur_2],
@@ -794,10 +795,7 @@ describe Administrateurs::ProceduresController, type: :controller do
       it 'creates a new procedure and redirect to it' do
         expect(response).to redirect_to admin_procedure_path(id: Procedure.last.id)
         expect(Procedure.last.cloned_from_library).to be_falsey
-        expect(Procedure.last.labels.present?).to be_truthy
-        expect(Procedure.last.labels.first.procedure_id).to eq(Procedure.last.id)
         expect(procedure.labels.first.procedure_id).to eq(procedure.id)
-
         expect(flash[:notice]).to have_content 'Démarche clonée. Pensez à vérifier les paramètres avant publication.'
       end
 
@@ -839,7 +837,8 @@ describe Administrateurs::ProceduresController, type: :controller do
                 sva_svr: '1',
                 mail_templates: '1',
                 ineligibilite: '1',
-                avis: '1'
+                avis: '1',
+                labels: '1'
               }
             }
           }
@@ -873,12 +872,13 @@ describe Administrateurs::ProceduresController, type: :controller do
           expect(Procedure.last.draft_revision.ineligibilite_message).to eq('Votre demande est inéligible')
           expect(Procedure.last.experts_require_administrateur_invitation).to be_truthy
           expect(Procedure.last.experts).not_to be_blank
+          expect(Procedure.last.labels).not_to be_blank
+          expect(Procedure.last.labels.first.procedure_id).to eq(Procedure.last.id)
           expect(Procedure.last.libelle).to eq 'Démarche avec un nouveau nom'
         end
       end
 
       context 'when the admin unchecks all options' do
-        let(:params) { { procedure_id: procedure.id } }
         let(:params) do
           {
             procedure_id: procedure.id,
@@ -899,7 +899,8 @@ describe Administrateurs::ProceduresController, type: :controller do
                 sva_svr: '0',
                 mail_templates: '0',
                 ineligibilite: '0',
-                avis: '0'
+                avis: '0',
+                labels: '0'
               }
             }
           }
@@ -937,6 +938,7 @@ describe Administrateurs::ProceduresController, type: :controller do
           expect(Procedure.last.draft_revision.ineligibilite_message).to be_nil
           expect(Procedure.last.experts_require_administrateur_invitation).to be_falsey
           expect(Procedure.last.experts).to be_blank
+          expect(Procedure.last.labels).to be_blank
         end
       end
     end
@@ -952,7 +954,6 @@ describe Administrateurs::ProceduresController, type: :controller do
 
       it 'creates a new procedure and redirect to it' do
         expect(response).to redirect_to admin_procedure_path(id: Procedure.last.id)
-        expect(Procedure.last.labels.present?).to be_truthy
         expect(flash[:notice]).to have_content 'Démarche clonée. Pensez à vérifier les paramètres avant publication.'
       end
     end

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -679,6 +679,15 @@ describe Administrateurs::ProceduresController, type: :controller do
     end
   end
 
+  describe 'GET #clone_settings' do
+    let(:procedure) { create(:procedure, administrateur: admin) }
+    let(:params) { { procedure_id: procedure.id } }
+
+    subject { get :clone_settings, params: params }
+
+    it { is_expected.to have_http_status(:success) }
+  end
+
   describe 'PUT #clone' do
     let(:procedure) { create(:procedure, :with_notice, :with_deliberation, :with_labels, administrateur: admin) }
     let(:params) { { procedure_id: procedure.id } }

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -717,7 +717,7 @@ describe Administrateurs::ProceduresController, type: :controller do
     end
   end
 
-  describe 'PUT #clone' do
+  describe 'POST #clone' do
     let(:procedure) do
       create(
         :procedure,
@@ -776,7 +776,7 @@ describe Administrateurs::ProceduresController, type: :controller do
         }
       }
     end
-    subject { put :clone, params: params }
+    subject { post :clone, params: params }
 
     before do
       procedure.groupe_instructeurs.each { |gi| gi.update!(contact_information: create(:contact_information)) }

--- a/spec/factories/mail_templates.rb
+++ b/spec/factories/mail_templates.rb
@@ -10,6 +10,8 @@ FactoryBot.define do
 
     factory :refused_mail, class: Mails::RefusedMail
 
+    factory :re_instructed_mail, class: Mails::ReInstructedMail
+
     factory :without_continuation_mail, class: Mails::WithoutContinuationMail
 
     factory :initiated_mail, class: Mails::InitiatedMail do

--- a/spec/graphql/demarche_spec.rb
+++ b/spec/graphql/demarche_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Types::DemarcheType, type: :graphql do
 
   describe 'demarche with clone' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :yes_no }], administrateurs: [admin]) }
-    let(:procedure_clone) { procedure.clone(admin, false) }
+    let(:procedure_clone) { procedure.clone(admin:) }
     let(:query) { DEMARCHE_WITH_CHAMP_DESCRIPTORS_QUERY }
     let(:variables) { { number: procedure_clone.id } }
     let(:champ_descriptor_id) { procedure.draft_revision.types_de_champ_public.first.to_typed_id }

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -724,9 +724,20 @@ describe Procedure do
     let(:instructeur_2) { create(:instructeur) }
     let!(:assign_to_1) { create(:assign_to, procedure: procedure, groupe_instructeur: groupe_instructeur_1, instructeur: instructeur_1) }
     let!(:assign_to_2) { create(:assign_to, procedure: procedure, groupe_instructeur: groupe_instructeur_1, instructeur: instructeur_2) }
+    let(:options) do
+      {
+        clone_attestation_template: true,
+        cloned_from_library: from_library,
+        clone_presentation: true,
+        clone_instructeurs: true,
+        clone_mail_templates: true,
+        clone_champs: true,
+        clone_annotations: true
+      }
+    end
 
     subject do
-      @procedure = procedure.clone(administrateur, from_library)
+      @procedure = procedure.clone(options:, admin: administrateur)
       @procedure.save
       @procedure
     end
@@ -914,7 +925,7 @@ describe Procedure do
       it 'should have a default groupe instructeur' do
         expect(subject.groupe_instructeurs.size).to eq(1)
         expect(subject.groupe_instructeurs.first.label).to eq(GroupeInstructeur::DEFAUT_LABEL)
-        expect(subject.groupe_instructeurs.first.instructeurs.size).to eq(0)
+        expect(subject.groupe_instructeurs.first.instructeurs.size).to eq(1)
       end
     end
 

--- a/spec/system/administrateurs/procedure_cloning_spec.rb
+++ b/spec/system/administrateurs/procedure_cloning_spec.rb
@@ -38,6 +38,8 @@ describe 'As an administrateur I wanna clone a procedure', js: true do
       expect(page.find_by_id('procedures')['data-item-count']).to eq('1')
       page.all('.card .dropdown .fr-btn').first.click
       page.all('.clone-btn').first.click
+      check 'Instructeurs', allow_label_click: true
+      click_on 'Cloner la démarche'
       visit admin_procedures_path(statut: "brouillons")
       expect(page.find_by_id('procedures')['data-item-count']).to eq('1')
       click_on Procedure.last.libelle
@@ -76,6 +78,8 @@ describe 'As an administrateur I wanna clone a procedure', js: true do
       expect(page).to have_content(Procedure.last.libelle)
       find('.button_to>button').click
       click_on 'Cloner'
+      check 'Instructeurs', allow_label_click: true
+      click_on 'Cloner la démarche'
       visit admin_procedures_path(statut: "brouillons")
       expect(page.find_by_id('procedures')['data-item-count']).to eq('1')
       click_on Procedure.last.libelle


### PR DESCRIPTION
cf #10912 

On ajoute une page de configuration du clonage.
On peut changer le titre de la démarche et choisir de garder ou pas les différents paramètres.
L'essentiel des changements est dans le commit `feat(procedure cloning): add configuration` (qui est un peu chargé).
Pour avoir une idée un peu plus claire des changements juste pour un paramètre à configurer, je vous conseille de regarder d'abord ce commit sur les labels : `feat(procedure cloning): add labels to cloning configuration page`  

Et sinon, deux autres petits changements : 
- ajout d'un bouton cloner dans le show de la démarche (une partie de #11481)
- ajout d'un warning dans la tuile "groupe instructeurs" si le routage n'est pas correctement configuré (utile notamment si on vient de cloner une démarche)

<img width="1710" alt="Capture d’écran 2025-05-16 à 15 55 39" src="https://github.com/user-attachments/assets/4549af58-7ee8-4415-80b7-98d13c2e7c0a" />

<img width="1710" alt="Capture d’écran 2025-05-16 à 15 55 49" src="https://github.com/user-attachments/assets/4451034b-e896-40fa-a128-b9ba3a8ae258" />

