### PR TITLE
ETQ administrateur, je souhaite que les exports template contiennent la valeur des champs supprimé dans une révision passée

### DIFF
--- a/app/models/concerns/dossier_export_concern.rb
+++ b/app/models/concerns/dossier_export_concern.rb
@@ -17,6 +17,8 @@ module DossierExportConcern
 
   def champ_values_for_export(types_de_champ, row_id: nil, export_template: nil, format:)
     types_de_champ.flat_map do |type_de_champ|
+      # TODO: filled_champ? or another method that should be able to fetch champ value no matter if the champ is no more in revision
+
       champ = filled_champ(type_de_champ, row_id:)
       if export_template.present?
         export_template

--- a/app/models/concerns/dossier_export_concern.rb
+++ b/app/models/concerns/dossier_export_concern.rb
@@ -17,9 +17,9 @@ module DossierExportConcern
 
   def champ_values_for_export(types_de_champ, row_id: nil, export_template: nil, format:)
     types_de_champ.flat_map do |type_de_champ|
-      # TODO: filled_champ? or another method that should be able to fetch champ value no matter if the champ is no more in revision
-
       champ = filled_champ(type_de_champ, row_id:)
+      champ ||= champs.find { _1.public_id == type_de_champ.public_id(_1.row_id) && _1.visible? }
+
       if export_template.present?
         export_template
           .columns_for_stable_id(type_de_champ.stable_id)

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -2253,6 +2253,18 @@ describe Dossier, type: :model do
             expect(dossier.champ_values_for_export(type_champs, format: :xlsx).size).to eq(3)
           end
         end
+
+        context 'for dossier having a champ not in his revision' do
+          let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, procedure:) }
+          let(:dossier_second_revision) { create(:dossier, :en_construction, :with_populated_champs, procedure:) }
+
+          it 'should see champ' do
+            expect do
+              dossier.rebase!
+              dossier.reload
+            end.not_to change { dossier.champ_values_for_export(procedure.types_de_champ_for_procedure_export, format: :xlsx) }
+          end
+        end
       end
 
       context "when procedure brouillon" do


### PR DESCRIPTION
hs: https://secure.helpscout.net/conversation/2958364374/2194308

# problème

Avec le nouveau système de champ, on utilise les projections lors des exports.
Sauf qu'il ne ressort pas des projections les champs qui ne sont pas dans une revision.
Or c'est un cas d'usage classique :
1. ETQ usager je depose (en_construction) mon dossier sur la revision n
2. ETQ admin, je supprime un des champ de la revision n, publie une revision n+1
3. Le dossier de l'usager (en_construction) passe sur la nouvelle revision
4. ETQ admin, je ne vois plus l'ancienne valeur saisie dans les exports

# solution 

Si la projection est vide, on essaie d'utiliser un champ de la collection `dossiers.champs` (donc les champs non projetés)