### PR TITLE
Amélioration : quelques améliorations du champ api

### DIFF
--- a/app/components/dossiers/errors_full_messages_component/errors_full_messages_component.html.haml
+++ b/app/components/dossiers/errors_full_messages_component/errors_full_messages_component.html.haml
@@ -1,7 +1,6 @@
 .fr-alert.fr-alert--error.fr-mb-3w{ role: 'alert' }
-
-  - if dedup_and_partitioned_errors.size > 0
+  - if dedup_errors.size > 0
     %h2#sumup-errors.fr-alert__title{ data: { controller: 'autofocus' }, tabindex: '-1' }
-      = t('.sumup_html.title', count: dedup_and_partitioned_errors.size)
-    %p= t('.sumup_html.content', count: dedup_and_partitioned_errors.size)
-    = render ExpandableErrorList.new(errors: dedup_and_partitioned_errors)
+      = t('.sumup_html.title', count: dedup_errors.size)
+    %p= t('.sumup_html.content', count: dedup_errors.size)
+    = render ExpandableErrorList.new(errors: dedup_errors)

--- a/app/components/referentiels/mapping_form_component/mapping_form_component.html.haml
+++ b/app/components/referentiels/mapping_form_component/mapping_form_component.html.haml
@@ -5,6 +5,7 @@
     - c.with_body do
       %p L'API n'a pas retournée une réponse valide, veuillez vérifier les paramètres du referentiel :
       %pre Endpoint: #{@referentiel.url}
+      %pre Status: #{JSON.pretty_generate(@referentiel.last_response_status)}
       %pre Body: #{JSON.pretty_generate(@referentiel.last_response_body)}
 
   %ul.fr-btns-group.fr-btns-group--inline-sm

--- a/app/components/referentiels/new_form_component/new_form_component.html.haml
+++ b/app/components/referentiels/new_form_component/new_form_component.html.haml
@@ -1,10 +1,13 @@
 = form_with model: @referentiel, scope: :referentiel, url: form_url, **form_options do |form|
   = form.hidden_field :referentiel_id, value: params[:referentiel_id]
   %div
-    = render Dsfr::RadioButtonListComponent.new(form:, target: :type,
-      buttons: [ { label: 'À partir d’une URL', value: 'Referentiels::APIReferentiel', hint: 'Connectez un champ à une API', data: { controller: 'autosubmit' } } ,
-        { label: 'À partir d’un fichier CSV', value: 'Referentiels::CsvReferentiel', hint: 'Connectez un champ à un CSV', disabled: true }]) do ||
-      Comment interroger votre référentiel ?
+    - if Referentiels::APIReferentiel.csv_available?
+      = render Dsfr::RadioButtonListComponent.new(form:, target: :type,
+        buttons: [ { label: 'À partir d’une URL', value: 'Referentiels::APIReferentiel', hint: 'Connectez un champ à une API', data: { controller: 'autosubmit' } } ,
+          { label: 'À partir d’un fichier CSV', value: 'Referentiels::CsvReferentiel', hint: 'Connectez un champ à un CSV', disabled: true }]) do ||
+        Comment interroger votre référentiel ?
+    - else
+      = form.hidden_field :type
 
     - if @referentiel.type == 'Referentiels::APIReferentiel'
       = render Dsfr::InputComponent.new(form:, attribute: :url, opts: { data: { controller: 'autosubmit' } }) do |c|
@@ -32,10 +35,13 @@
     %hr.fr-hr.fr-my-5w
 
   %div
