### PR TITLE
ETQ usager, j'aimerais que le champ adresse ne plante pas 

### DIFF
--- a/app/models/champs/address_champ.rb
+++ b/app/models/champs/address_champ.rb
@@ -244,7 +244,7 @@ class Champs::AddressChamp < Champs::TextChamp
         address_data['department_name'] = APIGeoService.departement_name('99')
       end
     elsif become_not_ban?
-      address_data['street_address'] = nil
+      address_data = { 'not_in_ban': 'true' }
     end
 
     if france?

--- a/app/models/champs/address_champ.rb
+++ b/app/models/champs/address_champ.rb
@@ -214,7 +214,7 @@ class Champs::AddressChamp < Champs::TextChamp
   end
 
   def become_international?
-    country_code_changed? && international? && country_code_was == 'FR'
+    country_code_changed? && international? && country_code_was.in?(['FR', nil])
   end
 
   def become_ban?
@@ -227,7 +227,6 @@ class Champs::AddressChamp < Champs::TextChamp
 
   def set_full_address
     address_data = self.value_json
-
     if become_ban? || become_france? || become_international?
       address_data.merge!(
         'department_code': nil,

--- a/app/tasks/maintenance/t20250602fix_bad_address_data_task.rb
+++ b/app/tasks/maintenance/t20250602fix_bad_address_data_task.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20250602fixBadAddressDataTask < MaintenanceTasks::Task
+    # Documentation: cette tâche modifie les données pour…
+
+    include RunnableOnDeployConcern
+    include StatementsHelpersConcern
+
+    # Uncomment only if this task MUST run imperatively on its first deployment.
+    # If possible, leave commented for manual execution later.
+    # run_on_first_deploy
+
+    def collection
+      Champs::AddressChamp.all
+    end
+
+    def process(champ)
+      is_partial_address = champ.department_code.blank?
+      is_international_address = champ.country_code != 'FR'
+
+      if is_partial_address && is_international_address
+
+        champ.update_column(:value_json, champ.value_json.merge(
+          department_code: '99',
+          department_name: 'Etranger'
+        ))
+      end
+    end
+
+    def count
+      with_statement_timeout("5min") do
+        collection.count(:id)
+      end
+    end
+  end
+end

--- a/spec/models/champs/address_champ_spec.rb
+++ b/spec/models/champs/address_champ_spec.rb
@@ -80,4 +80,34 @@ describe Champs::AddressChamp do
       expect(champ.commune_name).to eq("Nouméa")
     end
   end
+
+  context 'interaction with new address_component' do
+    context 'start with an address saved from the ban' do
+      let(:value_json) do
+        {
+          "type" => "housenumber",
+          "label" => "128 Rue Brancion 75015 Paris",
+          "geometry" => { "type" => "Point", "coordinates" => [2.301328, 48.828992] },
+          "city_code" => "75115",
+          "city_name" => "Paris 15e Arrondissement",
+          "not_in_ban" => "",
+          "postal_code" => "75015",
+          "region_code" => "11",
+          "region_name" => "Île-de-France",
+          "street_name" => "Rue Brancion",
+          "country_code" => "FR",
+          "country_name" => "France",
+          "street_number" => "128",
+          "street_address" => "128 Rue Brancion",
+          "department_code" => "75",
+          "department_name" => "Paris"
+        }
+      end
+      it 'changes to not in ban should reset other filled value' do
+        champ.not_in_ban = 'true'
+        champ.save!
+        expect(champ.value_json).to eq("not_in_ban" => "true", "country_code" => "FR")
+      end
+    end
+  end
 end

--- a/spec/models/champs/address_champ_spec.rb
+++ b/spec/models/champs/address_champ_spec.rb
@@ -109,5 +109,20 @@ describe Champs::AddressChamp do
         expect(champ.value_json).to eq("not_in_ban" => "true", "country_code" => "FR")
       end
     end
+
+    context 'start from an empty address' do
+      let(:value_json) { nil }
+
+      it 'transition from nil to CH country_code mainting consistent departement_code/name' do
+        champ.update(country_code: 'CH', street_address: '128 Rue Brancion 75015 Paris', not_in_ban: 'true')
+        expect(champ.value_json).to eq({
+          "not_in_ban" => "true",
+          "country_code" => "CH",
+          "street_address" => '128 Rue Brancion 75015 Paris',
+          "department_code" => "99",
+          "department_name" => "Etranger"
+        })
+      end
+    end
   end
 end

--- a/spec/tasks/maintenance/t20250602fix_bad_address_data_task_spec.rb
+++ b/spec/tasks/maintenance/t20250602fix_bad_address_data_task_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe T20250602fixBadAddressDataTask do
+    describe "#process" do
+      subject(:process) { described_class.process(address_champ) }
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :address }]) }
+      let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
+      let(:address_champ) { dossier.champs.first }
+
+      context "when the address is a partial address with international data" do
+        let(:value_json) do
+          {
+            "not_in_ban" => "true",
+            "country_code" => "CH",
+            "street_address" => "128 rue brancion, paris 75015"
+          }
+        end
+        before { address_champ.update_columns(value: "123 Main St", value_json:) }
+
+        it do
+          expect { process }
+            .to change { address_champ.reload.department_code }
+            .from(nil).to("99")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# 1. workflow kc 
https://demarches-simplifiees.sentry.io/issues/6626010951/events/oldest/?project=1429550&query=transaction%3A%2AController%2A%20is%3Aunresolved%20%22data%2Fapi_geo%22&referrer=oldest-event&sort=trends&stream_index=14

