### PR TITLE
[Correctif] ETQ administrateur l'éditeur ne scrolle pas en haut de l'écran si le libellé du champ est vide

### DIFF
--- a/app/components/procedure/errors_summary.rb
+++ b/app/components/procedure/errors_summary.rb
@@ -13,7 +13,7 @@ class Procedure::ErrorsSummary < ApplicationComponent
     when :types_de_champ_private_editor
       "Les annotations privées contiennent des erreurs"
     when :types_de_champ_public_editor
-      "Les champs formulaire contiennent des erreurs"
+      "Les champs du formulaire contiennent des erreurs"
     when :publication
       if @procedure.publiee?
         "Des problèmes empêchent la publication des modifications"

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -232,6 +232,7 @@ class Procedure < ApplicationRecord
     'types_de_champ/no_empty_drop_down': true,
     'types_de_champ/formatted': true,
     'types_de_champ/referentiel_ready': true,
+    'types_de_champ/libelle': true,
     on: [:types_de_champ_public_editor, :publication]
 
   validates :draft_types_de_champ_private,
@@ -241,6 +242,7 @@ class Procedure < ApplicationRecord
     'types_de_champ/no_empty_drop_down': true,
     'types_de_champ/formatted': true,
     'types_de_champ/referentiel_ready': true,
+    'types_de_champ/libelle': true,
     on: [:types_de_champ_private_editor, :publication]
 
   validate :check_juridique, on: [:create, :publication]

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -214,7 +214,6 @@ class TypeDeChamp < ApplicationRecord
     "text/plain"
   ], size: { less_than: 20.megabytes }, on: :update
 