-    = render Dsfr::RadioButtonListComponent.new(form:, target: :mode,
-      buttons: [ { label: 'Correspondance exacte', value: 'exact_match', hint: 'Vérification de l’existence de la donnée saisie dans la BDD du référentiel (exemple : plaque d’immatriculation, SIREN...)' } ,
-        { label: 'Autosuggestion au fur et à mesure de la saisie de l’usager', value: 'autocomplete', hint: 'Affichage de données issues de la BDD du référentiel correspondant en partie ou en totalité à la donnée saisie par l’usager (exemple : BDD de médicaments, modèles de véhicules...)', disabled: true }]) do
-      Mode de remplissage du champ par l’usager
+    - if Referentiels::APIReferentiel.autocomplete_available?
+      = render Dsfr::RadioButtonListComponent.new(form:, target: :mode,
+        buttons: [ { label: 'Correspondance exacte', value: 'exact_match', hint: 'Vérification de l’existence de la donnée saisie dans la BDD du référentiel (exemple : plaque d’immatriculation, SIREN...)' } ,
+          { label: 'Autosuggestion au fur et à mesure de la saisie de l’usager', value: 'autocomplete', hint: 'Affichage de données issues de la BDD du référentiel correspondant en partie ou en totalité à la donnée saisie par l’usager (exemple : BDD de médicaments, modèles de véhicules...)', disabled: true }]) do
+        Mode de remplissage du champ par l’usager
+    - else
+      = form.hidden_field :mode
 
     = render Dsfr::InputComponent.new(form:, attribute: :hint)
     = render Dsfr::InputComponent.new(form:, attribute: :test_data)

--- a/app/components/referentiels/new_form_component/new_form_component.html.haml
+++ b/app/components/referentiels/new_form_component/new_form_component.html.haml
@@ -13,7 +13,7 @@
       = render Dsfr::InputComponent.new(form:, attribute: :url, opts: { data: { controller: 'autosubmit' } }) do |c|
         - c.with_describedby do
           - if @referentiel.url.blank? || @referentiel.errors.where(:url).present?
-            = render Dsfr::AlertComponent.new(state: :warning, title: nil, size: :sm, heading_level: :p, extra_class_names:'') do |c|
+            = render Dsfr::AlertComponent.new(state: :warning, title: nil, size: :sm, heading_level: :p, extra_class_names: 'fr-mt-2w') do |c|
               - c.with_body do
                 %p
                   Pour des raisons de sécurité,

--- a/app/components/types_de_champ_editor/info_referentiel_component/info_referentiel_component.html.haml
+++ b/app/components/types_de_champ_editor/info_referentiel_component/info_referentiel_component.html.haml
@@ -19,4 +19,4 @@
           %li ou uniquement vérifier la correspondance exacte de saisie dans la BDD du référentiel
 
   %p.flex.column.align-end
-    = link_to "Configurer le champ", edit_referentiel_on_draft_or_clone_url, class: 'fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-equalizer-fill'
+    = link_to "Configurer le champ", edit_referentiel_on_draft_or_clone_url, class: 'fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-equalizer-fill', data: { turbo: false }

--- a/app/controllers/administrateurs/referentiels_controller.rb
+++ b/app/controllers/administrateurs/referentiels_controller.rb
@@ -74,7 +74,10 @@ module Administrateurs
       if params[:referentiel_id]
         Referentiel.find(params[:referentiel_id]).attributes.slice(*%w[url test_data hint mode type])
       else
-        referentiel_params
+        params = referentiel_params.to_h
+        params = params.merge(type: Referentiels::APIReferentiel) if !Referentiels::APIReferentiel.csv_available?
+        params = params.merge(mode: Referentiels::APIReferentiel.modes.fetch(:exact_match)) if !Referentiels::APIReferentiel.autocomplete_available?
+        params
       end
     end
   end

--- a/app/controllers/administrateurs/referentiels_controller.rb
+++ b/app/controllers/administrateurs/referentiels_controller.rb
@@ -16,23 +16,12 @@ module Administrateurs
     end
 
     def create
-      referentiel = @type_de_champ.build_referentiel(referentiel_params)
-
-      if referentiel.configured? && referentiel.update(referentiel_params)
-        redirect_to mapping_type_de_champ_admin_procedure_referentiel_path(@procedure, @type_de_champ.stable_id, referentiel)
-      else
-        referentiel.validate
-        component = Referentiels::NewFormComponent.new(referentiel:, type_de_champ: @type_de_champ, procedure: @procedure)
-        render turbo_stream: turbo_stream.replace(component.id, component)
-      end
+      handle_referentiel_save(@type_de_champ.build_referentiel(referentiel_params))
     end
 
     def update
