### PR TITLE
ETQ instructeur, dans la galerie de PJs, tous les badges des PJs sont de couleur grise

### DIFF
--- a/app/components/attachment/gallery_item_component.rb
+++ b/app/components/attachment/gallery_item_component.rb
@@ -80,7 +80,10 @@ class Attachment::GalleryItemComponent < ApplicationComponent
   def badge_updated_class
     class_names(
       "fr-badge fr-badge--sm" => true,
-      "highlighted" => seen_at.present? && updated_at&.>(seen_at)
+      # "highlighted" => seen_at.present? && updated_at&.>(seen_at)
+      # we remove the hihlighting.
+      # we let it commented because we want to test the reaction of instructors before deleting all the associated code
+      "highlighted" => false
     )
   end
 

--- a/spec/components/attachment/gallery_item_component_spec.rb
+++ b/spec/components/attachment/gallery_item_component_spec.rb
@@ -111,7 +111,8 @@ RSpec.describe Attachment::GalleryItemComponent, type: :component do
         end
 
         it 'displays datetime in the right style' do
-          expect(subject).to have_css('.highlighted')
+          # TODO: remove this test if we choose to remove the highlighting for new PJs
+          expect(subject).not_to have_css('.highlighted')
         end
       end
 
@@ -179,7 +180,8 @@ RSpec.describe Attachment::GalleryItemComponent, type: :component do
         end
 
         it 'displays datetime in the right style' do
-          expect(subject).to have_css('.highlighted')
+          # TODO: remove this test if we choose to remove the highlighting for new PJs
+          expect(subject).not_to have_css('.highlighted')
         end
       end
 


### PR DESCRIPTION
Dans la foulée de https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11725 on enlève le surlignement en orange du badge des PJS lorsqu'une nouvelle PJ est ajoutée ou modifiée par l'usager.
Pour l'instant on conserve tout le code associé pour faire machine arrière si besoin.

![Capture d’écran 2025-06-06 à 15 10 43](https://github.com/user-attachments/assets/ddfb304f-9680-494d-a8b9-8bddc2d33fac)
 