-  validates :libelle, presence: true, allow_blank: false, allow_nil: false
   validates :type_champ, presence: true, allow_blank: false, allow_nil: false
   validates :character_limit, numericality: {
     greater_than_or_equal_to: MINIMUM_TEXTAREA_CHARACTER_LIMIT_LENGTH,

--- a/app/validators/types_de_champ/libelle_validator.rb
+++ b/app/validators/types_de_champ/libelle_validator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class TypesDeChamp::LibelleValidator < ActiveModel::EachValidator
+  def validate_each(procedure, attribute, types_de_champ)
+    types_de_champ.each do |tdc|
+      if tdc.libelle.blank?
+        procedure.errors.add(
+          attribute,
+          procedure.errors.generate_message(attribute, :missing_libelle, { position: tdc.revision_types_de_champ.last.position + 1 }),
+          type_de_champ: tdc
+        )
+      end
+    end
+  end
+end

--- a/config/locales/models/procedure/en.yml
+++ b/config/locales/models/procedure/en.yml
@@ -88,6 +88,7 @@ en:
               empty_drop_down: 'requires at least one option'
               empty_csv: 'requires at least one csv file'
               inconsistent_header_section: "%{custom_message}"
+              missing_libelle: "field label in position %{position} must be filled"
               expression_reguliere_invalid: "is invalid"
               referentiel_not_ready: "is not configured"
             draft_types_de_champ_private:
@@ -97,6 +98,7 @@ en:
               empty_drop_down: 'requires at least one option'
               empty_csv: 'requires at least one csv file'
               inconsistent_header_section: "%{custom_message}"
+              missing_libelle: "field label in position %{position} must be filled"
               expression_reguliere_invalid: "is invalid"
             attestation_template:
               format: "%{attribute} %{message}"

--- a/config/locales/models/procedure/fr.yml
+++ b/config/locales/models/procedure/fr.yml
@@ -93,6 +93,7 @@ fr:
               empty_drop_down: 'doit comporter au moins un choix sélectionnable'
               empty_csv: 'doit comporter au moins un fichier csv'
               inconsistent_header_section: "%{custom_message}"
+              missing_libelle:  "Le libellé du champ en position %{position} doit être rempli"
               expression_reguliere_invalid: "est invalide, veuillez la corriger"
               referentiel_not_ready: "n'est pas configuré"
             draft_types_de_champ_private:
@@ -102,6 +103,7 @@ fr:
               empty_drop_down: 'doit comporter au moins un choix sélectionnable'
               empty_csv: 'doit comporter au moins un fichier csv'
               inconsistent_header_section: "%{custom_message}"
+              missing_libelle:  "Le libellé du champ en position %{position} doit être rempli"
               expression_reguliere_invalid: "est invalide, veuillez la corriger"
             attestation_template:
               format: "%{attribute} %{message}"

--- a/spec/components/procedures/errors_summary_spec.rb
+++ b/spec/components/procedures/errors_summary_spec.rb
@@ -25,7 +25,7 @@ describe Procedure::ErrorsSummary, type: :component do
       let(:validation_context) { :types_de_champ_public_editor }
 
       it 'shows errors and links for public only tdc' do
-        expect(page).to have_text("Erreur : Les champs formulaire contiennent des erreurs")
+        expect(page).to have_text("Erreur : Les champs du formulaire contiennent des erreurs")
         expect(page).to have_selector("a", text: "public")
         expect(page).to have_text("doit comporter au moins un champ répétable", count: 1)
         expect(page).not_to have_selector("a", text: "private")

--- a/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
+++ b/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
@@ -99,7 +99,7 @@ describe Administrateurs::TypesDeChampController, type: :controller do
       it do
         is_expected.to have_http_status(:ok)
         expect(assigns(:coordinate)).to eq(second_coordinate)
-        expect(flash.alert).to eq(["Le champ « Libelle » doit être rempli"])
+        expect(flash.alert).to be_nil
       end
     end
 

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -2,12 +2,6 @@
 
 describe TypeDeChamp do
   describe 'validation' do
-    context 'libelle' do
-      it { is_expected.not_to allow_value(nil).for(:libelle) }
-      it { is_expected.not_to allow_value('').for(:libelle) }
-      it { is_expected.to allow_value('Montant projet').for(:libelle) }
-    end
-
     context 'type' do
       it { is_expected.not_to allow_value(nil).for(:type_champ) }
       it { is_expected.not_to allow_value('').for(:type_champ) }
@@ -144,7 +138,7 @@ describe TypeDeChamp do
       type_de_champ.libelle = ''
       expect(type_de_champ.validate).to be_falsey
       messages = type_de_champ.errors.full_messages
-      expect(messages.size).to eq(2)
+      expect(messages.size).to eq(1)
       expect(messages.last).to eq("Le champ « La liste » doit commencer par une entrée de menu primaire de la forme <code style='white-space: pre-wrap;'>--texte--</code>")
     end
   end

--- a/spec/validators/types_de_champ/libelle_validator_spec.rb
+++ b/spec/validators/types_de_champ/libelle_validator_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TypesDeChamp::LibelleValidator do
+  let(:procedure) { create(:procedure, types_de_champ_public: types) }
+  let(:type_de_champ) { procedure.active_revision.types_de_champ_public.first }
+
+  subject { procedure.validate(:types_de_champ_public_editor) }
+
+  context 'with a text type de champ' do
+    let(:types) { [type: :text] }
+
+    context 'when libelle is filled' do
+      it 'does not add errors to the procedure' do
+        expect { subject }.not_to change { procedure.errors.count }
+      end
+    end
+
+    context 'when libelle is empty' do
+      before { type_de_champ.update(libelle: '') }
+
+      it 'does add errors to the procedure' do
+        expect { subject }.to change { procedure.errors.count }
+      end
+    end
+
+    context 'when libelle is nil' do
+      before { type_de_champ.update(libelle: nil) }
+
+      it 'does add errors to the procedure' do
+        expect { subject }.to change { procedure.errors.count }
+      end
+    end
+  end
+
+  context 'with linked drop down list type de champ' do
+    let(:types) { [type: :linked_drop_down_list] }
+    context 'when libelle is filled' do
+      it 'does not add errors to the procedure' do
+        expect { subject }.not_to change { procedure.errors.count }
+      end
+    end
+
+    context 'when libelle is empty' do
+      before { type_de_champ.update(libelle: '') }
+
+      it 'does add errors to the procedure' do
+        expect { subject }.to change { procedure.errors.count }
+      end
+    end
+
+    context 'when libelle is nil' do
+      before { type_de_champ.update(libelle: nil) }
+
+      it 'does add errors to the procedure' do
+        expect { subject }.to change { procedure.errors.count }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Et l'erreur est au format du dsfr

closes #11772