### PR TITLE
ETQ Administrateur, je souhaite que les instructeurs ne puissent se connecter à certaines démarches qu'avec PROCONNECT

### DIFF
--- a/app/components/procedure/card/pro_connect_restricted_component.rb
+++ b/app/components/procedure/card/pro_connect_restricted_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Procedure::Card::ProConnectRestrictedComponent < ApplicationComponent
+  def initialize(procedure:)
+    @procedure = procedure
+  end
+
+  def render?
+    feature_enabled?(:pro_connect_restricted)
+  end
+end

--- a/app/components/procedure/card/pro_connect_restricted_component/pro_connect_restricted_component.fr.yml
+++ b/app/components/procedure/card/pro_connect_restricted_component/pro_connect_restricted_component.fr.yml
@@ -1,0 +1,6 @@
+---
+fr:
+  title: Connexion ProConnect
+  subtitle: Obliger les administrateurs et instructeurs à se connecter via ProConnect pour accéder à la démarche
+  enabled: Activée
+  disabled: Désactivée

--- a/app/components/procedure/card/pro_connect_restricted_component/pro_connect_restricted_component.html.haml
+++ b/app/components/procedure/card/pro_connect_restricted_component/pro_connect_restricted_component.html.haml
@@ -1,0 +1,11 @@
+.fr-col-6.fr-col-md-4.fr-col-lg-3
+  = link_to pro_connect_restricted_admin_procedure_path(@procedure), class: 'fr-tile fr-enlarge-link' do
+    .fr-tile__body.flex.column.align-center.justify-between
+      - if @procedure.pro_connect_restricted?
+        %p.fr-badge.fr-badge--success= t('.enabled')
+      - else
+        %p.fr-badge= t('.disabled')
+      %div
+        %h3.fr-h6.fr-mt-10v= t('.title')
+        %p.fr-tile-subtitle= t('.subtitle')
+      %p.fr-btn.fr-btn--tertiary= t('views.shared.actions.edit')

--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -5,7 +5,7 @@ module Administrateurs
     layout 'all', only: [:all, :administrateurs]
     respond_to :html, :xlsx
 
-    before_action :retrieve_procedure, only: [:champs, :annotations, :modifications, :edit, :zones, :monavis, :update_monavis, :accuse_lecture, :update_accuse_lecture, :jeton, :update_jeton, :publication, :publish, :transfert, :close, :confirmation, :allow_expert_review, :allow_expert_messaging, :experts_require_administrateur_invitation, :reset_draft, :publish_revision, :check_path, :api_champ_columns, :path, :update_path, :rdv, :update_rdv]
+    before_action :retrieve_procedure, only: [:champs, :annotations, :modifications, :edit, :zones, :monavis, :update_monavis, :accuse_lecture, :update_accuse_lecture, :jeton, :update_jeton, :publication, :publish, :transfert, :close, :confirmation, :allow_expert_review, :allow_expert_messaging, :experts_require_administrateur_invitation, :reset_draft, :publish_revision, :check_path, :api_champ_columns, :path, :update_path, :rdv, :update_rdv, :pro_connect_restricted, :update_pro_connect_restricted]
     before_action :draft_valid?, only: [:apercu]
     after_action :reset_draft_procedure, only: [:update]
 
@@ -272,6 +272,16 @@ module Administrateurs
     end
 
     def jeton
+    end
+
+    def pro_connect_restricted
+      @logged_in_with_pro_connect = logged_in_with_pro_connect?
+    end
+
+    def update_pro_connect_restricted
+      @procedure.update!(procedure_params)
+      flash.notice = @procedure.pro_connect_restricted? ? "La démarche est restreinte à ProConnect" : "La démarche n'est plus restreinte à ProConnect"
+      redirect_to pro_connect_restricted_admin_procedure_path(@procedure)
     end
 
     def rdv
@@ -636,6 +646,7 @@ module Administrateurs
         :opendata,
         :procedure_expires_when_termine_enabled,
         :rdv_enabled,
+        :pro_connect_restricted,
         { zone_ids: [], procedure_tag_names: [] }
       ]
 

--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -5,7 +5,7 @@ module Administrateurs
     layout 'all', only: [:all, :administrateurs]
     respond_to :html, :xlsx
 
