### PR TITLE
ETQ Usager, je veux que la page récapitulative de la demande fasse état de l'historique

### DIFF
--- a/app/views/shared/dossiers/_demande.html.haml
+++ b/app/views/shared/dossiers/_demande.html.haml
@@ -14,7 +14,7 @@
           = t('views.shared.dossiers.demande.accuse_lecture_without_agreement')
 
   %h2.fr-h6.fr-background-alt--grey.fr-mb-0
-    .flex-grow.fr-py-3v.fr-px-2w= t('views.shared.dossiers.demande.en_construction')
+    .flex-grow.fr-py-3v.fr-px-2w= t('views.shared.dossiers.demande.history')
 
   - if dossier.depose_at.present?
     = render partial: "shared/dossiers/infos_generales", locals: { dossier: dossier, profile: profile }

--- a/app/views/shared/dossiers/_infos_generales.html.haml
+++ b/app/views/shared/dossiers/_infos_generales.html.haml
@@ -24,10 +24,9 @@
 
   - else
     - if dossier.justificatif_motivation.attached?
-      = render Dossiers::RowShowComponent.new(label: t('views.users.dossiers.show.status_overview.justificatif')) do |c|
-        - c.with_value do
-          .action
-            = render Attachment::ShowComponent.new(attachment: dossier.justificatif_motivation.attachment)
+      .fr-mb-2w
+        %span.champ-label= t('views.users.dossiers.show.status_overview.justificatif')
+        = render Attachment::ShowComponent.new(attachment: dossier.justificatif_motivation.attachment)
 
     - if dossier.motivation.present?
       %span.champ-label= t('views.users.dossiers.show.status_overview.motivation')

--- a/app/views/shared/dossiers/_infos_generales.html.haml
+++ b/app/views/shared/dossiers/_infos_generales.html.haml
@@ -1,10 +1,20 @@
 .fr-px-2w.fr-mb-4w
   .fr-my-2w
-    %p
-      = t(:submitted_at, scope: [:views, :shared, :dossiers, :form], datetime: l(dossier.depose_at))
-      %br
+    %ul
+      %li= t(:submitted_at, scope: [:views, :shared, :dossiers, :form], datetime: l(dossier.depose_at))
       - if dossier.last_champ_updated_at.present? && dossier.last_champ_updated_at > dossier.depose_at
-        = t(:updated_at, scope: [:views, :shared, :dossiers, :form], datetime: l(dossier.last_champ_updated_at))
+        %li= t(:updated_at, scope: [:views, :shared, :dossiers, :form], datetime: l(dossier.last_champ_updated_at))
+      - if dossier.en_instruction? || dossier.termine?
+        %li= t(:switched_to_instruction_at, scope: [:views, :shared, :dossiers, :form], datetime: l(dossier.en_instruction_at))
+      - if dossier.en_construction?
+        %li= t(:revert_to_submitted_at, scope: [:views, :shared, :dossiers, :form], datetime: l(dossier.en_construction_at))
+      - if dossier.termine?
+        - if dossier.accepte?
+          %li= t(:acceptee_at, scope: [:views, :shared, :dossiers, :form], datetime: l(dossier.processed_at))
+        - if dossier.refuse?
+          %li= t(:refuse_at, scope: [:views, :shared, :dossiers, :form], datetime: l(dossier.processed_at))
+        - if dossier.sans_suite?
+          %li= t(:closed_at, scope: [:views, :shared, :dossiers, :form], datetime: l(dossier.processed_at))
 
     .fr-highlight
       %p.fr-text--sm.fr-text-mention--grey= t('views.shared.dossiers.demande.en_construction_notice')

--- a/app/views/shared/dossiers/_infos_generales.html.haml
+++ b/app/views/shared/dossiers/_infos_generales.html.haml
@@ -7,7 +7,7 @@
         = t(:updated_at, scope: [:views, :shared, :dossiers, :form], datetime: l(dossier.last_champ_updated_at))
 
     .fr-highlight
