### PR TITLE
ETQ Instructeur: je veux un badge de notification "message" quel que soit l'expéditeur

### DIFF
--- a/app/controllers/concerns/instructeur_concern.rb
+++ b/app/controllers/concerns/instructeur_concern.rb
@@ -8,11 +8,8 @@ module InstructeurConcern
       @procedure_presentation ||= current_instructeur.procedure_presentation_for_procedure_id(params[:procedure_id])
     end
 
-    def set_notifications_sticker
+    def set_notifications
       @notifications_sticker = DossierNotification.notifications_sticker_for_instructeur_dossier(current_instructeur, dossier)
-    end
-
-    def set_notifications_dossier
       @notifications = DossierNotification.notifications_for_instructeur_dossier(current_instructeur, dossier)
     end
 

--- a/app/controllers/experts/avis_controller.rb
+++ b/app/controllers/experts/avis_controller.rb
@@ -177,6 +177,7 @@ module Experts
         timestamps << :last_commentaire_piece_jointe_updated_at if @commentaire.piece_jointe.attached?
 
         @commentaire.dossier.touch(*timestamps)
+        DossierNotification.create_notification(avis.dossier, :message)
 
         flash.notice = "Message envoyé"
         redirect_to messagerie_expert_avis_path(avis.procedure, avis)

--- a/app/controllers/instructeurs/commentaires_controller.rb
+++ b/app/controllers/instructeurs/commentaires_controller.rb
@@ -10,7 +10,7 @@ module Instructeurs
       retrieve_procedure_presentation if current_instructeur
       if commentaire.sent_by?(current_instructeur) || commentaire.sent_by?(current_expert)
         commentaire.soft_delete!
-        set_notifications_dossier
+        set_notifications
 
         flash.notice = t('.notice')
       else

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -299,6 +299,7 @@ module Instructeurs
       if @commentaire.errors.empty?
         @commentaire.dossier.touch(:last_commentaire_updated_at)
         current_instructeur.follow(dossier)
+        DossierNotification.create_notification(dossier, :message, except_instructeur: current_instructeur)
         flash.notice = "Message envoyé"
         redirect_to messagerie_instructeur_dossier_path(procedure, dossier, statut: statut)
       else

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -15,8 +15,7 @@ module Instructeurs
     before_action :redirect_on_dossier_in_batch_operation, only: [:archive, :unarchive, :follow, :unfollow, :passer_en_instruction, :repasser_en_construction, :repasser_en_instruction, :terminer, :restore, :destroy, :extend_conservation]
     before_action :set_gallery_attachments, only: [:show, :pieces_jointes, :annotations_privees, :avis, :messagerie, :personnes_impliquees, :reaffectation, :rendez_vous]
     before_action :retrieve_procedure_presentation, only: [:annotations_privees, :avis_new, :avis, :messagerie, :personnes_impliquees, :pieces_jointes, :reaffectation, :rendez_vous, :show, :dossier_labels, :passer_en_instruction, :repasser_en_construction, :repasser_en_instruction, :terminer, :pending_correction, :create_avis, :create_commentaire]
-    before_action :set_notifications_dossier, only: [:show, :annotations_privees, :avis, :avis_new, :messagerie, :personnes_impliquees, :pieces_jointes, :reaffectation, :rendez_vous, :dossier_labels, :repasser_en_construction, :repasser_en_instruction, :terminer, :create_avis, :create_commentaire]
-    before_action :set_notifications_sticker, only: [:show, :annotations_privees, :avis, :avis_new, :messagerie, :personnes_impliquees, :pieces_jointes, :reaffectation, :rendez_vous, :dossier_labels, :repasser_en_construction, :repasser_en_instruction, :terminer, :create_avis, :create_commentaire]
+    before_action :set_notifications, only: [:show, :annotations_privees, :avis, :avis_new, :messagerie, :personnes_impliquees, :pieces_jointes, :reaffectation, :rendez_vous, :dossier_labels, :repasser_en_construction, :repasser_en_instruction, :terminer, :create_avis, :create_commentaire]
 
     after_action :mark_demande_as_read, only: :show
     after_action :mark_messagerie_as_read, only: [:messagerie, :create_commentaire, :pending_correction]
@@ -181,7 +180,7 @@ module Instructeurs
       @dossier = dossier
       respond_to do |format|
         format.turbo_stream do
-          refresh_notifications
+          set_notifications
           render :change_state
         end
 
@@ -284,7 +283,7 @@ module Instructeurs
       respond_to do |format|
         format.turbo_stream do
           @dossier = dossier
-          refresh_notifications
+          set_notifications
           render :change_state
         end
 
@@ -613,11 +612,6 @@ module Instructeurs
         champs_attachments_ids + commentaires_attachments_ids + avis_attachments_ids + [justificatif_motivation_id]
       end
       @gallery_attachments = ActiveStorage::Attachment.where(id: gallery_attachments_ids)
