### PR TITLE
ETQ Usager, je vois les données automatiquement extraites de mon rib

### DIFF
--- a/app/assets/stylesheets/dsfr.scss
+++ b/app/assets/stylesheets/dsfr.scss
@@ -252,3 +252,28 @@ input[type='radio'] {
     display: initial !important;
   }
 }
+
+// we add fr-message--warning as only error/valid/exists
+.fr-message--warning::before {
+  flex: 0 0 auto;
+  vertical-align: calc((0.75em - var(--icon-size)) * 0.5);
+  background-color: currentColor;
+  width: var(--icon-size);
+  height: var(--icon-size);
+  -webkit-mask-size: 100% 100%;
+  mask-size: 100% 100%;
+  --icon-size: 1rem;
+  content: '';
+  display: inline-block;
+  margin-right: 0.25rem;
+  margin-top: 0.125rem;
+}
+
+.fr-message--warning::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='m12.866 3 9.526 16.5a1 1 0 0 1-.866 1.5H2.474a1 1 0 0 1-.866-1.5L11.134 3a1 1 0 0 1 1.732 0ZM11 16v2h2v-2h-2Zm0-7v5h2V9h-2Z'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='m12.866 3 9.526 16.5a1 1 0 0 1-.866 1.5H2.474a1 1 0 0 1-.866-1.5L11.134 3a1 1 0 0 1 1.732 0ZM11 16v2h2v-2h-2Zm0-7v5h2V9h-2Z'/%3E%3C/svg%3E");
+}
+
+.fr-message--warning {
+  color: var(--text-default-warning);
+}

--- a/app/components/dsfr/input_status_message_component.rb
+++ b/app/components/dsfr/input_status_message_component.rb
@@ -14,7 +14,8 @@ module Dsfr
     def statutable?
       rna_support_statut? ||
       referentiel_support_statut? ||
-      prefilled?
+      prefilled? ||
+      pjs_statut?
     end
 
     def rna_support_statut?
@@ -29,19 +30,37 @@ module Dsfr
       )
     end
 
+    def pjs_statut?
+      @champ.RIB? && @champ.piece_justificative_file.blobs.any?
+    end
+
     def statut_message
-      return t('.prefilled') if prefilled?
+      return { state: :info, text: t('.prefilled') } if prefilled?
       case @champ.type_de_champ.type_champ
       when TypeDeChamp.type_champs[:rna]
-        t(".rna.data_fetched", title: @champ.title, address: @champ.full_address)
+        { state: :info, text: t(".rna.data_fetched", title: @champ.title, address: @champ.full_address) }
       when TypeDeChamp.type_champs[:referentiel]
         if @champ.fetch_external_data_pending?
-          t(".referentiel.fetching")
+          { state: :info, text: t(".referentiel.fetching") }
         elsif @champ.fetch_external_data_error?
-          t(".referentiel.error", value: @champ.external_id)
+          { state: :info, text: t(".referentiel.error", value: @champ.external_id) }
         elsif @champ.value.present?
-          t(".referentiel.success", value: @champ.value)
+          { state: :valid, text: t(".referentiel.success", value: @champ.value) }
         end
+      when TypeDeChamp.type_champs[:piece_justificative]
+        ocr = @champ.piece_justificative_file&.blobs&.first&.ocr
+        iban = ocr&.dig('rib', 'iban')
+        bank_name = ocr&.dig('rib', 'bank_name')
+
+        if ocr.nil?
+          { state: :info, text: t('.pj.info') }
+        elsif iban.nil?
+          { state: :warning, text: t('.pj.warning') }
+        else
+          text = bank_name.present? ? t('.pj.valid_with_bank', iban:, bank_name:) : t('.pj.valid', iban:)
+          { state: :valid, text: }
+        end
+
       end
     end
   end

--- a/app/components/dsfr/input_status_message_component/input_status_message_component.en.yml
+++ b/app/components/dsfr/input_status_message_component/input_status_message_component.en.yml
@@ -7,3 +7,8 @@ en:
     error: "No item found for the reference: %{value}"
     success: "Reference found: %{value}"
   prefilled: "Prefilled data."
