### PR TITLE
tech: ajoute le endpoint `france_connect/redirect_uris` pour permettre a FC de fonctionner sur plusieurs domaines

### DIFF
--- a/app/controllers/france_connect_controller.rb
+++ b/app/controllers/france_connect_controller.rb
@@ -137,6 +137,19 @@ class FranceConnectController < ApplicationController
     end
   end
 
+  # OpenIdConnect use a special endpoint to retrieve the list of redirect URIs
+  # in case of multiple domains sharing the same sub by user
+  # see https://docs.partenaires.franceconnect.gouv.fr/fs/fs-technique/fs-technique-sector_identifier
+  def redirect_uris
+    uris = [FRANCE_CONNECT[:redirect_uri]]
+
+    if ENV['APP_HOST_LEGACY'].present? && ENV['APP_HOST_LEGACY'] != ENV['APP_HOST']
+      uris << "https://#{ENV['APP_HOST_LEGACY']}/france_connect/particulier/callback"
+    end
+
+    render json: uris
+  end
+
   private
 
   def set_user_by_confirmation_token

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -206,6 +206,8 @@ Rails.application.routes.draw do
     # to be migrated
     get 'particulier/callback' => :callback
     get 'particulier/merge_using_email_link/:email_merge_token' => :merge_using_email_link
+
+    get 'redirect_uris'
   end
 
   get 'pro_connect' => 'pro_connect#index'


### PR DESCRIPTION
tout en partageant les mm subs par compte