1. ETQ usager je saisi une adresse dans la ban (128 rue brancion paris, 75015)
```
value: "128 Rue Brancion 75015 Paris",
 data: nil,
 value_json:
  {"type" => "housenumber",
   "label" => "128 Rue Brancion 75015 Paris",
   "geometry" => {"type" => "Point", "coordinates" => [2.301328, 48.828992]},
   "city_code" => "75115",
   "city_name" => "Paris 15e Arrondissement",
   "not_in_ban" => "",
   "postal_code" => "75015",
   "region_code" => "11",
   "region_name" => "Île-de-France",
   "street_name" => "Rue Brancion",
   "country_code" => "FR",
   "country_name" => "France",
   "street_number" => "128",
   "street_address" => "128 Rue Brancion",
   "department_code" => "75",
   "department_name" => "Paris"},
```

jusque la tout va bien

2. Puis je declare ne pas me trouver dans la ban
```
 id: 923867529,
 dossier_id: 20961726,
 type: "Champs::AddressChamp",
 created_at: Mon, 02 Jun 2025 13:40:05.117031000 CEST +02:00,
 updated_at: Mon, 02 Jun 2025 13:44:38.984032000 CEST +02:00,
 private: false,
 etablissement_id: nil,
 fetch_external_data_exceptions: nil,
 rebased_at: nil,
 prefilled: nil,
 row_id: "N",
 stable_id: 4645898,
 stream: "main",
 updated_by: "martin.fourcade@beta.gouv.fr",
 value: "128 Rue Brancion 75015 Paris",
 data: nil,
 value_json:
  {"type" => "housenumber",
   "label" => "128 Rue Brancion 75015 Paris",
   "geometry" => {"type" => "Point", "coordinates" => [2.301328, 48.828992]},
   "city_code" => "75115",
   "city_name" => "Paris 15e Arrondissement",
   "not_in_ban" => "true",
   "postal_code" => "75015",
   "region_code" => "11",
   "region_name" => "Île-de-France",
   "street_name" => "Rue Brancion",
   "country_code" => "FR",
   "country_name" => "France",
   "street_number" => "128",
   "department_code" => "75",
   "department_name" => "Paris"},
 external_id: nil,
 discarded_at: nil>
```

bon c'est la lose, on sort de la ban, mais on ne reset le value json ce qui oriente a l'erreur sentry...

3. Puis je passe le champ pays en Suisse
```
 id: 923867529,
 dossier_id: 20961726,
 type: "Champs::AddressChamp",
 created_at: Mon, 02 Jun 2025 13:40:05.117031000 CEST +02:00,
 updated_at: Mon, 02 Jun 2025 13:45:13.261494000 CEST +02:00,
 private: false,
 etablissement_id: nil,
 fetch_external_data_exceptions: nil,
 rebased_at: nil,
 prefilled: nil,
 row_id: "N",
 stable_id: 4645898,
 stream: "main",
 updated_by: "martin.fourcade@beta.gouv.fr",
 value: "128 Rue Brancion 75015 Paris",
 data: nil,
 value_json:
  {"type" => "housenumber",
   "label" => "128 Rue Brancion 75015 Paris",
   "geometry" => {"type" => "Point", "coordinates" => [2.301328, 48.828992]},
   "city_code" => "75115",
   "city_name" => "Paris 15e Arrondissement",
   "not_in_ban" => "true",
   "postal_code" => "75015",
   "region_code" => "11",
   "region_name" => "Île-de-France",
   "street_name" => "Rue Brancion",
   "country_code" => "CH",
   "country_name" => "France",
   "street_number" => "128",
   "street_address" => "",
   "department_code" => "99",
   "department_name" => "Etranger"},
 external_id: nil,
 discarded_at: nil>
```

pas envie d'aller plus loin, deja jvais tester ca

4. Puis je passe le champ pays FR
```
 id: 923867529,
 dossier_id: 20961726,
 type: "Champs::AddressChamp",
 created_at: Mon, 02 Jun 2025 13:40:05.117031000 CEST +02:00,
 updated_at: Mon, 02 Jun 2025 13:45:51.079157000 CEST +02:00,
 private: false,
 etablissement_id: nil,
 fetch_external_data_exceptions: nil,
 rebased_at: nil,
 prefilled: nil,
 row_id: "N",
 stable_id: 4645898,
 stream: "main",
 updated_by: "martin.fourcade@beta.gouv.fr",
 value: "128 Rue Brancion 75015 Paris",
 data: nil,
 value_json:
  {"type" => "housenumber",
   "label" => "128 Rue Brancion 75015 Paris",
   "geometry" => {"type" => "Point", "coordinates" => [2.301328, 48.828992]},
   "city_code" => "75115",
   "city_name" => "Paris 15e Arrondissement",
   "not_in_ban" => "true",
   "postal_code" => "75015",
   "region_code" => "11",
   "region_name" => "Île-de-France",
   "street_name" => "Rue Brancion",
   "country_code" => "FR",
   "country_name" => "France",
   "street_number" => "128",
   "street_address" => "",
   "department_code" => "99",
   "department_name" => "Etranger"},
 external_id: nil,
 discarded_at: nil>
```