+  pj:
+    info: "The file content will be analyzed …"
+    warning: "Our system could not identify the IBAN number.<br>Please check your document, or ignore this message if you are confident about your file."
+    valid: "Our system identified the IBAN %{iban}"
+    valid_with_bank: "Our system identified the IBAN %{iban} - <b>%{bank_name}</b>"

--- a/app/components/dsfr/input_status_message_component/input_status_message_component.fr.yml
+++ b/app/components/dsfr/input_status_message_component/input_status_message_component.fr.yml
@@ -7,3 +7,8 @@ fr:
     error: "Aucun élément trouvé pour la référence : %{value}"
     success: "Référence trouvée : %{value}"
   prefilled: "Donnée remplie automatiquement."
+  pj:
+    info: "Le contenu du fichier va être analysé …"
+    warning: "Notre système n’a pas pu identifier le numéro IBAN.<br>Vérifiez votre document ou ne tenez pas compte de ce message si vous êtes sûr(e) de votre fichier."
+    valid: "Notre système a identifié l’IBAN %{iban}"
+    valid_with_bank: "Notre système a identifié l’IBAN %{iban} - <b>%{bank_name}</b>"

--- a/app/components/dsfr/input_status_message_component/input_status_message_component.html.haml
+++ b/app/components/dsfr/input_status_message_component/input_status_message_component.html.haml
@@ -5,4 +5,4 @@
 
       = @error_full_messages.to_sentence
   - elsif statutable?
-    %p.fr-info-text= statut_message
+    %p.fr-message{ class: "fr-message--#{statut_message[:state]}" }= sanitize(statut_message[:text])

--- a/app/components/editable_champ/piece_justificative_component.rb
+++ b/app/components/editable_champ/piece_justificative_component.rb
@@ -14,6 +14,12 @@ class EditableChamp::PieceJustificativeComponent < EditableChamp::EditableChampB
   end
 
   def max
-    [true, nil].include?(@champ.procedure&.piece_justificative_multiple?) ? Attachment::MultipleComponent::DEFAULT_MAX_ATTACHMENTS : 1
+    if @champ.RIB?
+      1
+    elsif [true, nil].include?(@champ.procedure&.piece_justificative_multiple?)
+      Attachment::MultipleComponent::DEFAULT_MAX_ATTACHMENTS
+    else
+      1
+    end
   end
 end

--- a/app/components/procedure/revision_changes_component/revision_changes_component.fr.yml
+++ b/app/components/procedure/revision_changes_component/revision_changes_component.fr.yml
@@ -32,6 +32,7 @@ fr:
     update_drop_down_secondary_description: La description secondaire du champ « %{label} » a été modifiée. La nouvelle description est « %{to} ».
     update_type_champ: Le type du champ « %{label} » a été modifié. Il est maintenant de type « %{to} ».
     update_piece_justificative_template: Le modèle de pièce justificative du champ « %{label} » a été modifié.
+    update_nature: La nature de pièce justificative « %{label} » a été modifiée en « %{to} ».
     update_notice_explicative: La notice explicative du champ « %{label} » a été modifiée.
     update_drop_down_options: "Les options de sélection du champ « %{label} » ont été modifiées :"
     update_drop_down_options_alert: "Le champ « %{label} » est utilisé pour le routage des dossiers. Veuillez mettre à jour la configuration des groupes d'instructeurs après avoir publié les modifications."

--- a/app/components/procedure/revision_changes_component/revision_changes_component.html.haml
+++ b/app/components/procedure/revision_changes_component/revision_changes_component.html.haml
@@ -44,6 +44,9 @@
       - when :piece_justificative_template
         - list.with_item do
           = t(".#{prefix}.update_piece_justificative_template", label: change.label)
+      - when :nature
+        - list.with_item do
+          = t(".#{prefix}.update_nature", label: change.label, to: change.to)
       - when :notice_explicative
         - list.with_item do
           = t(".#{prefix}.update_notice_explicative", label: change.label)

--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
@@ -54,6 +54,15 @@
                 = form.label :notice_explicative, "Notice explicative", for: dom_id(type_de_champ, :notice_explicative)
                 = render Attachment::EditComponent.new(**notice_explicative_options)
 
