### PR TITLE
ETQ Instructeur - précise le type de notification pouvant être personnalisées

### DIFF
--- a/config/locales/views/instructeurs/header/fr.yml
+++ b/config/locales/views/instructeurs/header/fr.yml
@@ -11,7 +11,7 @@ fr:
             en_construction: Ce dossier est en attente de prise en charge. Vous pouvez toutefois étendre cette durée d’un mois en cliquant sur le bouton suivant.
             termine: Le traitement de ce dossier est terminé, mais il va bientôt être supprimé. Si vous souhaitez en conserver une trace, vous pouvez le télécharger au format PDF.
           button_delay_expiration: "Conserver un mois de plus"
-          notification_management: Gestion des notifications
+          notification_management: Gestion des notifications par email
           follow_up: Suivi des dossiers
           procedure_management: Gestion de la démarche
           administrators_list: Administrateurs de la démarche

--- a/config/locales/views/instructeurs/procedures/email_notifications/fr.yml
+++ b/config/locales/views/instructeurs/procedures/email_notifications/fr.yml
@@ -5,7 +5,7 @@ fr:
         utils:
           positive: Oui
           negative: Non
-        title: Gestion des notifications
+        title: Gestion des notifications par email
         subtitle: Configurez sur cette page les notifications que vous souhaitez recevoir par email pour cette démarche.
         for_each_file_submitted:
           title: Recevoir une notification à chaque dossier déposé


### PR DESCRIPTION
en prévision de la sortie du nouveau dispositif de badge de notification sur les dossiers, on vient clarifier dans l'onglet actuel de quelle type de notification l'instructeur peut personnaliser l'envoi.

ping @marleneklok 

![Capture d’écran 2025-05-15 à 14 15 15](https://github.com/user-attachments/assets/8ccfa305-c45e-474f-b494-0b88e4f322c8)
![Capture d’écran 2025-05-15 à 14 15 23](https://github.com/user-attachments/assets/1add6ca5-f8d4-4ac4-a426-60cbb86a72ea)
