### PR TITLE
fix(notification) : lorsqu'un instructeur follow un dossier, on ajoute une notif annotation_instructeur quand il y en a réellement eu une

### DIFF
--- a/app/models/dossier_notification.rb
+++ b/app/models/dossier_notification.rb
@@ -62,7 +62,7 @@ class DossierNotification < ApplicationRecord
   def self.refresh_notifications_instructeur_for_dossier(instructeur, dossier)
     create_notification(dossier, :dossier_modifie, instructeur:) if dossier.last_champ_updated_at.present? && dossier.last_champ_updated_at > dossier.depose_at
     create_notification(dossier, :message_usager, instructeur:) if dossier.commentaires.sent_by_user.present?
-    create_notification(dossier, :annotation_instructeur, instructeur:) if dossier.champs.private_only.present?
+    create_notification(dossier, :annotation_instructeur, instructeur:) if dossier.last_champ_private_updated_at.present?
     create_notification(dossier, :avis_externe, instructeur:) if dossier.avis.with_answer.present?
     create_notification(dossier, :attente_correction, instructeur:) if dossier.pending_correction?
     create_notification(dossier, :attente_avis, instructeur:) if dossier.avis.without_answer.present?

--- a/spec/models/instructeur_spec.rb
+++ b/spec/models/instructeur_spec.rb
@@ -50,7 +50,7 @@ describe Instructeur, type: :model do
     end
 
     context "when a instructeur follow a dossier that has had notifications" do
-      let!(:dossier_with_notifications) { create(:dossier, :en_construction, last_champ_updated_at: Time.zone.now, depose_at: Time.zone.yesterday) }
+      let!(:dossier_with_notifications) { create(:dossier, :en_construction, last_champ_updated_at: Time.zone.now, depose_at: Time.zone.yesterday, last_champ_private_updated_at: Time.zone.now) }
       let!(:commentaire) { create(:commentaire, dossier: dossier_with_notifications) }
       let!(:avis_with_answer) { create(:avis, :with_answer, dossier: dossier_with_notifications) }
       let!(:avis_without_answer) { create(:avis, dossier: dossier_with_notifications) }


### PR DESCRIPTION
Pour les private champs, Il y a des cas où on créé les instances même si l'instructeur n'a renseigné aucune annotation. De fait, la condition initiale qui se limite à regarder l'existence d'instance private n'est pas suffisamment restrictive et engendre la création inutile de notifications.
Pour éviter une analyse fine qui consisterait à s'assurer qu'au moins l'une des instances des private champs d'un dossier n'est pas vide, on vient s'appuyer sur l'attribut last_champ_private_updated_at du dossier. A noter que cela demande à admettre la création inutile d'une notification dans le cas où un seul des instructeurs a ajouté une annotation avant de la retirer.

Enfin, ce fix demande à passer : https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11712 ; pour couvrir le cas où on aurait uniquement une annotation privée de type PJ associée au dossier. 