### PR TITLE
ETQ usager, je retrouve toutes les infos de contact du service dans le pied de page des mails DS

### DIFF
--- a/app/assets/stylesheets/icons.scss
+++ b/app/assets/stylesheets/icons.scss
@@ -198,11 +198,19 @@
     }
   }
 
+  &-info-i {
+    &:before,
+    &:after {
+      -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='currentColor'%3E%3Cpath d='M12 6C12.8284 6 13.5 5.32843 13.5 4.5C13.5 3.67157 12.8284 3 12 3C11.1716 3 10.5 3.67157 10.5 4.5C10.5 5.32843 11.1716 6 12 6ZM9 10H11V18H9V20H15V18H13V8H9V10Z'%3E%3C/path%3E%3C/svg%3E");
+      mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='currentColor'%3E%3Cpath d='M12 6C12.8284 6 13.5 5.32843 13.5 4.5C13.5 3.67157 12.8284 3 12 3C11.1716 3 10.5 3.67157 10.5 4.5C10.5 5.32843 11.1716 6 12 6ZM9 10H11V18H9V20H15V18H13V8H9V10Z'%3E%3C/path%3E%3C/svg%3E");
+    }
+  }
+
   &-intermediate-circle-fill {
     &:before,
     &:after {
-      -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22ZM7 11V13H17V11H7Z'%3E%3C/path%3E%3C/svg%3E");
-      mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22ZM7 11V13H17V11H7Z'%3E%3C/path%3E%3C/svg%3E");
+      -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22ZM7 11V13H17V11H7Z' fill='currentColor'%3E%3C/path%3E%3C/svg%3E");
+      mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22ZM7 11V13H17V11H7Z' fill='currentColor'%3E%3C/path%3E%3C/svg%3E");
     }
   }
 

--- a/app/components/procedure/service_list_contact_component/service_list_contact_component.fr.yml
+++ b/app/components/procedure/service_list_contact_component/service_list_contact_component.fr.yml
@@ -1,4 +1,4 @@
 fr:
   contact_instructeur: Envoyez directement un message à l’instructeur
-  faq_link: Consultez l'aide en ligne
-  contact_link: Consultez la page de contact de l'administration
+  faq_link: Consultez l’aide en ligne
+  contact_link: Consultez la page de contact de l’administration

--- a/app/components/procedure/service_list_contact_component/service_list_contact_component.html.haml
+++ b/app/components/procedure/service_list_contact_component/service_list_contact_component.html.haml
@@ -44,6 +44,6 @@
   - if other_contact_info.present?
     .flex.fr-mb-2v
       %dt.fr-mr-2v
-        %span.fr-fi-info-line.fr-icon--sm{ "aria-hidden": "true" }
+        %span.fr-icon-info-i.fr-icon--sm{ "aria-hidden": "true" }
       %dd
         = other_contact_info

--- a/app/views/layouts/mailers/_service_footer.html.haml
+++ b/app/views/layouts/mailers/_service_footer.html.haml
@@ -9,29 +9,38 @@
 - if service_or_contact_information.present?
   %table{ width: "100%", border: "0", cellspacing: "0", cellpadding: "0", style: "cursor:auto;color:#55575d;font-family:Helvetica, Arial, sans-serif;font-size:11px;line-height:22px;text-align:left;" }
     %tr
-      %td{ width: "50%", valign: "top" }
+      %td{ valign: "top" }
         %p
           %strong
             = t('.procedure_management')
           = service_or_contact_information.nom
           = service_or_contact_information.adresse
