### PR TITLE
ETQ Usager naviguant sur mobile, je veux que les intitulés des onglets soient visibles en intégralité

### DIFF
--- a/app/views/users/dossiers/show/_header.html.haml
+++ b/app/views/users/dossiers/show/_header.html.haml
@@ -25,8 +25,8 @@
 
     %nav.fr-tabs{ 'role': 'navigation', 'aria-label': t('views.users.dossiers.show.header.dossier_number', dossier_id: dossier.id) }
       %ul.fr-tabs__list{ role: 'tablist' }
-        = dynamic_tab_item(t('views.users.dossiers.show.header.summary'), dossier_path(dossier))
+        = dynamic_tab_item(t('views.users.dossiers.show.header.summary_html'), dossier_path(dossier))
         = dynamic_tab_item(t('views.users.dossiers.show.header.request'), [demande_dossier_path(dossier), modifier_dossier_path(dossier)])
-        = dynamic_tab_item(t('views.users.dossiers.show.header.mailbox'), messagerie_dossier_path(dossier))
+        = dynamic_tab_item(t('views.users.dossiers.show.header.mailbox_html'), messagerie_dossier_path(dossier))
         - if dossier.rdvs.any?
           = dynamic_tab_item(t('views.users.dossiers.show.header.rendez_vous'), rendez_vous_dossier_path(dossier))

--- a/app/views/users/dossiers/show/_header.html.haml
+++ b/app/views/users/dossiers/show/_header.html.haml
@@ -20,7 +20,7 @@
         .ml-auto
           = render partial: 'invites/dropdown', locals: { dossier: dossier, morphing: false }
           - if dossier.can_be_updated_by_user? && !current_page?(modifier_dossier_path(dossier))
-            = link_to t('views.users.dossiers.demande.edit_dossier'), modifier_dossier_path(dossier), class: 'fr-btn fr-btn-sm fr-ml-1w',
+            = link_to t('views.users.dossiers.demande.edit_dossier'), modifier_dossier_path(dossier), class: 'fr-btn fr-btn-sm fr-mt-2w fr-mt-md-0 fr-ml-md-1w',
               title: t('views.users.dossiers.demande.edit_dossier_title')
 
     %nav.fr-tabs{ 'role': 'navigation', 'aria-label': t('views.users.dossiers.show.header.dossier_number', dossier_id: dossier.id) }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -386,7 +386,7 @@ en:
           form: "Form"
           edit_siret: "Edit SIRET"
           edit_identity: "Edit identity data"
-          edit_identity_html: 'Edit identity<span aria-hidden="true"> data<span>'
+          edit_identity_html: 'Edit identity <span aria-hidden="true"> data<span>'
           accuse_lecture: This procedure is subject to a reading receipt.
           accuse_lecture_with_agreement: The user has read the decision taken on his file on %{agreement}.
           accuse_lecture_without_agreement: The user has not yet learned of the decision on their file.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -386,7 +386,7 @@ en:
           form: "Form"
           edit_siret: "Edit SIRET"
           edit_identity: "Edit identity data"
-          edit_identity_html: 'Edit identity <span aria-hidden="true">data<span>'
+          edit_identity_html: 'Edit identity<span aria-hidden="true"> data<span>'
           accuse_lecture: This procedure is subject to a reading receipt.
           accuse_lecture_with_agreement: The user has read the decision taken on his file on %{agreement}.
           accuse_lecture_without_agreement: The user has not yet learned of the decision on their file.
@@ -471,9 +471,9 @@ en:
           jdma_l2: Give us your feedback, it only takes 2 minutes.
         show:
           header:
-            summary: "Follow-up on your file"
+            summary_html: 'Follow-up<span class="fr-hidden fr-unhidden-sm"> on your file</span>'
             request: "Your file"
-            mailbox: "Administration messaging"
+            mailbox_html: '<span class="fr-hidden fr-unhidden-sm">Administration </span> messaging'
             rendez_vous: "Appointment"
             dossier_number: "File number %{dossier_id}"
             dossier_number_html: "File <span class='visually-hidden'>number</span> <span aria-hidden='true'>n.</span> %{dossier_id}"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -392,7 +392,7 @@ fr:
           form: "Sections du formulaire"
           edit_siret: "Modifier le SIRET"
           edit_identity: "Modifier l’identité"
