### PR TITLE
correctif accessibilité : utilisation d'apostrophes typographiques en lieu et place des apostrophes culbutées

### DIFF
--- a/app/assets/stylesheets/status_overview.scss
+++ b/app/assets/stylesheets/status_overview.scss
@@ -59,7 +59,7 @@
   }
 
   blockquote {
-    quotes: '« ' ' »' '‘' '’';
+    quotes: '« ' ' »' '’' '’';
     margin-bottom: $default-padding * 3;
   }
 

--- a/app/components/editable_champ/cojo_component/cojo_component.fr.yml
+++ b/app/components/editable_champ/cojo_component/cojo_component.fr.yml
@@ -1,8 +1,8 @@
 ---
 fr:
-  accreditation_number_label: Numéro d‘accréditation
-  accreditation_number_notice: Numéro d‘identification délivré par Paris 2024
+  accreditation_number_label: Numéro d’accréditation
+  accreditation_number_notice: Numéro d’identification délivré par Paris 2024
   accreditation_birthdate_label: Date de naissance
   accreditation_birthdate_hint: 'Format : JJ/MM/AAAA'
-  accreditation_number_error: Le numéro d‘accréditation est incorrect
-  accreditation_number_verification_pending: Vérification du numéro d‘accréditation en cours
+  accreditation_number_error: Le numéro d’accréditation est incorrect
+  accreditation_number_verification_pending: Vérification du numéro d’accréditation en cours

--- a/app/components/procedure/estimated_delay_component/estimated_delay_component.fr.yml
+++ b/app/components/procedure/estimated_delay_component/estimated_delay_component.fr.yml
@@ -2,5 +2,5 @@
 fr:
   explanation: Selon nos estimations, à partir des délais d’instruction constatés sur %{percentile}% des demandes qui ont été traitées lors des %{nb_recent_dossiers} derniers jours, les délais d’instruction sont les suivants
   fast_html: "<strong>Dans le meilleur des cas</strong>, le délai d’instruction est : <strong>%{estimation}</strong>."
-  mean_html: "Les <strong>dossiers demandant quelques échanges</strong> le délai d’instruction est d‘environ : <strong>%{estimation}</strong>."
+  mean_html: "Les <strong>dossiers demandant quelques échanges</strong> le délai d’instruction est d’environ : <strong>%{estimation}</strong>."
   slow_html: "Si votre <strong>dossier est incomplet</strong> ou qu’il faut beaucoup d’échanges avec l’administration, le délai d’instruction est d’environ <strong>%{estimation}</strong>."

--- a/app/components/types_de_champ_editor/champ_formatted_advanced_component/champ_formatted_advanced_component.fr.yml
+++ b/app/components/types_de_champ_editor/champ_formatted_advanced_component/champ_formatted_advanced_component.fr.yml
@@ -5,8 +5,8 @@ fr:
       Pensez aux ancres de début <code class="fr-background-alt--grey">^</code> et fin <code class="fr-background-alt--grey">$</code> :<br>
       <code class="fr-background-alt--grey">12 km</code> serait accepté par
       <code class="fr-background-alt--grey">/[[:digit:]]+/</code> mais rejeté par <code class="fr-background-alt--grey">/^[[:digit:]]+$/</code><br>
-      <a href="https://rubular.com" target="_blank" rel="external noreferrer noopener">Tester l‘expression et consulter la syntaxe sur rubular.com</a>
-    indications: Indications sur le format de saisie attendu (affichées à l‘usager)
+      <a href="https://rubular.com" target="_blank" rel="external noreferrer noopener">Tester l’expression et consulter la syntaxe sur rubular.com</a>
+    indications: Indications sur le format de saisie attendu (affichées à l’usager)
     indications_hint: 'Exemple : Numéro à 7 caractères comportant des chiffres et des lettres (exemple: AB446KP)'
     valid_exemple: Exemple de saisie valide (ou de format de saisie requis)
     error_message: Message d'erreur à afficher à l'usager en cas de saisie invalide

