### PR TITLE
ETQ usager je ne veux plus déposer une adresse hors BAN incomplète

### DIFF
--- a/app/components/editable_champ/address_component/address_component.html.haml
+++ b/app/components/editable_champ/address_component/address_component.html.haml
@@ -25,31 +25,21 @@
             = render EditableChamp::AsteriskMandatoryComponent.new
         = @form.select :country_code, pays_options, @champ.mandatory? ? { prompt: '' } : { include_blank: '' }, required: @champ.required?, id: @champ.country_input_id, class: "width-33-desktop fr-select small-margin"
 
-      .fr-input-group
-        = @form.label :street_address, for: @champ.street_input_id, class: 'fr-label' do
-          - capture do
-            = t('.street_label')
-            = render EditableChamp::AsteriskMandatoryComponent.new
-            %span.fr-hint-text= @champ.international? ? t('.street_international_hint') : t('.street_fr_hint')
-        = @form.text_field :street_address, class: "fr-input small-margin", id: @champ.street_input_id
+      = render Dsfr::InputComponent.new(form: @form, attribute: :street_address, opts: { class:"fr-input small-margin" }) do |c|
+        - c.with_label { t('.street_label') }
+        - c.with_hint { @champ.international? ? t('.street_international_hint') : t('.street_fr_hint') }
 
       - if @champ.international?
-        .fr-input-group
-          = @form.label :city_name, for: @champ.city_input_id, class: 'fr-label' do
-            - capture do
-              = t('.city_label')
-              = render EditableChamp::AsteriskMandatoryComponent.new
-              %span.fr-hint-text= t('.city_hint')
-          = @form.text_field :city_name, class: "width-33-desktop fr-input small-margin", id: @champ.city_input_id
+        = render Dsfr::InputComponent.new(form: @form, attribute: :city_name, opts: { class:"fr-input small-margin width-33-desktop " }) do |c|
+          - c.with_label { t('.city_label') }
+          - c.with_hint t('.city_hint')
+
 
         .fr-input-group
-          = @form.label :postal_code, for: @champ.postal_code_input_id, class: 'fr-label' do
-            - capture do
-              = t('.postal_code_label')
-              = render EditableChamp::AsteriskMandatoryComponent.new
-          = @form.text_field :postal_code, class: "width-33-desktop fr-input small-margin", id: @champ.postal_code_input_id
+          = render Dsfr::InputComponent.new(form: @form, attribute: :postal_code, opts: { class:"fr-input small-margin width-33-desktop " }) do |c|
+            - c.with_label { t('.postal_code_label') }
       - else
-        .fr-input-group
+        .fr-input-group{ class: class_names("fr-input-group--error": @champ.errors.include?(:commune_name)) }
           = @form.label :commune_name, for: @champ.city_input_id, class: 'fr-label' do
             - capture do
               = t('.commune_label')
@@ -57,3 +47,6 @@
               %span.fr-hint-text= t('.commune_hint')
           %react-fragment
             = render ReactComponent.new "ComboBox/RemoteComboBox", **commune_react_props
+
+          - if @champ.errors.include?(:commune_name)
+            %p.fr-error-text{ id: @champ.city_input_id }= @champ.errors.full_messages_for(:commune_name).first

--- a/app/models/champs/address_champ.rb
+++ b/app/models/champs/address_champ.rb
@@ -214,7 +214,7 @@ class Champs::AddressChamp < Champs::TextChamp
   end
 
   def become_france?
-    country_code_changed? && france?
+    country_code_changed? && france? && country_code_was.present?
   end
 
   def become_international?
@@ -233,14 +233,14 @@ class Champs::AddressChamp < Champs::TextChamp
     address_data = self.value_json
     if become_ban? || become_france? || become_international?
       address_data.merge!(
-        'department_code': nil,
-        'department_name': nil,
-        'region_code': nil,
-        'region_name': nil,
-        'city_code': nil,
-        'city_name': nil,
-        'street_address': nil,
-        'postal_code': nil
+        'department_code' => nil,
+        'department_name' => nil,
+        'region_code' => nil,
+        'region_name' => nil,
+        'city_code' => nil,
+        'city_name' => nil,
+        'street_address' => nil,
+        'postal_code' => nil
       )
       if become_international?
         address_data['department_code'] = '99'

--- a/app/tasks/maintenance/t20250602fix_bad_address_data_task.rb
+++ b/app/tasks/maintenance/t20250602fix_bad_address_data_task.rb
@@ -2,7 +2,8 @@
 
 module Maintenance
   class T20250602fixBadAddressDataTask < MaintenanceTasks::Task
-    # Documentation: cette tâche modifie les données pour…
+    # Documentation: rattrape des champs adresses avec des données incohérentes ou incomplètes
+    # après le déploiement du nouveau champ adresse hors BAN.
 
     include RunnableOnDeployConcern
     include StatementsHelpersConcern
