### PR TITLE
Tech: prépare migration de domaine de demarches.numerique.gouv.fr => demarche.numerique.gouv.fr

### DIFF
--- a/app/components/switch_domain_banner_component.rb
+++ b/app/components/switch_domain_banner_component.rb
@@ -9,7 +9,7 @@ class SwitchDomainBannerComponent < ApplicationComponent
 
   def render?
     return false unless helpers.switch_domain_enabled?(request)
-    return false if user&.preferred_domain_demarches_numerique_gouv_fr? && requested_from_new_domain?
+    return false if user&.preferred_domain_demarche_numerique_gouv_fr? && requested_from_new_domain?
 
     true
   end

--- a/app/components/switch_domain_banner_component/switch_domain_banner_component.en.yml
+++ b/app/components/switch_domain_banner_component/switch_domain_banner_component.en.yml
@@ -2,4 +2,4 @@
 en:
   message_new_domain: "demarches-simplifiees.fr is now called"
   follow_link: Follow this link to connect to the new address.
-  detected_error: We have detected a network error in your access. Contact your IT department to authorize connection to demarches.numerique.gouv.fr.
+  detected_error: We have detected a network error in your access. Contact your IT department to authorize connection to demarche.numerique.gouv.fr.

--- a/app/components/switch_domain_banner_component/switch_domain_banner_component.fr.yml
+++ b/app/components/switch_domain_banner_component/switch_domain_banner_component.fr.yml
@@ -2,4 +2,4 @@
 fr:
   message_new_domain: 'demarches-simplifiees.fr s’appelle maintenant'
   follow_link: Suivez ce lien pour vous connecter à la nouvelle adresse.
-  detected_error: Nous avons détecté une erreur réseau qui nous empêche de vous y rediriger. Contactez votre service informatique pour autoriser l‘accès à demarches.numerique.gouv.fr.
+  detected_error: Nous avons détecté une erreur réseau qui nous empêche de vous y rediriger. Contactez votre service informatique pour autoriser l‘accès à demarche.numerique.gouv.fr.

--- a/app/components/switch_domain_banner_component/switch_domain_banner_component.html.haml
+++ b/app/components/switch_domain_banner_component/switch_domain_banner_component.html.haml
@@ -20,7 +20,7 @@
   - c.with_title do
     = t(".message_new_domain")
     -# haml-lint:disable ApplicationNameLinter
-    = "#{helpers.link_to "demarches.numerique.gouv.fr", new_host_url}."
+    = "#{helpers.link_to "demarche.numerique.gouv.fr", new_host_url}."
     -# haml-lint:enable ApplicationNameLinter
 
     - if manual_switch?

--- a/app/components/switch_domain_banner_component/switch_domain_banner_component.html.haml
+++ b/app/components/switch_domain_banner_component/switch_domain_banner_component.html.haml
@@ -28,7 +28,7 @@
     - elsif auto_switch?
       %span#banner_auto_switch_error.hidden= t(".detected_error")
 