-    end
-
-    def refresh_notifications
-      set_notifications_dossier
-      set_notifications_sticker
     end
   end
 end

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -15,8 +15,8 @@ module Instructeurs
     before_action :redirect_on_dossier_in_batch_operation, only: [:archive, :unarchive, :follow, :unfollow, :passer_en_instruction, :repasser_en_construction, :repasser_en_instruction, :terminer, :restore, :destroy, :extend_conservation]
     before_action :set_gallery_attachments, only: [:show, :pieces_jointes, :annotations_privees, :avis, :messagerie, :personnes_impliquees, :reaffectation, :rendez_vous]
     before_action :retrieve_procedure_presentation, only: [:annotations_privees, :avis_new, :avis, :messagerie, :personnes_impliquees, :pieces_jointes, :reaffectation, :rendez_vous, :show, :dossier_labels, :passer_en_instruction, :repasser_en_construction, :repasser_en_instruction, :terminer, :pending_correction, :create_avis, :create_commentaire]
-    before_action :set_notifications_dossier, only: [:show, :annotations_privees, :avis, :avis_new, :messagerie, :personnes_impliquees, :pieces_jointes, :reaffectation, :rendez_vous, :pending_correction, :dossier_labels, :passer_en_instruction, :repasser_en_construction, :repasser_en_instruction, :terminer, :create_avis, :create_commentaire]
-    before_action :set_notifications_sticker, only: [:show, :annotations_privees, :avis, :avis_new, :messagerie, :personnes_impliquees, :pieces_jointes, :reaffectation, :rendez_vous, :pending_correction, :dossier_labels, :passer_en_instruction, :repasser_en_construction, :repasser_en_instruction, :terminer, :create_avis, :create_commentaire]
+    before_action :set_notifications_dossier, only: [:show, :annotations_privees, :avis, :avis_new, :messagerie, :personnes_impliquees, :pieces_jointes, :reaffectation, :rendez_vous, :dossier_labels, :repasser_en_construction, :repasser_en_instruction, :terminer, :create_avis, :create_commentaire]
+    before_action :set_notifications_sticker, only: [:show, :annotations_privees, :avis, :avis_new, :messagerie, :personnes_impliquees, :pieces_jointes, :reaffectation, :rendez_vous, :dossier_labels, :repasser_en_construction, :repasser_en_instruction, :terminer, :create_avis, :create_commentaire]
 
     after_action :mark_demande_as_read, only: :show
     after_action :mark_messagerie_as_read, only: [:messagerie, :create_commentaire, :pending_correction]
@@ -181,6 +181,7 @@ module Instructeurs
       @dossier = dossier
       respond_to do |format|
         format.turbo_stream do
+          refresh_notifications
           render :change_state
         end
 
@@ -283,7 +284,7 @@ module Instructeurs
       respond_to do |format|
         format.turbo_stream do
           @dossier = dossier
-          @notifications = DossierNotification.notifications_for_instructeur_dossier(current_instructeur, dossier)
+          refresh_notifications
           render :change_state
         end
 
@@ -612,6 +613,11 @@ module Instructeurs
         champs_attachments_ids + commentaires_attachments_ids + avis_attachments_ids + [justificatif_motivation_id]
       end
       @gallery_attachments = ActiveStorage::Attachment.where(id: gallery_attachments_ids)
+    end
+
+    def refresh_notifications
+      set_notifications_dossier
+      set_notifications_sticker
     end
   end
 end

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -24,6 +24,7 @@ module Instructeurs
     after_action :mark_annotations_privees_as_read, only: [:annotations_privees, :update_annotations]
     after_action :mark_pieces_jointes_as_read, only: [:pieces_jointes]
     after_action -> { destroy_notification(:dossier_modifie) }, only: [:show], if: -> { @notifications.any?(&:dossier_modifie?) }
+    after_action -> { destroy_notification(:message) }, only: [:messagerie], if: -> { @notifications.any?(&:message?) }
     after_action -> { destroy_notification(:message_usager) }, only: [:messagerie], if: -> { @notifications.any?(&:message_usager?) }
     after_action -> { destroy_notification(:annotation_instructeur) }, only: [:annotations_privees], if: -> { @notifications.any?(&:annotation_instructeur?) }
     after_action -> { destroy_notification(:avis_externe) }, only: [:avis], if: -> { @notifications.any?(&:avis_externe?) }

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -351,7 +351,7 @@ module Users
 
         @commentaire.dossier.touch(*timestamps)
 
-        DossierNotification.create_notification(dossier, :message_usager)
+        DossierNotification.create_notification(dossier, :message)
 
         flash.notice = t('.message_send')
         redirect_to messagerie_dossier_path(dossier)

--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -173,6 +173,7 @@ module DossierHelper
     when DossierNotification.notification_types.fetch(:dossier_depose)
       "fr-badge fr-badge--sm fr-badge--warning"
     when DossierNotification.notification_types.fetch(:dossier_modifie),
+      DossierNotification.notification_types.fetch(:message),
       DossierNotification.notification_types.fetch(:message_usager),
       DossierNotification.notification_types.fetch(:annotation_instructeur),
       DossierNotification.notification_types.fetch(:avis_externe)

--- a/app/models/columns/dossier_column.rb
+++ b/app/models/columns/dossier_column.rb
@@ -74,6 +74,9 @@ class Columns::DossierColumn < Column
         .joins(:groupe_instructeur)
         .where(groupe_instructeur_id: values)
     when 'dossier_notifications'
+      values << 'message_usager' if values.include?('message')
+      values << 'message' if values.include?('message_usager')
+
       dossiers
         .joins(:dossier_notifications)
         .where(dossier_notifications: { notification_type: values })

