### PR TITLE
Etq tech : je veux fiabiliser la creation des instructeurs_procedure

### DIFF
--- a/app/controllers/concerns/instructeur_procedure_concern.rb
+++ b/app/controllers/concerns/instructeur_procedure_concern.rb
@@ -8,19 +8,28 @@ module InstructeurProcedureConcern
 
     def ensure_instructeur_procedures_for(procedures)
       current_instructeur_procedures = current_instructeur.instructeurs_procedures.where(procedure_id: procedures.map(&:id))
-      top_position = current_instructeur_procedures.map(&:position).max || 0
-      missing_instructeur_procedures = procedures.sort_by(&:published_at).map(&:id).filter_map do |procedure_id|
-        if !procedure_id.in?(current_instructeur_procedures.map(&:procedure_id))
-          { instructeur_id: current_instructeur.id, procedure_id:, position: top_position += 1 }
+      top_position = current_instructeur_procedures.map(&:position).max.to_i
+      missing_instructeur_procedures = procedures.sort_by(&:published_at).filter_map do |procedure|
+        if !procedure.id.in?(current_instructeur_procedures.map(&:procedure_id))
+          { instructeur_id: current_instructeur.id, procedure_id: procedure.id, position: top_position += 1, last_revision_seen_id: procedure.published_revision_id }
         end
       end
       InstructeursProcedure.insert_all(missing_instructeur_procedures) if missing_instructeur_procedures.size.positive?
     end
 
     def find_or_create_instructeur_procedure(procedure)
-      InstructeursProcedure
-        .create_with(last_revision_seen_id: procedure.published_revision_id)
-        .find_or_create_by(instructeur: current_instructeur, procedure: procedure)
+      instructeur_procedure = InstructeursProcedure.find_or_initialize_by(
+        instructeur: current_instructeur,
+        procedure: procedure
+      )
+
+      if instructeur_procedure.new_record?
+        instructeur_procedure.last_revision_seen_id = procedure.published_revision_id
+        instructeur_procedure.position = current_instructeur.instructeurs_procedures.map(&:position).max.to_i + 1
+        instructeur_procedure.save!
+      end
+
+      instructeur_procedure
     end
   end
 end

--- a/app/controllers/concerns/instructeur_procedure_concern.rb
+++ b/app/controllers/concerns/instructeur_procedure_concern.rb
@@ -6,6 +6,17 @@ module InstructeurProcedureConcern
   included do
     private
 
+    def ensure_instructeur_procedures_for(procedures)
+      current_instructeur_procedures = current_instructeur.instructeurs_procedures.where(procedure_id: procedures.map(&:id))
+      top_position = current_instructeur_procedures.map(&:position).max || 0
+      missing_instructeur_procedures = procedures.sort_by(&:published_at).map(&:id).filter_map do |procedure_id|
+        if !procedure_id.in?(current_instructeur_procedures.map(&:procedure_id))
+          { instructeur_id: current_instructeur.id, procedure_id:, position: top_position += 1 }
+        end
+      end
+      InstructeursProcedure.insert_all(missing_instructeur_procedures) if missing_instructeur_procedures.size.positive?
+    end
+
     def find_or_create_instructeur_procedure(procedure)
       InstructeursProcedure
         .create_with(last_revision_seen_id: procedure.published_revision_id)

--- a/app/controllers/instructeurs/archives_controller.rb
+++ b/app/controllers/instructeurs/archives_controller.rb
@@ -10,7 +10,6 @@ module Instructeurs
 
     def index
       @average_dossier_weight = @procedure.average_dossier_weight
-      @instructeur_procedure = find_or_create_instructeur_procedure(@procedure)
       @count_dossiers_termines_by_month = @procedure.dossiers.processed_by_month(groupe_instructeurs).count
       @archives = Archive.for_groupe_instructeur(groupe_instructeurs).to_a
     end

--- a/app/controllers/instructeurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/instructeurs/groupe_instructeurs_controller.rb
@@ -11,7 +11,6 @@ module Instructeurs
 
     def index
       @procedure = procedure
-      @instructeur_procedure = find_or_create_instructeur_procedure(@procedure)
       redirect_to instructeur_groupe_path(@procedure, @procedure.defaut_groupe_instructeur) if !@procedure.routing_enabled?
       @groupes_instructeurs = paginated_groupe_instructeurs
     end
@@ -19,7 +18,6 @@ module Instructeurs
     def show
       @procedure = procedure
       @groupe_instructeur = groupe_instructeur
