### PR TITLE
Tecj: fix flaky test pour les clones

### DIFF
--- a/spec/models/concerns/dossier_clone_concern_spec.rb
+++ b/spec/models/concerns/dossier_clone_concern_spec.rb
@@ -412,7 +412,7 @@ RSpec.describe DossierCloneConcern do
       end
 
       it { expect { subject }.to change { dossier.filled_champs.size }.by(3) }
-      it { expect { subject }.to change { dossier.filled_champs.sort_by(&:created_at).map(&:to_s) }.from(['old value', 'Non', 'old value']).to(['new value for updated champ', 'Non', 'new value for updated champ in repetition', 'old value', 'new value for added champ', 'new value in repetition champ']) }
+      it { expect { subject }.to change { dossier.filled_champs.map(&:to_s).sort }.from(['Non', 'old value', 'old value']).to(["Non", "new value for added champ", "new value for updated champ", "new value for updated champ in repetition", "new value in repetition champ", "old value"]) }
 
       it "dossier after merge should be on last published revision" do
         expect(dossier.revision_id).to eq(procedure.revisions.first.id)


### PR DESCRIPTION
D'après ce que je vois, l'ordre d'insertion en base n'est ici pas déterministe, on ne peut donc pas se fier sur un order by `created_at` ( ni `id`). Et je n'ai pas l'impression qu'on cherche ici à tester un ordre d'insertion en particulier,  mais les valeurs.

> dossier.filled_champs.sort_by(&:id).map { [_1.id, _1.created_at, _1.to_s] }
[[314, Thu, 03 Jul 2025 18:27:54.239337000 CEST +02:00, "Non"],
 [316, Thu, 03 Jul 2025 18:27:54.265732000 CEST +02:00, "old value"],
 [319, Thu, 03 Jul 2025 18:27:54.277511000 CEST +02:00, "new value for updated champ in repetition"],
 [321, Thu, 03 Jul 2025 18:27:54.195723000 CEST +02:00, "new value for updated champ"],
 [326, Thu, 03 Jul 2025 18:27:54.818760000 CEST +02:00, "new value for added champ"],
 [327, Thu, 03 Jul 2025 18:27:54.828427000 CEST +02:00, "new value in repetition champ"]]