### PR TITLE
amélioration : ETQ administrateur j'ai une meilleure visibilité sur les changements d'un champs de type référentiel avancée

### DIFF
--- a/app/components/procedure/revision_changes_component.rb
+++ b/app/components/procedure/revision_changes_component.rb
@@ -8,7 +8,6 @@ class Procedure::RevisionChangesComponent < ApplicationComponent
 
     @tdc_changes = previous_revision.compare_types_de_champ(new_revision)
     @public_move_changes, @private_move_changes = @tdc_changes.filter { _1.op == :move }.partition { !_1.private? }
-
     @ineligibilite_rules_changes = previous_revision.compare_ineligibilite_rules(new_revision)
   end
 

--- a/app/components/procedure/revision_changes_component/revision_changes_component.fr.yml
+++ b/app/components/procedure/revision_changes_component/revision_changes_component.fr.yml
@@ -10,6 +10,14 @@ fr:
   add_option: "ajoutés : %{items}"
   remove_option: "supprimés : %{items}"
   invalid_routing_rules_alert: "Certains groupes d'instructeurs ont une règle de routage invalide. Veuillez mettre à jour la configuration des groupes d'instructeurs après avoir publié les modifications."
+
+  update_referentiel: &update_referentiel
+    referentiel_url: "L'URL de l'API du champ « %{label} » a été modifiée. La nouvelle URL est « %{to} »."
+    referentiel_mode: "Le mode d'intérogation du référentiel du champ « %{label} » a été modifié. Le nouveau mode est « %{to} »."
+    referentiel_hint: "L'indication à fournir à l'usager concernant le format de saisie attendu du champ « %{label} » a été modifiée. La nouvelle indication est « %{to} »."
+    referentiel_test_data: "L'exemple de saisie valide du champ « %{label} » a été modifié. Le nouvel exemple est « %{to} »."
+    referentiel_mapping: "Le mapping des données entre le champ et l'API du champ « %{label} » a été modifié."
+
   public:
     add: Le champ « %{label} » a été ajouté.
     add_mandatory: Le champ obligatoire « %{label} » a été ajouté.
@@ -77,6 +85,8 @@ fr:
     update_start_date: La date de début pour le champ « %{label} » a été modifiée. Le date est désormais %{to}.
     remove_end_date: La date de fin pour le champ « %{label} » a été supprimée.
     update_end_date: La date de fin pour le champ « %{label} » a été modifiée. La date est désormais %{to}.
+    <<: *update_referentiel
+
   private:
     add: L’annotation privée « %{label} » a été ajoutée.
     remove: L’annotation privée « %{label} » a été supprimée.
@@ -110,6 +120,8 @@ fr:
     update_expression_reguliere_exemple_text: L’exemple d’expression régulière de l’annotation privée « %{label} » a été modifiée. Le nouvel exemple est « %{to} ».
     remove_expression_reguliere_error_message: Le message d’erreur de l’expression régulière de l’annotation privée « %{label} » a été supprimé.
     update_expression_reguliere_error_message: Le message d’erreur de l’expression régulière de l’annotation privée « %{label} » a été modifiée. Le nouveau message est « %{to} ».
+    <<: *update_referentiel
+
   ineligibilite_rules:
     add: La condition d’inéligibilité « %{new_condition} » a été ajoutée.
     remove: La condition d’inéligibilité « %{previous_condition} » a été supprimée

--- a/app/components/procedure/revision_changes_component/revision_changes_component.html.haml
+++ b/app/components/procedure/revision_changes_component/revision_changes_component.html.haml
@@ -211,7 +211,9 @@
         - else
           - list.with_item do
             = t(".#{prefix}.update_max_character_length", label: change.label, to: change.to)
-
+      - when :referentiel_url, :referentiel_mode, :referentiel_hint, :referentiel_test_data, :referentiel_mapping
+        - list.with_item do
+          = t(".update_referentiel.#{change.attribute}", label: change.label, to: change.to)
   - if @public_move_changes.present?
     - list.with_item do
       = t(".public.move", count: @public_move_changes.size)

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -231,6 +231,7 @@ class Procedure < ApplicationRecord
     'types_de_champ/no_empty_block': true,
     'types_de_champ/no_empty_drop_down': true,
     'types_de_champ/formatted': true,
+    'types_de_champ/referentiel_ready': true,
     on: [:types_de_champ_public_editor, :publication]
 
   validates :draft_types_de_champ_private,