--- a/app/controllers/administrateurs/ineligibilite_rules_controller.rb
+++ b/app/controllers/administrateurs/ineligibilite_rules_controller.rb
@@ -11,7 +11,7 @@ module Administrateurs
       draft_revision.assign_attributes(procedure_revision_params)
 
       if draft_revision.validate(:ineligibilite_rules_editor) && draft_revision.save
-        flash[:notice] = "Les conditions d‘inéligibilité ont été modifiées."
+        flash[:notice] = "Les conditions d’inéligibilité ont été modifiées."
         redirect_to [:admin, @procedure]
       else
         flash[:alert] = draft_revision.errors.full_messages

--- a/app/graphql/mutations/dossier_supprimer_label.rb
+++ b/app/graphql/mutations/dossier_supprimer_label.rb
@@ -23,7 +23,7 @@ module Mutations
 
     def authorized?(dossier:, label:, **_args)
       if dossier.labels.exclude?(label)
-        [false, { errors: ["Ce label n‘est pas associé au dossier"] }]
+        [false, { errors: ["Ce label n’est pas associé au dossier"] }]
       else
         true
       end

--- a/app/tasks/maintenance/clean_header_section_options_task.rb
+++ b/app/tasks/maintenance/clean_header_section_options_task.rb
@@ -4,7 +4,7 @@ module Maintenance
   class CleanHeaderSectionOptionsTask < MaintenanceTasks::Task
     # In the rest of PR 10713
     # TypeDeChamp options may contain options which are not consistent with the
-    # type_champ (e.g. a ‘header_section’ TypeDeChamp which has a
+    # type_champ (e.g. a ’header_section’ TypeDeChamp which has a
     # drop_down_options key/value in its options).
     # The aim here is to clean up the options so that only those wich are useful
     # for the type_champ in question.

--- a/app/views/administrateurs/attestation_template_v2s/edit.html.haml
+++ b/app/views/administrateurs/attestation_template_v2s/edit.html.haml
@@ -21,7 +21,7 @@
             %p
               %strong Pour modifier l’attestation existante (actuellement délivrée aux usagers),
               = link_to("cliquez ici", edit_admin_procedure_attestation_template_path(@procedure)) + "."
-            %p Pour générer une attestation à la charte de l‘État, créez-la ci-dessous puis publiez-la: elle remplacera alors l’attestation actuelle.
+            %p Pour générer une attestation à la charte de l’État, créez-la ci-dessous puis publiez-la: elle remplacera alors l’attestation actuelle.
 
 
     .fr-grid-row.fr-grid-row--gutters

--- a/app/views/administrateurs/procedures/api_champ_columns.html.haml
+++ b/app/views/administrateurs/procedures/api_champ_columns.html.haml
@@ -11,6 +11,6 @@
 
   - if @type_de_champ.type_champ == "siret"
     %p.fr-hint-text
-      Nous affichons aussi aux instructeurs un lien vers l’annuaire de l‘entreprise,
+      Nous affichons aussi aux instructeurs un lien vers l’annuaire de l’entreprise,
       qui comporte davantage d’informations comme des données équivalentes aux extraits KBIS.
       = link_to("Voir un exemple", annuaire_link("35600000000048"), **external_link_attributes)

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -369,7 +369,7 @@ fr:
         form:
           submitted_at: "Déposé le %{datetime}"
           updated_at: "Modifié le %{datetime}"
-          download_attestation: "Télécharger l‘attestation"
+          download_attestation: "Télécharger l’attestation"
         edit:
           autosave: Votre dossier est enregistré automatiquement après chaque modification. Vous pouvez à tout moment fermer la fenêtre et reprendre plus tard là où vous en étiez.
         messages:
@@ -432,7 +432,7 @@ fr:
         archives_notice_title: Archivage des dossiers
         archives_notice_html: |
           Ces dossiers seront supprimés lorsque leur délai de conservation dans %{app_name} (%{duration_months} mois) sera expiré.