9. 500

supposition -> on est ds un cas pourri car on a des données incohérentes dans le value_json
  "country_code" => "FR",
  "department_code" => "99",
  "department_name" => "Etranger"

En effet, a la suite on fait appel a la method full_address?
```ruby
  def full_address?
    if france?
      city_code.present? && street_address.present?
    else
      postal_code.present? && city_name.present? && street_address.present?
    end
  end
```
Or on vient de repasser en france, ac de la donnée de departement etranger. Ça marche pas

```
curl 'http://localhost:3000/dossiers/20961726/brouillon' -X POST -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:138.0) Gecko/20100101 Firefox/138.0' -H 'Accept: text/vnd.turbo-stream.html' -H 'Accept-Language: en,fr-FR;q=0.7,en-US;q=0.3' -H 'Accept-Encoding: gzip, deflate, br, zstd' -H 'Referer: http://localhost:3000/dossiers/20961726/brouillon' -H 'x-csrf-token: YxDHBbmqHQgZQt6vQXrOuQuDJEDwiri7CQlEEREWucQNv5CCK4xPB_-uXMq0pjLniSgY3CTqtMum6f2BS_cKfg' -H 'x-http-method-override: PATCH' -H 'x-requested-with: XMLHttpRequest' -H 'Content-Type: multipart/form-data; boundary=----geckoformboundaryeaab2ab67ce3d4186a9d7c8c3cd49978' -H 'Origin: http://localhost:3000' -H 'Connection: keep-alive' -H 'Cookie: sidebar_collapsed=false; _csrf_token=XXX; trusted_device=XXX; __profilin=p%3Dt; locale=fr; _DS_session=XXX; csrf_token=SJX3q3MxXXX; session=XXX' -H 'Sec-Fetch-Dest: empty' -H 'Sec-Fetch-Mode: cors' -H 'Sec-Fetch-Site: same-origin' -H 'Priority: u=4' --data-binary $'------geckoformboundaryeaab2ab67ce3d4186a9d7c8c3cd49978\r\nContent-Disposition: form-data; name="dossier[champs_public_attributes][4645898][value]"\r\n\r\n\r\n------geckoformboundaryeaab2ab67ce3d4186a9d7c8c3cd49978\r\nContent-Disposition: form-data; name="dossier[champs_public_attributes][4645898][address]"\r\n\r\n\r\n------geckoformboundaryeaab2ab67ce3d4186a9d7c8c3cd49978\r\nContent-Disposition: form-data; name="dossier[champs_public_attributes][4645898][country_code]"\r\n\r\nFR\r\n------geckoformboundaryeaab2ab67ce3d4186a9d7c8c3cd49978\r\nContent-Disposition: form-data; name="dossier[champs_public_attributes][4645898][street_address]"\r\n\r\n\r\n------geckoformboundaryeaab2ab67ce3d4186a9d7c8c3cd49978\r\nContent-Disposition: form-data; name="dossier[champs_public_attributes][4645898][city_name]"\r\n\r\nParis 15e Arrondissement\r\n------geckoformboundaryeaab2ab67ce3d4186a9d7c8c3cd49978\r\nContent-Disposition: form-data; name="dossier[champs_public_attributes][4645898][postal_code]"\r\n\r\n75015\r\n------geckoformboundaryeaab2ab67ce3d4186a9d7c8c3cd49978\r\nContent-Disposition: form-data; name="validate"\r\n\r\ntrue\r\n------geckoformboundaryeaab2ab67ce3d4186a9d7c8c3cd49978--\r\n'
```

# 2. un autre workflow kc 

sentry: https://demarches-simplifiees.sentry.io/issues/6635035860/?project=1429550&query=transaction%3A%2AController%2A%20is%3Aunresolved%20%22data%2Fapi_geo%22&referrer=issue-stream&sort=trends&stream_index=2
https://demarches-simplifiees.sentry.io/issues/6620860112/?project=1429550&query=transaction%3A%2AController%2A%20is%3Aunresolved%20%22data%2Fapi_geo%22&referrer=issue-stream&sort=trends&stream_index=0
préambule : 

1. Un `Champs::AddressChamp` legacy (donc qui avait que le value et pas de value_json)
2. étant passé par la tache de migration T20250513BackfillNoBanAddressTask (donc a maintenant value_json = { not_in_ban: 'true', street_address: 'ancienne valeur', label: 'ancienne valeur'})
3. l'user a passé le champ en dehors de la france (ex: suisse cf: https://pad.numerique.gouv.fr/cEZBjzWHR0Cvx0_yEsT7kw?view)

Alors on se retrouvait avec un champ sans department_code, departement name