### PR TITLE
ETQ Usager: je suis redirigé vers www.demarches-simplifiees.fr si je ne suis pas connecté (correctif temporaire)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,7 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception, store: :cookie # define same store in config/initializers/active_storage.rb
 
+  before_action :redirect_to_legacy
   before_action :set_sentry_user
   before_action :redirect_if_untrusted
   before_action :reject, if: -> { ENV.fetch("MAINTENANCE_MODE", 'false') == 'true' }
@@ -45,6 +46,14 @@ class ApplicationController < ActionController::Base
       Current.contact_email = CONTACT_EMAIL
       Current.application_base_url = APPLICATION_BASE_URL
     end
+  end
+
+  def redirect_to_legacy
+    # rubocop:disable DS/ApplicationName
+    if !user_signed_in? && request.host == "demarches.numerique.gouv.fr"
+      redirect_to "https://www.demarches-simplifiees.fr#{request.fullpath}", allow_other_host: true
+    end
+    # rubocop:enable DS/ApplicationName
   end
 
   def staging_authenticate

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,7 +50,7 @@ class ApplicationController < ActionController::Base
 
   def redirect_to_legacy
     # rubocop:disable DS/ApplicationName
-    if !user_signed_in? && request.host == "demarches.numerique.gouv.fr"
+    if !user_signed_in? && request.host == "demarches.numerique.gouv.fr" && ENV.fetch("REDIRECT_GOUV_TO_DS", 'true') == 'true'
       redirect_to "https://www.demarches-simplifiees.fr#{request.fullpath}", allow_other_host: true
     end
     # rubocop:enable DS/ApplicationName

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -209,4 +209,62 @@ describe ApplicationController, type: :controller do
       end
     end
   end
+
+  describe '#redirect_to_legacy' do
+    before do
+      allow(@controller).to receive(:current_user).and_return(current_user)
+      allow(@controller).to receive(:redirect_to)
+      @request.host = host
+      @request.path = '/commencer/une_demarche'
+      @controller.send(:redirect_to_legacy)
+    end
+
+    context 'when a user is logged' do
+      let(:current_user) { create(:user) }
+
+      context 'when the host is a legacy domain' do
+        let(:host) { 'www.demarches-simplifiees.fr' }
+
+        it 'does not redirect' do
+          expect(@controller).not_to have_received(:redirect_to)
+        end
+      end
+
+      context 'when the host is demarches.numerique.gouv.fr' do
+        let(:host) { 'demarches.numerique.gouv.fr' }
+
+        it 'does not redirect' do
+          expect(@controller).not_to have_received(:redirect_to)
+        end
+      end
+    end
+
+    context 'when a user is not logged' do
+      let(:current_user) { nil }
+
+      context 'when the host is a legacy domain' do
+        let(:host) { 'www.demarches-simplifiees.fr' }
+
+        it 'does not redirect' do
+          expect(@controller).not_to have_received(:redirect_to)
+        end
+      end
+
+      context 'when the host is demarches.numerique.gouv.fr' do
+        let(:host) { 'demarches.numerique.gouv.fr' }
+
+        it 'does redirect' do
+          expect(@controller).to have_received(:redirect_to).with('https://www.demarches-simplifiees.fr/commencer/une_demarche', allow_other_host: true)
+        end
+      end
+
+      context 'when the host is dev.demarches.numerique.gouv.fr' do
+        let(:host) { 'dev.demarches.numerique.gouv.fr' }
+
+        it 'does redirect' do
+          expect(@controller).not_to have_received(:redirect_to)
+        end
+      end
+    end
+  end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -211,9 +211,16 @@ describe ApplicationController, type: :controller do
   end
 
   describe '#redirect_to_legacy' do
+    let(:redirect_env) { nil }
+
     before do
       allow(@controller).to receive(:current_user).and_return(current_user)
       allow(@controller).to receive(:redirect_to)
+
+      if !redirect_env.nil?
+        allow(ENV).to receive(:fetch).with("REDIRECT_GOUV_TO_DS", 'true').and_return(!redirect_env)
+      end
+
       @request.host = host
       @request.path = '/commencer/une_demarche'
       @controller.send(:redirect_to_legacy)
@@ -256,12 +263,20 @@ describe ApplicationController, type: :controller do
         it 'does redirect' do
           expect(@controller).to have_received(:redirect_to).with('https://www.demarches-simplifiees.fr/commencer/une_demarche', allow_other_host: true)
         end
+
+        context "when env var REDIRECT_GOUV_TO_DS is equal to 'false'" do
+          let(:redirect_env) { 'false' }
+
+          it 'does not redirect' do
+            expect(@controller).not_to have_received(:redirect_to)
+          end
+        end
       end
 
       context 'when the host is dev.demarches.numerique.gouv.fr' do
         let(:host) { 'dev.demarches.numerique.gouv.fr' }
 
-        it 'does redirect' do
+        it 'does not redirect' do
           expect(@controller).not_to have_received(:redirect_to)
         end
       end


### PR DESCRIPTION
et que je vais sur le site en gouv.fr

Raison:
france connect ne fonctionne pas encore sur le gouv.fr . Jusqu a présent on redirigeait juste les étapes de france connexion pour utiliser demarches-simplifiees.fr . 
Problème: le mécanisme de redirection vers le début d'une démarche après france connexion ne fonctionnait plus.
Résolution: on redirige au plus tôt tout trafic non loggué vers demarches-simplifiees.fr