@@ -20,11 +21,18 @@ module Maintenance
       is_international_address = champ.country_code != 'FR'
 
       if is_partial_address && is_international_address
-
         champ.update_column(:value_json, champ.value_json.merge(
           department_code: '99',
           department_name: 'Etranger'
         ))
+      end
+
+      if champ.department_code == "99" && !is_international_address && champ.city_code.present? && champ.postal_code.present?
+        city_data = APIGeoService.parse_city_code_and_postal_code("#{champ.city_code}-#{champ.postal_code}")
+
+        return if city_data.blank?
+
+        champ.update_column(:value_json, champ.value_json.merge!(city_data))
       end
     end
 

--- a/app/views/dossiers/show.pdf.prawn
+++ b/app/views/dossiers/show.pdf.prawn
@@ -188,7 +188,7 @@ def add_single_champ(pdf, champ)
   when 'Champs::AddressChamp'
     value = champ.blank? ? 'Non communiqué' : champ.to_s
     format_in_2_lines(pdf, tdc.libelle, value)
-    if champ.full_address?
+    if champ.full_address? && champ.france?
       format_in_2_lines(pdf, "Code INSEE :", champ.commune&.fetch(:code))
       format_in_2_lines(pdf, "Code Postal :", champ.commune&.fetch(:postal_code))
       format_in_2_lines(pdf, "Département :", champ.departement_code_and_name)

--- a/config/locales/models/champs/address_champ/en.yml
+++ b/config/locales/models/champs/address_champ/en.yml
@@ -3,4 +3,17 @@ en:
     attributes:
       champs/address_champ:
         hints:
-          value: "Enter an address, a street, a city. Example: 11 rue Réaumur, Paris"
+          value: 'Enter an address, a street, a city. Example: 11 rue Réaumur, Paris'
+    errors:
+      models:
+        champs/address_champ:
+          format: '%{message}'
+          attributes:
+            street_address:
+              required: Fill in a number or a street, or a place name
+            commune_name:
+              required: Fill in a city or municipality
+            city_name:
+              required: Fill in a city name
+            postal_code:
+              required: Fill in a zip code

--- a/config/locales/models/champs/address_champ/fr.yml
+++ b/config/locales/models/champs/address_champ/fr.yml
@@ -3,4 +3,17 @@ fr:
     attributes:
       champs/address_champ:
         hints:
-          value: "Saisissez une adresse, une voie, un lieu-dit ou une commune. Exemple : 11 rue Réaumur, Paris"
+          value: 'Saisir une adresse, une voie, un lieu-dit ou une commune. Exemple : 11 rue Réaumur, Paris'
+    errors:
+      models:
+        champs/address_champ:
+          format: '%{message}'
+          attributes:
+            street_address:
+              required: Renseigner un numéro, une voie, ou un lieu-dit
+            commune_name:
+              required: Renseigner la commune
+            city_name:
+              required: Renseigner un nom de ville
+            postal_code:
+              required: Renseigner un code postal ou zip code

--- a/spec/graphql/dossier_spec.rb
+++ b/spec/graphql/dossier_spec.rb
@@ -46,7 +46,9 @@ RSpec.describe Types::DossierType, type: :graphql do
         "street_number" => "33",
         "street_address" => "33 Rue Rébeval",
         "department_code" => "75",
-        "department_name" => "Paris"
+        "department_name" => "Paris",
+        "country_code" => "FR",
+        "country_name" => "France"
       }
     end
 
@@ -64,7 +66,7 @@ RSpec.describe Types::DossierType, type: :graphql do
         department_name: "Isère",
         country_code: "FR",
         country_name: "France"
-      }
+      }.stringify_keys
     end
 
     let(:international_address) do
@@ -78,7 +80,7 @@ RSpec.describe Types::DossierType, type: :graphql do
         department_name: APIGeoService.departement_name('99'),
         country_code: "IT",
         country_name: APIGeoService.country_name('IT')
-      }
+      }.stringify_keys
     end
 
     let(:rna) do

--- a/spec/models/champs/address_champ_spec.rb
+++ b/spec/models/champs/address_champ_spec.rb
@@ -129,9 +129,11 @@ describe Champs::AddressChamp do
       end
 
       context 'when address was partially filled with an international address' do
-        before { champ.update(country_code: 'CH', street_address: '18 rue du gruyere', not_in_ban: 'true') }
+        # Champ must first be transformed as international before setting address data
+        before { champ.update(country_code: 'CH', not_in_ban: 'true') }
 
         it 'updates departement_code/name' do
