### PR TITLE
[UX] J'ai plus de place dans la messagerie pour écrire mon message - la mention 'obligatoire' est déplacée proche du label

### DIFF
--- a/app/views/shared/dossiers/messages/_form.html.haml
+++ b/app/views/shared/dossiers/messages/_form.html.haml
@@ -5,9 +5,11 @@
     = f.hidden_field :last_commentaire, value: last_commentaire.id, name: :id
   - elsif local_assigns.has_key?(:dossier) &&  instructeur_signed_in? || administrateur_signed_in? || expert_signed_in?
     - placeholder = t('views.shared.dossiers.messages.form.write_message_placeholder')
-  %p.fr-text--sm.fr-text-mention--grey.fr-mb-1w= t('asterisk_html', scope: [:utils])
 
-  = render Dsfr::InputComponent.new(form: f, attribute: :body, autoresize: false, input_type: :text_area, opts: { rows: 5, placeholder: placeholder, title: placeholder, class: 'fr-input message-textarea'})
+  = f.label :body, class: "fr-label" do
+    = t('views.shared.dossiers.messages.form.message_label_mandatory')
+    = render EditableChamp::AsteriskMandatoryComponent.new
+  = f.text_area :body, rows: '5', placeholder: placeholder, title: placeholder, required: true, class: 'fr-input message-textarea'
 
   - if local_assigns.has_key?(:dossier)
     .fr-mt-3w.fr-input-group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -383,6 +383,7 @@ en:
         messages:
           form:
             send_message: "Send message"
+            message_label_mandatory: "Your message (mandatory)"
             write_message_placeholder: "Write your message here"
             write_message_to_administration_placeholder: "Write your message to the administration here"
         demande:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -388,6 +388,7 @@ fr:
         messages:
           form:
             send_message: "Envoyer le message"
+            message_label_mandatory: "Votre message (obligatoire)"
             write_message_placeholder: "Écrivez votre message ici"
             write_message_to_administration_placeholder: "Écrivez votre message à l’administration ici"
         demande:


### PR DESCRIPTION
<img width="1241" alt="Capture d’écran 2025-07-09 à 16 38 36" src="https://github.com/user-attachments/assets/1e18c6d0-a48c-4d6c-bd0f-61fc969aee9f" />
