### PR TITLE
[UX] ETQ instructeur, ma liste de messages envoyés aux usagers avec un brouillon est plus lisible

### DIFF
--- a/app/views/instructeurs/procedures/email_usagers.html.haml
+++ b/app/views/instructeurs/procedures/email_usagers.html.haml
@@ -19,15 +19,14 @@
 
   - if @bulk_messages.present?
     %section.list-avis.mt-8
-      %h1.tab-title
+      %h2.tab-title
         Messages envoyés précédemment
         %span.fr-badge= @bulk_messages.count
 
       %ul
         - @bulk_messages.each do |message|
-          %li.one-avis.flex.align-start
-            .width-100
-              %h2.claimant
-                %span.email= message.instructeur.email
-                %span.date a envoyé ce message à #{message.dossier_count} usagers le #{message.sent_at.strftime('%d/%m/%y à %H:%M')}
-              %p= message.body
+          %li
+            %b
+              = message.instructeur.email
+              a envoyé ce message à #{message.dossier_count} usagers le #{message.sent_at.strftime('%d/%m/%y à %H:%M')}
+            %p= message.body


### PR DESCRIPTION
**APRES**
<img width="1258" alt="Capture d’écran 2025-07-09 à 18 18 18" src="https://github.com/user-attachments/assets/8cd0697e-3423-4d1a-a1b6-9f447b37e290" />

**AVANT**
<img width="1234" alt="Capture d’écran 2025-07-09 à 18 19 04" src="https://github.com/user-attachments/assets/b2733d0a-7e21-4f90-8176-3297f483cce8" />