+            - if type_de_champ.piece_justificative?
+              .cell.fr-mt-1w
+                = form.label :nature, "Nature de la pièce", for: dom_id(type_de_champ, :nature)
+                = form.select :nature,
+                  TypeDeChamp.natures.keys.map { [it, it] } + [["Générique", nil]],
+                  { },
+                  class: 'fr-select small-margin small inline width-100',
+                  id: dom_id(type_de_champ, :nature)
+
             - if type_de_champ.piece_justificative_or_titre_identite?
               .cell.fr-mt-1w
                 = form.label :piece_justificative_template, "Modèle", for: dom_id(type_de_champ, :piece_justificative_template)

--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
@@ -54,7 +54,7 @@
                 = form.label :notice_explicative, "Notice explicative", for: dom_id(type_de_champ, :notice_explicative)
                 = render Attachment::EditComponent.new(**notice_explicative_options)
 
-            - if type_de_champ.piece_justificative?
+            - if type_de_champ.piece_justificative? && procedure.feature_enabled?(:ocr)
               .cell.fr-mt-1w
                 = form.label :nature, "Nature de la pièce", for: dom_id(type_de_champ, :nature)
                 = form.select :nature,

--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
@@ -54,6 +54,22 @@
                 = form.label :notice_explicative, "Notice explicative", for: dom_id(type_de_champ, :notice_explicative)
                 = render Attachment::EditComponent.new(**notice_explicative_options)
 
+            - if type_de_champ.piece_justificative_or_titre_identite?
+              .cell.fr-mt-1w
+                = form.label :piece_justificative_template, "Modèle", for: dom_id(type_de_champ, :piece_justificative_template)
+                = render Attachment::EditComponent.new(**piece_justificative_template_options)
+
+              - if type_de_champ.titre_identite?
+                .cell.fr-mt-1w
+                  = render Dsfr::AlertComponent.new(state: :info, heading_level: 'p') do |c|
+                    - c.with_body do
+                      Dans le cadre de la RGPD, le titre d’identité sera supprimé lors de l’acceptation, du refus ou du classement sans suite du dossier.<br />
+                      Aussi, pour des raisons de sécurité, un filigrane est automatiquement ajouté aux images.<br />
+                      Finalement, le titre d’identité ne sera ni disponible dans les zip de dossiers, ni téléchargeable par API.
+              - elsif procedure.piece_justificative_multiple?
+                .cell.fr-mt-1w
+                  %p Les usagers pourront envoyer plusieurs fichiers si nécessaire.
+
             - if type_de_champ.integer_number? || type_de_champ.decimal_number?
               .border-left-dark.fr-mt-2w
                 .cell
@@ -153,20 +169,6 @@
               .cell.fr-mt-1w
                 = form.label :drop_down_secondary_description, "Description du champ secondaire (optionnel)", for: dom_id(type_de_champ, :drop_down_secondary_description)
                 = form.text_area :drop_down_secondary_description, class: 'fr-input small-margin small width-100', rows: 3, id: dom_id(type_de_champ, :drop_down_secondary_description)
-          - if type_de_champ.piece_justificative_or_titre_identite?
-            .cell
-              = form.label :piece_justificative_template, "Modèle", for: dom_id(type_de_champ, :piece_justificative_template)
-              = render Attachment::EditComponent.new(**piece_justificative_template_options)
-
-              - if type_de_champ.titre_identite?
-                = render Dsfr::AlertComponent.new(state: :info, heading_level: 'p') do |c|
-                  - c.with_body do
-                    Dans le cadre de la RGPD, le titre d’identité sera supprimé lors de l’acceptation, du refus ou du classement sans suite du dossier.<br />
-                    Aussi, pour des raisons de sécurité, un filigrane est automatiquement ajouté aux images.<br />
-                    Finalement, le titre d’identité ne sera ni disponible dans les zip de dossiers, ni téléchargeable par API.
-              - elsif procedure.piece_justificative_multiple?
-                %p Les usagers pourront envoyer plusieurs fichiers si nécessaire.
-
           - if type_de_champ.carte?
             - type_de_champ.editable_options.each do |slice|
               .cell

