### PR TITLE
Tech: corrige le backfill des notifications pour les cas où un dossier doit avoir la même notif pour plusieurs instructeurs

### DIFF
--- a/app/tasks/maintenance/t20250417backfill_dossier_notification_for_attente_correction_task.rb
+++ b/app/tasks/maintenance/t20250417backfill_dossier_notification_for_attente_correction_task.rb
@@ -16,11 +16,6 @@ module Maintenance
       Dossier
         .joins('INNER JOIN dossier_corrections ON dossier_corrections.dossier_id = dossiers.id')
         .merge(DossierCorrection.pending)
-        .where.not(
-          id: DossierNotification
-            .where(notification_type: :attente_correction)
-            .select(:dossier_id)
-        )
         .includes(:followers_instructeurs)
         .map do |dossier|
           [dossier.id, dossier.followers_instructeur_ids]

--- a/app/tasks/maintenance/t20250424backfill_dossier_notification_for_attente_avis_task.rb
+++ b/app/tasks/maintenance/t20250424backfill_dossier_notification_for_attente_avis_task.rb
@@ -16,11 +16,6 @@ module Maintenance
       Dossier
         .joins(:avis)
         .merge(Avis.without_answer)
-        .where.not(
-          id: DossierNotification
-            .where(notification_type: :attente_avis)
-            .select(:dossier_id)
-        )
         .includes(:followers_instructeurs)
     end
 

--- a/spec/tasks/maintenance/t20250417backfill_dossier_notification_for_attente_correction_task_spec.rb
+++ b/spec/tasks/maintenance/t20250417backfill_dossier_notification_for_attente_correction_task_spec.rb
@@ -35,15 +35,6 @@ module Maintenance
         end
       end
 
-      context 'when dossier has pending correction and attente_correction notification' do
-        let!(:dossier_correction) { create(:dossier_correction, dossier:) }
-        let!(:attente_correction_notification) { create(:dossier_notification, :for_instructeur, dossier:, instructeur: follow_instructeur, notification_type: :attente_correction) }
-
-        it do
-          expect(collection).to eq([])
-        end
-      end
-
       context 'when dossier has pending correction but not attente_correction notification' do
         let!(:dossier_correction) { create(:dossier_correction, dossier:) }
         let!(:notification) { create(:dossier_notification, :for_instructeur, dossier:, instructeur: follow_instructeur) }

--- a/spec/tasks/maintenance/t20250424backfill_dossier_notification_for_attente_avis_task_spec.rb
+++ b/spec/tasks/maintenance/t20250424backfill_dossier_notification_for_attente_avis_task_spec.rb
@@ -35,15 +35,6 @@ module Maintenance
         end
       end
 
-      context 'when dossier has avis without answer and attente_avis notification' do
-        let!(:avis) { create(:avis, dossier:) }
-        let!(:attente_avis_notification) { create(:dossier_notification, :for_instructeur, dossier:, instructeur: follow_instructeur, notification_type: :attente_avis) }
-
-        it do
-          expect(collection).to eq([])
-        end
-      end
-
       context 'when dossier has avis without answer but not attente_avis notification' do
         let!(:avis) { create(:avis, dossier:) }
         let!(:notification) { create(:dossier_notification, :for_instructeur, dossier:, instructeur: follow_instructeur) }


### PR DESCRIPTION
c'est le `.find_or_create_by` qui se charge dans le process de pas créer de doublon