### PR TITLE
ETQ Tech - update les timestamps des PJ d'annotations privées

### DIFF
--- a/app/controllers/champs/piece_justificative_controller.rb
+++ b/app/controllers/champs/piece_justificative_controller.rb
@@ -31,7 +31,7 @@ class Champs::PieceJustificativeController < Champs::ChampController
       save_succeed = @champ.save(context:)
     end
 
-    if save_succeed && dossier.brouillon?
+    if save_succeed
       @champ.update_timestamps
     end
 

--- a/spec/controllers/champs/piece_justificative_controller_spec.rb
+++ b/spec/controllers/champs/piece_justificative_controller_spec.rb
@@ -2,7 +2,7 @@
 
 describe Champs::PieceJustificativeController, type: :controller do
   let(:user) { create(:user) }
-  let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }]) }
+  let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }], types_de_champ_private: [{ type: :piece_justificative }]) }
   let(:dossier) { create(:dossier, user: user, procedure: procedure) }
   let(:champ) { dossier.project_champs_public.first }
 
@@ -36,6 +36,16 @@ describe Champs::PieceJustificativeController, type: :controller do
 
       it 'updates dossier.last_champ_updated_at' do
         expect { subject }.to change { dossier.reload.last_champ_updated_at }
+      end
+    end
+
+    context 'when the champ is private and the dossier is not brouillon' do
+      let(:file) { fixture_file_upload('spec/fixtures/files/piece_justificative_0.pdf', 'application/pdf') }
+      let!(:dossier) { create(:dossier, :en_construction, user: user, procedure: procedure) }
+      let!(:champ) { dossier.project_champs_private.first }
+
+      it 'updates dossier.last_champ_private_updated_at' do
+        expect { subject }.to change { dossier.reload.last_champ_private_updated_at }
       end
     end
 


### PR DESCRIPTION
la condition dans le PJ controller pour éviter d'update les timestamps lorsque le dossier n'est pas en brouillon ne permet pas d'update dans le cas d'une annotation privée. En parallèle, on a déjà la méthode update_timestamps qui s'assure bien du cas où on veut pas actualiser pour les champs publics d'un dossier en construction.