### PR TITLE
ETQ administrateur, sur l’écran de gestion d’une démarche, je retrouve les actions proposées en page Liste

### DIFF
--- a/app/views/administrateurs/procedures/show.html.haml
+++ b/app/views/administrateurs/procedures/show.html.haml
@@ -6,6 +6,8 @@
 .fr-container.procedure-admin-container
   %ul.fr-btns-group.fr-btns-group--inline-sm.fr-btns-group--icon-left
     - if @procedure.validate(:publication)
+      - if @procedure.draft_revision.revision_types_de_champ_public.count > 0
+        = link_to t('preview', scope: [:layouts, :breadcrumb]), apercu_admin_procedure_path(@procedure), target: "_blank", class: 'fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-eye-line', id: "preview-procedure"
       - if !@procedure.brouillon?
         = link_to 'Cloner', admin_procedure_clone_settings_path(@procedure), class: 'fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-file-copy-line', id: "clone-procedure"
 

--- a/app/views/administrateurs/procedures/show.html.haml
+++ b/app/views/administrateurs/procedures/show.html.haml
@@ -8,6 +8,11 @@
     - if @procedure.validate(:publication)
       - if !@procedure.brouillon?
         = link_to 'Cloner', admin_procedure_clone_settings_path(@procedure), class: 'fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-file-copy-line', id: "clone-procedure"
+
+      - if @procedure.close? && @procedure.can_be_deleted_by_administrateur?
+        = link_to 'Supprimer', admin_procedure_path(@procedure), method: :delete, data: { confirm: 'Êtes-vous sûr de vouloir supprimer cette démarche ?' }, class: 'fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-delete-bin-line', id: 'delete-procedure'
+
+      - if !@procedure.brouillon?
         = link_to 'Télécharger', admin_procedure_archives_path(@procedure), class: 'fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-download-line', id: "archive-procedure"
 
         = link_to 'PDF', commencer_dossier_vide_for_revision_path(@procedure.active_revision), target: "_blank", rel: "noopener", class: 'fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-printer-line', id: "pdf-procedure"
@@ -17,6 +22,9 @@
 
       - if @procedure.brouillon?
         = link_to 'Cloner', admin_procedure_clone_settings_path(@procedure), class: 'fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-file-copy-line', id: "clone-procedure"
+
+      - if @procedure.brouillon? && @procedure.can_be_deleted_by_administrateur?
+        = link_to 'Supprimer', admin_procedure_path(@procedure), method: :delete, data: { confirm: 'Êtes-vous sûr de vouloir supprimer cette démarche ?' }, class: 'fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-delete-bin-line', id: 'delete-procedure'
 
       - if @procedure.publiee? || @procedure.brouillon?
         = link_to 'Envoyer une copie', admin_procedure_transfert_path(@procedure), class: 'fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-send-plane-line'

--- a/spec/views/administrateurs/procedures/show.html.haml_spec.rb
+++ b/spec/views/administrateurs/procedures/show.html.haml_spec.rb
@@ -2,7 +2,7 @@
 
 describe 'administrateurs/procedures/show', type: :view do
   let(:closed_at) { nil }
-  let(:procedure) { create(:procedure, :with_service, closed_at: closed_at) }
+  let(:procedure) { create(:procedure, :with_service, closed_at: closed_at, types_de_champ_public: [{ type: :yes_no }]) }
 
   before do
     assign(:procedure, procedure)
@@ -25,6 +25,7 @@ describe 'administrateurs/procedures/show', type: :view do
         expect(rendered).not_to have_css('#archive-procedure')
         expect(rendered).to have_css('#delete-procedure')
         expect(rendered).to have_css('#clone-procedure')
+        expect(rendered).to have_css('#preview-procedure')
       end
     end
   end
@@ -42,6 +43,7 @@ describe 'administrateurs/procedures/show', type: :view do
       expect(rendered).to have_css('#archive-procedure')
       expect(rendered).not_to have_css('#delete-procedure')
       expect(rendered).to have_css('#clone-procedure')
+      expect(rendered).to have_css('#preview-procedure')
     end
   end
 
@@ -59,6 +61,7 @@ describe 'administrateurs/procedures/show', type: :view do
       expect(rendered).to have_content('Réactiver')
       expect(rendered).to have_css('#delete-procedure')
       expect(rendered).to have_css('#clone-procedure')
+      expect(rendered).to have_css('#preview-procedure')
     end
   end
 

--- a/spec/views/administrateurs/procedures/show.html.haml_spec.rb
+++ b/spec/views/administrateurs/procedures/show.html.haml_spec.rb
@@ -18,11 +18,13 @@ describe 'administrateurs/procedures/show', type: :view do
         render
       end
 
-      it "render content" do
+      it "renders content" do
         expect(rendered).to have_css('#publish-procedure-link')
         expect(rendered).not_to have_css('#close-procedure-link')
         expect(rendered).to have_content('En test')
         expect(rendered).not_to have_css('#archive-procedure')
+        expect(rendered).to have_css('#delete-procedure')
+        expect(rendered).to have_css('#clone-procedure')
       end
     end
   end
@@ -34,12 +36,12 @@ describe 'administrateurs/procedures/show', type: :view do
       render
     end
 
-    describe 'archive button is visible' do
-      it { expect(rendered).not_to have_css('#publish-procedure-link') }
-      it { expect(rendered).to have_css('#close-procedure-link') }
-    end
-    describe 'archive button' do
-      it { expect(rendered).to have_css('#archive-procedure') }
+    it "renders content" do
+      expect(rendered).not_to have_css('#publish-procedure-link')
+      expect(rendered).to have_css('#close-procedure-link')
+      expect(rendered).to have_css('#archive-procedure')
+      expect(rendered).not_to have_css('#delete-procedure')
+      expect(rendered).to have_css('#clone-procedure')
     end
   end
 
@@ -48,16 +50,15 @@ describe 'administrateurs/procedures/show', type: :view do
       procedure.publish!
       procedure.close!
       procedure.reload
+      render
     end
 
-    describe 'Re-enable button is visible' do
-      before do
-        render
-      end
-
-      it { expect(rendered).not_to have_css('#close-procedure-link') }
-      it { expect(rendered).to have_css('#publish-procedure-link') }
-      it { expect(rendered).to have_content('Réactiver') }
+    it "renders content" do
+      expect(rendered).not_to have_css('#close-procedure-link')
+      expect(rendered).to have_css('#publish-procedure-link')
+      expect(rendered).to have_content('Réactiver')
+      expect(rendered).to have_css('#delete-procedure')
+      expect(rendered).to have_css('#clone-procedure')
     end
   end
 


### PR DESCRIPTION
closes #11481

- Le bouton "Cloner" a déjà été ajouté dans la PR https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11644
- Ici on ajoute les boutons "Supprimer" et "Prévisualiser le formulaire"
- Selon l'état de la démarche, les boutons sont placés à des endroits différents

**Pour une démarche en test :** 
<img width="1332" alt="Capture d’écran 2025-05-21 à 10 54 23" src="https://github.com/user-attachments/assets/8d79373d-2498-4a7f-b92b-d5d22bcb1ac0" />


**Pour une démarche close :**
<img width="1332" alt="Capture d’écran 2025-05-21 à 10 55 11" src="https://github.com/user-attachments/assets/5ffd73a2-7e5c-4fc6-8071-4fbfaace6efc" />


