### PR TITLE
ETQ Utitlisateur d'un lecteur ou d'une loupe d'écran, je veux que le boutons permettant d'afficher le contenu des sections ait un intitulé

### DIFF
--- a/app/components/viewable_champ/section_component/section_component.en.yml
+++ b/app/components/viewable_champ/section_component/section_component.en.yml
@@ -1,3 +1,3 @@
 ---
 en:
-  toggle_section: "Show/hide fields of « %{section} »"
+  toggle_section: "Fields of « %{section} »"

--- a/app/components/viewable_champ/section_component/section_component.fr.yml
+++ b/app/components/viewable_champ/section_component/section_component.fr.yml
@@ -1,3 +1,3 @@
 ---
 fr:
-  toggle_section: "Afficher/Cacher les champs de la section « %{section} »"
+  toggle_section: "Champs de la section « %{section} »"

--- a/app/components/viewable_champ/section_component/section_component.html.haml
+++ b/app/components/viewable_champ/section_component/section_component.html.haml
@@ -3,8 +3,9 @@
     %div{ class: class_names(flex: true, "top-bordered" => first_level?) }
       = render EditableChamp::HeaderSectionComponent.new(champ: header_section, html_class: { 'fr-m-0 fr-text--md fr-px-4v flex-grow': true, "fr-text-action-high--blue-france fr-py-2w": first_level?, 'fr-py-1v': !first_level? })
       - if ![champs, sections].map(&:empty?).all? && first_level?
-        %button{ type: "button", aria: { controls: section_id, "expanded": "true", label: t('.toggle_section', section: header_section.libelle) }, href: section_id, 'data-action': 'click->expand#toggle', class: "fr-btn fr-btn--tertiary-no-outline" }
+        %button{ type: "button", aria: { controls: section_id, "expanded": "true" }, href: section_id, 'data-action': 'click->expand#toggle', class: "fr-btn fr-btn--tertiary-no-outline" }
           %i.fr-icon-arrow-up-s-line{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
+          %span.fr-sr-only= t('.toggle_section', section: header_section.libelle)
 
   %div{ id: section_id, 'data-expand-target': 'content' }
     - if !champs.empty?


### PR DESCRIPTION
<img width="918" alt="" src="https://github.com/user-attachments/assets/9c01fa7b-64df-43d7-b851-25042fde6b31" />


# Après
<img width="1297" alt="Capture d’écran 2025-06-03 à 12 07 09" src="https://github.com/user-attachments/assets/08ace3d4-eeac-4d47-89ba-3733e7816e6f" />


# Avant
<img width="1287" alt="Capture d’écran 2025-06-03 à 12 07 31" src="https://github.com/user-attachments/assets/3c78dc93-4327-4552-9e5b-e798d3cb736a" />
