### PR TITLE
ETQ Instructeur - fix: je veux une notification dossier_modifie quand l'usager update son identité

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -160,6 +160,8 @@ module Users
         end
 
         @dossier.update!(autorisation_donnees: true, identity_updated_at: Time.zone.now)
+        DossierNotification.create_notification(dossier, :dossier_modifie)
+
         flash.notice = t('.identity_saved')
 
         if dossier.en_construction?

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -172,6 +172,27 @@ describe Users::DossiersController, type: :controller do
       end
     end
 
+    context "when there are instructeurs followers" do
+      let(:dossier_params) { { individual_attributes: { gender: 'M', nom: 'Mouse', prenom: 'Mickey' } } }
+      let(:instructeur_follower) { create(:instructeur) }
+      let(:instructeur_not_follower) { create(:instructeur) }
+      let!(:groupe_instructeur) { create(:groupe_instructeur, instructeurs: [instructeur_follower, instructeur_not_follower]) }
+
+      before do
+        dossier.assign_to_groupe_instructeur(groupe_instructeur, DossierAssignment.modes.fetch(:auto))
+        instructeur_follower.followed_dossiers << dossier
+      end
+
+      it "create dossier_modifie notification only for instructeur follower" do
+        expect { subject }.to change(DossierNotification, :count).by(1)
+
+        notification = DossierNotification.last
+        expect(notification.dossier_id).to eq(dossier.id)
+        expect(notification.instructeur_id).to eq(instructeur_follower.id)
+        expect(notification.notification_type).to eq("dossier_modifie")
+      end
+    end
+
     context 'when the identite cannot be updated by the user' do
       let(:dossier) { create(:dossier, :with_individual, :en_instruction, user: user, procedure: procedure) }
       let(:dossier_params) { { individual_attributes: { gender: 'M', nom: 'Mouse', prenom: 'Mickey' } } }


### PR DESCRIPTION
Au delà d'une modification du fond du dossier, il convient également de notifier d'un badge dossier_modifie lorsque l'usager update son identité, tel est le comportement de la pastille rouge actuelle.