### PR TITLE
Correctif : utilise le bon type pour le nombre de dossiers par démarche dans le manager

### DIFF
--- a/app/dashboards/procedure_dashboard.rb
+++ b/app/dashboards/procedure_dashboard.rb
@@ -56,7 +56,7 @@ class ProcedureDashboard < Administrate::BaseDashboard
     template: Field::Boolean,
     opendata: Field::Boolean,
     hide_instructeurs_email: Field::Boolean,
-    dossiers_count: Field::String
+    dossiers_count: Field::Number
   }.freeze
 
   # COLLECTION_ATTRIBUTES


### PR DESCRIPTION
Bug introduit ici : #11706
Voir : https://demarches-simplifiees.sentry.io/issues/6654091349?project=1429550