-      if @referentiel.update(referentiel_params)
-        redirect_to mapping_type_de_champ_admin_procedure_referentiel_path(@procedure, @type_de_champ.stable_id, @referentiel)
-      else
-        render :edit
-      end
+      @referentiel.assign_attributes(referentiel_params)
+      handle_referentiel_save(@referentiel)
     end
 
     def mapping_type_de_champ
@@ -50,6 +39,16 @@ module Administrateurs
     end
 
     private
+
+    def handle_referentiel_save(referentiel)
+      if referentiel.configured? && referentiel.save && params[:commit].present?
+        redirect_to mapping_type_de_champ_admin_procedure_referentiel_path(@procedure, @type_de_champ.stable_id, referentiel)
+      else
+        referentiel.validate
+        component = Referentiels::NewFormComponent.new(referentiel:, type_de_champ: @type_de_champ, procedure: @procedure)
+        render turbo_stream: turbo_stream.replace(component.id, component)
+      end
+    end
 
     def type_de_champ_mapping_params
       params.require(:type_de_champ)

--- a/app/models/referentiels/api_referentiel.rb
+++ b/app/models/referentiels/api_referentiel.rb
@@ -51,9 +51,9 @@ class Referentiels::APIReferentiel < Referentiel
     return if uri.tld == "gouv.fr" && uri.domain != "beta.gouv.fr"
     allowed_domains = ENV.fetch('ALLOWED_API_DOMAINS_FROM_FRONTEND', '').split(',')
     if allowed_domains.none? { |allowed_domain| uri.host && allowed_domain.include?(uri.host) }
-      errors.add(:url, "L'URL doit être autorisée par notre équipe, veuillez nous contacter")
+      errors.add(:url, :not_allowed, contact_email: CONTACT_EMAIL)
     end
   rescue URI::InvalidURIError, PublicSuffix::DomainInvalid
-    errors.add(:url, "L'URL est invalide")
+    errors.add(:url, :invalid_format)
   end
 end

--- a/app/models/referentiels/api_referentiel.rb
+++ b/app/models/referentiels/api_referentiel.rb
@@ -9,6 +9,13 @@ class Referentiels::APIReferentiel < Referentiel
   validate :url_allowed?
 
   before_save :name_as_uuid
+  def self.csv_available?
+    false
+  end
+
+  def self.autocomplete_available?
+    false
+  end
 
   def last_response_body
     (last_response || {}).fetch("body") { {} }

--- a/config/locales/models/referentiel/en.yml
+++ b/config/locales/models/referentiel/en.yml
@@ -8,5 +8,5 @@ fr:
         hint: "Expected format shown to the user"
         test_data: "Valid example used to test the API"
         hints:
-          url: "Example : https://api_1.ext/{id}, the segment {id} will be replaced by the field value. The http request will use the GET verb"
+          url_html: "Example : https://api_1.ext/<strong>{id}</strong>, the segment <strong>{id}</strong> will be replaced by the field value. The http request will use the GET verb"
           hint: "Example : ID containing 12 chars"

--- a/config/locales/models/referentiel/en.yml
+++ b/config/locales/models/referentiel/en.yml
@@ -1,5 +1,12 @@
 fr:
   activerecord:
+    errors:
+      models:
+        referentiels/api_referentiel:
+          attributes:
+            url:
+              invalid_format: "The URL format is invalid, please enter a valid URL, e.g., https://api_1.ext/"
+              not_allowed: "must be authorized by our team. Please contact us by email (%{contact_email}) and provide the URL and the API documentation you wish to integrate."
     models:
       referentiel: 'Field type'
     attributes:
@@ -8,5 +15,5 @@ fr:
         hint: "Expected format shown to the user"
         test_data: "Valid example used to test the API"
         hints:
-          url_html: "Example : https://api_1.ext/<strong>{id}</strong>, the segment <strong>{id}</strong> will be replaced by the field value. The http request will use the GET verb"
+          url_html: "Expected format: https://api_1.ext/<strong>{id}</strong>, the segment <strong>{id}</strong> will be replaced by the field value. The http request will use the GET verb"
           hint: "Example : ID containing 12 chars"

--- a/config/locales/models/referentiel/fr.yml
+++ b/config/locales/models/referentiel/fr.yml
@@ -1,5 +1,12 @@
 fr:
   activerecord:
