### PR TITLE
[Tech] Refactorisation de l'import des csv

### DIFF
--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -6,15 +6,11 @@ module Administrateurs
     include EmailSanitizableConcern
     include Logic
     include GroupeInstructeursSignatureConcern
+    include CsvParsingConcern
 
     before_action :ensure_not_super_admin!, only: [:add_instructeur]
 
     ITEMS_PER_PAGE = 25
-    CSV_MAX_SIZE = 1.megabyte
-    CSV_ACCEPTED_CONTENT_TYPES = [
-      "text/csv",
-      "application/vnd.ms-excel"
-    ]
 
     def index
       @procedure = procedure
@@ -343,7 +339,7 @@ module Administrateurs
         flash[:alert] = "Importation impossible : le poids du fichier est supérieur à #{number_to_human_size(CSV_MAX_SIZE)}"
 
       else
-        csv_content = SmarterCSV.process(csv_file, strings_as_keys: true, convert_values_to_numeric: false, force_utf8: true)
+        csv_content = parse_csv(csv_file)
 
         if csv_content.first.has_key?("groupe") && csv_content.first.has_key?("email")
           groupes_emails = csv_content.map { |r| r.to_h.slice('groupe', 'email') }

--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -136,13 +136,13 @@ module Administrateurs
       return flash[:alert] = "Importation impossible : le poids du fichier est supérieur à #{number_to_human_size(CSV_MAX_SIZE)}" if referentiel_file.size > CSV_MAX_SIZE
 
       type_de_champ = draft.find_and_ensure_exclusive_use(params[:stable_id])
-      csv_to_code = parse_csv(referentiel_file, keep_original_headers: true)
+      csv_content = parse_csv(referentiel_file, keep_original_headers: true)
 
-      return flash[:alert] = "Importation impossible : le fichier est vide ou mal interprété" if csv_to_code.empty?
-      return flash[:alert] = "Importation impossible : votre fichier CSV fait plus de #{helpers.number_with_delimiter(CSV_MAX_LINES)} lignes" if csv_to_code.size > CSV_MAX_LINES
+      return flash[:alert] = "Importation impossible : le fichier est vide ou mal interprété" if csv_content.empty?
+      return flash[:alert] = "Importation impossible : votre fichier CSV fait plus de #{helpers.number_with_delimiter(CSV_MAX_LINES)} lignes" if csv_content.size > CSV_MAX_LINES
 
-      headers = csv_to_code.first.keys
-      digest = Digest::SHA256.hexdigest(csv_to_code.to_json)
+      headers = csv_content.first.keys
+      digest = Digest::SHA256.hexdigest(csv_content.to_json)
 
       ActiveRecord::Base.transaction do
         referentiel = type_de_champ.create_referentiel!(
@@ -152,7 +152,7 @@ module Administrateurs
           digest: digest
         )
 