-    before_action :retrieve_procedure, only: [:champs, :annotations, :modifications, :edit, :zones, :monavis, :update_monavis, :accuse_lecture, :update_accuse_lecture, :jeton, :update_jeton, :publication, :publish, :transfert, :close, :confirmation, :allow_expert_review, :allow_expert_messaging, :experts_require_administrateur_invitation, :reset_draft, :publish_revision, :check_path, :api_champ_columns, :path, :update_path, :rdv, :update_rdv, :pro_connect_restricted, :update_pro_connect_restricted]
+    before_action :retrieve_procedure, only: [:show, :update, :champs, :annotations, :modifications, :edit, :zones, :monavis, :update_monavis, :accuse_lecture, :update_accuse_lecture, :jeton, :update_jeton, :publication, :publish, :transfert, :close, :confirmation, :allow_expert_review, :allow_expert_messaging, :experts_require_administrateur_invitation, :reset_draft, :publish_revision, :check_path, :api_champ_columns, :path, :update_path, :rdv, :update_rdv, :pro_connect_restricted, :update_pro_connect_restricted]
     before_action :draft_valid?, only: [:apercu]
     after_action :reset_draft_procedure, only: [:update]
 
@@ -120,8 +120,6 @@ module Administrateurs
     end
 
     def update
-      @procedure = current_administrateur.procedures.find(params[:id])
-
       if !@procedure.update(procedure_params)
         flash.now.alert = @procedure.errors.full_messages
         if @procedure.errors[:zones].present?

--- a/app/controllers/concerns/pro_connect_session_concern.rb
+++ b/app/controllers/concerns/pro_connect_session_concern.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module ProConnectSessionConcern
+  extend ActiveSupport::Concern
+
+  SESSION_INFO_COOKIE_NAME = :pro_connect_session_info
+
+  included do
+    def logged_in_with_pro_connect?
+      current_user.present? && cookies.encrypted[SESSION_INFO_COOKIE_NAME].present? && JSON.parse(cookies.encrypted[SESSION_INFO_COOKIE_NAME])['user_id'] == current_user.id
+    end
+
+    def set_pro_connect_session_info_cookie(user_id)
+      cookies.encrypted[SESSION_INFO_COOKIE_NAME] = { value: { user_id: }.to_json, secure: Rails.env.production?, httponly: true }
+    end
+
+    def delete_pro_connect_session_info_cookie
+      cookies.delete SESSION_INFO_COOKIE_NAME
+    end
+  end
+end

--- a/app/controllers/france_connect_controller.rb
+++ b/app/controllers/france_connect_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class FranceConnectController < ApplicationController
+  include ProConnectSessionConcern
+
   before_action :redirect_to_login_if_fc_aborted, only: [:callback]
   before_action :securely_retrieve_fci, only: [:merge_using_fc_email, :merge_using_password, :send_email_merge_request]
   before_action :securely_retrieve_fci_from_email_merge_token, only: [:merge_using_email_link]
@@ -54,6 +56,7 @@ class FranceConnectController < ApplicationController
       if @fci.user.can_france_connect?
         @fci.update(updated_at: Time.zone.now)
         connect_france_connect(@fci.user)
+        delete_pro_connect_session_info_cookie
       else
         destroy_fci_and_redirect_to_login(@fci)
       end
@@ -99,6 +102,7 @@ class FranceConnectController < ApplicationController
 
       flash.notice = t('france_connect.flash.connection_done', application_name: Current.application_name)
       connect_france_connect(user)
+      delete_pro_connect_session_info_cookie
     else
       flash.alert = t('france_connect.flash.invalid_password')
     end
@@ -121,6 +125,7 @@ class FranceConnectController < ApplicationController
 
     flash.notice = t('france_connect.flash.connection_done', application_name: Current.application_name)
     connect_france_connect(@fci.user)
+    delete_pro_connect_session_info_cookie
   end
 
   # TODO mutualiser avec le controller Users::ActivateController

--- a/app/controllers/pro_connect_controller.rb
+++ b/app/controllers/pro_connect_controller.rb
@@ -2,6 +2,8 @@
 
 # doc: https://github.com/numerique-gouv/proconnect-documentation/tree/main
 class ProConnectController < ApplicationController
+  include ProConnectSessionConcern
+
   before_action :redirect_to_login_if_fc_aborted, only: [:callback]
   before_action :check_state, only: [:callback]
 