+    errors:
+      models:
+        referentiels/api_referentiel:
+          attributes:
+            url:
+              invalid_format: "n'est pas au format d'une URL, saisissez une URL valide ex https://api_1.ext/"
+              not_allowed: "doit être autorisée par notre équipe. Veuillez nous contacter par mail (%{contact_email}) et nous indiquer l'URL et la documentation de l'API que vous souhaitez intégrer."
     models:
       referentiel: 'Type de champ'
     attributes:
@@ -8,5 +15,6 @@ fr:
         hint: "Indications à fournir à l’usager concernant le format de saisie attendu"
         test_data: "Exemple de saisie valide (affiché à l'usager et utilisé pour tester la requête)"
         hints:
-          url_html: "Exemple : https://api_1.ext/<strong>{id}</strong>, la section <strong>{id}</strong> sera remplacée par la valeur du champ. L'appel se fera en HTTP GET"
+          url_html: "Format attendu : https://api_1.ext/<strong>{id}</strong>, la section <strong>{id}</strong> sera remplacée par la valeur du champ. L'appel se fera en HTTP GET"
           hint: "Exemple : Identifiant de 12 caractères comportant des chiffres et des lettres (exemple : PG46YY6YWCX8)"
+    

--- a/config/locales/models/referentiel/fr.yml
+++ b/config/locales/models/referentiel/fr.yml
@@ -8,5 +8,5 @@ fr:
         hint: "Indications à fournir à l’usager concernant le format de saisie attendu"
         test_data: "Exemple de saisie valide (affiché à l'usager et utilisé pour tester la requête)"
         hints:
-          url: "Exemple : https://api_1.ext/{id}, la section {id} sera remplacée par la valeur du champ. L'appel se fera en HTTP GET"
+          url_html: "Exemple : https://api_1.ext/<strong>{id}</strong>, la section <strong>{id}</strong> sera remplacée par la valeur du champ. L'appel se fera en HTTP GET"
           hint: "Exemple : Identifiant de 12 caractères comportant des chiffres et des lettres (exemple : PG46YY6YWCX8)"

--- a/spec/components/dossiers/errors_full_messages_component_spec.rb
+++ b/spec/components/dossiers/errors_full_messages_component_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe Dossiers::ErrorsFullMessagesComponent, type: :component do
   let(:types_de_champ_public) { [type: :text] }
   let(:dossier) { create(:dossier, procedure:) }
   let(:component) { described_class.new(dossier:) }
-  subject { render_inline(component).to_html }
 
   describe 'render' do
     context 'when dossier does not have any error' do
+      subject { render_inline(component).to_html }
       it 'does not render' do
         expect(subject).to eq("")
       end
@@ -19,9 +19,10 @@ RSpec.describe Dossiers::ErrorsFullMessagesComponent, type: :component do
     context 'when dossier have error' do
       let(:champ) { dossier.champs.first }
 
-      before do
+      subject do
         dossier.validate(:champs_public_value)
         dossier.check_mandatory_and_visible_champs
+        render_inline(component).to_html
       end
 
       context 'when champ is repetition' do
@@ -81,6 +82,16 @@ RSpec.describe Dossiers::ErrorsFullMessagesComponent, type: :component do
       context 'when the champ is simple text' do
         it 'does render' do
           expect(subject).to have_link(champ.type_de_champ.libelle, href: "##{champ.focusable_input_id}")
+        end
+      end
+
+      context 'when champ is referentiel required and not filled' do
+        let(:referentiel) { create(:api_referentiel, :configured) }
+        let(:types_de_champ_public) { [{ type: :referentiel, referentiel:, mandatory: true }] }
+        before { champ.update(external_id: 'kthxbye') }
+
+        it 'focuses on focusable_input_id' do
+          expect(subject).to have_link(champ.libelle, href: "##{champ.focusable_input_id}", count: 1)
         end
       end
     end

--- a/spec/components/referentiels/new_form_component_spec.rb
+++ b/spec/components/referentiels/new_form_component_spec.rb
@@ -25,13 +25,14 @@ RSpec.describe Referentiels::NewFormComponent, type: :component do
       context 'when mode was not selected' do
         it 'forward referentiel_id if present in params' do
           inputs = {
-            type: 2,
-            mode: 2,
             referentiel_id: 1,
             test_data: 1,
             hint: 1,
             url: 0
           }
