### PR TITLE
ETQ usager, je peux cliquer sur les urls de la motivation

### DIFF
--- a/app/services/mail_template_presenter_service.rb
+++ b/app/services/mail_template_presenter_service.rb
@@ -3,6 +3,7 @@
 class MailTemplatePresenterService
   include ActionView::Helpers::SanitizeHelper
   include ActionView::Helpers::TextHelper
+  include ChampHelper
 
   def self.create_commentaire_for_state(dossier, state)
     if dossier.procedure.accuse_lecture? && Dossier::TERMINE.include?(state)
@@ -15,7 +16,7 @@ class MailTemplatePresenterService
   end
 
   def safe_body
-    sanitize(@email_template.body_for_dossier(@dossier), scrubber: Sanitizers::MailScrubber.new)
+    format_text_value(@email_template.body_for_dossier(@dossier))
   end
 
   def safe_subject

--- a/app/views/users/dossiers/show/_status_overview.html.haml
+++ b/app/views/users/dossiers/show/_status_overview.html.haml
@@ -66,7 +66,7 @@
 
             - if dossier.motivation.present?
               %h3= t('views.users.dossiers.show.status_overview.accepte_motivation')
-              %blockquote= simple_format(dossier.motivation)
+              %blockquote= format_text_value(dossier.motivation)
 
             = render partial: 'users/dossiers/show/download_justificatif', locals: { dossier: dossier }
 
@@ -84,7 +84,7 @@
 
             - if dossier.motivation.present?
               %h3= t('views.users.dossiers.show.status_overview.refuse_motivation')
-              %blockquote= simple_format(dossier.motivation)
+              %blockquote= format_text_value(dossier.motivation)
 
             = render partial: 'users/dossiers/show/download_justificatif', locals: { dossier: dossier }
             .action
@@ -100,4 +100,4 @@
 
             - if dossier.motivation.present?
               %h3= t('views.users.dossiers.show.status_overview.sans_suite_motivation')
-              %blockquote= simple_format(dossier.motivation)
+              %blockquote= format_text_value(dossier.motivation)

--- a/spec/factories/dossier.rb
+++ b/spec/factories/dossier.rb
@@ -247,11 +247,11 @@ FactoryBot.define do
       after(:create) do |dossier, _evaluator|
         motivation = case dossier.state
         when Dossier.states.fetch(:refuse)
-          'L’entreprise concernée n’est pas agréée.'
+          'L’entreprise concernée n’est pas agréée. Plus d’informations sur https://prefecture-93.fr/faq'
         when Dossier.states.fetch(:sans_suite)
-          'Le département n’est pas éligible. Veuillez remplir un nouveau dossier auprès de la DDT du 93.'
+          'Le département n’est pas éligible. Veuillez remplir un nouveau dossier auprès de la DDT du 93. Voir https://ddt-93.fr'
         else
-          'Vous avez validé les conditions.'
+          'Vous avez validé les conditions. Retrouvez votre dossier sur https://demarches-simplifiees.fr'
         end
         dossier.traitements.last.update!(motivation: motivation)
       end

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -2,6 +2,8 @@
 
 describe Dossier, type: :model do
   include ActionView::Helpers::SanitizeHelper
+  include ActionView::Helpers::TextHelper
+  include ChampHelper
 
   let(:user) { create(:user) }
 
@@ -1320,7 +1322,7 @@ describe Dossier, type: :model do
       email_template = dossier.procedure.email_template_for(dossier.state)
       commentaire = dossier.commentaires.last
 
-      expect(commentaire.body).to include(sanitize(email_template.subject_for_dossier(dossier)), sanitize(email_template.body_for_dossier(dossier)))
+      expect(commentaire.body).to include(sanitize(email_template.subject_for_dossier(dossier)), format_text_value(email_template.body_for_dossier(dossier)))
       expect(commentaire.dossier).to eq(dossier)
     end
   end