-        items_to_insert = csv_to_code.map do |row|
+        items_to_insert = csv_content.map do |row|
           {
             data: { row: row.transform_keys { Referentiel.header_to_path(_1) } },
             referentiel_id: referentiel.id

--- a/app/controllers/concerns/csv_parsing_concern.rb
+++ b/app/controllers/concerns/csv_parsing_concern.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module CsvParsingConcern
+  extend ActiveSupport::Concern
+
+  included do
+    CSV_MAX_SIZE = 1.megabyte
+    CSV_MAX_LINES = 5_000
+    CSV_ACCEPTED_CONTENT_TYPES = [
+      "text/csv",
+      "application/vnd.ms-excel"
+    ]
+
+    private
+
+    def csv_file?
+      CSV_ACCEPTED_CONTENT_TYPES.include?(referentiel_file.content_type) ||
+        CSV_ACCEPTED_CONTENT_TYPES.include?(marcel_content_type)
+    end
+
+    def parse_csv(file, strings_as_keys: true, keep_original_headers: false, convert_values_to_numeric: false)
+      raw_content = file.read
+
+      utf8_content = ensure_utf8(raw_content)
+
+      Tempfile.create(['referentiel', '.csv'], encoding: 'UTF-8') do |tempfile|
+        tempfile.write(utf8_content)
+        tempfile.rewind
+
+        begin
+          SmarterCSV.process(
+            tempfile.path,
+            strings_as_keys:,
+            keep_original_headers:,
+            convert_values_to_numeric:
+          )
+        rescue *[CSV::MalformedCSVError, SmarterCSV::NoColSepDetected, ArgumentError]
+          []
+        end
+      end
+    end
+
+    def ensure_utf8(content)
+      detection = CharlockHolmes::EncodingDetector.detect(content)
+      source_encoding = detection[:encoding] || 'Windows-1252'
+      CharlockHolmes::Converter.convert(content, source_encoding, 'UTF-8')
+    end
+  end
+end

--- a/app/controllers/manager/procedures_controller.rb
+++ b/app/controllers/manager/procedures_controller.rb
@@ -2,11 +2,8 @@
 
 module Manager
   class ProceduresController < Manager::ApplicationController
-    CSV_MAX_SIZE = 1.megabyte
-    CSV_ACCEPTED_CONTENT_TYPES = [
-      "text/csv",
-      "application/vnd.ms-excel"
-    ]
+    include CsvParsingConcern
+
     #
     # Administrate overrides
     #
@@ -157,8 +154,7 @@ module Manager
         flash[:alert] = "Importation impossible : le poids du fichier est supérieur à #{number_to_human_size(CSV_MAX_SIZE)}"
 
       else
-        procedure_tags = SmarterCSV.process(tags_csv_file, strings_as_keys: true, convert_values_to_numeric: false, force_utf8: true)
-          .map { |r| r.to_h.slice('demarche', 'tag') }
+        procedure_tags = csv_parse(tags_csv_file).map { |r| r.to_h.slice('demarche', 'tag') }
 
         invalid_ids = []
         procedure_tags.each do |procedure_tag|

--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -633,7 +633,7 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
       end
 
       context 'when csv file is in iso 8859 format' do
-        let(:csv_file) { fixture_file_upload('spec/fixtures/files/groupe_iso_8859.csv') }
+        let(:csv_file) { fixture_file_upload('spec/fixtures/files/groupe_iso_8859.csv', 'text/csv') }
 
         before do
           allow(GroupeInstructeurMailer).to receive(:notify_added_instructeurs)
@@ -653,7 +653,7 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
       end
 
       context 'when csv file is in iso 8859 format with invalid characters' do
-        let(:csv_file) { fixture_file_upload('spec/fixtures/files/groupe_iso_8859_invalid_characters.csv') }
+        let(:csv_file) { fixture_file_upload('spec/fixtures/files/groupe_iso_8859_invalid_characters.csv', 'text/csv') }
 
         before do
           allow(GroupeInstructeurMailer).to receive(:notify_added_instructeurs)
@@ -663,10 +663,10 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
           subject
         end
 
-        it 'works but delete invalid characters' do
+        it 'works and keep special characters' do
           expect(flash.notice).to be_present
           expect(flash.notice).to eq("La liste des instructeurs a été importée avec succès")
-          expect(procedure.groupe_instructeurs.pluck(:label)).to match_array(["Auvergne-Rhne-Alpes", "Vende", "défaut", "deuxième groupe"])
+          expect(procedure.groupe_instructeurs.pluck(:label)).to match_array(["Auvergne-Rhône-Alpes", "Vendée", "deuxième groupe", "défaut"])
           expect(GroupeInstructeurMailer).not_to have_received(:notify_added_instructeurs)
           expect(InstructeurMailer).to have_received(:confirm_and_notify_added_instructeur).exactly(4).times
         end

--- a/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
+++ b/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
@@ -198,6 +198,15 @@ describe Administrateurs::TypesDeChampController, type: :controller do
           expect(flash.alert).to eq("Importation impossible : le fichier est vide ou mal interprété")
         end
       end
+
+      context 'when the csv file is iso-8859 format, with CRLF line terminators and special characters (even in header)' do
+        let(:referentiel_file) { fixture_file_upload('spec/fixtures/files/modele-import-referentiel-iso-8859-crlf-special-characters.csv', 'text/csv') }
+        it 'works' do
+          expect { subject }.to change(Referentiel, :count).by(1).and change(ReferentielItem, :count).by(2)
+          expect(ReferentielItem.first.data).to eq({ "row" => { "adresse" => "115, Boulevard Exelmans, Paris, 75016", "email" => "moha.ali@diplomatie.gouv.fr", "nom" => "Mohamed Ali", "numero" => "UK +447 864 743 320" } })
+          expect(Referentiel.first.headers).to eq(["adresse", "nom", "numéro", "email"])
+        end
+      end
     end
   end
 

--- a/spec/fixtures/files/modele-import-referentiel-iso-8859-crlf-special-characters.csv
+++ b/spec/fixtures/files/modele-import-referentiel-iso-8859-crlf-special-characters.csv
@@ -1,0 +1,3 @@
+adresse ;nom;numéro;email
+115, Boulevard Exelmans, Paris, 75016;Mohamed Ali;UK +447 864 743 320;moha.ali@diplomatie.gouv.fr
+29, Rue des Fougères, Paris, 75020;Teddy Riner ;UK +447 842 064 443;teddy-lise.rinner@institut-francais.org.uk


### PR DESCRIPTION
Suite de cette [PR](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11775/) qui a permis de mieux gérer la détection de l'encodage et la reconversion en UTF8 lors de l'import des csv.
Le parsing des csv est extrait dans un concern et appliqué à l'import des groupes instructeurs et à l'import des tags.
Cela permet notamment de conserver les caractères spéciaux si le fichier csv est au format iso8859 