### PR TITLE
Corrige l'affichage des images dans les annonces de la page "Nouveautés"

### DIFF
--- a/app/helpers/release_notes_helper.rb
+++ b/app/helpers/release_notes_helper.rb
@@ -48,7 +48,7 @@ module ReleaseNotesHelper
 
   # Note: this affects all ActionText content rendering
   def sanitizer_allowed_tags
-    super + %w[a]
+    super + %w[a img] # re-add tag which removed from global config
   end
 
   def sanitizer_allowed_attributes

--- a/spec/helpers/release_notes_helper_spec.rb
+++ b/spec/helpers/release_notes_helper_spec.rb
@@ -17,5 +17,15 @@ RSpec.describe ReleaseNotesHelper, type: :helper do
 
       expect(processed_content.body.to_s).to include("No links here")
     end
+
+    context "image" do
+      let(:release_note) { build(:release_note, body: '<img src="http://example.com/image.png">') }
+
+      it "renders img tag" do
+        processed_content = helper.render_release_note_content(release_note.body)
+
+        expect(processed_content.body.to_s).to include('<img src="http://example.com/image.png">')
+      end
+    end
   end
 end


### PR DESCRIPTION
On a une directive globale qui bloque les img (et les liens) pour du contenu qu'on maitrise pas, mais pour les annonces on les veut et depuis rails 7.1 c'était cassé