--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
@@ -58,7 +58,7 @@
               .cell.fr-mt-1w
                 = form.label :nature, "Nature de la pièce", for: dom_id(type_de_champ, :nature)
                 = form.select :nature,
-                  TypeDeChamp.natures.keys.map { [it, it] } + [["Générique", nil]],
+                  TypeDeChamp.natures.to_a + [["Générique", nil]],
                   { },
                   class: 'fr-select small-margin small inline width-100',
                   id: dom_id(type_de_champ, :nature)

--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -226,6 +226,7 @@ module Administrateurs
         :expression_reguliere_indications,
         :expression_reguliere_exemple_text,
         :expression_reguliere_error_message,
+        :nature,
         editable_options: [
           :cadastres,
           :unesco,

--- a/app/jobs/image_processor_job.rb
+++ b/app/jobs/image_processor_job.rb
@@ -38,11 +38,11 @@ class ImageProcessorJob < ApplicationJob
     raise FileNotScannedYetError if blob.virus_scanner.pending?
     return if ActiveStorage::Attachment.find_by(blob_id: blob.id)&.record_type == "ActiveStorage::VariantRecord"
 
+    add_ocr_data(blob)
     auto_rotate(blob) if ["image/jpeg", "image/jpg"].include?(blob.content_type)
     uninterlace(blob) if blob.content_type == "image/png"
     create_representations(blob) if blob.representation_required?
     add_watermark(blob) if blob.watermark_pending?
-    add_ocr_data(blob)
   end
 
   private

--- a/app/jobs/image_processor_job.rb
+++ b/app/jobs/image_processor_job.rb
@@ -108,7 +108,7 @@ class ImageProcessorJob < ApplicationJob
     record = blob&.attachments&.first&.record
     return false if !record.is_a?(Champs::PieceJustificativeChamp)
 
-    record.libelle&.include?("RIB") || false
+    record.RIB?
   end
 
   def retry_or_discard

--- a/app/jobs/image_processor_job.rb
+++ b/app/jobs/image_processor_job.rb
@@ -99,7 +99,6 @@ class ImageProcessorJob < ApplicationJob
 
   def add_ocr_data(blob)
     return if !rib?(blob)
-    return if !Flipper.enabled?(:ocr, blob)
 
     blob.update!(ocr: OCRService.analyze(blob))
   end

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -73,6 +73,7 @@ class Champ < ApplicationRecord
     :expression_reguliere,
     :expression_reguliere_exemple_text,
     :expression_reguliere_error_message,
+    :RIB?,
     to: :type_de_champ
 
   delegate(*TypeDeChamp.type_champs.values.map { "#{_1}?".to_sym }, to: :type_de_champ)

--- a/app/models/champs/piece_justificative_champ.rb
+++ b/app/models/champs/piece_justificative_champ.rb
@@ -20,4 +20,32 @@ class Champs::PieceJustificativeChamp < Champ
   def search_terms
     # We don’t know how to search inside documents yet
   end
+
+  def fetch_external_data?
+    RIB?
+  end
+
+  def poll_external_data?
+    true
+  end
+
+  def fetch_external_data_pending?
+    return false if piece_justificative_file.blobs.count == 0
+
+    piece_justificative_file.blobs.first.ocr.nil?
+  end
+
+  def external_data_fetched?
+    return true if piece_justificative_file.blobs.count == 0
+
+    piece_justificative_file.blobs.first.ocr.present?
+  end
+
+  def fetch_external_data
+    nil # the ocr information is added by the ImageProcessorJob when the blob is attached
+  end
+
+  def fetch_external_data_later
+    nil # the job is already enqueued by the ImageProcessorJob when the blob is attached
+  end
 end

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -437,6 +437,12 @@ class ProcedureRevision < ApplicationRecord
           from_type_de_champ.filename_for_attachement(:piece_justificative_template),
           to_type_de_champ.filename_for_attachement(:piece_justificative_template))
       end
