### PR TITLE
ETQ Utilisateur d'un lecteur d'écran, je veux que le bloc d'aide ne contienne pas de listes imbriquées inutiles

### DIFF
--- a/app/assets/stylesheets/new_footer.scss
+++ b/app/assets/stylesheets/new_footer.scss
@@ -24,3 +24,9 @@
   font-size: 0.75rem;
   line-height: 1.25rem;
 }
+
+.fr-footer .fr-download__link {
+  font-size: 0.75rem;
+  line-height: 1.25rem;
+  color: var(--text-default-grey);
+}

--- a/app/components/procedure/service_list_contact_component.rb
+++ b/app/components/procedure/service_list_contact_component.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class Procedure::ServiceListContactComponent < ApplicationComponent
-  attr_reader :dossier, :faq_link, :contact_link, :email, :telephone, :telephone_url, :other_contact_info, :horaires
+  attr_reader :dossier, :faq_link, :contact_link, :email, :telephone, :telephone_url, :other_contact_info, :horaires, :footer
 
-  def initialize(service_or_contact_information:, dossier:)
+  def initialize(service_or_contact_information:, dossier:, footer: false)
     @dossier = dossier
     @faq_link = service_or_contact_information.respond_to?(:faq_link) ? service_or_contact_information.faq_link : nil
     @contact_link = service_or_contact_information.respond_to?(:contact_link) ? service_or_contact_information.contact_link : nil
@@ -12,5 +12,6 @@ class Procedure::ServiceListContactComponent < ApplicationComponent
     @telephone_url = service_or_contact_information.telephone_url
     @other_contact_info = service_or_contact_information.respond_to?(:other_contact_info) ? service_or_contact_information.other_contact_info : nil
     @horaires = service_or_contact_information.horaires
+    @footer = footer
   end
 end

--- a/app/components/procedure/service_list_contact_component/service_list_contact_component.html.haml
+++ b/app/components/procedure/service_list_contact_component/service_list_contact_component.html.haml
@@ -1,43 +1,49 @@
-- if faq_link.present?
-  %li.fr-mb-1w
-    = link_to t('.faq_link'), faq_link , title: helpers.new_tab_suffix(t('.faq_link')), class: 'fr-link fr-link--sm', **helpers.external_link_attributes
-- if contact_link.present?
-  %li.fr-mb-2w
-    = link_to t('.contact_link'), contact_link, title: helpers.new_tab_suffix(t('.contact_link')), class: 'fr-link fr-link--sm', **helpers.external_link_attributes
+- if faq_link.present? && contact_link.present?
+  %ul
+    %li.fr-mb-2v
+      = link_to t('.faq_link'), faq_link , title: helpers.new_tab_suffix(t('.faq_link')), class: footer ? '' : 'fr-link fr-link--sm', **helpers.external_link_attributes
+    %li.fr-mb-2w
+      = link_to t('.contact_link'), contact_link, title: helpers.new_tab_suffix(t('.contact_link')), class: footer ? '' : 'fr-link fr-link--sm', **helpers.external_link_attributes
 
-%li.border-left-dark
-  %dl
-    - if dossier.present? && dossier&.messagerie_available?
-      .flex.fr-mb-2v
-        %dt.fr-mr-2v
-          %span.fr-icon-message-2-line.fr-icon--sm{ "aria-hidden": "true" }
-          %span.visually-hidden= t('layouts.mailers.service_footer.by_messagerie')
-        %dd
-          = link_to t('.contact_instructeur'), messagerie_dossier_path(dossier)
+- elsif faq_link.present? || contact_link.present?
+  .fr-mb-2w
+    - if faq_link.present?
+      = link_to t('.faq_link'), faq_link , title: helpers.new_tab_suffix(t('.faq_link')), class: footer ? '' : 'fr-link fr-link--sm', **helpers.external_link_attributes
+    - if contact_link.present?
+      = link_to t('.contact_link'), contact_link, title: helpers.new_tab_suffix(t('.contact_link')), class: footer ? '' : 'fr-link fr-link--sm', **helpers.external_link_attributes
 
-    - if email.present?
-      .flex.fr-mb-2v
-        %dt.fr-mr-2v
-          %span.fr-icon-mail-line.fr-icon--sm{ "aria-hidden": "true" }
-          %span.visually-hidden= t('layouts.mailers.service_footer.by_email')
-        %dd
-          = link_to email, "mailto:#{email}"
+%dl.border-left-dark
+  - if dossier.present? && dossier&.messagerie_available?
     .flex.fr-mb-2v
       %dt.fr-mr-2v
-        %span.fr-icon-phone-line.fr-icon--sm{ "aria-hidden": "true" }
-        %span.visually-hidden= t('layouts.mailers.service_footer.by_phone')
+        %span.fr-icon-message-2-line.fr-icon--sm{ "aria-hidden": "true" }
+        %span.visually-hidden= t('layouts.mailers.service_footer.by_messagerie')
       %dd
-        = link_to telephone, telephone_url
+        = link_to t('.contact_instructeur'), messagerie_dossier_path(dossier)
+
+  - if email.present?
     .flex.fr-mb-2v
       %dt.fr-mr-2v
-        %span.fr-icon-time-line.fr-icon--sm{ "aria-hidden": "true" }
-        %span.visually-hidden= t('layouts.mailers.service_footer.schedule')
+        %span.fr-icon-mail-line.fr-icon--sm{ "aria-hidden": "true" }
+        %span.visually-hidden= t('layouts.mailers.service_footer.by_email')
       %dd
