### PR TITLE
ETQ instructeur, corrige la page "personnes impliquées" lorsqu'un dossier a été automatiquement passé en instruction plusieurs fois

### DIFF
--- a/app/models/traitement.rb
+++ b/app/models/traitement.rb
@@ -59,7 +59,7 @@ class Traitement < ApplicationRecord
         end
       end
     elsif state == Dossier.states.fetch(:en_instruction)
-      if previous_state != Dossier.states.fetch(:en_construction)
+      if previous_state != Dossier.states.fetch(:en_construction) && instructeur?
         :repasse_en_instruction
       elsif instructeur?
         :passe_en_instruction

--- a/spec/models/traitement.rb
+++ b/spec/models/traitement.rb
@@ -62,6 +62,10 @@ describe Traitement, type: :model do
 
       dossier.traitements.passer_en_instruction
       expect(dossier.traitements.last.event).to eq(:passe_en_instruction_automatiquement)
+
+      # again passer_en_instruction: simulate a bug for some dossiers having multiple consecutive "en instruction" automatic traitements
+      dossier.traitements.passer_en_instruction
+      expect(dossier.traitements.last.event).to eq(:passe_en_instruction_automatiquement)
     end
   end
 end


### PR DESCRIPTION
Des dossiers ont plusieurs traitements consécutifs automatiques "en instruction". Cette PR corrige le nom de l'événement qu'on en déduit car il ne s'agit pas d'un repassage en instruction.

https://demarches-simplifiees.sentry.io/issues/6614751244
https://secure.helpscout.net/conversation/2944163075/2191337?folderId=1653799

L'origine du pb vient peut-être de la tache de fermeture de démarche qui jouerait les transitions plusieurs fois ? A suivre dans une autre PR