-          edit_identity_html: 'Modifier <span aria-hidden="true">l’identité</span>'
+          edit_identity_html: 'Modifier<span aria-hidden="true"> l’identité</span>'
           accuse_lecture: Cette démarche est soumise à un accusé de lecture.
           accuse_lecture_with_agreement: L’usager a pris connaissance de la décision concernant son dossier le %{agreement}.
           accuse_lecture_without_agreement: L’usager n’a pas encore pris connaissance de la décision concernant son dossier.
@@ -481,9 +481,9 @@ fr:
           jdma_l2: Donnez-nous votre avis, cela ne prend que 2 minutes.
         show:
           header:
-            summary: "Suivi de votre dossier"
+            summary_html: 'Suivi<span class="fr-hidden fr-unhidden-sm"> de votre dossier</span>'
             request: "Votre dossier"
-            mailbox: "Messagerie administration"
+            mailbox_html: 'Messagerie<span class="fr-hidden fr-unhidden-sm"> administration</span>'
             rendez_vous: "Rendez-vous"
             dossier_number: "Dossier numéro %{dossier_id}"
             dossier_number_html: "Dossier <span class='visually-hidden'>numéro</span> <span aria-hidden='true'>nº</span> %{dossier_id}"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -392,7 +392,7 @@ fr:
           form: "Sections du formulaire"
           edit_siret: "Modifier le SIRET"
           edit_identity: "Modifier l’identité"
-          edit_identity_html: 'Modifier<span aria-hidden="true"> l’identité</span>'
+          edit_identity_html: 'Modifier <span aria-hidden="true"> l’identité</span>'
           accuse_lecture: Cette démarche est soumise à un accusé de lecture.
           accuse_lecture_with_agreement: L’usager a pris connaissance de la décision concernant son dossier le %{agreement}.
           accuse_lecture_without_agreement: L’usager n’a pas encore pris connaissance de la décision concernant son dossier.

--- a/spec/system/users/dossier_shared_examples.rb
+++ b/spec/system/users/dossier_shared_examples.rb
@@ -30,7 +30,7 @@ RSpec.shared_examples 'the user can send messages to the instructeur' do
     visit dossier_path(dossier)
 
     expect(page).to have_current_path(dossier_path(dossier))
-    click_on 'Messagerie administration'
+    click_on 'Messagerie administration'
 
     expect(page).to have_current_path(messagerie_dossier_path(dossier))
     expect(page).to have_content(commentaire.body)

--- a/spec/views/users/dossiers/show/_header.html.haml_spec.rb
+++ b/spec/views/users/dossiers/show/_header.html.haml_spec.rb
@@ -16,7 +16,7 @@ describe 'users/dossiers/show/header', type: :view do
     expect(rendered).to have_text("en construction")
 
     expect(rendered).to have_selector("nav.fr-tabs")
-    expect(rendered).to have_link("Suivi de votre dossier", href: dossier_path(dossier))
+    expect(rendered).to have_link("Suivi de votre dossier", href: dossier_path(dossier))
     expect(rendered).to have_link("Votre dossier", href: demande_dossier_path(dossier))
   end
 


### PR DESCRIPTION
- Adaptation des intitulés des onglets sur les terminaux de faible largeur
- Restauration de l'espace manquant dans le lien "Modifier l'identité"
- Ajustement des espaces entre les boutons d'actions sur les terminaux de fiable largeur

# Après
![Capture d’écran 2025-06-02 à 10 58 13](https://github.com/user-attachments/assets/3a422b98-6c47-427b-8f70-15b6ec0b8b78)

# Avant
![Capture d’écran 2025-06-02 à 10 59 38](https://github.com/user-attachments/assets/1a165b66-3c92-4cfb-a2a7-cba098c43dbe)

# Vue desktop
![Capture d’écran 2025-06-02 à 11 06 09](https://github.com/user-attachments/assets/af0c558d-60b8-48ab-94a1-566f9fbebfc5)