@@ -239,6 +240,7 @@ class Procedure < ApplicationRecord
     'types_de_champ/no_empty_block': true,
     'types_de_champ/no_empty_drop_down': true,
     'types_de_champ/formatted': true,
+    'types_de_champ/referentiel_ready': true,
     on: [:types_de_champ_private_editor, :publication]
 
   validate :check_juridique, on: [:create, :publication]

--- a/app/validators/types_de_champ/referentiel_ready_validator.rb
+++ b/app/validators/types_de_champ/referentiel_ready_validator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class TypesDeChamp::ReferentielReadyValidator < ActiveModel::EachValidator
+  def validate_each(procedure, attribute, types_de_champ)
+    types_de_champ.filter(&:referentiel?).each do |referentiel_champ|
+      unless referentiel_champ.referentiel&.ready?
+        procedure.errors.add(
+          attribute,
+          procedure.errors.generate_message(attribute, :referentiel_not_ready, { value: referentiel_champ.libelle }),
+          type_de_champ: referentiel_champ
+        )
+      end
+    end
+  end
+end

--- a/config/locales/models/procedure/en.yml
+++ b/config/locales/models/procedure/en.yml
@@ -89,6 +89,7 @@ en:
               empty_csv: 'requires at least one csv file'
               inconsistent_header_section: "%{custom_message}"
               expression_reguliere_invalid: "is invalid"
+              referentiel_not_ready: "is not configured"
             draft_types_de_champ_private:
               format: 'Private field %{message}'
               invalid_condition: "have an invalid logic"

--- a/config/locales/models/procedure/fr.yml
+++ b/config/locales/models/procedure/fr.yml
@@ -94,6 +94,7 @@ fr:
               empty_csv: 'doit comporter au moins un fichier csv'
               inconsistent_header_section: "%{custom_message}"
               expression_reguliere_invalid: "est invalide, veuillez la corriger"
+              referentiel_not_ready: "n'est pas configuré"
             draft_types_de_champ_private:
               format: 'L’annotation privée %{message}'
               invalid_condition: "a une logique conditionnelle invalide"

--- a/spec/validators/types_de_champ/referentiel_ready_validator_spec.rb
+++ b/spec/validators/types_de_champ/referentiel_ready_validator_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TypesDeChamp::ReferentielReadyValidator do
+  let(:procedure) { create(:procedure, types_de_champ_public:) }
+  let(:referentiel) { create(:api_referentiel, :configured) }
+  let(:types_de_champ_public) { [{ type: :referentiel, referentiel: }] }
+
+  subject { procedure.validate(:types_de_champ_public_editor) }
+
+  context 'when all referentiel is ready' do
+    before { expect_any_instance_of(Referentiels::APIReferentiel).to receive(:ready?).and_return(true) }
+
+    it 'does not add errors to the procedure' do
+      expect { subject }.not_to change { procedure.errors.count }
+    end
+  end
+
+  context 'when all referentiel is not ready' do
+    before { expect_any_instance_of(Referentiels::APIReferentiel).to receive(:ready?).and_return(false) }
+
+    it 'does not add errors to the procedure' do
+      expect { subject }.to change { procedure.errors.count }
+    end
+  end
+end


### PR DESCRIPTION
progress: https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/11161 : follows up https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11522, https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11577 & https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11577

ETQ administateur, je suis bloqué si la configuration de mon référentiel n'est pas valide : 
<img width="1222" alt="Capture d’écran 2025-05-20 à 3 09 53 PM" src="https://github.com/user-attachments/assets/5b3084fc-219a-4ef0-92cb-77a66e0ab46a" />

ETQ administrateur, je peux visualiser les changements liés aux modification d'un référentiel :
<img width="1231" alt="Capture d’écran 2025-05-20 à 2 42 53 PM" src="https://github.com/user-attachments/assets/75670577-fa11-4f06-9b6b-114585854ed5" />

La suite :
* feedback du sim sur https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11522
* gerer le mapping, cf: etape 3/3 de la conf admin (donc remonter plus d'info de l'API a l'usager, a l'instructeur, voir le prefill d'autres champs).
* gerer le filtre/affichage ETQ instructeur des champs selectionnés visible pour lui
* continuer a propager [https://github.com/https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11028](la nouvelle logique] de retour d'API a d'autres champs : en plus du RNA/champ api, on devrait pouvoir le faire pour le RNFF