-      @instructeur_procedure = find_or_create_instructeur_procedure(@procedure)
       @instructeurs = paginated_instructeurs
       @maybe_typos = flash[:maybe_typos]
     end

--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -29,7 +29,7 @@ module Instructeurs
 
       @procedures = all_procedures.order(closed_at: :desc, unpublished_at: :desc, published_at: :desc, created_at: :desc)
       publiees_or_closes_with_dossiers_en_cours = all_procedures_for_listing.publiees.or(all_procedures.closes.where(id: procedures_dossiers_en_cours))
-      current_instructeur.ensure_instructeur_procedures_for(publiees_or_closes_with_dossiers_en_cours)
+      ensure_instructeur_procedures_for(publiees_or_closes_with_dossiers_en_cours)
       @all_procedures_en_cours = publiees_or_closes_with_dossiers_en_cours.order_by_position_for(current_instructeur)
       @procedures_en_cours = @all_procedures_en_cours.page(params[:page]).per(ITEMS_PER_PAGE)
       closes_with_no_dossier_en_cours = all_procedures.closes.excluding(all_procedures.closes.where(id: procedures_dossiers_en_cours))
@@ -76,7 +76,7 @@ module Instructeurs
     end
 
     def update_order_positions
-      current_instructeur.update_instructeur_procedures_positions(ordered_procedure_ids_params)
+      InstructeursProcedure.update_instructeur_procedures_positions(current_instructeur, ordered_procedure_ids_params)
       redirect_to instructeur_procedures_path, notice: "L'ordre des démarches a été mis à jour."
     end
 

--- a/app/helpers/procedure_helper.rb
+++ b/app/helpers/procedure_helper.rb
@@ -77,13 +77,4 @@ module ProcedureHelper
     !procedure.replaced_by_procedure.discarded? &&
     procedure.replaced_by_procedure.path.present? # TODO: to remove when all path are added, cf: https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11453
   end
-
-  def procedure_has_unseen_revisions?(instructeur_procedure)
-    return false if instructeur_procedure.procedure.published_revision_id.blank?
-
-    last_seen_id = instructeur_procedure.last_revision_seen_id
-    return false if last_seen_id.blank?
-
-    last_seen_id < instructeur_procedure.procedure.published_revision_id
-  end
 end

--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -113,26 +113,6 @@ class Instructeur < ApplicationRecord
     end
   end
 
-  def ensure_instructeur_procedures_for(procedures)
-    current_instructeur_procedures = instructeurs_procedures.where(procedure_id: procedures.map(&:id))
-    top_position = current_instructeur_procedures.map(&:position).max || 0
-    missing_instructeur_procedures = procedures.sort_by(&:published_at).map(&:id).filter_map do |procedure_id|
-      if !procedure_id.in?(current_instructeur_procedures.map(&:procedure_id))
-        { instructeur_id: id, procedure_id:, position: top_position += 1 }
-      end
-    end
-    InstructeursProcedure.insert_all(missing_instructeur_procedures) if missing_instructeur_procedures.size.positive?
-  end
-
-  def update_instructeur_procedures_positions(ordered_procedure_ids)
-    procedure_id_position = ordered_procedure_ids.reverse.each.with_index.to_h
-    InstructeursProcedure.transaction do
-      procedure_id_position.each do |procedure_id, position|
-        InstructeursProcedure.where(procedure_id:, instructeur_id: id).update(position:)
-      end
-    end
-  end
-
   def procedure_presentation_for_procedure_id(procedure_id)
     assign_to = assign_to_for_procedure_id(procedure_id)
     assign_to.procedure_presentation || assign_to.create_procedure_presentation!

--- a/app/models/instructeurs_procedure.rb
+++ b/app/models/instructeurs_procedure.rb
@@ -3,4 +3,13 @@
 class InstructeursProcedure < ApplicationRecord
   belongs_to :instructeur
   belongs_to :procedure
+
+  def self.update_instructeur_procedures_positions(instructeur, ordered_procedure_ids)
+    procedure_id_position = ordered_procedure_ids.reverse.each.with_index.to_h
+    InstructeursProcedure.transaction do
+      procedure_id_position.each do |procedure_id, position|
+        InstructeursProcedure.where(procedure_id:, instructeur:).update(position:)
+      end
+    end
+  end
 end