-      %p.fr-text--sm.fr-text-mention--grey Sauf mention contraire, les champs ont été saisis à la date du dépôt du dossier.
+      %p.fr-text--sm.fr-text-mention--grey= t('views.shared.dossiers.demande.en_construction_notice')
 
   - if profile == 'usager' && dossier.hide_info_with_accuse_lecture?
     = render Dossiers::AccuseLectureComponent.new(dossier: dossier)

--- a/app/views/shared/dossiers/_infos_generales.html.haml
+++ b/app/views/shared/dossiers/_infos_generales.html.haml
@@ -24,7 +24,7 @@
 
   - else
     - if dossier.justificatif_motivation.attached?
-      = render Dossiers::RowShowComponent.new(label: "Justificatif") do |c|
+      = render Dossiers::RowShowComponent.new(label: t('views.users.dossiers.show.status_overview.justificatif')) do |c|
         - c.with_value do
           .action
             = render Attachment::ShowComponent.new(attachment: dossier.justificatif_motivation.attachment)
@@ -35,6 +35,6 @@
         %strong= simple_format(dossier.motivation)
 
     - if dossier.attestation.present? && dossier.attestation.pdf.attached?
-      = render Dossiers::RowShowComponent.new(label: "Attestation") do |c|
+      = render Dossiers::RowShowComponent.new(label: t('views.users.dossiers.show.status_overview.attestation')) do |c|
         - c.with_value do
           = render Dsfr::DownloadComponent.new(attachment: dossier.attestation.pdf, name: t(:download_attestation, scope: [:views, :shared, :dossiers, :form]))

--- a/app/views/shared/dossiers/_infos_generales.html.haml
+++ b/app/views/shared/dossiers/_infos_generales.html.haml
@@ -30,9 +30,9 @@
             = render Attachment::ShowComponent.new(attachment: dossier.justificatif_motivation.attachment)
 
     - if dossier.motivation.present?
-      = render Dossiers::RowShowComponent.new(label: "Motivation") do |c|
-        - c.with_value do
-          = render SimpleFormatComponent.new(dossier.motivation, allow_a: false)
+      %span.champ-label= t('views.users.dossiers.show.status_overview.motivation')
+      %blockquote.fr-m-0
+        %strong= simple_format(dossier.motivation)
 
     - if dossier.attestation.present? && dossier.attestation.pdf.attached?
       = render Dossiers::RowShowComponent.new(label: "Attestation") do |c|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -363,7 +363,12 @@ en:
         form:
           submitted_at: "Submitted on %{datetime}"
           updated_at: "Updated on %{datetime}"
+          switched_to_instruction_at: "Switched to instruction on %{datetime}"
+          revert_to_submitted_at: "Correction requested on on %{datetime}"
           download_attestation: "Download attestation"
+          acceptee_at: "Accepted on %{datetime}"
+          refuse_at: "Declined on %{datetime}"
+          closed_at: "Closed on %{datetime}"
         edit:
           autosave: Your file is automatically saved after each modification. You can close the window at any time and pick up where you left off later.
         messages:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -489,6 +489,7 @@ en:
             delay_text_sva_svr: "You will receive a reply from the administration no later than %{date}."
             status_completed: completed
             use_mailbox_for_questions_html: "<strong>You have a question?</strong> Use the mailbox to <a href=\"%{mailbox_url}\">contact the administration directly</a>."
+            motivation: "Motivation :"
             acceptee_html: "Your file had been <strong>accepted</strong>."
             accepte_motivation: "Reason"
             accepte_attestation: "Download the attestation"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -372,6 +372,8 @@ en:
             write_message_placeholder: "Write your message here"
             write_message_to_administration_placeholder: "Write your message to the administration here"
         demande:
+          history: "File history"
+          en_construction_notice: "Unless otherwise indicated, fields were entered on the date the file was submitted."
           requester_identity: "Identity of the requester"
           mandataire_identity: "Identity of toe mandatary"
           requester_identity_updated_at: "updated on %{date}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -490,6 +490,8 @@ en:
             status_completed: completed
             use_mailbox_for_questions_html: "<strong>You have a question?</strong> Use the mailbox to <a href=\"%{mailbox_url}\">contact the administration directly</a>."
             motivation: "Motivation :"
+            attestation: "Attestation :"
+            justificatif: "Justification :"
             acceptee_html: "Your file had been <strong>accepted</strong>."
             accepte_motivation: "Reason"
             accepte_attestation: "Download the attestation"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -500,6 +500,8 @@ fr:
             status_completed: terminé
             use_mailbox_for_questions_html: "<strong>Vous avez une question ?</strong> Utilisez la messagerie pour <a href=\"%{mailbox_url}\">contacter l’administration directement</a>."
             motivation: "Motivation :"
+            attestation: "Attestation :"
+            justificatif: "Justificatif :"
             acceptee_html: "Votre dossier a été <strong>accepté</strong>."
             accepte_motivation: "Motif de l’acceptation"
             accepte_attestation: "Télécharger l’attestation"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -499,6 +499,7 @@ fr:
             delay_text_sva_svr: "Vous aurez un retour de l’administration au plus tard le %{date}."
             status_completed: terminé
             use_mailbox_for_questions_html: "<strong>Vous avez une question ?</strong> Utilisez la messagerie pour <a href=\"%{mailbox_url}\">contacter l’administration directement</a>."
+            motivation: "Motivation :"
             acceptee_html: "Votre dossier a été <strong>accepté</strong>."
             accepte_motivation: "Motif de l’acceptation"
             accepte_attestation: "Télécharger l’attestation"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -369,6 +369,11 @@ fr:
         form:
           submitted_at: "Déposé le %{datetime}"
           updated_at: "Modifié le %{datetime}"
+          switched_to_instruction_at: "Passé en instruction le %{datetime}"
+          revert_to_submitted_at: "Correction demandée le %{datetime}"
+          acceptee_at: "Accepté le %{datetime}"
+          refuse_at: "Refusé le %{datetime}"
+          closed_at: "Classé sans suite le %{datetime}"
           download_attestation: "Télécharger l’attestation"
         edit:
           autosave: Votre dossier est enregistré automatiquement après chaque modification. Vous pouvez à tout moment fermer la fenêtre et reprendre plus tard là où vous en étiez.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -378,7 +378,8 @@ fr:
             write_message_placeholder: "Écrivez votre message ici"
             write_message_to_administration_placeholder: "Écrivez votre message à l’administration ici"
         demande:
-          en_construction: "Date de dépôt du dossier"
+          history: "Historique du dossier"
+          en_construction_notice: "Sauf mention contraire, les champs ont été saisis à la date du dépôt du dossier."
           requester_identity: "Identité du demandeur"
           mandataire_identity: "Identité du mandataire"
           requester_identity_updated_at: "modifiée le %{date}"


### PR DESCRIPTION
Pour que la page récapitulative de la demande puisse servir d'alternative au fichier PDF, il faut qu'elle contienne l'historique de la demande.

# Après
![Capture d’écran 2025-05-23 à 11 00 55](https://github.com/user-attachments/assets/ab70b12b-6ce0-435a-a20b-ab0c22bc196e)
<img width="929" alt="" src="https://github.com/user-attachments/assets/b3a78ca1-ef94-437e-8d8d-6bdfd99bde41" />
<img width="925" alt="" src="https://github.com/user-attachments/assets/f38f6143-1bac-4de6-a001-c0fd233fe80d" />

# Avant
![Capture d’écran 2025-05-23 à 11 02 40](https://github.com/user-attachments/assets/4a1634ce-03db-46d9-b983-713095835a24)