-- if user && !user.preferred_domain_demarches_numerique_gouv_fr? && requested_from_new_domain?
+- if user && !user.preferred_domain_demarche_numerique_gouv_fr? && requested_from_new_domain?
   = form_tag(helpers.preferred_domain_path, method: :patch, remote: true, name: "update-preferred-domain") do
     :javascript
       document.addEventListener('noticeClosed', function(e) {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,9 +38,9 @@ class ApplicationController < ActionController::Base
     Current.host = request.host_with_port
 
     if Current.host.include?(".gouv.fr")
-      Current.application_name = "demarches.numerique.gouv.fr"
-      Current.contact_email = "contact@demarches.numerique.gouv.fr"
-      Current.application_base_url = "https://demarches.numerique.gouv.fr"
+      Current.application_name = "demarche.numerique.gouv.fr"
+      Current.contact_email = "contact@demarche.numerique.gouv.fr"
+      Current.application_base_url = "https://demarche.numerique.gouv.fr"
     else
       Current.application_name = APPLICATION_NAME
       Current.contact_email = CONTACT_EMAIL
@@ -50,7 +50,7 @@ class ApplicationController < ActionController::Base
 
   def redirect_to_legacy
     # rubocop:disable DS/ApplicationName
-    if !user_signed_in? && request.host == "demarches.numerique.gouv.fr" && ENV.fetch("REDIRECT_GOUV_TO_DS", 'true') == 'true'
+    if !user_signed_in? && request.host == "demarche.numerique.gouv.fr" && ENV.fetch("REDIRECT_GOUV_TO_DS", 'true') == 'true'
       redirect_to "https://www.demarches-simplifiees.fr#{request.fullpath}", allow_other_host: true
     end
     # rubocop:enable DS/ApplicationName

--- a/app/controllers/france_connect_controller.rb
+++ b/app/controllers/france_connect_controller.rb
@@ -15,7 +15,7 @@ class FranceConnectController < ApplicationController
 
     if ENV['REDIRECT_FC_GOUV'].present?
       # rubocop:disable DS/ApplicationName
-      return redirect_to 'https://www.demarches-simplifiees.fr/france_connect', allow_other_host: true if Current.host.starts_with?('demarches.numerique.gouv.fr')
+      return redirect_to 'https://www.demarches-simplifiees.fr/france_connect', allow_other_host: true if Current.host.ends_with?('.numerique.gouv.fr')
       # rubocop:enable DS/ApplicationName
     end
 

--- a/app/lib/dolist/api.rb
+++ b/app/lib/dolist/api.rb
@@ -195,7 +195,7 @@ module Dolist
     end
 
     def sender_id(domain)
-      if domain == "demarches.numerique.gouv.fr"
+      if domain == "demarches.numerique.gouv.fr" || domain == "demarche.numerique.gouv.fr"
         Rails.application.secrets.dolist[:gouv_sender_id]
       else
         Rails.application.secrets.dolist[:default_sender_id]

--- a/app/mailers/concerns/mailer_defaults_configurable_concern.rb
+++ b/app/mailers/concerns/mailer_defaults_configurable_concern.rb
@@ -32,8 +32,8 @@ module MailerDefaultsConfigurableConcern
     def configure_defaults_for_user(user)
       return if !user.is_a?(User) # not for super-admins
 
-      if user.preferred_domain_demarches_numerique_gouv_fr?
-        set_currents_for_demarches_numerique_gouv_fr
+      if user.preferred_domain_demarche_numerique_gouv_fr?
+        set_currents_for_demarche_numerique_gouv_fr
       else
         set_currents_for_legacy
       end
@@ -55,7 +55,7 @@ module MailerDefaultsConfigurableConcern
 
     private
 
-    def set_currents_for_demarches_numerique_gouv_fr
+    def set_currents_for_demarche_numerique_gouv_fr
       Current.application_name = "demarches.numerique.gouv.fr"
       Current.host = "demarches.numerique.gouv.fr"
       Current.contact_email = "contact@demarches.numerique.gouv.fr"

--- a/app/models/commentaire.rb
+++ b/app/models/commentaire.rb
@@ -16,7 +16,7 @@ class Commentaire < ApplicationRecord
   normalizes :body, with: NORMALIZES_NON_PRINTABLE_PROC
 
   FILE_MAX_SIZE = 20.megabytes
-  SYSTEM_EMAILS = ["demarches.numerique.gouv.fr", CONTACT_EMAIL, OLD_CONTACT_EMAIL]
+  SYSTEM_EMAILS = ["demarche.numerique.gouv.fr", "demarches.numerique.gouv.fr", CONTACT_EMAIL, OLD_CONTACT_EMAIL]
 
   validates :piece_jointe,
     content_type: AUTHORIZED_CONTENT_TYPES,

--- a/app/models/concerns/domain_migratable_concern.rb
+++ b/app/models/concerns/domain_migratable_concern.rb
@@ -4,14 +4,14 @@ module DomainMigratableConcern
   extend ActiveSupport::Concern
 
   included do
-    enum :preferred_domain, { demarches_numerique_gouv_fr: 0, demarches_simplifiees_fr: 1 }, prefix: true
+    enum :preferred_domain, { demarche_numerique_gouv_fr: 0, demarches_simplifiees_fr: 1 }, prefix: true
 
     validates :preferred_domain, inclusion: { in: User.preferred_domains.keys, allow_nil: true }
 
     def update_preferred_domain(host)
       case host
       when ApplicationHelper::APP_HOST
-        preferred_domain_demarches_numerique_gouv_fr!
+        preferred_domain_demarche_numerique_gouv_fr!
       when ApplicationHelper::APP_HOST_LEGACY
         preferred_domain_demarches_simplifiees_fr!
       end

--- a/lib/linters/application_name_linter.rb
+++ b/lib/linters/application_name_linter.rb
@@ -5,7 +5,7 @@ if defined?(HamlLint)
     class Linter::ApplicationNameLinter < Linter
       include LinterRegistry
 
-      FORBIDDEN = 'demarches.numerique.gouv.fr'
+      FORBIDDEN = 'demarche.numerique.gouv.fr'
       REPLACEMENT = "APPLICATION_NAME"
       MSG = 'Hardcoding %s is forbidden, use %s instead'
 

--- a/spec/components/dossiers/message_component_spec.rb
+++ b/spec/components/dossiers/message_component_spec.rb
@@ -127,8 +127,8 @@ RSpec.describe Dossiers::MessageComponent, type: :component do
       end
 
       describe 'autolink simple urls' do
-        let(:commentaire) { create(:commentaire, instructeur: instructeur, body: "rdv sur https://demarches.numerique.gouv.fr") }
-        it { is_expected.to have_link("https://demarches.numerique.gouv.fr", href: "https://demarches.numerique.gouv.fr") }
+        let(:commentaire) { create(:commentaire, instructeur: instructeur, body: "rdv sur https://demarche.numerique.gouv.fr") }
+        it { is_expected.to have_link("https://demarche.numerique.gouv.fr", href: "https://demarche.numerique.gouv.fr") }
       end
     end
 

--- a/spec/components/simple_format_component_spec.rb
+++ b/spec/components/simple_format_component_spec.rb
@@ -111,7 +111,7 @@ TEXT
         bonjour https://www.demarches-simplifiees.fr
         nohttp www.ds.io
         ecrivez à ds@rspec.io
-        <a href="https://demarches.numerique.gouv.fr">lien html</a>
+        <a href="https://demarche.numerique.gouv.fr">lien html</a>
         [lien markdown](https://github.com)
       TEXT
     end
@@ -140,7 +140,7 @@ TEXT
 
       it "render html link" do
         link = page.find_link("lien html").native
-        expect(link[:href]).to eq("https://demarches.numerique.gouv.fr")
+        expect(link[:href]).to eq("https://demarche.numerique.gouv.fr")
       end
 
       it "convert markdown link" do

--- a/spec/components/switch_domain_banner_component_spec.rb
+++ b/spec/components/switch_domain_banner_component_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe SwitchDomainBannerComponent, type: :component do
     end
 
     context "when user has already set preferred domain" do
-      let(:user) { create(:user, preferred_domain: :demarches_numerique_gouv_fr) }
+      let(:user) { create(:user, preferred_domain: :demarche_numerique_gouv_fr) }
 
       it "does not render the banner" do
         expect(rendered.to_html).to be_empty

--- a/spec/components/switch_domain_banner_component_spec.rb
+++ b/spec/components/switch_domain_banner_component_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe SwitchDomainBannerComponent, type: :component do
   let(:app_host_legacy) { "demarches-simplifiees.fr" }
-  let(:app_host) { "demarches.numerique.gouv.fr" }
+  let(:app_host) { "demarche.numerique.gouv.fr" }
 
   let(:user) { create(:user) }
   let(:request_host) { app_host_legacy }
@@ -51,7 +51,7 @@ RSpec.describe SwitchDomainBannerComponent, type: :component do
     let(:path) { "/admin/procedures" }
 
     it "generate an url to the new domain" do
-      expect(rendered.to_html).to have_link("demarches.numerique.gouv.fr", href: "http://demarches.numerique.gouv.fr/admin/procedures")
+      expect(rendered.to_html).to have_link("demarche.numerique.gouv.fr", href: "http://demarche.numerique.gouv.fr/admin/procedures")
       expect(rendered.to_html).not_to include("window.location")
       expect(rendered.to_html).to include("Suivez ce lien")
     end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -237,8 +237,8 @@ describe ApplicationController, type: :controller do
         end
       end
 
-      context 'when the host is demarches.numerique.gouv.fr' do
-        let(:host) { 'demarches.numerique.gouv.fr' }
+      context 'when the host is demarche.numerique.gouv.fr' do
+        let(:host) { 'demarche.numerique.gouv.fr' }
 
         it 'does not redirect' do
           expect(@controller).not_to have_received(:redirect_to)
@@ -257,8 +257,8 @@ describe ApplicationController, type: :controller do
         end
       end
 
-      context 'when the host is demarches.numerique.gouv.fr' do
-        let(:host) { 'demarches.numerique.gouv.fr' }
+      context 'when the host is demarche.numerique.gouv.fr' do
+        let(:host) { 'demarche.numerique.gouv.fr' }
 
         it 'does redirect' do
           expect(@controller).to have_received(:redirect_to).with('https://www.demarches-simplifiees.fr/commencer/une_demarche', allow_other_host: true)
@@ -273,8 +273,8 @@ describe ApplicationController, type: :controller do
         end
       end
 
-      context 'when the host is dev.demarches.numerique.gouv.fr' do
-        let(:host) { 'dev.demarches.numerique.gouv.fr' }
+      context 'when the host is dev.demarche.numerique.gouv.fr' do
+        let(:host) { 'dev.demarche.numerique.gouv.fr' }
 
         it 'does not redirect' do
           expect(@controller).not_to have_received(:redirect_to)

--- a/spec/controllers/faq_controller_spec.rb
+++ b/spec/controllers/faq_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe FAQController, type: :controller do
 
   describe "GET #show" do
     before do
-      allow(Current).to receive(:application_name).and_return('demarches.numerique.gouv.fr')
+      allow(Current).to receive(:application_name).and_return('demarche.numerique.gouv.fr')
     end
 
     render_views
@@ -49,7 +49,7 @@ RSpec.describe FAQController, type: :controller do
     context "when the FAQ exists" do
       it "renders the show template with the FAQ content and metadata" do
         get :show, params: { category: 'usager', slug: 'je-veux-changer-mon-adresse-email' }
-        expect(response.body).to include('Si vous disposez d’un compte usager sur demarches.numerique.gouv.fr')
+        expect(response.body).to include('Si vous disposez d’un compte usager sur demarche.numerique.gouv.fr')
 
         # link to siblings
         expect(response.body).to include(faq_path(category: 'usager', slug: 'je-veux-changer-mon-mot-de-passe'))

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -61,7 +61,7 @@ describe Users::RegistrationsController, type: :controller do
 
         subject
 
-        expect(User.last.preferred_domain_demarches_numerique_gouv_fr?).to be_truthy
+        expect(User.last.preferred_domain_demarche_numerique_gouv_fr?).to be_truthy
       end
     end
 

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -94,7 +94,7 @@ describe Users::SessionsController, type: :controller do
         it 'update preferred domain' do
           subject
 
-          expect(user.reload.preferred_domain_demarches_numerique_gouv_fr?).to be_truthy
+          expect(user.reload.preferred_domain_demarche_numerique_gouv_fr?).to be_truthy
         end
       end
     end

--- a/spec/fixtures/cassettes/annuaire_service_public_failure_20004021000000.yml
+++ b/spec/fixtures/cassettes/annuaire_service_public_failure_20004021000000.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - demarches.numerique.gouv.fr
+      - demarche.numerique.gouv.fr
       Expect:
       - ''
   response:

--- a/spec/fixtures/cassettes/annuaire_service_public_success_20004021000060.yml
+++ b/spec/fixtures/cassettes/annuaire_service_public_success_20004021000060.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - demarches.numerique.gouv.fr
+      - demarche.numerique.gouv.fr
       Expect:
       - ''
   response:

--- a/spec/mailers/devise_user_mailer_spec.rb
+++ b/spec/mailers/devise_user_mailer_spec.rb
@@ -60,10 +60,10 @@ RSpec.describe DeviseUserMailer, type: :mailer do
         let(:user) { create(:user, preferred_domain: :demarche_numerique_gouv_fr) }
 
         it "respect preferred domain" do
-          expect(header_value("From", subject.message)).to eq("Ne pas répondre <ne-pas-repondre@demarches.numerique.gouv.fr>")
-          expect(header_value("Reply-To", subject.message)).to eq("Ne pas répondre <ne-pas-repondre@demarches.numerique.gouv.fr>")
-          expect(subject.message.to_s).to include("demarches.numerique.gouv.fr/users/confirmation")
-          expect(subject.message.to_s).to include("//demarches.numerique.gouv.fr/assets/")
+          expect(header_value("From", subject.message)).to eq("Ne pas répondre <ne-pas-repondre@demarche.numerique.gouv.fr>")
+          expect(header_value("Reply-To", subject.message)).to eq("Ne pas répondre <ne-pas-repondre@demarche.numerique.gouv.fr>")
+          expect(subject.message.to_s).to include("demarche.numerique.gouv.fr/users/confirmation")
+          expect(subject.message.to_s).to include("//demarche.numerique.gouv.fr/assets/")
         end
       end
     end
@@ -83,8 +83,8 @@ RSpec.describe DeviseUserMailer, type: :mailer do
         let(:user) { create(:user, preferred_domain: :demarche_numerique_gouv_fr) }
 
         it "respect preferred domain" do
-          expect(header_value("From", subject.message)).to include("@demarches.numerique.gouv.fr")
-          expect(subject.message.to_s).to include("demarches.numerique.gouv.fr/users/password")
+          expect(header_value("From", subject.message)).to include("@demarche.numerique.gouv.fr")
+          expect(subject.message.to_s).to include("demarche.numerique.gouv.fr/users/password")
         end
       end
     end

--- a/spec/mailers/devise_user_mailer_spec.rb
+++ b/spec/mailers/devise_user_mailer_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe DeviseUserMailer, type: :mailer do
       end
 
       context "new domain" do
-        let(:user) { create(:user, preferred_domain: :demarches_numerique_gouv_fr) }
+        let(:user) { create(:user, preferred_domain: :demarche_numerique_gouv_fr) }
 
         it "respect preferred domain" do
           expect(header_value("From", subject.message)).to eq("Ne pas répondre <ne-pas-repondre@demarches.numerique.gouv.fr>")
@@ -80,7 +80,7 @@ RSpec.describe DeviseUserMailer, type: :mailer do
       end
 
       context "new domain" do
-        let(:user) { create(:user, preferred_domain: :demarches_numerique_gouv_fr) }
+        let(:user) { create(:user, preferred_domain: :demarche_numerique_gouv_fr) }
 
         it "respect preferred domain" do
           expect(header_value("From", subject.message)).to include("@demarches.numerique.gouv.fr")

--- a/spec/mailers/dossier_mailer_spec.rb
+++ b/spec/mailers/dossier_mailer_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe DossierMailer, type: :mailer do
     it_behaves_like 'a dossier notification'
 
     context "when user prefers new domain" do
-      let(:user) { create(:user, preferred_domain: :demarches_numerique_gouv_fr) }
+      let(:user) { create(:user, preferred_domain: :demarche_numerique_gouv_fr) }
 
       it 'includes the correct body content and sender email' do
         expect(subject.body).to include(dossier_url(dossier, host: 'demarches.numerique.gouv.fr'))
@@ -368,7 +368,7 @@ RSpec.describe DossierMailer, type: :mailer do
     end
 
     context 'when recipient has preferred domain' do
-      let(:dossier_transfer) { create(:dossier_transfer, email: create(:user, preferred_domain: :demarches_numerique_gouv_fr).email) }
+      let(:dossier_transfer) { create(:dossier_transfer, email: create(:user, preferred_domain: :demarche_numerique_gouv_fr).email) }
       it 'includes a link with the preferred domain in the email body' do
         expect(subject.body).to include(dossiers_url(statut: "dossiers-transferes", host: 'demarches.numerique.gouv.fr'))
       end

--- a/spec/mailers/dossier_mailer_spec.rb
+++ b/spec/mailers/dossier_mailer_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe DossierMailer, type: :mailer do
       let(:user) { create(:user, preferred_domain: :demarche_numerique_gouv_fr) }
 
       it 'includes the correct body content and sender email' do
-        expect(subject.body).to include(dossier_url(dossier, host: 'demarches.numerique.gouv.fr'))
-        expect(header_value("From", subject)).to include("ne-pas-repondre@demarches.numerique.gouv.fr")
+        expect(subject.body).to include(dossier_url(dossier, host: 'demarche.numerique.gouv.fr'))
+        expect(header_value("From", subject)).to include("ne-pas-repondre@demarche.numerique.gouv.fr")
       end
     end
 
@@ -370,7 +370,7 @@ RSpec.describe DossierMailer, type: :mailer do
     context 'when recipient has preferred domain' do
       let(:dossier_transfer) { create(:dossier_transfer, email: create(:user, preferred_domain: :demarche_numerique_gouv_fr).email) }
       it 'includes a link with the preferred domain in the email body' do
-        expect(subject.body).to include(dossiers_url(statut: "dossiers-transferes", host: 'demarches.numerique.gouv.fr'))
+        expect(subject.body).to include(dossiers_url(statut: "dossiers-transferes", host: 'demarche.numerique.gouv.fr'))
       end
     end
 

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe NotificationMailer, type: :mailer do
       end
 
       context "when user has preferred domain" do
-        let(:user) { create(:user, preferred_domain: :demarches_numerique_gouv_fr) }
+        let(:user) { create(:user, preferred_domain: :demarche_numerique_gouv_fr) }
 
         it 'adjusts links and sender email for user preferred domain' do
           expect(mail.body).to have_link(href: dossier_url(dossier, host: 'demarches.numerique.gouv.fr'))

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -141,8 +141,8 @@ RSpec.describe NotificationMailer, type: :mailer do
         let(:user) { create(:user, preferred_domain: :demarche_numerique_gouv_fr) }
 
         it 'adjusts links and sender email for user preferred domain' do
-          expect(mail.body).to have_link(href: dossier_url(dossier, host: 'demarches.numerique.gouv.fr'))
-          expect(header_value("From", mail)).to include("@demarches.numerique.gouv.fr")
+          expect(mail.body).to have_link(href: dossier_url(dossier, host: 'demarche.numerique.gouv.fr'))
+          expect(header_value("From", mail)).to include("@demarche.numerique.gouv.fr")
         end
       end
     end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe UserMailer, type: :mailer do
         let(:user) { create(:user, preferred_domain: :demarche_numerique_gouv_fr) }
 
         it do
-          expect(subject.body).to have_link("Commencer la démarche « #{procedure.libelle} »", href: commencer_sign_in_url(path: procedure.path, host: "demarches.numerique.gouv.fr"))
-          expect(header_value("From", subject)).to include("@demarches.numerique.gouv.fr")
+          expect(subject.body).to have_link("Commencer la démarche « #{procedure.libelle} »", href: commencer_sign_in_url(path: procedure.path, host: "demarche.numerique.gouv.fr"))
+          expect(header_value("From", subject)).to include("@demarche.numerique.gouv.fr")
         end
       end
     end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe UserMailer, type: :mailer do
       it { expect(subject.body).to have_link("Commencer la démarche « #{procedure.libelle} »", href: commencer_sign_in_url(path: procedure.path, host: ENV.fetch("APP_HOST_LEGACY"))) }
 
       context "when user has preferred domain" do
-        let(:user) { create(:user, preferred_domain: :demarches_numerique_gouv_fr) }
+        let(:user) { create(:user, preferred_domain: :demarche_numerique_gouv_fr) }
 
         it do
           expect(subject.body).to have_link("Commencer la démarche « #{procedure.libelle} »", href: commencer_sign_in_url(path: procedure.path, host: "demarches.numerique.gouv.fr"))

--- a/spec/models/commentaire_spec.rb
+++ b/spec/models/commentaire_spec.rb
@@ -41,8 +41,8 @@ describe Commentaire do
       it { is_expected.to be_truthy }
     end
 
-    context 'with demarches.numerique.gouv.fr' do
-      let(:email) { "contact@demarches.numerique.gouv.fr" }
+    context 'with demarche.numerique.gouv.fr' do
+      let(:email) { "contact@demarche.numerique.gouv.fr" }
 
       it { is_expected.to be_truthy }
     end

--- a/spec/services/faqs_loader_service_spec.rb
+++ b/spec/services/faqs_loader_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe FAQsLoaderService do
-  let(:substitutions) { { application_name: "demarches.numerique.gouv.fr", application_base_url: APPLICATION_BASE_URL, contact_email: CONTACT_EMAIL } }
+  let(:substitutions) { { application_name: "demarche.numerique.gouv.fr", application_base_url: APPLICATION_BASE_URL, contact_email: CONTACT_EMAIL } }
   let(:service) { FAQsLoaderService.new(substitutions) }
 
   context "behavior with stubbed markdown files" do
@@ -42,7 +42,7 @@ RSpec.describe FAQsLoaderService do
 
     describe '#find' do
       it 'returns a file with variable substitutions' do
-        expect(service.find('usager/faq1').content).to include('Welcome to demarches.numerique.gouv.fr')
+        expect(service.find('usager/faq1').content).to include('Welcome to demarche.numerique.gouv.fr')
       end
 
       it 'caches file readings', caching: true do


### PR DESCRIPTION
Globamenent un gsub + quelques cas particuliers où on a besoin de garder les 2 .gouv