### PR TITLE
ETQ Admin je dispose d'une balise pour renseigner le nom du service des informations de contact

### DIFF
--- a/app/models/concerns/tags_substitution_concern.rb
+++ b/app/models/concerns/tags_substitution_concern.rb
@@ -119,7 +119,7 @@ module TagsSubstitutionConcern
     {
       id: 'dossier_service_name',
       libelle: 'nom du service',
-      description: 'Le nom du service instructeur qui traite le dossier',
+      description: 'Le nom du service de la démarche',
       lambda: -> (d) { d.procedure.organisation_name || '' },
       available_for_states: Dossier::SOUMIS
     }
@@ -238,6 +238,14 @@ module TagsSubstitutionConcern
     }
   ]
 
+  CONTACT_INFORMATION_NAME_TAG = {
+    id: 'dossier_contact_information_name',
+    libelle: 'nom du service instructeur',
+    description: 'Le nom du service qui traite le dossier (celui des informations de contact du groupe instructeur s’il existe, sinon celui de la démarche)',
+    lambda: -> (d) { d.service&.nom || '' },
+    available_for_states: Dossier::SOUMIS
+  }
+
   SHARED_TAG_IDS = (DOSSIER_TAGS + DOSSIER_TAGS_FOR_MAIL + INDIVIDUAL_TAGS + ENTREPRISE_TAGS + ROUTAGE_TAGS).map { _1[:id] }
 
   def identity_tags
@@ -349,6 +357,7 @@ module TagsSubstitutionConcern
   def contextual_dossier_tags
     tags = []
     tags << DOSSIER_SVA_SVR_DECISION_DATE_TAG if respond_to?(:procedure) && procedure.sva_svr_enabled?
+    tags << CONTACT_INFORMATION_NAME_TAG if respond_to?(:procedure) && procedure.routing_enabled? && procedure.groupe_instructeurs.any? { _1.contact_information.present? }
     tags
   end
 

--- a/spec/models/concerns/tags_substitution_concern_spec.rb
+++ b/spec/models/concerns/tags_substitution_concern_spec.rb
@@ -440,6 +440,17 @@ describe TagsSubstitutionConcern, type: :model do
       it { is_expected.to eq('20/09/2024') }
     end
 
+    context "with a contact information name tag" do
+      let(:template) { '--nom du service instructeur--' }
+      let(:procedure) { create(:procedure, :routee) }
+      let(:groupe_instructeur) { procedure.defaut_groupe_instructeur }
+      let!(:contact_information) { create(:contact_information, groupe_instructeur:, nom: 'Service local') }
+
+      before { dossier.passer_en_construction! }
+
+      it { is_expected.to eq('Service local') }
+    end
+
     context "when the template has a libellé démarche tag" do
       let(:template) { 'body --libellé démarche--' }
 


### PR DESCRIPTION
On avait les balises pour le nom du service de la démarche, pour le nom du groupe instructeur, mais pas pour le nom du service des informations de contact du groupe instructeur.
On l'ajoute suite à un retour au support : https://secure.helpscout.net/conversation/2931381306/2182383?viewId=1653799

<img width="990" alt="Capture d’écran 2025-05-14 à 11 29 32" src="https://github.com/user-attachments/assets/8b3efdaa-e6ef-4eb6-9ff6-b6c8952c40f7" />