--- a/app/views/instructeurs/procedures/_header.html.haml
+++ b/app/views/instructeurs/procedures/_header.html.haml
@@ -12,17 +12,17 @@
 
       %li.fr-nav__item.relative
         %button.fr-nav__btn{ 'aria-expanded': 'false', 'aria-controls': "menu-procedure", 'aria-current': ('page' if current_nav_section == 'procedure_management') }
-          %span.relative{ class: class_names("fr-pr-1w" => procedure_has_unseen_revisions?(@instructeur_procedure)) }
+          %span.relative{ class: class_names("fr-pr-1w" => @has_unseen_revision_notification) }
             = t('instructeurs.dossiers.header.banner.procedure_management')
-            - if procedure_has_unseen_revisions?(@instructeur_procedure)
+            - if @has_unseen_revision_notification
               %span.notifications{ 'aria-label': 'notifications' }
         #menu-procedure.fr-collapse.fr-menu
           %ul.fr-menu__list
             %li
               = link_to procedure_history_instructeur_procedure_path(procedure), class: 'fr-nav__link position-relative' do
-                %span.relative{ class: class_names("fr-pr-2w" => procedure_has_unseen_revisions?(@instructeur_procedure)) }
+                %span.relative{ class: class_names("fr-pr-2w" => @has_unseen_revision_notification) }
                   = t('instructeurs.dossiers.header.banner.history.title')
-                  - if procedure_has_unseen_revisions?(@instructeur_procedure)
+                  - if @has_unseen_revision_notification
                     %span.notifications{ 'aria-label': 'notifications' }
             %li
               = link_to t('instructeurs.dossiers.header.banner.administrators_list'), administrateurs_instructeur_procedure_path(procedure), class: 'fr-nav__link'

--- a/db/migrate/20250721071117_add_check_constraint_on_instructeurs_procedures_position.rb
+++ b/db/migrate/20250721071117_add_check_constraint_on_instructeurs_procedures_position.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCheckConstraintOnInstructeursProceduresPosition < ActiveRecord::Migration[7.1]
+  def change
+    add_check_constraint :instructeurs_procedures, "position IS NOT NULL", name: "instructeurs_procedures_position_null", validate: false
+  end
+end

--- a/db/migrate/20250721071351_validate_and_add_not_null_position_on_instructeurs_procedures.rb
+++ b/db/migrate/20250721071351_validate_and_add_not_null_position_on_instructeurs_procedures.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ValidateAndAddNotNullPositionOnInstructeursProcedures < ActiveRecord::Migration[7.1]
+  def up
+    validate_check_constraint :instructeurs_procedures, name: "instructeurs_procedures_position_null"
+    change_column_null :instructeurs_procedures, :position, false
+    remove_check_constraint :instructeurs_procedures, name: "instructeurs_procedures_position_null"
+  end
+
+  def down
+    add_check_constraint :instructeurs_procedures, "position IS NOT NULL", name: "instructeurs_procedures_position_null", validate: false
+    change_column_null :instructeurs_procedures, :position, true
+  end
+end

--- a/db/migrate/20250721071536_remove_default_from_position_in_instructeurs_procedures.rb
+++ b/db/migrate/20250721071536_remove_default_from_position_in_instructeurs_procedures.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveDefaultFromPositionInInstructeursProcedures < ActiveRecord::Migration[7.1]
+  def change
+    change_column_default :instructeurs_procedures, :position, from: 99, to: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_07_10_085322) do
+ActiveRecord::Schema[7.1].define(version: 2025_07_21_071536) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_stat_statements"
@@ -851,7 +851,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_10_085322) do
     t.datetime "created_at", null: false
     t.bigint "instructeur_id", null: false
     t.bigint "last_revision_seen_id"
-    t.integer "position", default: 99
+    t.integer "position", null: false
     t.bigint "procedure_id", null: false
     t.datetime "updated_at", null: false
     t.index ["instructeur_id", "procedure_id"], name: "index_instructeurs_procedures_on_instructeur_and_procedure", unique: true

--- a/spec/controllers/instructeurs/procedures_controller_spec.rb
+++ b/spec/controllers/instructeurs/procedures_controller_spec.rb
@@ -1183,7 +1183,6 @@ describe Instructeurs::ProceduresController, type: :controller do
 
       it 'updates the last_revision_seen_id in instructeur_procedure' do
         expect(assigns(:instructeur_procedure).last_revision_seen_id).to eq(revision.id)
-        expect(assigns(:instructeur_procedure).position).to eq(99)
       end
     end
 