-          <a href="%{doc_url}" rel="external noopener" target="_blank" title="Documentation sur l‘archivage des dossiers">En savoir plus</a>
+          <a href="%{doc_url}" rel="external noopener" target="_blank" title="Documentation sur l’archivage des dossiers">En savoir plus</a>
           <br/>
           Pour sauvegarder et archiver vos dossiers sur votre serveur, vous devez les télécharger.
       avis:

--- a/config/locales/models/dossier_notification/fr.yml
+++ b/config/locales/models/dossier_notification/fr.yml
@@ -9,6 +9,6 @@ fr:
         attente_correction: En attente de correction
         attente_avis: En attente d'avis externe
         message_usager: Message usager
-        # TODO: switch to ‘Annotation instructeur’ during global renaming
+        # TODO: switch to ’Annotation instructeur’ during global renaming
         annotation_instructeur: Annotation privée
         avis_externe: Avis externe

--- a/config/locales/views/instructeurs/fr.yml
+++ b/config/locales/views/instructeurs/fr.yml
@@ -15,7 +15,7 @@ fr:
         dossier_depose: 'Déposé depuis longtemps'
         dossier_modifie: 'Dossier modifié'
         message_usager: 'Message usager'
-        # TODO: switch to ‘Annotation instructeur’ during global renaming
+        # TODO: switch to ’Annotation instructeur’ during global renaming
         annotation_instructeur: 'Annotation privée'
         avis_externe: 'Avis externe'
         attente_correction: 'En attente de correction'

--- a/config/locales/views/users/procedure_footer/fr.yml
+++ b/config/locales/views/users/procedure_footer/fr.yml
@@ -36,5 +36,5 @@ fr:
           title: Trouver une maison France Services
           url: 'https://www.transformation.gouv.fr/france-services'
         carte_inclusion:
-          title: Carte des lieux d‘inclusion numérique
+          title: Carte des lieux d’inclusion numérique
           url: 'https://cartographie.societenumerique.gouv.fr/'

--- a/doc/faqs/usager/01_comment-trouver-ma-demarche.fr.md
+++ b/doc/faqs/usager/01_comment-trouver-ma-demarche.fr.md
@@ -19,7 +19,7 @@ title: "Comment trouver ma démarche ?"
 
 > Pour effectuer un dépôt sur %{application_name} vous devez notamment disposer d’un lien qui vous a été communiqué par l’administration.
 
-> Par exemple s‘il s‘agit d'une démarche relative à un titre de séjour, vous trouverez l‘information sur le site de la préfécture dont vous dépendez. S‘il s'agit d‘une demande de Pass Culture, vous trouverez les liens utiles sur le site du Pass Culture, etc…
+> Par exemple s’il s’agit d'une démarche relative à un titre de séjour, vous trouverez l’information sur le site de la préfécture dont vous dépendez. S’il s'agit d’une demande de Pass Culture, vous trouverez les liens utiles sur le site du Pass Culture, etc…
 
 ## 1. Trouver le lien de votre démarche
 

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -1660,7 +1660,7 @@ describe API::V2::GraphqlController do
         it "should return an error" do
           expect(gql_data).to eq(dossierSupprimerLabel: {
             dossier: nil,
-            errors: [{ message: "Ce label n‘est pas associé au dossier" }]
+            errors: [{ message: "Ce label n’est pas associé au dossier" }]
           })
         end
       end

--- a/spec/helpers/procedure_helper_spec.rb
+++ b/spec/helpers/procedure_helper_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe ProcedureHelper, type: :helper do
     context 'without champs' do
       let(:procedure) { create(:procedure) }
 
-      it 'never displays ‘zero minutes’' do
+      it 'never displays ’zero minutes’' do
         expect(subject).to eq(1)
       end
     end

--- a/spec/models/concerns/tags_substitution_concern_spec.rb
+++ b/spec/models/concerns/tags_substitution_concern_spec.rb
@@ -184,17 +184,17 @@ describe TagsSubstitutionConcern, type: :model do
     context 'when the procedure has a type de champ with apostrophes' do
       let(:types_de_champ_public) do
         [
-          { libelle: "Intitulé de l'‘«\"évènement\"»’" }
+          { libelle: "Intitulé de l'’«\"évènement\"»’" }
         ]
       end
 
       context 'and they are used in the template' do
