### PR TITLE
ETQ Superadmin, sur le Backoffice Manager, je veux accéder directement au numéro et à la procédure concernée par un dossier totalement supprimé

### DIFF
--- a/app/views/manager/dossiers/index.html.erb
+++ b/app/views/manager/dossiers/index.html.erb
@@ -36,7 +36,7 @@ It renders the `_table` partial to display details about the resources.
   <section class='main-content__body'>
     <p>
     ⚠️⚠️ Le dossier n° <%= @deleted_dossier.dossier_id %> a été <b>supprimé le <%= l(@deleted_dossier.deleted_at) %></b> pour la raison : <b><%= t("activerecord.attributes.deleted_dossier.reason.#{@deleted_dossier.reason}") %></b>. ⚠️⚠️<br>
-    il appartenait à la procédure « <%= @deleted_dossier.procedure.libelle %> ».
+    il appartenait à la procédure <%= link_to "n° #{@deleted_dossier.procedure.id} « #{@deleted_dossier.procedure.libelle} »", manager_procedure_path(@deleted_dossier.procedure) %>
     </p>
   </section>
 <%- end -%>


### PR DESCRIPTION
Actuellement : 

![Image](https://github.com/user-attachments/assets/4435dacd-3d13-4710-890a-50712e6ae1bd)

Proposition avec un numéro (pour éviter la confusion de doublons) et un lien direct vers l'écran manager de la procédure.
Exemple : 

![Image](https://github.com/user-attachments/assets/2276a1f1-99a1-41c0-b27e-7da1c74c5f34)