### PR TITLE
ETQ SuperAdmin je peux voir le nombre de dossiers sur la page d'une démarche dans le manager

### DIFF
--- a/app/dashboards/procedure_dashboard.rb
+++ b/app/dashboards/procedure_dashboard.rb
@@ -55,7 +55,8 @@ class ProcedureDashboard < Administrate::BaseDashboard
     tags: Field::Text,
     template: Field::Boolean,
     opendata: Field::Boolean,
-    hide_instructeurs_email: Field::Boolean
+    hide_instructeurs_email: Field::Boolean,
+    dossiers_count: Field::String
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -81,6 +82,7 @@ class ProcedureDashboard < Administrate::BaseDashboard
     :path,
     :procedure_paths,
     :aasm_state,
+    :dossiers_count,
     :administrateurs,
     :instructeurs,
     :groupe_instructeurs,

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -571,6 +571,10 @@ class Procedure < ApplicationRecord
     active_revision.revision_types_de_champ_public.filter(&:used_by_routing_rules?).map(&:libelle)
   end
 
+  def dossiers_count
+    dossiers.count
+  end
+
   def can_be_deleted_by_administrateur?
     brouillon? || dossiers.state_en_instruction.empty?
   end

--- a/config/locales/models/procedure/fr.yml
+++ b/config/locales/models/procedure/fr.yml
@@ -127,3 +127,4 @@ fr:
     label:
       procedure:
         routing_champs: Champ(s) de routage
+        dossiers_count: Nombre de dossiers


### PR DESCRIPTION
Jusqu'à présent, cette information n'était disponible que dans l'index des démarches.
On l'ajoute au show de la démarche.
Intérêt : quand on fait du support et qu'on arrive sur cette page via le numéro de la démarche, on a l'info directement. Plus besoin de faire une recherche dans la liste des démarches.

![Capture d’écran 2025-05-28 à 16 14 23](https://github.com/user-attachments/assets/2d3d3bcb-802e-47b6-bac1-9eda9cf39401)
 