--- a/spec/views/users/dossiers/show/_status_overview.html.haml_spec.rb
+++ b/spec/views/users/dossiers/show/_status_overview.html.haml_spec.rb
@@ -69,9 +69,12 @@ describe 'users/dossiers/show/_status_overview', type: :view do
   context 'when accepté' do
     let(:dossier) { create :dossier, :accepte, :with_motivation }
 
-    it { is_expected.not_to have_selector('.status-timeline') }
-    it { is_expected.to have_selector('.status-explanation .accepte') }
-    it { is_expected.to have_text(dossier.motivation) }
+    it 'works' do
+      expect(subject).not_to have_selector('.status-timeline')
+      expect(subject).to have_selector('.status-explanation .accepte')
+      expect(subject).to have_text(dossier.motivation)
+      expect(subject).to have_link('https://demarches-simplifiees.fr', href: 'https://demarches-simplifiees.fr')
+    end
 
     context 'with attestation' do
       let(:dossier) { create :dossier, :accepte, :with_attestation }
@@ -82,25 +85,33 @@ describe 'users/dossiers/show/_status_overview', type: :view do
   context 'when refusé' do
     let(:dossier) { create :dossier, :refuse, :with_motivation }
 
-    it { is_expected.not_to have_selector('.status-timeline') }
-    it { is_expected.to have_selector('.status-explanation .refuse') }
-    it { is_expected.to have_text(dossier.motivation) }
-    it { is_expected.to have_link(nil, href: messagerie_dossier_url(dossier, anchor: 'new_commentaire')) }
+    it 'works' do
+      expect(subject).not_to have_selector('.status-timeline')
+      expect(subject).to have_selector('.status-explanation .refuse')
+      expect(subject).to have_text(dossier.motivation)
+      expect(subject).to have_link(nil, href: messagerie_dossier_url(dossier, anchor: 'new_commentaire'))
+      expect(subject).to have_link('https://prefecture-93.fr/faq', href: 'https://prefecture-93.fr/faq')
+    end
   end
 
   context 'when classé sans suite' do
     let(:dossier) { create :dossier, :sans_suite, :with_motivation }
 
-    it { is_expected.not_to have_selector('.status-timeline') }
-    it { is_expected.to have_selector('.status-explanation .sans-suite') }
-    it { is_expected.to have_text(dossier.motivation) }
+    it 'works' do
+      expect(subject).not_to have_selector('.status-timeline')
+      expect(subject).to have_selector('.status-explanation .sans-suite')
+      expect(subject).to have_text(dossier.motivation)
+      expect(subject).to have_link('https://ddt-93.fr', href: 'https://ddt-93.fr')
+    end
   end
 
   context 'when terminé but the procedure has an accuse de lecture' do
     let(:dossier) { create(:dossier, :sans_suite, :with_motivation, procedure: create(:procedure, :accuse_lecture)) }
 
-    it { is_expected.not_to have_selector('.status-explanation .sans-suite') }
-    it { is_expected.not_to have_text(dossier.motivation) }
-    it { is_expected.to have_text('Cette démarche est soumise à un accusé de lecture.') }
+    it 'works' do
+      expect(subject).not_to have_selector('.status-explanation .sans-suite')
+      expect(subject).not_to have_text(dossier.motivation)
+      expect(subject).to have_text('Cette démarche est soumise à un accusé de lecture.')
+    end
   end
 end


### PR DESCRIPTION
closes #11364

On rend les urls présentes dans la motivation cliquables

**Dans le résumé**

<img width="1361" alt="Capture d’écran 2025-05-26 à 16 11 43" src="https://github.com/user-attachments/assets/3b125ba4-6001-4e13-bf86-28c3e83c3e6e" />

**Dans la messagerie**

<img width="1361" alt="Capture d’écran 2025-05-26 à 16 11 23" src="https://github.com/user-attachments/assets/208a88a2-1921-4c56-80eb-f07148980f07" />


**Dans les emails**

<img width="1361" alt="Capture d’écran 2025-05-26 à 16 11 11" src="https://github.com/user-attachments/assets/e18040d2-276d-4bdd-93ea-8bf86a1a0840" />