--- a/spec/factories/instructeurs_procedure.rb
+++ b/spec/factories/instructeurs_procedure.rb
@@ -4,5 +4,7 @@ FactoryBot.define do
   factory :instructeurs_procedure do
     association :instructeur
     association :procedure
+
+    position { 1 }
   end
 end

--- a/spec/models/concerns/instructeur_procedure_concern_spec.rb
+++ b/spec/models/concerns/instructeur_procedure_concern_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+RSpec.describe InstructeurProcedureConcern do
+  include InstructeurProcedureConcern
+
+  let(:current_instructeur) { create(:instructeur) }
+
+  describe '.ensure_instructeur_procedures_for' do
+    let!(:procedures) { create_list(:procedure, 5, :published) }
+
+    context 'when some procedures are missing for the instructeur' do
+      before do
+        create(:instructeurs_procedure, instructeur: current_instructeur, procedure: procedures.first, position: 0, last_revision_seen_id: procedures.first.published_revision_id)
+      end
+
+      it 'creates missing instructeurs_procedures with correct attributes' do
+        expect {
+          ensure_instructeur_procedures_for(procedures)
+        }.to change { InstructeursProcedure.count }.by(4)
+
+        instructeur_procedures = InstructeursProcedure.where(instructeur: current_instructeur)
+        expect(instructeur_procedures.pluck(:procedure_id)).to match_array(procedures.map(&:id))
+        expect(instructeur_procedures.pluck(:position)).to eq([0, 1, 2, 3, 4])
+        expect(instructeur_procedures.pluck(:last_revision_seen_id)).to match_array(procedures.map(&:published_revision_id))
+      end
+    end
+
+    context 'when all procedures already exist for the instructeur' do
+      before do
+        procedures.each_with_index do |procedure, index|
+          create(:instructeurs_procedure, instructeur: current_instructeur, procedure: procedure, position: index + 1)
+        end
+      end
+
+      it 'does not create any new instructeurs_procedures' do
+        expect {
+          ensure_instructeur_procedures_for(procedures)
+        }.not_to change { InstructeursProcedure.count }
+      end
+    end
+  end
+
+  describe '.find_or_create_instructeur_procedure' do
+    let(:procedure) { create(:procedure, :published) }
+
+    context "when the instructeurs_procedure already exist" do
+      let!(:instructeur_procedure) { create(:instructeurs_procedure, instructeur: current_instructeur, procedure:, position: 0, last_revision_seen_id: procedure.published_revision_id) }
+
+      it 'does not create any new instructeurs_procedures' do
+        expect {
+          find_or_create_instructeur_procedure(procedure)
+        }.not_to change { InstructeursProcedure.count }
+      end
+    end
+
+    context "when the instructeurs_procedure does not exist" do
+      it "create an instructeurs_procedure with correct attributes" do
+        expect {
+          find_or_create_instructeur_procedure(procedure)
+        }.to change { InstructeursProcedure.count }.by(1)
+
+        instructeur_procedure = InstructeursProcedure.first
+        expect(instructeur_procedure.position).to eq(1)
+        expect(instructeur_procedure.last_revision_seen_id).to eq(procedure.published_revision_id)
+      end
+    end
+  end
+end

--- a/spec/models/instructeur_spec.rb
+++ b/spec/models/instructeur_spec.rb
@@ -722,69 +722,6 @@ describe Instructeur, type: :model do
     end
   end
 