--- a/app/models/commentaire.rb
+++ b/app/models/commentaire.rb
@@ -23,9 +23,10 @@ class Commentaire < ApplicationRecord
     size: { less_than: FILE_MAX_SIZE }
 
   scope :updated_since?, -> (date) { where('commentaires.updated_at > ?', date) }
-  scope :sent_by_user, -> {
-    where(instructeur_id: nil, expert_id: nil)
-      .where.not(email: SYSTEM_EMAILS)
+  scope :to_notify, -> (instructeur) {
+    where.not(email: SYSTEM_EMAILS)
+      .where(discarded_at: nil)
+      .where("instructeur_id IS NULL OR instructeur_id != ?", instructeur.id)
   }
 
   after_create :notify

--- a/app/models/concerns/dossier_correctable_concern.rb
+++ b/app/models/concerns/dossier_correctable_concern.rb
@@ -20,7 +20,7 @@ module DossierCorrectableConcern
 
       corrections.create!(commentaire:, reason:)
 
-      create_attente_correction_notification
+      create_dossier_notifications(commentaire.instructeur)
 
       log_pending_correction_operation(commentaire, reason) if procedure.sva_svr_enabled?
 
@@ -79,8 +79,9 @@ module DossierCorrectableConcern
       log_dossier_operation(commentaire.instructeur, operation, commentaire)
     end
 
-    def create_attente_correction_notification
+    def create_dossier_notifications(except_instructeur)
       DossierNotification.create_notification(self, :attente_correction)
+      DossierNotification.create_notification(self, :message, except_instructeur:)
     end
   end
 end

--- a/app/models/dossier_notification.rb
+++ b/app/models/dossier_notification.rb
@@ -141,7 +141,7 @@ class DossierNotification < ApplicationRecord
   def self.notifications_sticker_for_instructeur_dossier(instructeur, dossier)
     types = {
       demande: [:dossier_modifie],
-      annotations_instructeur: [:annotation_instructeur],
+      annotations_privees: [:annotation_instructeur],
       avis_externe: [:avis_externe],
       messagerie: [:message_usager, :message]
     }

--- a/app/models/dossier_notification.rb
+++ b/app/models/dossier_notification.rb
@@ -73,7 +73,7 @@ class DossierNotification < ApplicationRecord
 
   def self.refresh_notifications_instructeur_for_dossier(instructeur, dossier)
     create_notification(dossier, :dossier_modifie, instructeur:) if dossier.last_champ_updated_at.present? && dossier.last_champ_updated_at > dossier.depose_at
-    create_notification(dossier, :message, instructeur:) if dossier.commentaires.sent_by_user.present?
+    create_notification(dossier, :message, instructeur:) if dossier.commentaires.to_notify(instructeur).present?
     create_notification(dossier, :annotation_instructeur, instructeur:) if dossier.last_champ_private_updated_at.present?
     create_notification(dossier, :avis_externe, instructeur:) if dossier.avis.with_answer.present?
     create_notification(dossier, :attente_correction, instructeur:) if dossier.pending_correction?

--- a/app/models/dossier_notification.rb
+++ b/app/models/dossier_notification.rb
@@ -13,6 +13,7 @@ class DossierNotification < ApplicationRecord
   enum :notification_type, {
     dossier_depose: 'dossier_depose',
     dossier_modifie: 'dossier_modifie',
+    message: 'message',
     message_usager: 'message_usager',
     annotation_instructeur: 'annotation_instructeur',
     avis_externe: 'avis_externe',
@@ -26,33 +27,40 @@ class DossierNotification < ApplicationRecord
     self.sort_by { |notif| notification_types.keys.index(notif.notification_type) }
   }
 
-  scope :type_news, -> { where(notification_type: [:dossier_modifie, :message_usager, :annotation_instructeur, :avis_externe]) }
+  scope :type_news, -> { where(notification_type: [:dossier_modifie, :message, :message_usager, :annotation_instructeur, :avis_externe]) }
 
   def self.create_notification(dossier, notification_type, instructeur: nil, except_instructeur: nil)
     case notification_type
     when :dossier_depose
       if !dossier.procedure.declarative? && !dossier.procedure.sva_svr_enabled?
-        DossierNotification.find_or_create_by!(
-          dossier:,
-          notification_type:,
-          groupe_instructeur_id: dossier.groupe_instructeur_id
-        ) do |notification|
-          notification.display_at = dossier.depose_at + DELAY_DOSSIER_DEPOSE
-        end
+        groupe_instructeur_id = dossier.groupe_instructeur_id
+        display_at = dossier.depose_at + DELAY_DOSSIER_DEPOSE
+
+        find_or_create_notification(dossier, notification_type, groupe_instructeur_id:, display_at:)
       end
 
-    when :dossier_modifie, :attente_correction, :attente_avis, :message_usager, :annotation_instructeur, :avis_externe
+    # TEMP : pendant la transition de :message_usager vers :message, on évite
+    # de créer une notification :message si une :message_usager existe déjà.
+    when :message
       instructeur_ids = Array(instructeur&.id.presence || dossier.followers_instructeur_ids)
       instructeur_ids -= [except_instructeur.id] if except_instructeur.present?
 
       instructeur_ids.each do |instructeur_id|
-        DossierNotification.find_or_create_by!(
+        next if DossierNotification.exists?(
           dossier:,
-          notification_type:,
-          instructeur_id:
-        ) do |notification|
-          notification.display_at = Time.current
-        end
+          instructeur_id:,
+          notification_type: :message_usager
+        )
+
+        find_or_create_notification(dossier, notification_type, instructeur_id:)
+      end
+
+    when :dossier_modifie, :attente_correction, :attente_avis, :annotation_instructeur, :avis_externe
+      instructeur_ids = Array(instructeur&.id.presence || dossier.followers_instructeur_ids)
+      instructeur_ids -= [except_instructeur.id] if except_instructeur.present?
+
+      instructeur_ids.each do |instructeur_id|
+        find_or_create_notification(dossier, notification_type, instructeur_id:)
       end
     end
   end
@@ -65,7 +73,7 @@ class DossierNotification < ApplicationRecord
 
   def self.refresh_notifications_instructeur_for_dossier(instructeur, dossier)
     create_notification(dossier, :dossier_modifie, instructeur:) if dossier.last_champ_updated_at.present? && dossier.last_champ_updated_at > dossier.depose_at
-    create_notification(dossier, :message_usager, instructeur:) if dossier.commentaires.sent_by_user.present?
+    create_notification(dossier, :message, instructeur:) if dossier.commentaires.sent_by_user.present?
     create_notification(dossier, :annotation_instructeur, instructeur:) if dossier.last_champ_private_updated_at.present?
     create_notification(dossier, :avis_externe, instructeur:) if dossier.avis.with_answer.present?
     create_notification(dossier, :attente_correction, instructeur:) if dossier.pending_correction?
@@ -132,17 +140,19 @@ class DossierNotification < ApplicationRecord
 
   def self.notifications_sticker_for_instructeur_dossier(instructeur, dossier)
     types = {
-      demande: :dossier_modifie,
-      annotations_instructeur: :annotation_instructeur,
-      avis_externe: :avis_externe,
-      messagerie: :message_usager
+      demande: [:dossier_modifie],
+      annotations_instructeur: [:annotation_instructeur],
+      avis_externe: [:avis_externe],
+      messagerie: [:message_usager, :message]
     }
 
     return types.transform_values { false } if dossier.archived
 
     notifications = DossierNotification.where(dossier:, instructeur:)
 
-    types.transform_values { |type| notifications.exists?(notification_type: type) }
+    types.transform_values do |notification_types|
+      notifications.exists?(notification_type: notification_types)
+    end
   end
 
   def self.notifications_counts_for_instructeur_procedures(groupe_instructeur_ids, instructeur)
@@ -167,7 +177,7 @@ class DossierNotification < ApplicationRecord
     dossier_ids_by_procedure.transform_values do |dossier_ids|
       notifications = dossier_ids
         .flat_map { |id| notifications_by_dossier_id[id] || [] }
-        .group_by(&:notification_type)
+        .group_by { |n| n.notification_type.in?(['message', 'message_usager']) ? 'message' : n.notification_type }
 
       notification_types.keys.index_with { |type| notifications[type]&.count }.compact
     end
@@ -190,12 +200,14 @@ class DossierNotification < ApplicationRecord
       .group_by(&:dossier_id)
 
     dossiers_by_statut.filter_map do |statut, dossiers|
-      notifs = dossiers.flat_map { |d| notifications_by_dossier_id[d.id] || [] }.group_by(&:notification_type)
-      next if notifs.empty?
+      notifications = dossiers
+        .flat_map { |d| notifications_by_dossier_id[d.id] || [] }
+        .group_by { |n| n.notification_type.in?(['message', 'message_usager']) ? 'message' : n.notification_type }
+      next if notifications.empty?
 
-      sorted_notifs = notification_types.keys.index_with { |type| notifs[type] }.compact
+      sorted_notifications = notification_types.keys.index_with { |type| notifications[type] }.compact
 
-      [statut, sorted_notifs]
+      [statut, sorted_notifications]
     end.to_h
   end
 
@@ -229,5 +241,18 @@ class DossierNotification < ApplicationRecord
       .where(dossier_notifications: { instructeur: })
       .distinct
       .count
+  end
+end
+
+private
+
+def find_or_create_notification(dossier, notification_type, groupe_instructeur_id: nil, instructeur_id: nil, display_at: Time.current)
+  DossierNotification.find_or_create_by!(
+    dossier:,
+    notification_type:,
+    groupe_instructeur_id:,
+    instructeur_id:
+  ) do |notification|
+    notification.display_at = display_at
   end
 end

--- a/app/tasks/maintenance/t20250522backfill_dossier_notification_for_message_task.rb
+++ b/app/tasks/maintenance/t20250522backfill_dossier_notification_for_message_task.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module Maintenance
-  class T20250522backfillDossierNotificationForMessageUsagerTask < MaintenanceTasks::Task
+  class T20250522backfillDossierNotificationForMessageTask < MaintenanceTasks::Task
     # Documentation: cette tâche permet de créer les DossierNotification manquantes
-    # de type 'MESSAGE USAGER'
+    # de type 'MESSAGE'
 
     include RunnableOnDeployConcern
     include StatementsHelpersConcern
@@ -24,9 +24,15 @@ module Maintenance
     def process(follow)
       return if follow.instructeur.nil? # we have follow without instructeur !
 
+      return if DossierNotification.exists?(
+          dossier_id: follow.dossier_id,
+          instructeur_id: follow.instructeur_id,
+          notification_type: :message_usager
+        )
+
       DossierNotification.find_or_create_by!(
         dossier_id: follow.dossier_id,
-        notification_type: :message_usager,
+        notification_type: :message,
         instructeur_id: follow.instructeur_id
       ) do |notification|
         notification.display_at = Time.zone.now

--- a/app/tasks/maintenance/t20250625update_dossier_notification_message_usager_to_message_task.rb
+++ b/app/tasks/maintenance/t20250625update_dossier_notification_message_usager_to_message_task.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20250625updateDossierNotificationMessageUsagerToMessageTask < MaintenanceTasks::Task
+    # Documentation: cette tâche vient update notification_type des
+    # instances de DossierNotification de type :message_usager en :message
+
+    include RunnableOnDeployConcern
+    include StatementsHelpersConcern
+
+    # Uncomment only if this task MUST run imperatively on its first deployment.
+    # If possible, leave commented for manual execution later.
+    # run_on_first_deploy
+
+    def collection
+      DossierNotification.where(notification_type: [:message, :message_usager])
+    end
+
+    def process(notification)
+      notification.update!(notification_type: :message)
+    end
+  end
+end

--- a/app/tasks/maintenance/t20250625update_procedure_presentation_filters_with_message_usager_task.rb
+++ b/app/tasks/maintenance/t20250625update_procedure_presentation_filters_with_message_usager_task.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20250625updateProcedurePresentationFiltersWithMessageUsagerTask < MaintenanceTasks::Task
+    # Documentation: cette tâche modifie les données pour…
+
+    include RunnableOnDeployConcern
+    include StatementsHelpersConcern
+
+    # Uncomment only if this task MUST run imperatively on its first deployment.
+    # If possible, leave commented for manual execution later.
+    run_on_first_deploy
+
+    STATE_FILTERS = [
+      :tous_filters,
+      :suivis_filters,
+      :traites_filters,
+      :a_suivre_filters,
+      :archives_filters,
+      :expirant_filters,
+      :supprimes_filters,
+      :supprimes_recemment_filters
+    ].freeze
+
+    def collection
+      ProcedurePresentation.includes(assign_to: :procedure)
+    end
+
+    def process(pp)
+      Rails.logger.debug { "Task T20250625updateProcedurePresentationFiltersWithMessageUsagerTask process procedure_presentation_id=##{pp.id}" }
+      changed_pp = false
+
+      STATE_FILTERS.each do |state_filter|
+        current_state_filters = pp.send(state_filter)
+        next if current_state_filters.empty?
+        next unless current_state_filters.any? { |f| f.column.table == 'dossier_notifications' }
+        changed_pp = true
+
+        new_state_filters = current_state_filters.map do |filter|
+          if filter.column.table == "dossier_notifications" && filter.filter == "message_usager"
+            FilteredColumn.new(
+              column: pp.procedure.dossier_notifications_column,
+              filter: "message"
+            )
+          else
+            filter
+          end
+        end
+
+        pp.send("#{state_filter}=", new_state_filters)
+      # a column can be not found for various reasons (deleted tdc, changed type, etc)
+      # in this case we just ignore the error and continue
+      rescue ActiveRecord::RecordNotFound
+      end
+
+      pp.save! if changed_pp
+    end
+  end
+end

--- a/app/views/instructeurs/commentaires/destroy.turbo_stream.haml
+++ b/app/views/instructeurs/commentaires/destroy.turbo_stream.haml
@@ -2,5 +2,9 @@
   = turbo_stream.update @commentaire do
     = render Dossiers::MessageComponent.new(commentaire: @commentaire, connected_user: @commentaire.instructeur || @commentaire.expert)
 
-  - if current_user.instructeur? && @commentaire.dossier_correction.present?
+  - if current_user.instructeur?
     = turbo_stream.replace 'header-top', partial: 'instructeurs/dossiers/header_top', locals: { dossier: @commentaire.dossier, procedure_presentation: @procedure_presentation, notifications: @notifications }
+
+    - if @notifications_sticker.present?
+      - @notifications_sticker.keys.each do |label|
+        = turbo_stream.replace "notification-sticker-#{label.to_s}", partial: 'shared/notification_sticker', locals: { label: label.to_s, notification: @notifications_sticker[label] }

--- a/app/views/instructeurs/dossiers/_header_bottom.html.haml
+++ b/app/views/instructeurs/dossiers/_header_bottom.html.haml
@@ -11,7 +11,7 @@
 
       = dynamic_tab_item(t('views.instructeurs.dossiers.tab_steps.private_annotations'),
         annotations_privees_instructeur_dossier_path(dossier.procedure, dossier, statut: params[:statut]),
-        notification: notifications_sticker[:annotations_instructeur])
+        notification: notifications_sticker[:annotations_privees])
 
       = dynamic_tab_item(t('views.instructeurs.dossiers.tab_steps.external_opinion'),
         [avis_instructeur_dossier_path(dossier.procedure, dossier, statut: params[:statut]),

--- a/app/views/instructeurs/dossiers/_header_top.html.haml
+++ b/app/views/instructeurs/dossiers/_header_top.html.haml
@@ -7,7 +7,8 @@
   %div
     .fr-my-1w.fr-badge-group
       = status_badge(dossier.state)
-      = tags_notification(notifications)
+      - if notifications.present?
+        = tags_notification(notifications)
       = render Instructeurs::SVASVRDecisionBadgeComponent.new(dossier:, procedure: dossier.procedure, with_label: true)
 
   = render partial: 'instructeurs/dossiers/expiration_banner', locals: { dossier: }

--- a/app/views/instructeurs/dossiers/change_state.turbo_stream.haml
+++ b/app/views/instructeurs/dossiers/change_state.turbo_stream.haml
@@ -1,1 +1,4 @@
 = turbo_stream.replace 'header-top', partial: 'header_top', locals: { dossier: @dossier, procedure_presentation: @procedure_presentation, notifications: @notifications }
+
+- @notifications_sticker.keys.each do |label|
+  = turbo_stream.replace "notification-sticker-#{label.to_s}", partial: 'shared/notification_sticker', locals: { label: label.to_s, notification: @notifications_sticker[label] }

--- a/app/views/shared/_notification_sticker.html.haml
+++ b/app/views/shared/_notification_sticker.html.haml
@@ -1,0 +1,3 @@
+%div{ id: "notification-sticker-#{label.parameterize.underscore}" }
+  - if notification
+    %span.notifications{ 'aria-label': 'notifications' }

--- a/app/views/shared/_tab_item.html.haml
+++ b/app/views/shared/_tab_item.html.haml
@@ -1,6 +1,5 @@
 %li{ class: "relative #{(active ? 'active' : nil)}" }
-  - if notification
-    %span.notifications{ 'aria-label': 'notifications' }
+  = render partial: 'shared/notification_sticker', locals: { label:, notification: }
   = link_to(url, 'aria-current': active ? 'page' : nil, class: class_names("fr-tabs__tab", html_class) ) do
     - if badge.present?
       %span.fr-badge.fr-badge--blue-ecume.fr-mr-1w= badge

--- a/config/locales/models/dossier_notification/fr.yml
+++ b/config/locales/models/dossier_notification/fr.yml
@@ -8,7 +8,8 @@ fr:
         dossier_modifie: Dossier modifié
         attente_correction: En attente de correction
         attente_avis: En attente d'avis externe
-        message_usager: Message usager
+        message: Message
+        message_usager: Message
         # TODO: switch to ’Annotation instructeur’ during global renaming
         annotation_instructeur: Annotation privée
         avis_externe: Avis externe

--- a/config/locales/views/instructeurs/fr.yml
+++ b/config/locales/views/instructeurs/fr.yml
@@ -14,7 +14,7 @@ fr:
       filterable_notification:
         dossier_depose: 'Déposé depuis longtemps'
         dossier_modifie: 'Dossier modifié'
-        message_usager: 'Message usager'
+        message: 'Message'
         # TODO: switch to ’Annotation instructeur’ during global renaming
         annotation_instructeur: 'Annotation privée'
         avis_externe: 'Avis externe'

--- a/spec/controllers/experts/avis_controller_spec.rb
+++ b/spec/controllers/experts/avis_controller_spec.rb
@@ -379,6 +379,22 @@ describe Experts::AvisController, type: :controller do
 
         it { is_expected.to redirect_to(root_path) }
       end
+
+      context "when there are instructeurs followers" do
+        before do
+          instructeur.followed_dossiers << dossier
+          subject
+        end
+
+        it "create message notification for instructeurs follower" do
+          expect(DossierNotification.count).to eq(1)
+
+          notification = DossierNotification.last
+          expect(notification.dossier_id).to eq(dossier.id)
+          expect(notification.instructeur_id).to eq(instructeur.id)
+          expect(notification.notification_type).to eq("message")
+        end
+      end
     end
 
     describe '#avis_new' do

--- a/spec/controllers/instructeurs/commentaires_controller_spec.rb
+++ b/spec/controllers/instructeurs/commentaires_controller_spec.rb
@@ -5,6 +5,7 @@ describe Instructeurs::CommentairesController, type: :controller do
   let(:instructeur) { create(:instructeur) }
   let(:procedure) { create(:procedure, :published, :for_individual, instructeurs: [instructeur]) }
   let(:dossier) { create(:dossier, :en_construction, :with_individual, procedure: procedure) }
+
   render_views
 
   context 'as instructeur' do

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -727,18 +727,18 @@ describe Instructeurs::DossiersController, type: :controller do
 
     context "when the usager had sent a message" do
       let!(:other_instructeur) { create(:instructeur) }
-      let!(:notification_current_instructeur) { create(:dossier_notification, :for_instructeur, dossier:, instructeur:, notification_type: :message_usager) }
-      let!(:notification_other_instructeur) { create(:dossier_notification, :for_instructeur, dossier:, instructeur: other_instructeur, notification_type: :message_usager) }
+      let!(:notification_current_instructeur) { create(:dossier_notification, :for_instructeur, dossier:, instructeur:, notification_type: :message) }
+      let!(:notification_other_instructeur) { create(:dossier_notification, :for_instructeur, dossier:, instructeur: other_instructeur, notification_type: :message) }
 
-      it "destroy message_usager notification only for the current_instructeur" do
+      it "destroy message notification only for the current_instructeur" do
         subject
 
         expect(
-          DossierNotification.exists?(instructeur:, dossier: dossier, notification_type: :message_usager)
+          DossierNotification.exists?(instructeur:, dossier: dossier, notification_type: :message)
         ).to be_falsey
 
         expect(
-          DossierNotification.exists?(instructeur: other_instructeur, dossier: dossier, notification_type: :message_usager)
+          DossierNotification.exists?(instructeur: other_instructeur, dossier: dossier, notification_type: :message)
         ).to be_truthy
       end
     end

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -803,6 +803,27 @@ describe Instructeurs::DossiersController, type: :controller do
         expect(flash.alert).to be_present
       end
     end
+
+    context "when there are others instructeurs followers" do
+      let(:another_instructeur) { create(:instructeur) }
+      let(:groupe_instructeur) { create(:groupe_instructeur, instructeurs: [instructeur, another_instructeur]) }
+
+      before do
+        dossier.assign_to_groupe_instructeur(groupe_instructeur, DossierAssignment.modes.fetch(:auto))
+        instructeur.followed_dossiers << dossier
+        another_instructeur.followed_dossiers << dossier
+        subject
+      end
+
+      it "create message notification only for others instructeurs follower" do
+        expect(DossierNotification.count).to eq(1)
+
+        notification = DossierNotification.last
+        expect(notification.dossier_id).to eq(dossier.id)
+        expect(notification.instructeur_id).to eq(another_instructeur.id)
+        expect(notification.notification_type).to eq("message")
+      end
+    end
   end
 
   describe "#create_avis" do

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -1760,12 +1760,12 @@ describe Users::DossiersController, type: :controller do
         dossier.assign_to_groupe_instructeur(groupe_instructeur, DossierAssignment.modes.fetch(:auto))
       end
 
-      it "create message_usager notification only for instructeur follower" do
+      it "create message notification only for instructeur follower" do
         expect { subject }.to change(DossierNotification, :count).by(2)
 
         notifications = DossierNotification.where(
           dossier_id: dossier.id,
-          notification_type: :message_usager
+          notification_type: :message
         )
 
         expect(notifications.pluck(:instructeur_id)).to match_array([

--- a/spec/models/dossier_notification_spec.rb
+++ b/spec/models/dossier_notification_spec.rb
@@ -93,6 +93,23 @@ RSpec.describe DossierNotification, type: :model do
           expect(notifications.map(&:notification_type)).to match_array(['message', 'message_usager'])
         end
       end
+
+      context "when instructeur send a message" do
+        let!(:notification_args) { { except_instructeur: instructeur_follower } }
+
+        it "create notification for instructeurs followers, except instructeur sender" do
+          subject
+
+          expect(DossierNotification.count).to eq(1)
+
+          notification = DossierNotification.first
+          expect(notification.dossier).to eq(dossier)
+          expect(notification.groupe_instructeur).to be_nil
+          expect(notification.instructeur).to eq(other_instructeur_follower)
+          expect(notification.notification_type).to eq('message')
+          expect(DossierNotification.to_display).to include(notification)
+        end
+      end
     end
   end
 

--- a/spec/models/dossier_notification_spec.rb
+++ b/spec/models/dossier_notification_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe DossierNotification, type: :model do
         other_instructeur_follower.followed_dossiers << dossier
       end
 
-      context "when user send a message" do
+      context "when user or expert send a message" do
         it "create notification for instructeurs followers" do
           subject
 

--- a/spec/models/dossier_notification_spec.rb
+++ b/spec/models/dossier_notification_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe DossierNotification, type: :model do
       it do
         is_expected.to eq({
           demande: true,
-          annotations_instructeur: false,
+          annotations_privees: false,
           avis_externe: false,
           messagerie: false
         })

--- a/spec/models/instructeur_spec.rb
+++ b/spec/models/instructeur_spec.rb
@@ -65,7 +65,7 @@ describe Instructeur, type: :model do
           DossierNotification.exists?(instructeur:, dossier: dossier_with_notifications, notification_type: :annotation_instructeur)
         ).to be_truthy
         expect(
-          DossierNotification.exists?(instructeur:, dossier: dossier_with_notifications, notification_type: :message_usager)
+          DossierNotification.exists?(instructeur:, dossier: dossier_with_notifications, notification_type: :message)
         ).to be_truthy
         expect(
           DossierNotification.exists?(instructeur:, dossier: dossier_with_notifications, notification_type: :dossier_modifie)

--- a/spec/models/instructeur_spec.rb
+++ b/spec/models/instructeur_spec.rb
@@ -54,12 +54,14 @@ describe Instructeur, type: :model do
       let!(:commentaire) { create(:commentaire, dossier: dossier_with_notifications) }
       let!(:avis_with_answer) { create(:avis, :with_answer, dossier: dossier_with_notifications) }
       let!(:avis_without_answer) { create(:avis, dossier: dossier_with_notifications) }
-      let!(:commentaire_correction) { create(:commentaire, dossier: dossier_with_notifications) }
+      let!(:commentaire_correction) { create(:commentaire, dossier: dossier_with_notifications, instructeur:) }
       let!(:correction) { create(:dossier_correction, dossier: dossier_with_notifications, commentaire: commentaire_correction) }
 
-      before { instructeur.follow(dossier_with_notifications) }
+      subject { instructeur.follow(dossier_with_notifications) }
 
       it "creates all previous notifications for the instructeur" do
+        subject
+
         expect(DossierNotification.count).to eq(6)
         expect(
           DossierNotification.exists?(instructeur:, dossier: dossier_with_notifications, notification_type: :annotation_instructeur)
@@ -79,6 +81,20 @@ describe Instructeur, type: :model do
         expect(
           DossierNotification.exists?(instructeur:, dossier: dossier_with_notifications, notification_type: :attente_correction)
         ).to be_truthy
+      end
+
+      context "when there are only commentaires from the instructeur who starts to follow" do
+        before do
+          commentaire.update!(instructeur:)
+        end
+
+        it "does not create message notification" do
+          subject
+
+          expect(DossierNotification.count).to eq(5)
+
+          expect(DossierNotification.pluck(:notification_type)).not_to include('message')
+        end
       end
     end
   end

--- a/spec/tasks/maintenance/t20250625update_dossier_notification_message_usager_to_message_task_spec.rb
+++ b/spec/tasks/maintenance/t20250625update_dossier_notification_message_usager_to_message_task_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe T20250625updateDossierNotificationMessageUsagerToMessageTask do
+    let(:dossier) { create(:dossier) }
+    let(:instructeur) { create(:instructeur) }
+    let!(:notification_message_usager) { create(:dossier_notification, :for_instructeur, dossier:, instructeur:, notification_type: :message_usager) }
+
+    describe "#collection" do
+      subject(:collection) { described_class.collection }
+
+      let!(:other_notification) { create(:dossier_notification, :for_instructeur, dossier:, instructeur:, notification_type: :dossier_modifie) }
+
+      it "includes only :message_usager notification" do
+        expect(collection).to include(notification_message_usager)
+        expect(collection).not_to include(other_notification)
+      end
+    end
+
+    describe "#process" do
+      subject(:process) { described_class.process(notification_message_usager) }
+
+      it "updates notification_type :message_usager to :message" do
+        subject
+        expect(notification_message_usager.notification_type).to eq('message')
+      end
+    end
+  end
+end

--- a/spec/tasks/maintenance/t20250625update_procedure_presentation_filters_with_message_usager_task_spec.rb
+++ b/spec/tasks/maintenance/t20250625update_procedure_presentation_filters_with_message_usager_task_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe T20250625updateProcedurePresentationFiltersWithMessageUsagerTask do
+    let(:procedure) { create(:procedure) }
+    let(:instructeur) { create(:instructeur) }
+    let(:assign_to) { create(:assign_to, procedure: procedure, instructeur: instructeur) }
+    let!(:procedure_presentation) { create(:procedure_presentation, assign_to: assign_to) }
+
+    describe "#process" do
+      subject(:process) { described_class.process(procedure_presentation) }
+
+      context "when procedure_presentation has not filter" do
+        it "does not change procedure_presentation" do
+          expect { process }.not_to change { procedure_presentation }
+        end
+      end
+
+      context "when procedure_presentation has filters but none on notification_type" do
+        before do
+          procedure_presentation.update!(
+            suivis_filters: [
+              FilteredColumn.new(
+                column: procedure.dossier_id_column,
+                filter: "1"
+              )
+            ]
+          )
+        end
+
+        it "does not change procedure_presentation filters" do
+          expect { process }.not_to change { procedure_presentation }
+        end
+      end
+
+      context "when procedure_presentation has notification_type filter" do
+        context "which is not 'message_usager'" do
+          before do
+            procedure_presentation.update!(
+              suivis_filters: [
+                FilteredColumn.new(
+                  column: procedure.dossier_notifications_column,
+                  filter: "dossier_modifie"
+                )
+              ]
+            )
+          end
+
+          it "refesh DossierColumn to obtain correct options_for_select" do
+            expect { process }.to change { procedure_presentation.suivis_filters }
+          end
+
+          it "does not change notification_type filter" do
+            expect { process }.not_to change { procedure_presentation.suivis_filters.map(&:to_json) }
+          end
+        end
+
+        context "which is 'message_usager'" do
+          before do
+            procedure_presentation.update!(
+              suivis_filters: [
+                FilteredColumn.new(
+                  column: procedure.dossier_notifications_column,
+                  filter: "message_usager"
+                )
+              ]
+            )
+          end
+
+          it "refesh DossierColumn to obtain correct options_for_select" do
+            expect { process }.to change { procedure_presentation.suivis_filters }
+          end
+
+          it "updates filter to 'message'" do
+            subject
+            expect(procedure_presentation.suivis_filters.first.column).to eq(procedure.dossier_notifications_column)
+            expect(procedure_presentation.suivis_filters.first.filter).to eq('message')
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Chantier Badge de notification**

On vient élargir le badge "Message Usager" à "Message" pour également inclure les messages des instructeurs, et ceux des experts. En somme, en dehors des messages automatiques, tout événements dans la messagerie entraînera la création d'un badge de notification "Message".

Ceci est une PR de transition, une prochaine PR viendra nettoyer définitivement toute références dans le code à "message_usager".

Durant cette transition, on gère les data "message_usager" (ancien) et "message" (nouveau) de façon confondu. Deux MT visent à migrer en base les data relatives à "message_usager" vers "message" : (i) DossierNotification.notification_type, et (ii) ProcedurePresentation dans ses filtres.

La MT de backfill est également à jouer pour rattraper les notifications relatives aux nouveaux messages des instructeurs et experts qui n'auraient pas été vu par les instructeurs.