+          champ.update(street_address: '18 rue du gruyere')
           expect(champ.value_json).to eq({
             "not_in_ban" => "true",
             "country_code" => "CH",
@@ -146,7 +148,8 @@ describe Champs::AddressChamp do
 
       context 'when address was fully filled with an international address' do
         it 'can be to_s and is considered as full_address' do
-          champ.update(country_code: 'CH', street_address: '18 rue de la gruyere', not_in_ban: 'true', postal_code: '1010', city_name: 'Lausanne')
+          champ.update(not_in_ban: true, country_code: "CH")
+          champ.update(street_address: '18 rue de la gruyere', postal_code: '1010', city_name: 'Lausanne')
           expect(champ.full_address?).to be_truthy
           expect(champ.to_s).to eq('18 rue de la gruyere, Lausanne 1010 Suisse')
         end

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -232,11 +232,31 @@ describe 'The user', js: true do
     find('label', text: 'Je ne trouve pas mon adresse dans les suggestions').click
     fill_in('Numéro et nom de voie, ou lieu-dit', with: '2 rue de la paix')
     scroll_to(find_field('Ville ou commune'), align: :center)
+    expect(page).to have_content('Renseigner la commune')
     fill_in('Ville ou commune', with: '60400')
     find('.fr-menu__item', text: 'Brétigny (60400)').click
     wait_until { champ_for('address').city_name == 'Brétigny' }
     expect(champ_for('address').street_address).to eq('2 rue de la paix')
     expect(champ_for('address').full_address?).to be_truthy
+
+    # Becomes international
+    select('Bolivie', from: form_id_for('Pays'))
+    wait_until { champ_for('address').country_code == 'BO' }
+    expect(page).to have_content("Renseigner un nom de ville")
+    fill_in('Ville', with: 'La Paz')
+    wait_until { champ_for('address').city_name == 'La Paz' }
+
+    expect(page).to have_content("Renseigner un code postal")
+    fill_in('Code postal', with: '123')
+    wait_until { champ_for('address').postal_code == '123' }
+    expect(champ_for('address').full_address?).to be_truthy
+
+    # Becomes France again
+    select('France', from: form_id_for('Pays'))
+    wait_until { champ_for('address').country_code == 'FR' }
+    fill_in('Ville ou commune', with: '60400')
+    find('.fr-menu__item', text: 'Brétigny (60400)').click
+    wait_until { champ_for('address').city_name == 'Brétigny' }
   end
 
   scenario 'numbers champs formatting' do

--- a/spec/tasks/maintenance/t20250602fix_bad_address_data_task_spec.rb
+++ b/spec/tasks/maintenance/t20250602fix_bad_address_data_task_spec.rb
@@ -26,6 +26,38 @@ module Maintenance
             .from(nil).to("99")
         end
       end
+
+      context "when the address is france not ban but department code is still international" do
+        let(:value_json) do
+          {
+            "not_in_ban" => "true",
+            "country_code" => "FR",
+            "city_code" => "75115",
+            "postal_code" => "75015",
+            "street_address" => "128 rue brancion, paris 75015",
+            "department_code" => "99",
+            "department_name" => "Etranger"
+          }
+        end
+
+        before { address_champ.update_columns(value_json:) }
+
+        it do
+          expect { process }.to change { address_champ.reload.value_json }.to({
+            "city_code" => "75115",
+           "city_name" => "Paris 15e Arrondissement",
+           "not_in_ban" => "true",
+           "postal_code" => "75015",
+           "region_code" => "11",
+           "region_name" => "Île-de-France",
+           "country_code" => "FR",
+           "country_name" => "France",
+           "street_address" => "128 rue brancion, paris 75015",
+           "department_code" => "75",
+           "department_name" => "Paris"
+          })
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
On valide que chaque sous champ est présent, que ce soit parceque le champ et obligatoire, ou parce-qu'un des sous champs a été saisi.

Par simplicité pour le moment, c'est validé comme le reste, ce qui signifie que l'erreur est affichée dès qu'on a commencé à remplir/blur un champ, ou dans le cas d'un champ mandatory dès qu'on passe hors BAN. On pourra améliorer ça + tard.

Corrige aussi un crash du champ lors du repassage en France (ne nettoyait pas bien le department_code entre autres) et rattrape la bad data qui bloque les champs. https://demarches-simplifiees.sentry.io/issues/?project=1429550&query=is%3Aunresolved%20commune&referrer=issue-list&statsPeriod=14d

⚠️ Ce fix a impliqué d'adapter quelques tests car la logique du champ suit l'UX: il s'attend à ce que la bascule `not ban / international / france`  se fasse dans un premier update, puis dans un second on set les valeurs. Autrement dit, dans les tests on ne peut pas set d'un bloc tout un value json.   (et ça me donne l'impression que c'est fragile, notamment pour d'éventuelles future maintenance tasks de rattrapage). 



Le PDF enlève aussi la mention de code INSEE, département etc… quand on est à l'international.

<img width="431" alt="Capture d’écran 2025-06-05 à 12 55 46" src="https://github.com/user-attachments/assets/6bf64ee9-f5bc-413b-90ac-fb15698daa0a" />
<img width="431" alt="Capture d’écran 2025-06-05 à 12 55 30" src="https://github.com/user-attachments/assets/234864e5-15f7-4061-b820-279777b83512" />

https://github.com/user-attachments/assets/03d10e7c-1ed9-439b-8929-9d61f0151a67