@@ -47,6 +49,8 @@ class ProConnectController < ApplicationController
     if user.instructeur?
       user.instructeur.update!(pro_connect_id_token: id_token)
     end
+
+    set_pro_connect_session_info_cookie(user.id)
 
     sign_in(:user, user)
     redirect_to stored_location_for(:user) || root_path

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -18,6 +18,7 @@ class Users::SessionsController < Devise::SessionsController
 
     if user&.valid_password?(params[:user][:password])
       delete_france_connect_cookies
+      delete_pro_connect_session_info_cookie
       user.update(loged_in_with_france_connect: nil)
       user.update_preferred_domain(Current.host) if helpers.switch_domain_enabled?(request)
     end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -5,6 +5,7 @@ class Users::SessionsController < Devise::SessionsController
   include TrustedDeviceConcern
   include ActionView::Helpers::DateHelper
   include FranceConnectConcern
+  include ProConnectSessionConcern
 
   layout 'login', only: [:new, :create]
 
@@ -55,6 +56,8 @@ class Users::SessionsController < Devise::SessionsController
       current_user&.instructeur&.update(pro_connect_id_token: nil)
 
       sign_out :user
+
+      delete_pro_connect_session_info_cookie
 
       if logged_in_with_france_connect?
         return redirect_to france_connect_logout_url(callback: root_url), allow_other_host: true

--- a/app/models/concerns/procedure_clone_concern.rb
+++ b/app/models/concerns/procedure_clone_concern.rb
@@ -82,7 +82,8 @@ module ProcedureCloneConcern
     'rdv_enabled',
     'routing_alert',
     'api_particulier_token',
-    'no_gender'
+    'no_gender',
+    'pro_connect_restricted'
   ]
 
   NEW_MAX_DUREE_CONSERVATION = Expired::DEFAULT_DOSSIER_RENTENTION_IN_MONTH

--- a/app/views/administrateurs/procedures/pro_connect_restricted.html.haml
+++ b/app/views/administrateurs/procedures/pro_connect_restricted.html.haml
@@ -1,0 +1,41 @@
+= render partial: 'administrateurs/breadcrumbs',
+  locals: { steps: [['Démarches', admin_procedures_back_path(@procedure)],
+                    [@procedure.libelle.truncate_words(10), admin_procedure_path(@procedure)],
+                    ['ProConnect']] }
+
+.fr-container
+  .fr-grid-row
+    .fr-col-12.fr-col-offset-md-2.fr-col-md-8
+      %h1.fr-h2 Connexion ProConnect
+
+      = render Dsfr::CalloutComponent.new(title: nil) do |c|
+        - c.with_body do
+          %p
+            Cette option permet de limiter l'accès à la démarche : les
+            %strong administrateurs
+            et les
+            %strong instructeurs
+            pourront accéder à la démarche
+            %strong uniquement en se connectant via ProConnect.
+
+      - unless @logged_in_with_pro_connect
+        = render Dsfr::AlertComponent.new(title: nil, state: :warning, extra_class_names: 'fr-my-2w') do |c|
+          - c.with_body do
+            %p
+              Pour activer cette fonctionnalité, vous devez commencer par
+              = link_to "vous connecter avec ProConnect", pro_connect_path
+
+      %ul.fr-toggle__list
+        %li
+          = form_for(@procedure,
+            method: :patch,
+            url: pro_connect_restricted_admin_procedure_path(@procedure),
+            data: { controller: 'autosubmit', turbo: 'true' }) do |f|
+
+            = render Dsfr::ToggleComponent.new(form: f,
+              target: :pro_connect_restricted,
+              title: "Obliger les administrateurs et les instructeurs à se connecter via ProConnect pour accéder à la démarche",
+              disabled: !@logged_in_with_pro_connect,
+              opt: { checked: @procedure.pro_connect_restricted? })
+
+= render Procedure::FixedFooterComponent.new(procedure: @procedure, extra_class_names: 'fr-col-offset-md-2 fr-col-md-8' )

--- a/app/views/administrateurs/procedures/show.html.haml
+++ b/app/views/administrateurs/procedures/show.html.haml
@@ -114,3 +114,4 @@
     = render Procedure::Card::AccuseLectureComponent.new(procedure: @procedure)
     = render Procedure::Card::LabelsComponent.new(procedure: @procedure)
     = render Procedure::Card::RdvComponent.new(procedure: @procedure)
