### PR TITLE
ETQ tech - fix: je veux masquer les badges de notifications pour les dossiers archivés ou à la corbeille

### DIFF
--- a/app/models/dossier_notification.rb
+++ b/app/models/dossier_notification.rb
@@ -140,7 +140,9 @@ class DossierNotification < ApplicationRecord
   end
 
   def self.notifications_counts_for_instructeur_procedures(groupe_instructeur_ids, instructeur)
-    dossiers = Dossier.where(groupe_instructeur_id: groupe_instructeur_ids)
+    dossiers = Dossier
+      .where(groupe_instructeur_id: groupe_instructeur_ids)
+      .visible_by_administration
 
     dossier_ids_by_procedure = dossiers
       .joins(:revision)


### PR DESCRIPTION
En attendant les badges "expiration" et "suppression" : on masque (sans supprimer) toutes les éventuels badges de notifications dès lors qu'un dossier considéré se voit archivé ou mis à la corbeille.

Un fix par ailleurs sur la synthèse des badges (encore sous FF), pour ne pas comptabiliser des éventuels notifications de dossiers supprimés par l'usager.