### PR TITLE
ETQ Usager d'un lecteur d'écran, je veux que les liens permettant de modifier mon identité sur la page récapitulative soient explicites sans contexte.

### DIFF
--- a/app/components/dossiers/individual_form_component/individual_form_component.en.yml
+++ b/app/components/dossiers/individual_form_component/individual_form_component.en.yml
@@ -3,5 +3,5 @@ en:
   self_title: Your identity
   callout_text: "You are acting as a proxy for a principal, either professionally (such as accountant, lawyer, civil servant…) or personally (family). Make sure to respect the conditions of"
   callout_link: Articles 1984 and following of the Civil Code.
-  callout_link_title: Articles 1984 and following of the Civil Code
+  callout_link_title: Articles 1984 and following of the Civil Code.
   beneficiaire_title: "Identity of the beneficiary"

--- a/app/components/dossiers/individual_form_component/individual_form_component.fr.yml
+++ b/app/components/dossiers/individual_form_component/individual_form_component.fr.yml
@@ -1,7 +1,7 @@
 ---
 fr:
   self_title: Votre identité
-  callout_text: Vous agissez en tant que mandataire, soit professionnellement (comme expert-comptable, avocat, agent public…) soit personnellement (famille). Assurez-vous de respecter les conditions
-  callout_link: des Articles 1984 et suivants du Code civil.
-  callout_link_title: Articles 1984 et suivants du Code civil
+  callout_text: Vous agissez en tant que mandataire, soit professionnellement (comme expert-comptable, avocat, agent public…) soit personnellement (famille). Assurez-vous de respecter les conditions des
+  callout_link: Articles 1984 et suivants du Code civil.
+  callout_link_title: Articles 1984 et suivants du Code civil.
   beneficiaire_title: Identité du bénéficiaire

--- a/app/views/shared/dossiers/_demande.html.haml
+++ b/app/views/shared/dossiers/_demande.html.haml
@@ -21,18 +21,18 @@
 
 
   - if dossier.for_tiers?
-    %h2.fr-h6.fr-background-alt--grey.fr-mb-0.flex
-      .flex-grow.fr-py-3v.fr-px-2w= t('views.shared.dossiers.demande.mandataire_identity')
+    .fr-background-alt--grey.flex
+      %h2#mandataire_identity.fr-h6.fr-mb-0.flex-grow.fr-py-3v.fr-px-2w= t('views.shared.dossiers.demande.mandataire_identity')
 
       - if dossier.individual.present? && profile == 'usager' && !dossier.read_only?
-        = link_to t('views.shared.dossiers.demande.edit_identity'), identite_dossier_path(dossier), class: 'fr-py-3v fr-btn fr-btn--tertiary-no-outline'
+        = link_to t('views.shared.dossiers.demande.edit_identity_html'), identite_dossier_path(dossier), class: 'fr-py-3v fr-btn fr-btn--tertiary-no-outline', id: 'edit_mandataire_identity', 'aria-labelledby': 'edit_mandataire_identity mandataire_identity'
 
 
     = render partial: "shared/dossiers/mandataire_infos", locals: { user_deleted: dossier.user_deleted?, email: dossier.user_email_for(:display), dossier: dossier }
 
   .tab-title
-    %h2.fr-h6.fr-background-alt--grey.fr-mb-0.flex
-      .flex-grow.fr-py-3v.fr-px-2w
+    .fr-background-alt--grey.flex
+      %h2#requester_identity.fr-h6.fr-mb-0.flex-grow.fr-py-3v.fr-px-2w
         = t('views.shared.dossiers.demande.requester_identity')
 
         - if dossier.identity_updated_at.present? && demande_seen_at&.<(dossier.identity_updated_at)
@@ -43,7 +43,7 @@
         = link_to t('views.shared.dossiers.demande.edit_siret'), siret_dossier_path(dossier), class: 'fr-py-3v fr-btn fr-btn--tertiary-no-outline'
 
       - if dossier.individual.present? && profile == 'usager' && !dossier.read_only?
-        = link_to t('views.shared.dossiers.demande.edit_identity'), identite_dossier_path(dossier), class: 'fr-py-3v fr-btn fr-btn--tertiary-no-outline'
+        = link_to t('views.shared.dossiers.demande.edit_identity_html'), identite_dossier_path(dossier), class: 'fr-py-3v fr-btn fr-btn--tertiary-no-outline', id: 'edit_requester_identity', 'aria-labelledby': 'edit_requester_identity requester_identity'
 
 
   = render partial: "shared/dossiers/user_infos", locals: { user_deleted: dossier.user_deleted?, email: dossier.user_email_for(:display), for_tiers: dossier.for_tiers?, beneficiaire_mail: dossier.for_tiers? ? dossier.individual.email : ""}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -379,6 +379,7 @@ en:
           form: "Form"
           edit_siret: "Edit SIRET"
           edit_identity: "Edit identity data"
+          edit_identity_html: 'Edit identity <span aria-hidden="true">data<span>'
           accuse_lecture: This procedure is subject to a reading receipt.
           accuse_lecture_with_agreement: The user has read the decision taken on his file on %{agreement}.
           accuse_lecture_without_agreement: The user has not yet learned of the decision on their file.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -386,6 +386,7 @@ fr:
           form: "Sections du formulaire"
           edit_siret: "Modifier le SIRET"
           edit_identity: "Modifier l’identité"
+          edit_identity_html: 'Modifier <span aria-hidden="true">l’identité</span>'
           accuse_lecture: Cette démarche est soumise à un accusé de lecture.
           accuse_lecture_with_agreement: L’usager a pris connaissance de la décision concernant son dossier le %{agreement}.
           accuse_lecture_without_agreement: L’usager n’a pas encore pris connaissance de la décision concernant son dossier.


### PR DESCRIPTION
# Après

https://github.com/user-attachments/assets/3b2d69a7-0b46-4bfd-b85a-15901ddd7f79


# Avant

https://github.com/user-attachments/assets/63b7358f-6ac7-478b-bf7d-740a5407f8e5