+    = render Procedure::Card::ProConnectRestrictedComponent.new(procedure: @procedure)

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -30,6 +30,7 @@ features = [
   :referentiel_type_de_champ,
   :groupe_instructeur_api_hack,
   :rdv,
+  :pro_connect_restricted,
   :sva,
   :switch_domain,
   :export_avec_horodatage,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -661,6 +661,8 @@ Rails.application.routes.draw do
         patch 'update_jeton'
         get 'rdv'
         patch 'rdv', to: 'procedures#update_rdv'
+        get 'pro_connect_restricted'
+        patch 'pro_connect_restricted', to: 'procedures#update_pro_connect_restricted'
         put :allow_expert_review
         put :allow_expert_messaging
         put :experts_require_administrateur_invitation

--- a/db/migrate/20250523084451_add_pro_connect_restricted_to_procedures.rb
+++ b/db/migrate/20250523084451_add_pro_connect_restricted_to_procedures.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddProConnectRestrictedToProcedures < ActiveRecord::Migration[7.1]
+  def change
+    add_column :procedures, :pro_connect_restricted, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1047,6 +1047,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_26_085657) do
     t.bigint "parent_procedure_id"
     t.string "path"
     t.boolean "piece_justificative_multiple", default: true, null: false
+    t.boolean "pro_connect_restricted", default: false, null: false
     t.boolean "procedure_expires_when_termine_enabled", default: true
     t.datetime "published_at", precision: nil
     t.bigint "published_revision_id"

--- a/spec/components/procedure/card/pro_connect_restricted_component_spec.rb
+++ b/spec/components/procedure/card/pro_connect_restricted_component_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Procedure::Card::ProConnectRestrictedComponent, type: :component do
+  before do
+    allow_any_instance_of(described_class).to receive(:feature_enabled?).and_return(true)
+  end
+
+  subject { render_inline(described_class.new(procedure:)) }
+
+  let(:procedure) { create(:procedure, pro_connect_restricted:) }
+
+  context "when ProConnect restriction is enabled" do
+    let(:pro_connect_restricted) { true }
+
+    it { is_expected.to have_css('p.fr-badge.fr-badge--success', text: "Activée") }
+    it { is_expected.to have_css('h3.fr-h6', text: "ProConnect") }
+  end
+
+  context "when ProConnect restriction is disabled" do
+    let(:pro_connect_restricted) { false }
+
+    it { is_expected.to have_css('p.fr-badge', text: "Désactivée") }
+    it { is_expected.to have_css('h3.fr-h6', text: "ProConnect") }
+  end
+end

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -1848,4 +1848,30 @@ describe Administrateurs::ProceduresController, type: :controller do
       end
     end
   end
+
+  describe 'GET #show' do
+    subject { get :show, params: { id: procedure.id } }
+
+    context 'when ProConnect is required' do
+      let(:procedure) { create(:procedure, pro_connect_restricted: true, administrateur: admin) }
+      it 'redirects to pro_connect_path and sets a flash message' do
+        subject
+
+        expect(response).to redirect_to(pro_connect_path)
+        expect(flash[:alert]).to eq("Vous devez vous connecter par ProConnect pour accéder à cette démarche")
+      end
+
+      context "and the cookie is set" do
+        before do
+          cookies.encrypted[ProConnectSessionConcern::SESSION_INFO_COOKIE_NAME] = { value: { user_id: admin.user.id }.to_json }
+        end
+
+        it "does not redirect to pro_connect_path" do
+          subject
+
+          expect(response).not_to redirect_to(pro_connect_path)
+        end
+      end
+    end
+  end
 end

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -1057,6 +1057,17 @@ describe Instructeurs::DossiersController, type: :controller do
         ).to be_truthy
       end
     end
+
+    context "when procedure has pro_connect restriction" do
+      before do
+        procedure.update!(pro_connect_restricted: true)
+      end
+
+      it "redirects to pro_connect_restricted page" do
+        get :show, params: { procedure_id: procedure.id, dossier_id: dossier.id, statut: 'a-suivre' }
+        expect(response).to redirect_to(pro_connect_path)
+      end
+    end
   end
 
   describe 'navigation accross next/prev dossiers' do