-  describe '.ensure_instructeur_procedures_for' do
-    let(:instructeur) { create(:instructeur) }
-    let!(:procedures) { create_list(:procedure, 5, published_at: Time.current) }
-
-    context 'when some procedures are missing for the instructeur' do
-      before do
-        create(:instructeurs_procedure, instructeur: instructeur, procedure: procedures.first, position: 0)
-      end
-
-      it 'creates missing instructeurs_procedures with correct positions' do
-        expect {
-          instructeur.ensure_instructeur_procedures_for(procedures)
-        }.to change { InstructeursProcedure.count }.by(4)
-
-        instructeur_procedures = InstructeursProcedure.where(instructeur: instructeur)
-        expect(instructeur_procedures.pluck(:procedure_id)).to match_array(procedures.map(&:id))
-        expect(instructeur_procedures.pluck(:position)).to eq([0, 1, 2, 3, 4])
-      end
-    end
-
-    context 'when all procedures already exist for the instructeur' do
-      before do
-        procedures.each_with_index do |procedure, index|
-          create(:instructeurs_procedure, instructeur: instructeur, procedure: procedure, position: index + 1)
-        end
-      end
-
-      it 'does not create any new instructeurs_procedures' do
-        expect {
-          instructeur.ensure_instructeur_procedures_for(procedures)
-        }.not_to change { InstructeursProcedure.count }
-      end
-    end
-  end
-
-  describe '.update_instructeur_procedures_positions' do
-    let(:instructeur) { create(:instructeur) }
-    let!(:procedures) { create_list(:procedure, 5, published_at: Time.current) }
-
-    before do
-      procedures.each_with_index do |procedure, index|
-        create(:instructeurs_procedure, instructeur: instructeur, procedure: procedure, position: index + 1)
-      end
-    end
-
-    it 'updates the positions of the specified instructeurs_procedures' do
-      instructeur.update_instructeur_procedures_positions(procedures.map(&:id))
-
-      updated_positions = InstructeursProcedure
-        .where(instructeur:)
-        .order(:procedure_id)
-        .pluck(:procedure_id, :position)
-
-      expect(updated_positions).to match_array([
-        [procedures[0].id, 4],
-        [procedures[1].id, 3],
-        [procedures[2].id, 2],
-        [procedures[3].id, 1],
-        [procedures[4].id, 0]
-      ])
-    end
-  end
-
   private
 
   def assign(procedure_to_assign, instructeur_assigne: instructeur)

--- a/spec/models/instructeurs_procedure_spec.rb
+++ b/spec/models/instructeurs_procedure_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe InstructeursProcedure, type: :model do
+  describe '.update_instructeur_procedures_positions' do
+    let(:instructeur) { create(:instructeur) }
+    let!(:procedures) { create_list(:procedure, 5, published_at: Time.current) }
+
+    before do
+      procedures.each_with_index do |procedure, index|
+        create(:instructeurs_procedure, instructeur: instructeur, procedure: procedure, position: index + 1)
+      end
+    end
+
+    it 'updates the positions of the specified instructeurs_procedures' do
+      InstructeursProcedure.update_instructeur_procedures_positions(instructeur, procedures.map(&:id))
+
+      updated_positions = InstructeursProcedure
+        .where(instructeur:)
+        .order(:procedure_id)
+        .pluck(:procedure_id, :position)
+
+      expect(updated_positions).to match_array([
+        [procedures[0].id, 4],
+        [procedures[1].id, 3],
+        [procedures[2].id, 2],
+        [procedures[3].id, 1],
+        [procedures[4].id, 0]
+      ])
+    end
+  end
+end

--- a/spec/tasks/maintenance/t20250320_fix_instructeurs_procedures_without_position_task_spec.rb
+++ b/spec/tasks/maintenance/t20250320_fix_instructeurs_procedures_without_position_task_spec.rb
@@ -4,12 +4,17 @@ require "rails_helper"
 
 module Maintenance
   RSpec.describe T20250320FixInstructeursProceduresWithoutPositionTask do
+    # we finally added a not null constraint on position in #11876
+    before do
+      ActiveRecord::Base.connection.execute("ALTER TABLE instructeurs_procedures ALTER COLUMN position DROP NOT NULL;")
+    end
+
     describe "#process" do
       subject(:process) { described_class.process(element) }
 
       let(:element) { create(:instructeurs_procedure, position: nil) }
 
-      it "updates the instructeur_procedure position to 0" do
+      it "updates the instructeur_procedure position to 99" do
         expect { process }.to change { element.reload.position }.from(nil).to(99)
       end
     end


### PR DESCRIPTION
Dans la perspective de la feature de personnalisation de l'affichage des badges de notifications, laquelle s'appuiera sur la table InstructeursProcedure, nous avons besoin de fiabiliser l'assignation des attributs lors de la création des instances de cette table.

Cela vient notamment faire suite au fix: https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11501 :
- on remplace la position par défaut 99 par une contrainte non nulle ;
- on n'appelle plus find_or_create à chaque page, seulement pour la show du tableau de suivi des dossiers, à l'image du comportement de notification des exports.

Sur le dernier point, il s'agit là d'une proposition de simplification temporaire, de sorte en attendant d'avoir une cohérence avec la notification des exports qui ne s'affiche pas dans le header si le user n'est pas sur le tableau de suivi des dossiers. Dans une prochaine PR, on pourrait donc imaginer d'assurer le comportement de chacune des pastilles de notification dans le header (historique des révisions et exports) quelque soit la page sur laquelle nous sommes (intégrant ce header). 