-        = horaires
+        = link_to email, "mailto:#{email}"
+  .flex.fr-mb-2v
+    %dt.fr-mr-2v
+      %span.fr-icon-phone-line.fr-icon--sm{ "aria-hidden": "true" }
+      %span.visually-hidden= t('layouts.mailers.service_footer.by_phone')
+    %dd
+      = link_to telephone, telephone_url
+  .flex.fr-mb-2v
+    %dt.fr-mr-2v
+      %span.fr-icon-time-line.fr-icon--sm{ "aria-hidden": "true" }
+      %span.visually-hidden= t('layouts.mailers.service_footer.schedule')
+    %dd
+      = horaires
 
-    - if other_contact_info.present?
-      .flex.fr-mb-2v
-        %dt.fr-mr-2v
-          %span.fr-fi-info-line.fr-icon--sm{ "aria-hidden": "true" }
-        %dd
-          = other_contact_info
+  - if other_contact_info.present?
+    .flex.fr-mb-2v
+      %dt.fr-mr-2v
+        %span.fr-fi-info-line.fr-icon--sm{ "aria-hidden": "true" }
+      %dd
+        = other_contact_info

--- a/app/components/simple_format_component.rb
+++ b/app/components/simple_format_component.rb
@@ -60,7 +60,7 @@ class SimpleFormatComponent < ApplicationComponent
     end.join.lstrip
 
     @renderer = Redcarpet::Markdown.new(
-      Redcarpet::BareRenderer.new(class_names_map: { list: 'fr-ol-content--override' }),
+      Redcarpet::BareRenderer.new(class_names_map: class_names_map.merge(list: 'fr-ol-content--override')),
       REDCARPET_EXTENSIONS.merge(autolink: @allow_a)
     )
   end

--- a/app/views/shared/dossiers/_update_contact_information.html.haml
+++ b/app/views/shared/dossiers/_update_contact_information.html.haml
@@ -1,11 +1,11 @@
-#contact_information
+#contact_information.fr-text--xs
   - service_or_contact_information = dossier&.service_or_contact_information || procedure.service
   - if service_or_contact_information.present?
     %h3.fr-footer__top-cat= I18n.t('users.procedure_footer.managed_by.header')
-    .fr-footer__top-link.fr-pb-3w
+    .fr-pb-3w
       %span{ lang: :fr }= service_or_contact_information.pretty_nom
-      %div{ lang: :fr }
-        = render SimpleFormatComponent.new(service_or_contact_information.adresse, class_names_map: {paragraph: 'fr-footer__content-desc'})
+      %div.fr-text--xs{ lang: :fr }
+        = render SimpleFormatComponent.new(service_or_contact_information.adresse, class_names_map: {paragraph: 'fr-text--xs'})
   %h3.fr-footer__top-cat
     - if dossier.present? && dossier.depose_at.present?
       = I18n.t('help_dropdown.help_filled_dossier')
@@ -14,5 +14,4 @@
     - else
       = I18n.t('help_dropdown.procedure_title')
   - if service_or_contact_information.present?
-    %ul.fr-footer__top-list
-      = render Procedure::ServiceListContactComponent.new(service_or_contact_information: service_or_contact_information, dossier: dossier)
+    = render Procedure::ServiceListContactComponent.new(service_or_contact_information: service_or_contact_information, dossier: dossier, footer: true)

--- a/app/views/shared/dossiers/_update_contact_information.html.haml
+++ b/app/views/shared/dossiers/_update_contact_information.html.haml
@@ -2,10 +2,9 @@
   - service_or_contact_information = dossier&.service_or_contact_information || procedure.service
   - if service_or_contact_information.present?
     %h3.fr-footer__top-cat= I18n.t('users.procedure_footer.managed_by.header')
-    .fr-pb-3w
-      %span{ lang: :fr }= service_or_contact_information.pretty_nom
-      %div.fr-text--xs{ lang: :fr }
-        = render SimpleFormatComponent.new(service_or_contact_information.adresse, class_names_map: {paragraph: 'fr-text--xs'})
+    %div{ lang: :fr }
+      = service_or_contact_information.pretty_nom
+      = render SimpleFormatComponent.new(service_or_contact_information.adresse, class_names_map: {paragraph: 'fr-text--xs'})
   %h3.fr-footer__top-cat
     - if dossier.present? && dossier.depose_at.present?
       = I18n.t('help_dropdown.help_filled_dossier')

--- a/app/views/shared/help/dropdown_items/_service_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_service_item.html.haml
@@ -2,5 +2,4 @@
 .fr-pl-1w
   %h1.fr-mb-1v
     = title
-  %ul
-    = render Procedure::ServiceListContactComponent.new(service_or_contact_information: service, dossier: dossier)
+  = render Procedure::ServiceListContactComponent.new(service_or_contact_information: service, dossier: dossier)


### PR DESCRIPTION
# Suppression de listes inappropriées
__Après__
![Capture d’écran 2025-06-09 à 11 46 18](https://github.com/user-attachments/assets/4fc07ff0-9730-46b3-8470-337696f7aab6)

__Avant__
![Capture d’écran 2025-06-09 à 11 46 47](https://github.com/user-attachments/assets/09915fcf-e3da-4cc2-a8ab-40bfa58b7e03)


# Uniformisation des styles du pied de page
__Après__
![Capture d’écran 2025-06-09 à 11 40 51](https://github.com/user-attachments/assets/2b808a89-8a0d-42d4-b805-a463fcb589e7)

__Avant__
![Capture d’écran 2025-06-09 à 11 41 06](https://github.com/user-attachments/assets/30fda6dc-8cc1-4018-8c32-17e87eacc7da)