--- a/spec/controllers/instructeurs/procedures_controller_spec.rb
+++ b/spec/controllers/instructeurs/procedures_controller_spec.rb
@@ -720,6 +720,31 @@ describe Instructeurs::ProceduresController, type: :controller do
           expect(response.body).to have_selector('span.fr-tag', text: 'Urgent')
         end
       end
+
+      context 'when ProConnect is required' do
+        before do
+          procedure.update!(pro_connect_restricted: true)
+        end
+
+        it 'redirects to pro_connect_path and sets a flash message' do
+          subject
+
+          expect(response).to redirect_to(pro_connect_path)
+          expect(flash[:alert]).to eq("Vous devez vous connecter par ProConnect pour accéder à cette démarche")
+        end
+
+        context "and the cookie is set" do
+          before do
+            cookies.encrypted[ProConnectSessionConcern::SESSION_INFO_COOKIE_NAME] = { value: { user_id: instructeur.user.id }.to_json }
+          end
+
+          it "does not redirect to pro_connect_path" do
+            subject
+
+            expect(response).not_to redirect_to(pro_connect_path)
+          end
+        end
+      end
     end
 
     describe 'caches statut and page query param' do

--- a/spec/controllers/pro_connect_controller_spec.rb
+++ b/spec/controllers/pro_connect_controller_spec.rb
@@ -108,6 +108,12 @@ describe ProConnectController, type: :controller do
           it "sets email_verified_at" do
             expect { subject }.to change { instructeur.user.reload.email_verified_at }.from(nil)
           end
+
+          it "sets the pro_connect_session_info cookie" do
+            subject
+
+            expect(cookies.encrypted[ProConnectSessionConcern::SESSION_INFO_COOKIE_NAME]).to eq({ user_id: instructeur.user.id }.to_json)
+          end
         end
       end
 

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -139,6 +139,8 @@ describe Users::SessionsController, type: :controller do
         cookies.encrypted[FranceConnectController::STATE_COOKIE_NAME] = 'state'
       end
 
+      cookies.encrypted[ProConnectSessionConcern::SESSION_INFO_COOKIE_NAME] = { value: { user_id: user.id }.to_json }
+
       delete :destroy
     end
 
@@ -182,6 +184,11 @@ describe Users::SessionsController, type: :controller do
       it 'redirect to pro connect logout page' do
         expect(response.location).to include(pro_connect_id_token)
         expect(instructeur.reload.pro_connect_id_token).to be_nil
+      end
+
+      it "deletes the pro_connect_session_info cookie" do
+        expect(response.cookies.keys).to include(ProConnectSessionConcern::SESSION_INFO_COOKIE_NAME.to_s)
+        expect(response.cookies[ProConnectSessionConcern::SESSION_INFO_COOKIE_NAME]).to be_nil
       end
     end
   end


### PR DESCRIPTION
Fixes #11159
Fonctionnalité feature flipée pour l'instant
On ajoute une tuile de configuration coté Admin
<img width="471" alt="Capture d’écran 2025-07-03 à 15 06 17" src="https://github.com/user-attachments/assets/1312b9d5-4be5-4239-8f0d-f130f1b409f1" />
Un écran de configuration, qui necessite pour l'activation que l'admin soit Pro connecté
<img width="931" alt="Capture d’écran 2025-07-03 à 15 06 21" src="https://github.com/user-attachments/assets/27fe766e-54c9-4e44-9998-5d4f0d428dad" />
<img width="916" alt="Capture d’écran 2025-07-03 à 15 06 48" src="https://github.com/user-attachments/assets/e2e03f72-22a1-4e4f-8a4e-1ee032a82b20" />
<img width="922" alt="Capture d’écran 2025-07-03 à 15 07 37" src="https://github.com/user-attachments/assets/4bbfcf25-13b8-4b25-89a8-9d20fc53f1c2" />

Une fois la fonctionnalité activée, les admins et instructeurs sont redirigés vers la page pro connect s'ils souhaitent acceder à une démarche protégé sans pro connexion.
<img width="1185" alt="Capture d’écran 2025-07-03 à 15 08 02" src="https://github.com/user-attachments/assets/34237d1f-135b-44d5-a953-34d194c3f77d" />
