### PR TITLE
ETQ Usager d'un lecteur d'écran, je veux que le contenu du titre princpal soit correctement ordonné

### DIFF
--- a/app/assets/stylesheets/flex.scss
+++ b/app/assets/stylesheets/flex.scss
@@ -47,6 +47,10 @@
     flex-direction: column;
   }
 
+  &.column-reverse {
+    flex-direction: column-reverse;
+  }
+
   @media (min-width: $two-columns-breakpoint) {
     &.row-lg {
       flex-direction: row;

--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -82,7 +82,7 @@ module DossierHelper
 
   def status_badge_user(dossier, alignment_class = '')
     if dossier.hide_info_with_accuse_lecture?
-      tag.span 'traité', role: 'status', class: "fr-badge fr-badge--sm fr-badge--no-icon #{alignment_class}"
+      tag.span 'traité', class: "fr-badge fr-badge--sm fr-badge--no-icon #{alignment_class}"
     else
       status_badge(dossier.state, alignment_class)
     end
@@ -90,7 +90,7 @@ module DossierHelper
 
   def status_badge(state, alignment_class = '')
     status_text = dossier_display_state(state, lower: true)
-    tag.span status_text, role: 'status', class: class_names(
+    tag.span status_text, class: class_names(
       'fr-badge fr-badge--sm' => true,
       'fr-badge--no-icon' => Dossier.states.fetch(:accepte).exclude?(state),
       class_badge_state(state) => true,
@@ -116,11 +116,11 @@ module DossierHelper
         "fr-badge fr-badge--sm",
         "fr-badge--warning super" => profile == :for_user,
         html_class => true
-      ), role: 'status')
+      ))
   end
 
   def correction_resolved_badge(html_class: nil)
-    tag.span(Dossier.human_attribute_name("pending_correction.resolved"), class: ['fr-badge fr-badge--sm fr-badge--success', html_class], role: 'status')
+    tag.span(Dossier.human_attribute_name("pending_correction.resolved"), class: ['fr-badge fr-badge--sm fr-badge--success', html_class])
   end
 
   def tags_label(labels)

--- a/app/views/shared/dossiers/_header.html.haml
+++ b/app/views/shared/dossiers/_header.html.haml
@@ -1,10 +1,10 @@
-%h1
-  = dossier.procedure.libelle
-  = status_badge_user(dossier, 'super')
-  %br
+%h1.flex.column-reverse
   %span.fr-h2
     = t('views.users.dossiers.show.header.dossier_number_html', dossier_id: dossier.id)
     = t('views.users.dossiers.show.header.created_date', date_du_dossier: I18n.l(dossier.created_at))
+  %span
+    = dossier.procedure.libelle
+    = status_badge_user(dossier, 'super')
 
 = render(partial: 'users/dossiers/expiration_banner', locals: {dossier: dossier})
 

--- a/app/views/users/dossiers/show/_header.html.haml
+++ b/app/views/users/dossiers/show/_header.html.haml
@@ -1,14 +1,14 @@
 .sub-header
   .fr-container
-    %h1
-      = dossier.procedure.libelle
-      = status_badge_user(dossier, 'super')
-      = pending_correction_badge(:for_user) if dossier.pending_correction?
-      %br
+    %h1.flex.column-reverse
       %span.fr-h2
         = t('views.users.dossiers.show.header.dossier_number_html', dossier_id: dossier.id)
         - if dossier.depose_at.present?
           = t('views.users.dossiers.show.header.submit_date', date_du_dossier: I18n.l(dossier.depose_at))
+      %span
+        = dossier.procedure.libelle
+        = status_badge_user(dossier, 'super')
+        = pending_correction_badge(:for_user) if dossier.pending_correction?
 
     = render(partial: 'users/dossiers/expiration_banner', locals: {dossier: dossier})
 


### PR DESCRIPTION
# Fait apparaître les données relatives au dossier en premier dans le code HTML
__Après__
<img width="1082" alt="" src="https://github.com/user-attachments/assets/f6ac2d91-43ac-441c-8779-0b004e6b4af4" />

__Avant__
<img width="1071" alt="" src="https://github.com/user-attachments/assets/6214c362-38a9-4119-bc68-173685e3dad4" />


# Supprimer les `role=status"` inutiles sur les badges
__Après__
<img width="987" alt="" src="https://github.com/user-attachments/assets/8ecdc55c-e91a-415f-a0ff-ac60ba7be225" />

__Avant__
<img width="1062" alt="" src="https://github.com/user-attachments/assets/f81f1e3a-9f80-4334-b1c7-469168de993f" />