+      if from_type_de_champ.nature != to_type_de_champ.nature
+        changes << ProcedureRevisionChange::UpdateChamp.new(from_type_de_champ,
+          :nature,
+          from_type_de_champ.nature,
+          to_type_de_champ.nature)
+      end
     elsif to_type_de_champ.explication?
       if from_type_de_champ.checksum_for_attachment(:notice_explicative) != to_type_de_champ.checksum_for_attachment(:notice_explicative)
         changes << ProcedureRevisionChange::UpdateChamp.new(from_type_de_champ,

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -109,6 +109,8 @@ class TypeDeChamp < ApplicationRecord
     referentiel: 'referentiel'
   }
 
+  enum :nature, { RIB: 'RIB' }
+
   SIMPLE_ROUTABLE_TYPES = [
     type_champs.fetch(:drop_down_list),
     type_champs.fetch(:communes),

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -624,7 +624,6 @@ class TypeDeChamp < ApplicationRecord
     # logic (RNA, SIRET, etc.)
     case type_champ
     when type_champs.fetch(:carte),
-      type_champs.fetch(:piece_justificative),
       type_champs.fetch(:titre_identite),
       type_champs.fetch(:rna)
       false

--- a/app/services/ocr_service.rb
+++ b/app/services/ocr_service.rb
@@ -21,6 +21,10 @@ class OCRService
       { error: { code:, message: reason.message } }
     end
   rescue StandardError => e
-    Sentry.capture_exception(e, extra: { blob_url: blob_url })
+    if Rails.env.development?
+      raise e # In development, raise the error to see it in the console
+    else
+      Sentry.capture_exception(e, extra: { blob_url: blob_url })
+    end
   end
 end

--- a/db/migrate/20250710085322_add_nature_column_to_type_de_champ.rb
+++ b/db/migrate/20250710085322_add_nature_column_to_type_de_champ.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNatureColumnToTypeDeChamp < ActiveRecord::Migration[7.1]
+  def change
+    add_column :types_de_champ, :nature, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_06_26_085657) do
+ActiveRecord::Schema[7.1].define(version: 2025_07_10_085322) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_stat_statements"
@@ -1297,6 +1297,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_26_085657) do
     t.text "description"
     t.string "libelle"
     t.boolean "mandatory", default: true
+    t.text "nature"
     t.jsonb "options"
     t.boolean "private", default: false, null: false
     t.bigint "referentiel_id"

--- a/spec/components/input_status_message_component_spec.rb
+++ b/spec/components/input_status_message_component_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Dsfr::InputStatusMessageComponent, type: :component do
           allow(champ).to receive(:title).and_return("Title")
           allow(champ).to receive(:address).and_return("123 Street")
 
-          expect(subject).to have_css(".fr-info-text") # , text: I18n.t(".rna.data_fetched", title: "Title", address: "123 Street"))
+          expect(subject).to have_css(".fr-message--info") # , text: I18n.t(".rna.data_fetched", title: "Title", address: "123 Street"))
         end
       end
     end
@@ -44,7 +44,7 @@ RSpec.describe Dsfr::InputStatusMessageComponent, type: :component do
         end
 
         it "renders the pending message" do
-          expect(subject).to have_css(".fr-info-text", text: "Recherche en cours.")
+          expect(subject).to have_css(".fr-message--info", text: "Recherche en cours.")
         end
       end
 
@@ -55,7 +55,7 @@ RSpec.describe Dsfr::InputStatusMessageComponent, type: :component do
         end
 
         it "renders the error message 'KC'" do
-          expect(subject).to have_css(".fr-info-text", text: "Aucun élément trouvé pour la référence : ")
+          expect(subject).to have_css(".fr-message--info", text: "Aucun élément trouvé pour la référence : ")
         end
       end
 
@@ -66,7 +66,46 @@ RSpec.describe Dsfr::InputStatusMessageComponent, type: :component do
           allow(champ).to receive(:value).and_return('value')
         end
         it "renders the OK message" do
