### PR TITLE
ETQ usager, clarifie l'UX d'un champ adresse hors BAN

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -410,16 +410,19 @@
         padding-left: 0;
       }
 
-      .row {
-        border-radius: 4px;
-        border: 1px solid $border-grey;
-        padding: $default-padding;
-        margin-bottom: 2 * $default-padding;
+      .champs-group {
+        margin-bottom: 2rem;
       }
     }
 
+    .champs-group {
+      border-radius: 4px;
+      border: 1px solid var(--border-default-grey);
+      padding: 1rem;
+    }
+
     .utils-repetition-required
-      .row:first-child
+      .champs-group:first-child
       .utils-repetition-required-destroy-button {
       display: none;
     }

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -437,6 +437,17 @@
     }
   }
 
+  .fr-input-address-ban--disabled {
+    & > .fr-label,
+    & > .fr-hint-text,
+    & > .fr-label .fr-hint-text {
+      color: var(--text-disabled-grey);
+    }
+    .address-ban .fr-ds-combobox .fr-autocomplete {
+      opacity: 0.5; // Réduit l'opacité de l'icône droite en background. L'input étant autant disabled, cette opacité s'ajoute à celle du disabled
+    }
+  }
+
   input.aa-input,
   input.aa-hint {
     border-radius: 4px;

--- a/app/components/editable_champ/address_component.rb
+++ b/app/components/editable_champ/address_component.rb
@@ -5,6 +5,10 @@ class EditableChamp::AddressComponent < EditableChamp::EditableChampBaseComponen
     'fr-select'
   end
 
+  def dsfr_group_classname
+    class_names(super, "fr-input-address-ban--disabled" => !@champ.ban?)
+  end
+
   def react_props
     react_input_opts(id: @champ.input_id,
       class: 'fr-mt-1w',

--- a/app/components/editable_champ/address_component/address_component.en.yml
+++ b/app/components/editable_champ/address_component/address_component.en.yml
@@ -1,7 +1,11 @@
 en:
   street_label: Street name and number or, place name
+  street_fr_hint: 'Example : 12 Main Street'
+  street_international_hint: 'Example : 12 Main Street'
   city_label: City
+  city_hint: 'Example : London'
   commune_label: City or Municipality
+  commune_hint: 'Enter the name or postal code of the city then, select the municipality in the list. Example : Strasbourg'
   postal_code_label: Postal code
   country_label: Country
   not_in_ban: I cannot find my address in the suggestions

--- a/app/components/editable_champ/address_component/address_component.fr.yml
+++ b/app/components/editable_champ/address_component/address_component.fr.yml
@@ -1,7 +1,11 @@
 fr:
-  street_label: Nom et numéro de voie, ou, lieu-dit
+  street_label: Numéro et nom de voie, ou lieu-dit
+  street_fr_hint: 'Exemple : 11 rue des Mimosas'
+  street_international_hint: 'Exemple : 12 Main Street'
   city_label: Ville
+  city_hint: 'Exemple : London'
   commune_label: Ville ou commune
+  commune_hint: 'Renseignez le nom ou le code postal de la ville puis, sélectionnez la commune dans la liste. Exemple : Strasbourg'
   postal_code_label: Code postal
   country_label: Pays
   not_in_ban: Je ne trouve pas mon adresse dans les suggestions

--- a/app/components/editable_champ/address_component/address_component.html.haml
+++ b/app/components/editable_champ/address_component/address_component.html.haml
@@ -13,27 +13,40 @@
 - if !@champ.ban?
   .fr-input-group
     = @form.label :country_code, for: @champ.country_input_id, class: 'fr-label' do
-      - t('.country_label')
+      - capture do
+        = t('.country_label')
+        = render EditableChamp::AsteriskMandatoryComponent.new
     = @form.select :country_code, pays_options, @champ.mandatory? ? { prompt: '' } : { include_blank: '' }, required: @champ.required?, id: @champ.country_input_id, class: "width-33-desktop fr-select small-margin"
 
   .fr-input-group
     = @form.label :street_address, for: @champ.street_input_id, class: 'fr-label' do
-      - t('.street_label')
+      - capture do
+        = t('.street_label')
+        = render EditableChamp::AsteriskMandatoryComponent.new
+        %span.fr-hint-text= t('.street_hint')
     = @form.text_field :street_address, class: "width-66-desktop fr-input small-margin", id: @champ.street_input_id
 
   - if @champ.international?
     .fr-input-group
       = @form.label :city_name, for: @champ.city_input_id, class: 'fr-label' do
-        - t('.city_label')
+        - capture do
+          = t('.city_label')
+          = render EditableChamp::AsteriskMandatoryComponent.new
+          %span.fr-hint-text= t('.city_hint')
       = @form.text_field :city_name, class: "width-33-desktop fr-input small-margin", id: @champ.city_input_id
 
     .fr-input-group
       = @form.label :postal_code, for: @champ.postal_code_input_id, class: 'fr-label' do
-        - t('.postal_code_label')
+        - capture do
+          = t('.postal_code_label')
+          = render EditableChamp::AsteriskMandatoryComponent.new
       = @form.text_field :postal_code, class: "width-33-desktop fr-input small-margin", id: @champ.postal_code_input_id
   - else
     .fr-input-group
       = @form.label :commune_name, for: @champ.city_input_id, class: 'fr-label' do
-        - t('.commune_label')
+        - capture do
+          = t('.commune_label')
+          = render EditableChamp::AsteriskMandatoryComponent.new
+          %span.fr-hint-text= t('.commune_hint')
       %react-fragment
         = render ReactComponent.new "ComboBox/RemoteComboBox", **commune_react_props

--- a/app/components/editable_champ/address_component/address_component.html.haml
+++ b/app/components/editable_champ/address_component/address_component.html.haml
@@ -1,4 +1,4 @@
-.fr-input-group
+.fr-input-group.address-ban
   %react-fragment
     = render ReactComponent.new "ComboBox/RemoteComboBox", **react_props do
       = render ReactComponent.new "ComboBox/ComboBoxValueSlot", field: :data, name: @form.field_name(:address)

--- a/app/components/editable_champ/address_component/address_component.html.haml
+++ b/app/components/editable_champ/address_component/address_component.html.haml
@@ -4,49 +4,56 @@
       = render ReactComponent.new "ComboBox/ComboBoxValueSlot", field: :data, name: @form.field_name(:address)
 
 .fr-input-group
-  .fr-fieldset__element
-    .fr-checkbox-group
-      = @form.check_box :not_in_ban, { class: "fr-input", checked: !@champ.ban?, disabled: @champ.international? }, 'true', 'false'
-      = @form.label :not_in_ban, class: 'fr-label' do
-        - t('.not_in_ban')
+  .fr-checkbox-group
+    = @form.check_box :not_in_ban, { class: "fr-input", checked: !@champ.ban?, disabled: @champ.international? }, 'true', 'false'
+    = @form.label :not_in_ban, class: 'fr-label' do
+      - t('.not_in_ban')
 
 - if !@champ.ban?
-  .fr-input-group
-    = @form.label :country_code, for: @champ.country_input_id, class: 'fr-label' do
-      - capture do
-        = t('.country_label')
-        = render EditableChamp::AsteriskMandatoryComponent.new
-    = @form.select :country_code, pays_options, @champ.mandatory? ? { prompt: '' } : { include_blank: '' }, required: @champ.required?, id: @champ.country_input_id, class: "width-33-desktop fr-select small-margin"
-
-  .fr-input-group
-    = @form.label :street_address, for: @champ.street_input_id, class: 'fr-label' do
-      - capture do
-        = t('.street_label')
-        = render EditableChamp::AsteriskMandatoryComponent.new
-        %span.fr-hint-text= t('.street_hint')
-    = @form.text_field :street_address, class: "width-66-desktop fr-input small-margin", id: @champ.street_input_id
-
-  - if @champ.international?
+  .fr-mt-3w
     .fr-input-group
-      = @form.label :city_name, for: @champ.city_input_id, class: 'fr-label' do
-        - capture do
-          = t('.city_label')
-          = render EditableChamp::AsteriskMandatoryComponent.new
-          %span.fr-hint-text= t('.city_hint')
-      = @form.text_field :city_name, class: "width-33-desktop fr-input small-margin", id: @champ.city_input_id
+      %span.fr-label
+        = @champ.libelle
+      - if @champ.description.present?
+        .fr-hint-text{ id: @champ.describedby_id }= render SimpleFormatComponent.new(@champ.description, allow_a: true)
 
-    .fr-input-group
-      = @form.label :postal_code, for: @champ.postal_code_input_id, class: 'fr-label' do
-        - capture do
-          = t('.postal_code_label')
-          = render EditableChamp::AsteriskMandatoryComponent.new
-      = @form.text_field :postal_code, class: "width-33-desktop fr-input small-margin", id: @champ.postal_code_input_id
-  - else
-    .fr-input-group
-      = @form.label :commune_name, for: @champ.city_input_id, class: 'fr-label' do
-        - capture do
-          = t('.commune_label')
-          = render EditableChamp::AsteriskMandatoryComponent.new
-          %span.fr-hint-text= t('.commune_hint')
-      %react-fragment
-        = render ReactComponent.new "ComboBox/RemoteComboBox", **commune_react_props
+    .champs-group
+      .fr-input-group
+        = @form.label :country_code, for: @champ.country_input_id, class: 'fr-label' do
+          - capture do
+            = t('.country_label')
+            = render EditableChamp::AsteriskMandatoryComponent.new
+        = @form.select :country_code, pays_options, @champ.mandatory? ? { prompt: '' } : { include_blank: '' }, required: @champ.required?, id: @champ.country_input_id, class: "width-33-desktop fr-select small-margin"
+
+      .fr-input-group
+        = @form.label :street_address, for: @champ.street_input_id, class: 'fr-label' do
+          - capture do
+            = t('.street_label')
+            = render EditableChamp::AsteriskMandatoryComponent.new
+            %span.fr-hint-text= @champ.international? ? t('.street_international_hint') : t('.street_fr_hint')
+        = @form.text_field :street_address, class: "fr-input small-margin", id: @champ.street_input_id
+
+      - if @champ.international?
+        .fr-input-group
+          = @form.label :city_name, for: @champ.city_input_id, class: 'fr-label' do
+            - capture do
+              = t('.city_label')
+              = render EditableChamp::AsteriskMandatoryComponent.new
+              %span.fr-hint-text= t('.city_hint')
+          = @form.text_field :city_name, class: "width-33-desktop fr-input small-margin", id: @champ.city_input_id
+
+        .fr-input-group
+          = @form.label :postal_code, for: @champ.postal_code_input_id, class: 'fr-label' do
+            - capture do
+              = t('.postal_code_label')
+              = render EditableChamp::AsteriskMandatoryComponent.new
+          = @form.text_field :postal_code, class: "width-33-desktop fr-input small-margin", id: @champ.postal_code_input_id
+      - else
+        .fr-input-group
+          = @form.label :commune_name, for: @champ.city_input_id, class: 'fr-label' do
+            - capture do
+              = t('.commune_label')
+              = render EditableChamp::AsteriskMandatoryComponent.new
+              %span.fr-hint-text= t('.commune_hint')
+          %react-fragment
+            = render ReactComponent.new "ComboBox/RemoteComboBox", **commune_react_props

--- a/app/components/editable_champ/repetition_row_component/repetition_row_component.html.haml
+++ b/app/components/editable_champ/repetition_row_component/repetition_row_component.html.haml
@@ -1,4 +1,4 @@
-.row{ id: "safe-row-selector-#{row_id}" }
+.champs-group{ id: "safe-row-selector-#{row_id}" }
   - if @types_de_champ.size > 1
     %fieldset.fr-mx-0.fr-px-0
       %legend.block-id.fr-px-0= "#{@type_de_champ.libelle} "

--- a/app/views/shared/champs/address/_show.html.haml
+++ b/app/views/shared/champs/address/_show.html.haml
@@ -1,17 +1,19 @@
-%p= champ.to_s
+%p.fr-mb-0= champ.to_s
 - if champ.full_address?
   - if champ.france?
-    - if champ.ban?
-      %p.fr-text--sm
-        L'adresse provient de la
-        = link_to 'BAN', 'https://adresse.data.gouv.fr/decouvrir-la-BAN'
-    %p.fr-text--sm
+    %p.fr-text--sm.fr-mb-0
       Code INSEE :
       = champ.city_code
-    %p.fr-text--sm
-      Departement :
+    %p.fr-text--sm.fr-mb-0.fr-text--secondary
+      Département :
       = champ.departement_code_and_name
+
+    - if champ.ban?
+      %p.fr-text--sm.fr-mt-1w
+        = content_tag :span, class: "fr-tag fr-fi-information-line fr-tag--icon-left fr-tag--sm font-weight-normal" do
+          L’adresse est connue de la&nbsp;
+          %acronym{ title: "Base Adresse Nationale" } BAN
   - else
-    %p.fr-text--sm
+    %p.fr-text--sm.fr-mb-0
       Pays :
       = champ.country_name

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -229,7 +229,7 @@ describe 'The user', js: true do
     fill_individual
 
     find('label', text: 'Je ne trouve pas mon adresse dans les suggestions').click
-    fill_in('Nom et numéro de voie, ou, lieu-dit', with: '2 rue de la paix')
+    fill_in('Numéro et nom de voie, ou lieu-dit', with: '2 rue de la paix')
     scroll_to(find_field('Ville ou commune'), align: :center)
     fill_in('Ville ou commune', with: '60400')
     find('.fr-menu__item', text: 'Brétigny (60400)').click

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -150,27 +150,27 @@ describe 'The user', js: true do
     expect(page).to have_field('sub type de champ', with: 'super texte')
 
     # first repetition have a destroy hidden
-    expect(page).to have_selector(".repetition .row .utils-repetition-required-destroy-button", count: 1, visible: false)
-    expect(page).to have_selector(".repetition .row", count: 1)
+    expect(page).to have_selector(".repetition .champs-group .utils-repetition-required-destroy-button", count: 1, visible: false)
+    expect(page).to have_selector(".repetition .champs-group", count: 1)
 
     # adding an element means we can ddestroy last item
     click_on 'Ajouter un élément pour'
-    expect(page).to have_selector(".repetition .row:first-child .utils-repetition-required-destroy-button", count: 1, visible: false)
-    expect(page).to have_selector(".repetition .row", count: 2)
-    expect(page).to have_selector(".repetition .row:last-child .utils-repetition-required-destroy-button", count: 1, visible: true)
+    expect(page).to have_selector(".repetition .champs-group:first-child .utils-repetition-required-destroy-button", count: 1, visible: false)
+    expect(page).to have_selector(".repetition .champs-group", count: 2)
+    expect(page).to have_selector(".repetition .champs-group:last-child .utils-repetition-required-destroy-button", count: 1, visible: true)
 
-    within '.repetition .row:first-child' do
+    within '.repetition .champs-group:first-child' do
       fill_in('sub type de champ', with: 'un autre texte')
       blur
     end
 
     expect do
-      within '.repetition .row:last-child' do
+      within '.repetition .champs-group:last-child' do
         click_on 'Supprimer l’élément'
       end
-      wait_until { page.all(".row").size == 1 }
+      wait_until { page.all(".champs-group").size == 1 }
       # removing a repetition means one child only, thus its button destroy is not visible
-      expect(page).to have_selector(".repetition .row:first-child .utils-repetition-required-destroy-button", count: 1, visible: false)
+      expect(page).to have_selector(".repetition .champs-group:first-child .utils-repetition-required-destroy-button", count: 1, visible: false)
     end.to change { Champ.where.not(discarded_at: nil).count }
   end
 


### PR DESCRIPTION
https://mattermost.incubateur.net/betagouv/pl/m8gjreixep8uibf8ymk66usm5o (entre autres)

<img width="1206" alt="Capture d’écran 2025-05-22 à 13 27 45" src="https://github.com/user-attachments/assets/c834fb9d-6573-4f9c-9a1d-99f5eb542f3a" />

Pour l'effet désactivé sur le label et l'icône, on ne peut pas utiliser la classe native du dsfr, car les autres champs hors BAN sont nesté dans l'input group désactivé, et donc tous les labels seraient désactivés aussi.

<img width="1206" alt="Capture d’écran 2025-05-22 à 14 22 16" src="https://github.com/user-attachments/assets/fd13006a-4132-4917-9e0e-de1f56b3dcfa" />


<img width="327" alt="Capture d’écran 2025-05-22 à 12 19 24" src="https://github.com/user-attachments/assets/e4d381a2-0747-4b96-9be4-c5a27995522a" />



Reste à faire : la case doit tjs restée active qu'on soit en mode BAN ou pas (actuellement elle est désactivée si le pays est hors france)
