### PR TITLE
ETQ instructeur je veux qu'une date d'expiration du dossier s'affiche dans les exports 

### DIFF
--- a/app/graphql/types/dossier_type.rb
+++ b/app/graphql/types/dossier_type.rb
@@ -87,7 +87,7 @@ module Types
 
     def date_expiration
       if !object.en_instruction?
-        object.expiration_date
+        object.expired_at
       end
     end
 

--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -217,7 +217,7 @@ module DossierHelper
   end
 
   def safe_expiration_date(dossier)
-    l(dossier.expiration_date, format: '%d/%m/%Y')
+    l(dossier.expired_at, format: '%d/%m/%Y')
   end
 
   def annuaire_link(siren_or_siret = nil)

--- a/app/models/concerns/columns_concern.rb
+++ b/app/models/concerns/columns_concern.rb
@@ -132,7 +132,7 @@ module ColumnsConcern
     end
 
     def dossier_dates_columns
-      ['created_at', 'updated_at', 'last_champ_updated_at', 'depose_at', 'en_construction_at', 'en_instruction_at', 'processed_at']
+      ['created_at', 'updated_at', 'last_champ_updated_at', 'depose_at', 'en_construction_at', 'en_instruction_at', 'processed_at', 'expired_at']
         .map { |column| dossier_col(table: 'self', column:, type: :datetime) }
     end
 

--- a/config/locales/models/procedure_presentation/en.yml
+++ b/config/locales/models/procedure_presentation/en.yml
@@ -27,6 +27,7 @@ en:
             mandataire_last_name: "Tier last name"
             mandataire_first_name: "Tier first name"
             accuse_lecture_agreement_at: 'Read receipt'
+            expired_at: 'Expired since'
           user:
             id: User Id
             email: Requester

--- a/config/locales/models/procedure_presentation/fr.yml
+++ b/config/locales/models/procedure_presentation/fr.yml
@@ -31,6 +31,7 @@ fr:
             last_champ_updated_at: Date de dernière modification (usager)
             motivation: 'Motivation de la décision'
             accuse_lecture_agreement_at: 'Accusé de lecture'
+            expired_at: 'Date d’expiration'
           user:
             id: Identifiant du demandeur
             email: Demandeur

--- a/spec/views/instructeur/dossiers/_expiration_banner.html.haml_spec.rb
+++ b/spec/views/instructeur/dossiers/_expiration_banner.html.haml_spec.rb
@@ -12,6 +12,7 @@ describe 'instructeur/dossiers/expiration_banner', type: :view do
   end
   let(:i18n_key_state) { state }
   subject do
+    dossier.update_expired_at unless dossier.en_instruction?
     render('instructeurs/dossiers/expiration_banner',
            dossier: dossier,
            current_user: build(:user))

--- a/spec/views/instructeur/dossiers/show.html.haml_spec.rb
+++ b/spec/views/instructeur/dossiers/show.html.haml_spec.rb
@@ -145,6 +145,8 @@ describe 'instructeurs/dossiers/show', type: :view do
     let(:procedure) { create(:procedure, :published, duree_conservation_dossiers_dans_ds: 6, procedure_expires_when_termine_enabled: true) }
     let!(:dossier) { create(:dossier, state: :accepte, procedure: procedure, processed_at: 175.days.ago) }
 
+    before { dossier.update_expired_at }
+
     it 'displays the correct actions' do
       expect(subject).to have_text('Conserver un mois de plus')
       within("form[action=\"#{repasser_en_instruction_instructeur_dossier_path(dossier.procedure, dossier)}\"]") do

--- a/spec/views/users/dossiers/_expiration_banner.html.haml_spec.rb
+++ b/spec/views/users/dossiers/_expiration_banner.html.haml_spec.rb
@@ -13,6 +13,7 @@ describe 'users/dossiers/expiration_banner', type: :view do
   end
   let(:i18n_key_state) { state }
   subject do
+    dossier.update_expired_at unless dossier.en_instruction?
     render('users/dossiers/expiration_banner',
            dossier: dossier,
            current_user: build(:user))


### PR DESCRIPTION
closes #10612
- Ajoute la date d'expiration dans les filtres et les exports (pas dans l'export par défaut mais disponible dans les modèles d'export)
- Utilise l'attribut `expired_at` pour afficher la date d'expiration (plutôt que la calculer à la volée)

⚠️  Ne merger qu'après avoir fait passer la maintenance task `app/tasks/maintenance/t20250611backfill_dossiers_expired_at_task.rb`