+          input[:mode] = 2 if Referentiels::APIReferentiel.autocomplete_available?
+          input[:type] = 2 if Referentiels::APIReferentiel.csv_available?
+
           expect(page).to have_css('form[method=post]')
           expect(page).to have_css("form[action=\"#{url_helpers.admin_procedure_referentiels_path(procedure, type_de_champ.stable_id)}\"]")
           expect(page).not_to have_selector('input[type="file"]')

--- a/spec/models/referentiel_spec.rb
+++ b/spec/models/referentiel_spec.rb
@@ -47,7 +47,7 @@ describe Referentiel do
 
             it 'adds an error' do
               referentiel.validate
-              expect(referentiel.errors[:url]).to include("L'URL doit être autorisée par notre équipe, veuillez nous contacter")
+              expect(referentiel.errors[:url]).to include("doit être autorisée par notre équipe. Veuillez nous contacter par mail (contact@demarches-simplifiees.fr) et nous indiquer l'URL et la documentation de l'API que vous souhaitez intégrer.")
             end
           end
 
@@ -56,7 +56,7 @@ describe Referentiel do
 
             it 'adds an invalid URL error' do
               referentiel.validate
-              expect(referentiel.errors[:url]).to include("L'URL est invalide")
+              expect(referentiel.errors[:url]).to include("n'est pas au format d'une URL, saisissez une URL valide ex https://api_1.ext/")
             end
           end
 
@@ -83,7 +83,7 @@ describe Referentiel do
 
             it 'adds an error' do
               referentiel.validate
-              expect(referentiel.errors[:url]).to include("L'URL doit être autorisée par notre équipe, veuillez nous contacter")
+              expect(referentiel.errors[:url]).to include("doit être autorisée par notre équipe. Veuillez nous contacter par mail (contact@demarches-simplifiees.fr) et nous indiquer l'URL et la documentation de l'API que vous souhaitez intégrer.")
             end
           end
         end

--- a/spec/system/administrateurs/api_referentiel_spec.rb
+++ b/spec/system/administrateurs/api_referentiel_spec.rb
@@ -28,13 +28,17 @@ describe 'Referentiel API:' do
 
     # configure connection
     VCR.use_cassette('referentiel/rnb_as_admin') do
-      find('label[for="referentiel_type_referentielsapireferentiel"]').click
+      if Referentiels::APIReferentiel.csv_available?
+        find('label[for="referentiel_type_referentielsapireferentiel"]').click
+      end
       find("#referentiel_url").fill_in(with: 'google.com')
       expect(page).to have_content("L'URL est invalide")
       find("#referentiel_url").fill_in(with: 'https://google.com')
       expect(page).to have_content("L'URL doit être autorisée par notre équipe, veuillez nous contacter")
       find("#referentiel_url").fill_in(with: 'https://rnb-api.beta.gouv.fr/api/alpha/buildings/{id}/')
-      find('label[for="referentiel_mode_exact_match"]').click
+      if Referentiels::APIReferentiel.autocomplete_available?
+        find('label[for="referentiel_mode_exact_match"]').click
+      end
       fill_in("Indications à fournir à l’usager concernant le format de saisie attendu", with: "Saisir votre numero de bâtiment")
       fill_in("Exemple de saisie valide (affiché à l'usager et utilisé pour tester la requête)", with: "PG46YY6YWCX8")
       click_on('Étape suivante')

--- a/spec/system/administrateurs/api_referentiel_spec.rb
+++ b/spec/system/administrateurs/api_referentiel_spec.rb
@@ -32,9 +32,9 @@ describe 'Referentiel API:' do
         find('label[for="referentiel_type_referentielsapireferentiel"]').click
       end
       find("#referentiel_url").fill_in(with: 'google.com')
-      expect(page).to have_content("L'URL est invalide")
+      expect(page).to have_content("n'est pas au format d'une URL, saisissez une URL valide ex https://api_1.ext/")
       find("#referentiel_url").fill_in(with: 'https://google.com')