+        %strong= t('.ask_question')
+        %ul{ style: "padding: 0 0 0 10px; margin: 0" }
+          - if service_or_contact_information.faq_link.present?
+            %li= link_to t('.faq_link'), service_or_contact_information.faq_link, target: '_blank', rel: 'noopener'
+          - if service_or_contact_information.contact_link.present?
+            %li= link_to t('.contact_link'), service_or_contact_information.contact_link, target: '_blank', rel: 'noopener'
+          - if dossier.present? && dossier.messagerie_available?
+            %li
+              %span= t('.by_messagerie')
+              %span= link_to t('.by_messagerie_link'), messagerie_dossier_url(dossier), target: '_blank', rel: 'noopener'
+          - elsif service_or_contact_information.email.present?
+            %li
+              %span= t('.by_email')
+              %span= link_to service_or_contact_information.email, "mailto:#{service_or_contact_information.email}"
+          - elsif service_or_contact_information.respond_to?(:contact_link) && service_or_contact_information.contact_link.present?
+            %li= link_to t('.by_contact_link'), service_or_contact_information.contact_link, target: '_blank', rel: 'noopener'
+          - if service_or_contact_information.telephone_url.present?
+            %li
+              %span= t('.by_phone')
+              %span= link_to service_or_contact_information.telephone, service_or_contact_information.telephone_url
+          %li= "#{t('.schedule')} #{ formatted_horaires(service_or_contact_information.horaires) }"
+          - if service_or_contact_information.other_contact_info.present?
+            %li
+              %span= t('.other_contact_info')
+              %span= service_or_contact_information.other_contact_info
         %p
           = t('.email_sent_to')
           %br
-          = dossier.user_email_for(:notification)
-      %td{ width: "50%", valign: "top", style: "padding-left:10px;" }
-        %p
-          %strong
-            = t('.ask_question')
-          %br
-          - if dossier.present? && dossier.messagerie_available?
-            = link_to t('.by_messagerie'), messagerie_dossier_url(dossier), target: '_blank', rel: 'noopener'
-          - elsif service_or_contact_information.email.present?
-            = t('.by_email')
-            = link_to service_or_contact_information.email, "mailto:#{service_or_contact_information.email}"
-          - elsif service_or_contact_information.respond_to?(:contact_link) && service_or_contact_information.contact_link.present?
-            = link_to t('.by_contact_link'), service_or_contact_information.contact_link, target: '_blank', rel: 'noopener'
-          - if service_or_contact_information.telephone_url.present?
-            %br= t('.by_phone')
-            = link_to service_or_contact_information.telephone, service_or_contact_information.telephone_url
-          %br= "#{t('.schedule')} #{ formatted_horaires(service_or_contact_information.horaires) }"
+          = link_to dossier.user_email_for(:notification), "mailto: #{dossier.user_email_for(:notification)}"

--- a/app/views/layouts/mailers/_service_footer.html.haml
+++ b/app/views/layouts/mailers/_service_footer.html.haml
@@ -43,4 +43,7 @@
         %p
           = t('.email_sent_to')
           %br
-          = link_to dossier.user_email_for(:notification), "mailto: #{dossier.user_email_for(:notification)}"
+          - if params[:controller] == 'administrateurs/mail_templates'
+            = link_to t('.fake_usager_email'), "mailto: #{t('.fake_usager_email')}"
+          - else
+            = link_to dossier.user_email_for(:notification), "mailto: #{dossier.user_email_for(:notification)}"

--- a/config/locales/views/layouts/mailers/en.yml
+++ b/config/locales/views/layouts/mailers/en.yml
@@ -9,10 +9,14 @@ en:
         ask_question: "Ask a question about your file:"
         email_sent_to: "This email has been sent to :"
         by_messagerie: "Messaging :"
+        by_messagerie_link: send a message directly to the instructor
         by_contact_link: "Contact page :"
         by_email: "Email :"
         by_phone: "Phone :"
         schedule: "Schedule :"
+        faq_link: Consult the online help
+        contact_link: Consult the administration contact page
+        other_contact_info: "Other contact informations :"
       signature:
         team: "The team"
       for_tiers:

--- a/config/locales/views/layouts/mailers/en.yml
+++ b/config/locales/views/layouts/mailers/en.yml
@@ -17,6 +17,7 @@ en:
         faq_link: Consult the online help
         contact_link: Consult the administration contact page
         other_contact_info: "Other contact informations :"
+        fake_usager_email: 'user.adress@mail.com'
       signature:
         team: "The team"
       for_tiers:

--- a/config/locales/views/layouts/mailers/fr.yml
+++ b/config/locales/views/layouts/mailers/fr.yml
@@ -7,13 +7,17 @@ fr:
         contact_admin: Pour vous adresser à votre administration, passez directement par la
         file_messagerie: messagerie du dossier
         procedure_management: "Cette démarche est gérée par :"
-        ask_question: "Poser une question sur votre dossier :"
-        email_sent_to: "Cet email a été envoyé à l'adresse :"
-        by_messagerie: "Messagerie :"
+        ask_question: "Une question sur votre dossier ?"
+        email_sent_to: "Cet email a été envoyé à l'adresse :"
+        by_messagerie: "Messagerie du dossier :"
+        by_messagerie_link: envoyez directement un message à l’instructeur
         by_contact_link: "Page de contact :"
         by_email: "Adresse électronique :"
         by_phone: "Téléphone :"
         schedule: "Horaires :"
+        faq_link: Consultez l’aide en ligne
+        contact_link: Consultez la page de contact de l’administration
+        other_contact_info: "Précisions :"
       signature:
         team: "L’équipe"
       for_tiers:

--- a/config/locales/views/layouts/mailers/fr.yml
+++ b/config/locales/views/layouts/mailers/fr.yml
@@ -18,6 +18,7 @@ fr:
         faq_link: Consultez l’aide en ligne
         contact_link: Consultez la page de contact de l’administration
         other_contact_info: "Précisions :"
+        fake_usager_email: 'adresse.usager@mail.com'
       signature:
         team: "L’équipe"
       for_tiers:

--- a/spec/factories/service.rb
+++ b/spec/factories/service.rb
@@ -13,6 +13,9 @@ FactoryBot.define do
     etablissement_infos { { adresse: "75 rue du Louvre\n75002\nPARIS\nFRANCE" } }
     etablissement_lat { 48.87 }
     etablissement_lng { 2.34 }
+    faq_link { 'https://faq.en-ligne.fr' }
+    contact_link { 'https://contact.en-ligne.fr' }
+    other_contact_info { 'Merci de contacter en priorité votre antenne locale' }
 
     association :administrateur
   end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -62,6 +62,13 @@ RSpec.describe NotificationMailer, type: :mailer do
         expect(mail.subject).to eq("Votre dossier nº #{dossier.id} a bien été déposé (#{procedure.libelle})")
         expect(body).to include("Votre dossier nº&nbsp;#{dossier.id}")
         expect(body).to include(procedure.service.nom)
+        expect(body).to include(procedure.service.adresse)
+        expect(body).to include(procedure.service.faq_link)
+        expect(body).to include(procedure.service.contact_link)
+        expect(body).to include(messagerie_dossier_url(dossier, host: ENV.fetch("APP_HOST_LEGACY")))
+        expect(body).to include(procedure.service.telephone)
+        expect(body).to include(procedure.service.horaires)
+        expect(body).to include(procedure.service.other_contact_info)
         expect(mail.attachments.first.filename).to eq("attestation-depot_dossier-#{dossier.id}.pdf")
       end
     end


### PR DESCRIPTION
closes #11646

- Change l'icône Info dans le footer du dossier usager

AVANT
![Capture d’écran 2025-06-27 à 17 07 18](https://github.com/user-attachments/assets/12285b0d-5b42-43cb-a61f-9ad99a3f7a75)


APRÈS
![Capture d’écran 2025-06-27 à 17 07 44](https://github.com/user-attachments/assets/9976bfea-43fd-4c42-b999-5c0b36f4c64d)


- Met à jour le contenu du footer des emails de notification

AVANT
![Capture d’écran 2025-06-27 à 17 12 37](https://github.com/user-attachments/assets/8035a995-a24e-4578-a658-2cadf7591fae)


APRÈS

![Capture d’écran 2025-06-27 à 17 14 54](https://github.com/user-attachments/assets/cb2a5456-a266-4cea-9493-c74a4d1ff84a)

- ETQ admin dans la prévisualisation des templates d'emails on met une fausse adresse mail pour l'usager

![Capture d’écran 2025-06-27 à 17 17 42](https://github.com/user-attachments/assets/0d5a2574-780c-42ae-a781-479e95bd5e50)

 