### PR TITLE
[Fix UI] Meilleure intégration du design de la liste des démarches

### DIFF
--- a/app/assets/stylesheets/02_utils.scss
+++ b/app/assets/stylesheets/02_utils.scss
@@ -172,6 +172,10 @@
   vertical-align: super;
 }
 
+.align-middle {
+  vertical-align: middle;
+}
+
 .border-left {
   border-left: 4px solid var(--background-contrast-grey);
   padding-left: $default-padding;

--- a/app/components/dsfr/copy_button_component/copy_button_component.html.haml
+++ b/app/components/dsfr/copy_button_component/copy_button_component.html.haml
@@ -1,5 +1,5 @@
 %span{ data: { controller: 'clipboard', clipboard_text_value: @text } }
-  %button.fr-btn.fr-icon-clipboard-line.fr-btn--sm.fr-btn--tertiary-no-outline{ data: { action: 'clipboard#copy' }, title: @title }
+  %button.fr-btn.fr-icon-clipboard-line.fr-btn--sm.fr-btn--tertiary-no-outline.align-middle{ data: { action: 'clipboard#copy' }, title: @title }
     = @title
   %span.fr-text--sm.hidden{ data: { clipboard_target: 'success' } }
     = @success || t('.copy_confirmation')

--- a/app/views/instructeurs/procedures/_list.html.haml
+++ b/app/views/instructeurs/procedures/_list.html.haml
@@ -80,17 +80,17 @@
                               = link_to t('instructeurs.dossiers.header.banner.export_templates'), export_templates_instructeur_procedure_path(p), class: 'fr-nav__link'
 
       .fr-hidden.fr-unhidden-lg
-        .flex.align-center
-          %h3.card-title.fr-mb-0.fr-ml-1w
-            = link_to procedure_libelle_with_number(p), instructeur_procedure_path(p)
-            = render Dsfr::CopyButtonComponent.new(text: commencer_url(p.path), title: t('instructeurs.dossiers.header.banner.copy_link_button'))
+        %h3.card-title.fr-mb-0.fr-ml-1w
+          = link_to procedure_libelle_with_number(p), instructeur_procedure_path(p)
 
-          = procedure_badge(p)
+          = render Dsfr::CopyButtonComponent.new(text: commencer_url(p.path), title: t('instructeurs.dossiers.header.banner.copy_link_button'))
+          = procedure_badge(p, 'align-middle')
 
-    .flex.align-center.fr-hidden-lg.fr-mb-2w
+    .fr-hidden-lg.fr-mb-2w
       %h3.card-title.fr-mb-0.fr-ml-1w
         = link_to procedure_libelle_with_number(p), instructeur_procedure_path(p)
-      = procedure_badge(p, 'fr-ml-2w')
+        = render Dsfr::CopyButtonComponent.new(text: commencer_url(p.path), title: t('instructeurs.dossiers.header.banner.copy_link_button'))
+        = procedure_badge(p, 'align-middle')
 
     %ul.procedure-stats.flex.fr-background-alt--grey.fr-p-1w.justify-around.wrap
       %li.fr-btn.fr-btn--tertiary-no-outline.flex.justify-center.fr-enlarge-link.fr-my-1w


### PR DESCRIPTION
Il y avait un souci de design avec les badges lorsque le texte passait sur pls lignes.
Et en version petit ecran, il n'y avait plus le bouton pour copier/coller le lien

**AVANT**
<img width="976" alt="Capture d’écran 2025-05-15 à 15 41 44" src="https://github.com/user-attachments/assets/52f94967-9228-4c6f-a9d9-d7b2176d3854" />

**APRES**
<img width="982" alt="Capture d’écran 2025-05-15 à 15 40 46" src="https://github.com/user-attachments/assets/20f5e411-8759-4393-9a84-ff2c9f2a2de0" />