-        let(:template) { "--Intitulé de l'‘«\"évènement\"»’--" }
+        let(:template) { "--Intitulé de l'’«\"évènement\"»’--" }
 
         context 'and their value in the dossier are not nil' do
           before do
             dossier.project_champs_public
-              .find { |champ| champ.libelle == "Intitulé de l'‘«\"évènement\"»’" }
+              .find { |champ| champ.libelle == "Intitulé de l'’«\"évènement\"»’" }
               .update(value: 'ceci est mon évènement')
           end
 

--- a/spec/system/administrateurs/procedure_update_spec.rb
+++ b/spec/system/administrateurs/procedure_update_spec.rb
@@ -41,7 +41,7 @@ describe 'Administrateurs can edit procedures', js: true do
   end
 
   context 'when the procedure is published' do
-    scenario 'the administrator can edit the libellé, but can‘t change the path' do
+    scenario 'the administrator can edit the libellé, but can’t change the path' do
       visit root_path
       click_on procedure.libelle
       find('#presentation').click

--- a/spec/views/shared/dossiers/_infos_generales.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_infos_generales.html.haml_spec.rb
@@ -19,7 +19,7 @@ describe 'shared/dossiers/_infos_generales', type: :view do
         pdf = dossier.attestation.pdf
         expect(dossier).to receive(:attestation).and_return(double(pdf: pdf)).at_least(2)
         expect(subject).to have_text('Attestation')
-        expect(subject).to have_text("Télécharger l‘attestation")
+        expect(subject).to have_text("Télécharger l’attestation")
       end
     end
   end
@@ -49,7 +49,7 @@ describe 'shared/dossiers/_infos_generales', type: :view do
         pdf = dossier.attestation.pdf
         expect(dossier).to receive(:attestation).and_return(double(pdf: pdf)).at_least(2)
         expect(subject).to have_text('Attestation')
-        expect(subject).to have_text("Télécharger l‘attestation")
+        expect(subject).to have_text("Télécharger l’attestation")
       end
     end
 

--- a/spec/views/users/dossiers/show/_status_overview.html.haml_spec.rb
+++ b/spec/views/users/dossiers/show/_status_overview.html.haml_spec.rb
@@ -41,7 +41,7 @@ describe 'users/dossiers/show/_status_overview', type: :view do
       expect(subject).to have_selector('.status-explanation .en-construction')
       expect(subject).to have_text('Selon nos estimations, à partir des délais d’instruction constatés')
       expect(subject).to have_text("Dans le meilleur des cas, le délai d’instruction est : 1 jour.")
-      expect(subject).to have_text("Les dossiers demandant quelques échanges le délai d’instruction est d‘environ : 2 jours.")
+      expect(subject).to have_text("Les dossiers demandant quelques échanges le délai d’instruction est d’environ : 2 jours.")
       expect(subject).to have_text("Si votre dossier est incomplet ou qu’il faut beaucoup d’échanges avec l’administration, le délai d’instruction est d’environ 3 jours.")
     end
   end
@@ -60,7 +60,7 @@ describe 'users/dossiers/show/_status_overview', type: :view do
       expect(subject).to have_selector('.status-explanation .en-instruction')
       expect(subject).to have_text('Selon nos estimations, à partir des délais d’instruction constatés')
       expect(subject).to have_text("Dans le meilleur des cas, le délai d’instruction est : 1 jour.")
-      expect(subject).to have_text("Les dossiers demandant quelques échanges le délai d’instruction est d‘environ : 2 jours.")
+      expect(subject).to have_text("Les dossiers demandant quelques échanges le délai d’instruction est d’environ : 2 jours.")
       expect(subject).to have_text("Si votre dossier est incomplet ou qu’il faut beaucoup d’échanges avec l’administration, le délai d’instruction est d’environ 3 jours.")
     end
   end


### PR DESCRIPTION
propage le fix de https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11663 a toute l'app