### PR TITLE
ETQ instructeur, lorsque le dossier change de statut, je veux pouvoir passer au dossier suivant (ou précédent)

### DIFF
--- a/app/models/cache/procedure_dossier_pagination.rb
+++ b/app/models/cache/procedure_dossier_pagination.rb
@@ -77,7 +77,13 @@ class Cache::ProcedureDossierPagination
 
   def renew_ids(from_id:)
     value = read_cache
-    value[:ids] = fetch_ids_around(from_id:)
+    ids_around = fetch_ids_around(from_id:)
+
+    # if ids_around is empty, it means that the current dossier was not found in all fetch ids (it can have changed status)
+    # we do not want to refresh the cache in this case, it would break navigation
+    return if ids_around.empty?
+
+    value[:ids] = ids_around
 
     write_cache(value)
   end

--- a/spec/models/cache/procedure_dossier_pagination_spec.rb
+++ b/spec/models/cache/procedure_dossier_pagination_spec.rb
@@ -28,6 +28,7 @@ describe Cache::ProcedureDossierPagination do
       let(:next_page_ids) { (0..10).to_a }
 
       subject { instance.next_dossier_id(from_id: cached_ids.last) }
+
       before do
         allow(instance).to receive(:fetch_all_ids).and_return(next_page_ids)
       end
@@ -40,10 +41,26 @@ describe Cache::ProcedureDossierPagination do
     context 'when procedure.dossiers.by_statut does not include searched dossiers anymore' do
       let(:cached_ids) { [] }
       let(:next_page_ids) { [] }
+
       before { allow(instance).to receive(:fetch_all_ids).and_return(next_page_ids) }
 
       it 'works' do
         expect(instance.next_dossier_id(from_id: 50)).to eq(nil)
+      end
+    end
+
+    context "when dossier 4 change status" do
+      let(:cached_ids) { [1, 2, 3, 4] }
+      let(:all_ids_after_change) { [1, 2, 3] }
+
+      subject { instance.next_dossier_id(from_id: cached_ids.last) }
+
+      before do
+        allow(instance).to receive(:fetch_all_ids).and_return(all_ids_after_change)
+      end
+
+      it "should not refresh paginated_ids" do
+        expect { subject }.not_to change { instance.send(:ids) }.from(cached_ids)
       end
     end
   end


### PR DESCRIPTION
fixes #11249

Correction d'un cas particulier :
Lorsque l'instructeur est sur le dernier ou le premier dossier de la liste et qu'il le change de statut, la navigation Dossier Suivant ou Précédent, est cassée.