-          expect(subject).to have_css(".fr-info-text", text: 'value')
+          expect(subject).to have_css(".fr-message--valid", text: 'value')
+        end
+      end
+    end
+
+    context 'with piece_justificative champs (RIB)' do
+      let(:types_de_champ_public) { [{ type: :piece_justificative, nature: 'RIB' }] }
+
+      context "when OCR is nil" do
+        before do
+          allow(champ).to receive(:piece_justificative_file).and_return(double(blobs: [double]))
+          allow(champ.piece_justificative_file.blobs.first).to receive(:ocr).and_return(nil)
+        end
+
+        it "renders the info message" do
+          expect(subject).to have_css(".fr-message--info")
+        end
+      end
+
+      context "when OCR exists but IBAN is nil" do
+        before do
+          allow(champ).to receive(:piece_justificative_file).and_return(double(blobs: [double]))
+          allow(champ.piece_justificative_file.blobs.first).to receive(:ocr).and_return({ 'rib' => {} })
+        end
+
+        it "renders the warning message" do
+          expect(subject).to have_css(".fr-message--warning")
+        end
+      end
+
+      context "when IBAN is present" do
+        let(:iban) { "FRjesuisuniban" }
+
+        before do
+          allow(champ).to receive(:piece_justificative_file).and_return(double(blobs: [double]))
+          allow(champ.piece_justificative_file.blobs.first).to receive(:ocr).and_return({ 'rib' => { 'iban' => iban } })
+        end
+
+        it "renders the valid message with IBAN" do
+          expect(subject).to have_css(".fr-message--valid", text: iban)
         end
       end
     end

--- a/spec/jobs/image_processor_job_spec.rb
+++ b/spec/jobs/image_processor_job_spec.rb
@@ -153,9 +153,9 @@ describe ImageProcessorJob, type: :job do
     let(:ocr_service) { instance_double("OcrService") }
     let(:procedure) do
       create(:procedure,
-             types_de_champ_public: [{ type: :piece_justificative, libelle: }])
+             types_de_champ_public: [{ type: :piece_justificative, nature: }])
     end
-    let(:libelle) { "votre RIB" }
+    let(:nature) { "RIB" }
 
     let (:dossier) { create(:dossier, procedure:) }
     let(:analysis) { { "some" => "data" } }
@@ -180,7 +180,7 @@ describe ImageProcessorJob, type: :job do
     end
 
     context "when the blob does not contain a RIB" do
-      let(:libelle) { "votre facture" }
+      let(:nature) { nil }
 
       it "does not call OcrService.analyze nor set ocr data" do
         expect(OCRService).not_to have_received(:analyze)

--- a/spec/jobs/image_processor_job_spec.rb
+++ b/spec/jobs/image_processor_job_spec.rb
@@ -167,7 +167,6 @@ describe ImageProcessorJob, type: :job do
     end
 
     before do
-      allow(Flipper).to receive(:enabled?).with(:ocr, blob).and_return(true)
       allow(OCRService).to receive(:analyze).and_return(analysis)
 
       described_class.perform_now(blob)


### PR DESCRIPTION
Pour l'instant, on n 'a pas l'interface admin pour configurer le champ en RIB. Peut être l' attendre pour un feature flip facile ?

RAF :
- [x] s'assurer qu'on ne casse pas le système de watermarking qui fonctionne aussi en polling (?)
- [x] voir si y a des tests a mettre et comment
- [x] voir si y a moyen de feature flipper par procédure mais pas sur sans plein de requete supplémentaire


https://github.com/user-attachments/assets/84dbc25e-3cb9-4478-8883-22b447fd866e


Affichage de l'option coté admin : 

<img width="2400" height="1014" alt="Screenshot 2025-07-11 at 13-56-12 demarches-simplifiees fr" src="https://github.com/user-attachments/assets/8da8d35a-547d-412e-8d57-2dad8da75deb" />


Pour le faire tourner en local
- installer [la taupe](https://github.com/demarches-simplifiees/la_taupe) , lancer ./launch_demo.sh
- commenter la ligne 38 d'ImageProcessorJob `# raise FileNotScannedYetError if blob.virus_scanner.pending?`
- j'ai du également ajouter ` ActiveStorage::Current.url_options = { host: ENV.fetch("HOST", "localhost:3000") }` en début de la méthode `  def self.analyze(blob)` du `ocr_service`
- ajouter la var d'env `OCR_SERVICE_URL="http://localhost:8080/analyze"`