### PR TITLE
Tech: corrige la maintenance de task de migration flipper

### DIFF
--- a/app/tasks/maintenance/t20250512prepare_unify_flipper_values_task.rb
+++ b/app/tasks/maintenance/t20250512prepare_unify_flipper_values_task.rb
@@ -23,6 +23,8 @@ module Maintenance
         flipper_gate_dup = flipper_gate.dup
         flipper_gate_dup.update(value: flipper_gate.value.sub(':', ';'))
       end
+    rescue ActiveRecord::RecordNotUnique
+      # NOOP
     end
   end
 end


### PR DESCRIPTION
suite de https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/9897

des gates peuvent déjà exister au bon format quand on l'update, ce qui lève une exception d'unicité