### PR TITLE
[Bug] fix InvalidRegularExpression bug

### DIFF
--- a/app/models/columns/json_path_column.rb
+++ b/app/models/columns/json_path_column.rb
@@ -26,6 +26,14 @@ class Columns::JSONPathColumn < Columns::ChampColumn
     dossiers.with_type_de_champ(stable_id)
       .where(condition)
       .ids
+
+  rescue ActiveRecord::StatementInvalid => e
+    if e.cause.is_a?(PG::InvalidRegularExpression)
+      Rails.logger.warn("filtered_ids fallback: Invalid regex — #{e.message}")
+      []
+    else
+      raise
+    end
   end
 
   private

--- a/spec/models/columns/json_path_column_spec.rb
+++ b/spec/models/columns/json_path_column_spec.rb
@@ -25,18 +25,36 @@ describe Columns::JSONPathColumn do
   end
 
   describe '#filtered_ids' do
-    let(:jsonpath) { '$.city_name' }
+    context 'with regular search' do
+      let(:jsonpath) { '$.city_name' }
 
-    subject { column.filtered_ids(Dossier.all, ['reno', 'Lyon']) }
+      subject { column.filtered_ids(Dossier.all, ['reno', 'Lyon']) }
 
-    context 'when champ has value_json' do
-      before { champ.update(value_json: { city_name: 'Grenoble' }) }
+      context 'when champ has value_json' do
+        before { champ.update(value_json: { city_name: 'Grenoble' }) }
 
-      it { is_expected.to eq([dossier.id]) }
+        it { is_expected.to eq([dossier.id]) }
+      end
+
+      context 'when champ has no value_json' do
+        it { is_expected.to eq([]) }
+      end
     end
 
-    context 'when champ has no value_json' do
-      it { is_expected.to eq([]) }
+    context 'with avanced search using special characters' do
+      let(:jsonpath) { '$.city_name' }
+
+      subject { column.filtered_ids(Dossier.all, ['*reno*', 'Lyon']) }
+
+      context 'when champ has value_json we catch Invalid Regex error and return []' do
+        before { champ.update(value_json: { city_name: 'Grenoble' }) }
+
+        it { is_expected.to eq([]) }
+      end
+
+      context 'when champ has no value_json we catch Invalid Regex error and return []' do
+        it { is_expected.to eq([]) }
+      end
     end
   end
 


### PR DESCRIPTION
Suite à une conversation avec une instructrice qui ne peut accéder à son onglet "en cours"
//EDIT Apres recherche dans la prod, le filtre demandé contient des `*`.
On a décidé de ne pas permettre ce filtre avancé et de rendre un tableau vide, pour permettre à l'utilisateur de supprimer son filtre au lieu d'avoir une erreur 500.

https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_e374eed7-2a39-4226-81ba-1ff0175516eb/


https://demarches-simplifiees.sentry.io/issues/6510292056/?environment=production&project=1429550&query=&referrer=issue-stream&stream_index=0