### PR TITLE
Correctif : ETQ admin lorsque je clone une démarche je ne vois la case à cocher Jeton API entreprise que si le jeton est configuré

### DIFF
--- a/app/views/administrateurs/procedures/clone_settings.html.haml
+++ b/app/views/administrateurs/procedures/clone_settings.html.haml
@@ -111,7 +111,7 @@
               .fr-hint-text
                 = t('administrateurs.procedures.clone.types_de_champ_count', count: @procedure.active_revision.types_de_champ_private.count)
 
-      - if @is_same_admin && @procedure.api_entreprise_token.present?
+      - if @is_same_admin && @procedure.has_api_entreprise_token?
         .fr-fieldset__element
           .fr-checkbox-group
             = f.check_box 'clone_options[api_entreprise_token]', checked: true

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -694,11 +694,12 @@ describe Administrateurs::ProceduresController, type: :controller do
     end
 
     context 'when admin is the owner of the procedure' do
-      it 'displays all options' do
+      it 'displays all relevant options' do
         is_expected.to have_http_status(:success)
         expect(response.body).to include "Service"
         expect(response.body).to include "Administrateurs"
         expect(response.body).to include "Instructeurs"
+        expect(response.body).not_to include "Jeton API entreprise"
       end
     end
 


### PR DESCRIPTION
**Avant**

![clone-settings-1](https://github.com/user-attachments/assets/1456aabc-face-4e2e-a0b1-8dfd86eb173f)

et 

![tuile](https://github.com/user-attachments/assets/6a7d3436-e185-4c35-bc96-1e4ac56ef7fd)

**Après**
la case à cocher "Jeton API entreprise" n'apparait plus si la démarche parent n'a pas de jeton configuré