-      expect(page).to have_content("L'URL doit être autorisée par notre équipe, veuillez nous contacter")
+      expect(page).to have_content("doit être autorisée par notre équipe. Veuillez nous contacter par mail (contact@demarches-simplifiees.fr) et nous indiquer l'URL et la documentation de l'API que vous souhaitez intégrer.")
       find("#referentiel_url").fill_in(with: 'https://rnb-api.beta.gouv.fr/api/alpha/buildings/{id}/')
       if Referentiels::APIReferentiel.autocomplete_available?
         find('label[for="referentiel_mode_exact_match"]').click


### PR DESCRIPTION
progress: https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/11161 – follows up https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11522#pullrequestreview-2853882114 –  tx pr tes retours @LeSim !

Cette PR est une itération sur differents aspects du type de champ référentiel avancé

# ETQ admin

## Quelques correctifs

- [x] si je me suis trompé ds l'url de l'api, que je reviens de l'étape 2 à l'étape 1, pour modifier l'url, je suis automatiquement redirigé vers l'étape 2 a chaque modification de caractères.

un bug sry

- [x] lorsqu'on commence a configurer, on est en bas de la page, on doit scroller vers le haut

c'était un prob turbo. désactivé turbo sur ce lien.

## Simplification et espacement du formulaire de creation/edition d'un référentiel avancé : 

- [x] ajouter un margin entre l'input url et le message
- [x] dans la configuration, faut il déjà présenter avec un csv alors qu'il n'est pas cliquable ?

>  <img width="1218" alt="Capture d’écran 2025-05-23 à 11 00 10 AM" src="https://github.com/user-attachments/assets/7f9bec20-06b8-4009-8757-dc137cc7720f" />

## Amélioration de la lisibilité des hints / messages d'erreur du  formulaire de creation/edition d'un référentiel avancé : 

- [x] la description de l'input url est tout pale, je n'ai pas vu tout de suite le coup de le {id} . peut etre le mettre en gras ?
- [x] le message d erreur : "Le champ « URL de l'API » L'URL doit être autorisée par notre équipe, veuillez nous contacter", est un peu confus. Peut etre faut il mettre un call to action ?

> <img width="850" alt="Capture d’écran 2025-05-23 à 11 15 43 AM" src="https://github.com/user-attachments/assets/6dff50c4-9866-4bfc-b804-d085c88364e6" />

## Ajout du statut d'erreur sur le formulaire de mapping du referentiel avancé

- [x] dans le message d'erreur, dans l etape 2 mapping, impossible de contacter le referentiel, ajouter le code d'erreur ?

> <img width="869" alt="Capture d’écran 2025-05-23 à 11 31 05 AM" src="https://github.com/user-attachments/assets/f4711e08-dc34-4833-8eaa-1b333ca1742e" />

# ETQ Usager


- [x] sur firerox, 2 requetes sont faites a chaque changement du champ referentiel, dont 1 qui est annulée en NS_BINDING_ABORTED

C'est sur une icone dsfr cf : 

<img width="842" alt="Capture d’écran 2025-05-23 à 2 25 38 PM" src="https://github.com/user-attachments/assets/76018546-3bc2-4c5d-8603-d596e9328a40" />

Enfait, c'est du caching, juste ffx met ce message etonnant : NS_BINDING_ABORTED en local host. Arrive pas en prod 

<img width="474" alt="Capture d’écran 2025-05-23 à 2 25 51 PM" src="https://github.com/user-attachments/assets/b0393c90-2daf-407d-999a-ab25c1194c0f" />


- [x] j'ai soumis un dossier avant que la requete est eu le temps de finir, j ai eu 2 messages d'erreur la ou il pourrait y en avoir qu'un seul
  - referentiel externe RBNB Résultat introuvable. Vérifiez vos informations.
  - referentiel externe RBNB doit être rempli

![Screenshot 2025-05-21 at 10-55-33 Dossier 15288379 en brouillon (test referentiel) - Étape 2 Formulaire · demarches-simplifiees fr](https://github.com/user-attachments/assets/bea1ef8c-f0bf-4260-941f-47c104f573e0)
