### PR TITLE
fix(turbo_poll_controller): without given interval to the component, it starts polling at interval 0. request server a bit too much

### DIFF
--- a/app/javascript/controllers/turbo_poll_controller.ts
+++ b/app/javascript/controllers/turbo_poll_controller.ts
@@ -12,7 +12,7 @@ export class TurboPollController extends ApplicationController {
   static values = {
     url: String,
     strategy: { type: String, default: 'fibonacci' },
-    interval: Number
+    interval: { type: Number, default: 2000 }
   };
 
   declare readonly urlValue: string;


### PR DESCRIPTION
en l'absence de valeur fourni au composant, je me serais attendu a une `this.intervalValue` à `undefined`.

<img width="525" alt="Capture d’écran 2025-05-22 à 5 30 18 PM" src="https://github.com/user-attachments/assets/d14c95e5-2884-4483-a254-eaeb0a43e413" />

sauf que non, c'est 0 (j'imagine le typage cas un undefinied en 0 ?)

<img width="566" alt="Capture d’écran 2025-05-22 à 5 29 41 PM" src="https://github.com/user-attachments/assets/b112d35f-ec17-48af-95b8-a92863f5e60c" />

bref, derriere on tabasse le endpoint car l'interval est a 0

(en tous cas sous ffx)

testé ac un RNF champ