### PR TITLE
ETQ administrateur, je peux configurer un champ référentiel avancé en mode autosuggestion. ETQ usager je peux utiliser un champ référentiel avancé en mode autosuggestion

### DIFF
--- a/app/components/editable_champ/referentiel_component.rb
+++ b/app/components/editable_champ/referentiel_component.rb
@@ -8,4 +8,16 @@ class EditableChamp::ReferentielComponent < EditableChamp::EditableChampBaseComp
   def dsfr_input_classname
     exact_match? ? 'fr-input' : nil
   end
+
+  def react_autocomplete_props
+    react_input_opts(id: @champ.focusable_input_id,
+      class: 'fr-mt-1w',
+      name: @form.field_name(:value),
+      placeholder: t('views.components.remote_combobox'),
+      selected_key: @champ.selected_key,
+      items: @champ.selected_items,
+      loader: data_sources_data_source_referentiel_path(referentiel_id: referentiel.id),
+      minimum_input_length: 2,
+      is_disabled: false)
+  end
 end

--- a/app/components/editable_champ/referentiel_component/referentiel_component.html.haml
+++ b/app/components/editable_champ/referentiel_component/referentiel_component.html.haml
@@ -1,2 +1,7 @@
 - if exact_match?
   = @form.text_field :external_id, input_opts(id: @champ.focusable_input_id, required: @champ.required?, class: "width-33-desktop fr-input", novalidate: 'true', aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" })
+- else
+  .fr-input-group.address-ban
+    %react-fragment
+      = render ReactComponent.new "ComboBox/RemoteComboBox", **react_autocomplete_props do
+        = render ReactComponent.new "ComboBox/ComboBoxValueSlot", field: :data, name: @form.field_name(:data)

--- a/app/components/referentiels/autocomplete_configuration_component.rb
+++ b/app/components/referentiels/autocomplete_configuration_component.rb
@@ -68,7 +68,8 @@ class Referentiels::AutocompleteConfigurationComponent < Referentiels::MappingFo
   end
 
   def maybe_datasources
-    JSONPathUtil.array_paths_with_examples(referentiel.last_response_body)
+    JSONPathUtil.filter_selectable_datasources(referentiel.last_response_body)
+      .transform_values(&:first) # extract first option from all possible ones
       .sort
       .to_h
   end

--- a/app/components/referentiels/autocomplete_configuration_component.rb
+++ b/app/components/referentiels/autocomplete_configuration_component.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+class Referentiels::AutocompleteConfigurationComponent < Referentiels::MappingFormBase
+  def id
+    :autocomplete_configuration
+  end
+
+  def back_url
+    edit_admin_procedure_referentiel_path(procedure, type_de_champ.stable_id, referentiel.id)
+  end
+
+  def form_url
+    update_autocomplete_configuration_admin_procedure_referentiel_path(procedure, type_de_champ.stable_id, referentiel.id)
+  end
+
+  def datasource
+    datasource_jsonpath = referentiel.datasource
+
+    return nil if datasource_jsonpath.nil?
+    JsonPath.on(referentiel.last_response_body, datasource_jsonpath).first&.first
+  end
+
+  def autocomplete_template
+    referentiel.template
+  end
+
+  def select_datasource_radio_tag(jsonpath)
+    radio_button_tag(
+      "referentiel[datasource]",
+      jsonpath,
+      referentiel.autocomplete_configuration.fetch("datasource", nil) == jsonpath
+    )
+  end
+
+  def tags
+    jsonpaths = JSONPathUtil.hash_to_jsonpath(datasource)
+    properties = jsonpaths.map do |jsonpath, value|
+      {
+        libelle: "#{jsonpath} (#{value})",
+        id: jsonpath
+      }
+    end
+    { properties: }
+  end
+
+  def form_datasource_options
+    {
+      method: :patch,
+      data: {
+        controller: "autosubmit",
+        autosubmit_debounce_delay_value: 1000,
+        turbo: true
+      },
+      html: { novalidate: 'novalidate' }
+    }
+  end
+
+  def form_template_options
+    {
+      method: :patch,
+      data: {
+        autosubmit_debounce_delay_value: 1000,
+        turbo: true
+
+      },
+      html: { novalidate: 'novalidate' }
+    }
+  end
+
+  def maybe_datasources
+    JSONPathUtil.array_paths_with_examples(referentiel.last_response_body)
+      .sort
+      .to_h
+  end
+
+  def only_one_datasource?
+    maybe_datasources.size == 1
+  end
+
+  def default_datasource
+    return nil if maybe_datasources.empty?
+    maybe_datasources&.keys&.first
+  end
+end

--- a/app/components/referentiels/autocomplete_configuration_component/autocomplete_configuration_component.html.haml
+++ b/app/components/referentiels/autocomplete_configuration_component/autocomplete_configuration_component.html.haml
@@ -1,0 +1,51 @@
+%div{ id: }
+  = form_with model: @referentiel, scope: :referentiel, url: form_url, **form_datasource_options do |f|
+    %div{ class: bordered_container_class_names }
+      = render Referentiels::ResponseRendererComponent.new(referentiel:)
+      - if maybe_datasources.size.zero?
+        = render Dsfr::AlertComponent.new(title: "Votre source de données ne semble pas compatible", state: :error) do |c|
+          - c.with_body do
+            %p
+              Votre source de données ne contient pas de tableau. Veuillez vérifier la configuration de votre référentiel.
+      - else
+        .fr-table.fr-table--bordered.fr-mb-6w
+          .fr-table__wrapper
+            .fr-table__container
+              .fr-table__content
+                %table
+                  %caption Sélectionnez la source de données à exploiter pour l'autocomplete
+                  %thead
+                    %tr
+                      %th.fr-cell--fixed Propriété
+                      %th Exemple de donnée
+                      %th Choisir
+                  %tbody
+                    - maybe_datasources.each do |jsonpath, value|
+                      %tr
+                        %td.fr-cell--fixed= jsonpath
+                        %td.fr-cell--multiline
+                          %pre= JSON.pretty_generate(value)
+                        %td.text-center= select_datasource_radio_tag(jsonpath)
+
+  - if datasource.present?
+    = form_with model: @referentiel, scope: :referentiel, url: form_url, **form_template_options do |f|
+      %div{ class: "#{bordered_container_class_names} fr-mt-5w" }
+        #autocomplete.fr-my-4w{ data: { controller: 'tiptap', tiptap_insert_after_tag_value: ' ' } }
+          .fr-input-group{ class: class_names("fr-input-group--error" => f.object.errors.include?(:tiptap_template)) }
+            %label.fr-label
+              Choisir les propriétés qui seront affichées dans les options de l'autocomplete
+              %span.fr-hint-text Vous pouvez utiliser les balises pour construire les éléments suggérés
+
+            #editor.tiptap-editor{ data: { tiptap_target: 'editor' }, aria: { describedby: "autocomplete_configuration-json-body-message"} }
+            = hidden_field_tag "referentiel[tiptap_template]", @referentiel.tiptap_template, data: { tiptap_target: 'input' }
+
+            .fr-error-text{ id: "autocomplete_configuration-json-body-message", class: class_names("hidden" => !f.object.errors.include?(:tiptap_template)) }
+              - if f.object.errors.include?(:tiptap_template)
+                = render partial: "shared/errors_list", locals: { object: f.object, attribute: :tiptap_template }
+
+          = render TagsButtonListComponent.new(tags:)
+
+      %ul.fr-btns-group.fr-btns-group--inline-sm.flex.justify-center.fr-mt-5w
+        %li= link_to "Annuler", champs_admin_procedure_path(@procedure), class: 'fr-btn fr-btn--secondary fr-mr-3w'
+        %li= link_to "Étape précédente", back_url, class: 'fr-btn fr-btn--secondary'
+        %li= f.submit "Étape suivante", class: "fr-btn"

--- a/app/components/referentiels/mapping_form_component.rb
+++ b/app/components/referentiels/mapping_form_component.rb
@@ -5,10 +5,16 @@ class Referentiels::MappingFormComponent < Referentiels::MappingFormBase
 
   def last_request_keys
     JSONPathUtil.hash_to_jsonpath(referentiel.last_response_body)
+      .sort
+      .to_h
   end
 
   def back_url
-    edit_admin_procedure_referentiel_path(procedure, type_de_champ.stable_id, referentiel.id)
+    if referentiel.autocomplete?
+      autocomplete_configuration_admin_procedure_referentiel_path(procedure, type_de_champ.stable_id, referentiel.id)
+    else
+      edit_admin_procedure_referentiel_path(procedure, type_de_champ.stable_id, referentiel.id)
+    end
   end
 
   def cast_tag(jsonpath, value)

--- a/app/components/referentiels/mapping_form_component/mapping_form_component.html.haml
+++ b/app/components/referentiels/mapping_form_component/mapping_form_component.html.haml
@@ -27,7 +27,7 @@
                       %br
                       (pour afficher à l'usager et/ou l'instructeur)
                 %tbody
-                  - last_request_keys.sort.each do |jsonpath, example_value|
+                  - last_request_keys.each do |jsonpath, example_value|
                     %tr{ data: { controller: "referentiel-mapping" } }
                       %td.fr-cell--fixed
                         %span.hidden{ id: label_check_prefill(jsonpath) }= "Utiliser #{jsonpath} pour préremplir le formulaire"

--- a/app/components/referentiels/new_form_component/new_form_component.html.haml
+++ b/app/components/referentiels/new_form_component/new_form_component.html.haml
@@ -37,8 +37,8 @@
 
     %div
       = render Dsfr::RadioButtonListComponent.new(form:, target: :mode,
-        buttons: [ { label: 'Correspondance exacte', value: 'exact_match', hint: 'Vérification de l’existence de la donnée saisie dans la BDD du référentiel (exemple : plaque d’immatriculation, SIREN...)' } ,
-          { label: 'Autosuggestion au fur et à mesure de la saisie de l’usager', value: 'autocomplete', hint: 'Affichage de données issues de la BDD du référentiel correspondant en partie ou en totalité à la donnée saisie par l’usager (exemple : BDD de médicaments, modèles de véhicules...)' }]) do
+        buttons: [ { label: 'Correspondance exacte', value: 'exact_match', hint: 'Vérification de l’existence de la donnée saisie dans la base du référentiel (exemple : plaque d’immatriculation, SIREN...)' } ,
+          { label: 'Autosuggestion au fur et à mesure de la saisie de l’usager', value: 'autocomplete', hint: 'Affichage de données issues de la base du référentiel correspondant en partie ou en totalité à la donnée saisie par l’usager (exemple : base de médicaments, modèles de véhicules...)' }]) do
         Mode de remplissage du champ par l’usager
 
       = render Dsfr::InputComponent.new(form:, attribute: :hint)

--- a/app/components/referentiels/new_form_component/new_form_component.html.haml
+++ b/app/components/referentiels/new_form_component/new_form_component.html.haml
@@ -36,7 +36,7 @@
       %hr.fr-hr.fr-my-5w
 
     %div
-      = render Dsfr::RadioButtonListComponent.new(form:, target: :mode,
+      = render Dsfr::RadioButtonListComponent.new(form:, target: :mode, error: @referentiel.errors.full_messages_for(:mode).join(", "),
         buttons: [ { label: 'Correspondance exacte', value: 'exact_match', hint: 'Vérification de l’existence de la donnée saisie dans la base du référentiel (exemple : plaque d’immatriculation, SIREN...)' } ,
           { label: 'Autosuggestion au fur et à mesure de la saisie de l’usager', value: 'autocomplete', hint: 'Affichage de données issues de la base du référentiel correspondant en partie ou en totalité à la donnée saisie par l’usager (exemple : base de médicaments, modèles de véhicules...)' }]) do
         Mode de remplissage du champ par l’usager

--- a/app/components/referentiels/new_form_component/new_form_component.html.haml
+++ b/app/components/referentiels/new_form_component/new_form_component.html.haml
@@ -36,13 +36,10 @@
       %hr.fr-hr.fr-my-5w
 
     %div
-      - if Referentiels::APIReferentiel.autocomplete_available?
-        = render Dsfr::RadioButtonListComponent.new(form:, target: :mode,
-          buttons: [ { label: 'Correspondance exacte', value: 'exact_match', hint: 'Vérification de l’existence de la donnée saisie dans la BDD du référentiel (exemple : plaque d’immatriculation, SIREN...)' } ,
-            { label: 'Autosuggestion au fur et à mesure de la saisie de l’usager', value: 'autocomplete', hint: 'Affichage de données issues de la BDD du référentiel correspondant en partie ou en totalité à la donnée saisie par l’usager (exemple : BDD de médicaments, modèles de véhicules...)', disabled: true }]) do
-          Mode de remplissage du champ par l’usager
-      - else
-        = form.hidden_field :mode
+      = render Dsfr::RadioButtonListComponent.new(form:, target: :mode,
+        buttons: [ { label: 'Correspondance exacte', value: 'exact_match', hint: 'Vérification de l’existence de la donnée saisie dans la BDD du référentiel (exemple : plaque d’immatriculation, SIREN...)' } ,
+          { label: 'Autosuggestion au fur et à mesure de la saisie de l’usager', value: 'autocomplete', hint: 'Affichage de données issues de la BDD du référentiel correspondant en partie ou en totalité à la donnée saisie par l’usager (exemple : BDD de médicaments, modèles de véhicules...)' }]) do
+        Mode de remplissage du champ par l’usager
 
       = render Dsfr::InputComponent.new(form:, attribute: :hint)
       = render Dsfr::InputComponent.new(form:, attribute: :test_data)

--- a/app/components/referentiels/stepper_component.rb
+++ b/app/components/referentiels/stepper_component.rb
@@ -15,19 +15,21 @@ class Referentiels::StepperComponent < ViewComponent::Base
   end
 
   def step_title
-    if step_component.in?([Referentiels::NewFormComponent, Referentiels::ConfigurationErrorComponent])
+    if step_component == Referentiels::NewFormComponent || (step_component == Referentiels::ConfigurationErrorComponent && referentiel.exact_match?)
       "Requête"
     elsif step_component == Referentiels::MappingFormComponent
       "Réponse et mapping"
     elsif step_component == Referentiels::PrefillAndDisplayComponent
       "Pré remplissage des champs et/ou affichage des données récupérées"
+    elsif step_component == Referentiels::AutocompleteConfigurationComponent || (step_component == Referentiels::ConfigurationErrorComponent && referentiel.autocomplete?)
+      "Configuration de l'autocomplétion"
     end
   end
 
   def next_step_title
-    if step_component == Referentiels::NewFormComponent
+    if step_component == Referentiels::NewFormComponent && referentiel.mode == 'autocomplete'
       "Configuration de l'autocomplétion"
-    elsif step_component == Referentiels::NewFormComponent
+    elsif step_component == Referentiels::NewFormComponent && referentiel.mode == 'exact_match' || step_component == Referentiels::AutocompleteConfigurationComponent
       "Réponse et mapping"
     elsif step_component == Referentiels::MappingFormComponent
       "Pré remplissage des champs et/ou affichage des données récupérées"
@@ -42,10 +44,16 @@ class Referentiels::StepperComponent < ViewComponent::Base
       2
     when [Referentiels::PrefillAndDisplayComponent, 'exact_match']
       3
+    when [Referentiels::AutocompleteConfigurationComponent, 'autocomplete']
+      2
+    when [Referentiels::MappingFormComponent, 'autocomplete']
+      3
+    when [Referentiels::PrefillAndDisplayComponent, 'autocomplete']
+      4
     end
   end
 
   def step_count
-    3
+    referentiel.mode == 'exact_match' ? 3 : 4
   end
 end

--- a/app/components/tags_button_list_component/tags_button_list_component.en.yml
+++ b/app/components/tags_button_list_component/tags_button_list_component.en.yml
@@ -6,3 +6,4 @@ en:
     dossier: File
     champ_public: Form data
     champ_private: Private annotations
+    properties: JSON properties

--- a/app/components/tags_button_list_component/tags_button_list_component.fr.yml
+++ b/app/components/tags_button_list_component/tags_button_list_component.fr.yml
@@ -6,3 +6,4 @@ fr:
     dossier: Dossier
     champ_public: Formulaire
     champ_private: Annotations privées
+    properties: Balises issues des propriétés de la source de donnée

--- a/app/components/types_de_champ_editor/info_referentiel_component/info_referentiel_component.html.haml
+++ b/app/components/types_de_champ_editor/info_referentiel_component/info_referentiel_component.html.haml
@@ -19,6 +19,10 @@
             %li proposer des autosuggestions au fur et à mesure de la saisie de l’usager (issue de la base du référentiel)
             %li vérifier la correspondance exacte de saisie dans la base du référentiel
             %li et/ou pré-remplir d'autres champ avec une donnée issues du référentiel
+          %p.notice__desc
+            Vous pouvez vous référer à
+            = link_to "notre documentation", "https://doc.demarches-simplifiees.fr/tutoriels/champ-referentiel-avance-a-configurer", target: "_blank"
+            = " pour prendre en main ce champ"
   - if ready? && type_de_champ.referentiel_mapping_prefillable_with_stable_id.present?
     = render Dsfr::AlertComponent.new(title: "Résumé du pré-remplissage automatique", state: :info, heading_level: 'h2', extra_class_names: 'fr-mb-2w') do |c|
       - c.with_body do

--- a/app/components/types_de_champ_editor/info_referentiel_component/info_referentiel_component.html.haml
+++ b/app/components/types_de_champ_editor/info_referentiel_component/info_referentiel_component.html.haml
@@ -16,8 +16,7 @@
           %p.fr-notice__title Ce champ sera présenté à l’usager sous forme d’un champ de type « Texte court ».
           %p.notice__desc.fr-mt-2w Lors de la configuration, vous pourrez choisir de :
           %ul.fr-mt-0
-            - if Referentiels::APIReferentiel.autocomplete_available?
-              %li proposer des autosuggestions au fur et à mesure de la saisie de l’usager (issue de la BDD du référentiel)
+            %li proposer des autosuggestions au fur et à mesure de la saisie de l’usager (issue de la BDD du référentiel)
             %li vérifier la correspondance exacte de saisie dans la BDD du référentiel
             %li et/ou pré-remplir d'autres champ avec une donnée issues du référentiel
   - if ready? && type_de_champ.referentiel_mapping_prefillable_with_stable_id.present?

--- a/app/components/types_de_champ_editor/info_referentiel_component/info_referentiel_component.html.haml
+++ b/app/components/types_de_champ_editor/info_referentiel_component/info_referentiel_component.html.haml
@@ -16,8 +16,8 @@
           %p.fr-notice__title Ce champ sera présenté à l’usager sous forme d’un champ de type « Texte court ».
           %p.notice__desc.fr-mt-2w Lors de la configuration, vous pourrez choisir de :
           %ul.fr-mt-0
-            %li proposer des autosuggestions au fur et à mesure de la saisie de l’usager (issue de la BDD du référentiel)
-            %li vérifier la correspondance exacte de saisie dans la BDD du référentiel
+            %li proposer des autosuggestions au fur et à mesure de la saisie de l’usager (issue de la base du référentiel)
+            %li vérifier la correspondance exacte de saisie dans la base du référentiel
             %li et/ou pré-remplir d'autres champ avec une donnée issues du référentiel
   - if ready? && type_de_champ.referentiel_mapping_prefillable_with_stable_id.present?
     = render Dsfr::AlertComponent.new(title: "Résumé du pré-remplissage automatique", state: :info, heading_level: 'h2', extra_class_names: 'fr-mb-2w') do |c|

--- a/app/controllers/administrateurs/referentiels_controller.rb
+++ b/app/controllers/administrateurs/referentiels_controller.rb
@@ -71,14 +71,15 @@ module Administrateurs
     def handle_referentiel_save(referentiel)
       cache_bust_last_response_and_mapping = referentiel.url_changed?
 
-      if referentiel.configured? && referentiel.save
+      saved = referentiel.configured? && referentiel.save
+      if saved
         if cache_bust_last_response_and_mapping
           @type_de_champ.update!(referentiel_mapping: {})
           referentiel.update!(last_response: nil, autocomplete_configuration: {})
         end
       end
 
-      if params[:commit].present?
+      if saved && params[:commit].present?
         if referentiel.autocomplete?
           redirect_to autocomplete_configuration_admin_procedure_referentiel_path(@procedure, @type_de_champ.stable_id, referentiel)
         else

--- a/app/controllers/administrateurs/referentiels_controller.rb
+++ b/app/controllers/administrateurs/referentiels_controller.rb
@@ -104,7 +104,6 @@ module Administrateurs
       else
         params = referentiel_params.to_h
         params = params.merge(type: Referentiels::APIReferentiel) if !Referentiels::APIReferentiel.csv_available?
-        params = params.merge(mode: Referentiels::APIReferentiel.modes.fetch(:exact_match)) if !Referentiels::APIReferentiel.autocomplete_available?
         params
       end
     end

--- a/app/controllers/administrateurs/referentiels_controller.rb
+++ b/app/controllers/administrateurs/referentiels_controller.rb
@@ -5,7 +5,7 @@ module Administrateurs
     before_action :retrieve_procedure
     before_action :retrieve_type_de_champ
     before_action :retrieve_referentiel, except: [:new, :create]
-    before_action :reachable_referentiel?, only: [:mapping_type_de_champ]
+    before_action :reachable_referentiel?, only: [:mapping_type_de_champ, :autocomplete_configuration]
     layout 'empty_layout'
 
     def new
@@ -34,8 +34,11 @@ module Administrateurs
       else
         @referentiel.validate
         component = Referentiels::AutocompleteConfigurationComponent.new(referentiel: @referentiel, type_de_champ: @type_de_champ, procedure: @procedure)
-        render turbo_stream: turbo_stream.update(component.id, component)
+        render turbo_stream: turbo_stream.replace(component.id, component)
       end
+    end
+
+    def autocomplete_configuration
     end
 
     def mapping_type_de_champ

--- a/app/controllers/administrateurs/referentiels_controller.rb
+++ b/app/controllers/administrateurs/referentiels_controller.rb
@@ -79,7 +79,7 @@ module Administrateurs
       end
 
       if params[:commit].present?
-        if referentiel.autocomplete? # maybe wrap in a method
+        if referentiel.autocomplete?
           redirect_to autocomplete_configuration_admin_procedure_referentiel_path(@procedure, @type_de_champ.stable_id, referentiel)
         else
           redirect_to mapping_type_de_champ_admin_procedure_referentiel_path(@procedure, @type_de_champ.stable_id, referentiel)

--- a/app/controllers/concerns/turbo_champs_concern.rb
+++ b/app/controllers/concerns/turbo_champs_concern.rb
@@ -8,7 +8,8 @@ module TurboChampsConcern
   def champs_to_turbo_update(params, champs)
     to_update = champs.filter { _1.public_id.in?(params.keys) }
       .filter { _1.refresh_after_update? || _1.user_buffer_changes? }
-
+    prefillable_champs = champs.filter { it.referentiel? && it.autocomplete? }
+    to_update += prefillable_champs.map(&:prefillable_champs).flatten.uniq if prefillable_champs.any?
     to_show, to_hide = champs.filter { it.conditional? || it.child? }
       .partition(&:visible?)
       .map { champs_to_one_selector(_1 - to_update) }

--- a/app/controllers/data_sources/referentiel_controller.rb
+++ b/app/controllers/data_sources/referentiel_controller.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+class DataSources::ReferentielController < ApplicationController
+  before_action :mark_as_retryable, :referentiel_service, :referentiel
+  MAX_QUERY_SIZE = 100
+
+  def search
+    if query && params[:referentiel_id].present?
+      return render json: [] if referentiel&.autocomplete_configuration.blank?
+
+      begin
+        result = referentiel_service.call(query)
+
+        case result
+        in Dry::Monads::Success(body)
+          formatted = ReferentielAutocompleteRenderService.new(body, referentiel).format_response
+          return render json: formatted
+        in Dry::Monads::Failure(data) if data[:retryable]
+          raise RetryableError if @retryable
+          Sentry.set_extras(body: data[:body], code: data[:code]) if data.is_a?(Hash)
+          Sentry.capture_message("Referentiel API retryable failure")
+        in Dry::Monads::Failure(data)
+          Sentry.set_extras(body: data[:body], code: data[:code]) if data.is_a?(Hash)
+          Sentry.capture_message("Referentiel API failure")
+        end
+      rescue RetryableError
+        @retryable = false
+        retry
+      rescue StandardError => e
+        Sentry.capture_exception(e)
+      end
+    end
+    render json: []
+  end
+
+  private
+
+  def mark_as_retryable
+    @retryable = true
+  end
+
+  def referentiel_service
+    @referentiel_service ||= ReferentielService.new(referentiel: referentiel, timeout:)
+  end
+
+  def timeout
+    ReferentielService::API_TIMEOUT / 2 # due to retry
+  end
+
+  def query
+    return nil if params[:q].blank?
+    return nil if params[:q].length <= 2
+    return nil if params[:q].length > MAX_QUERY_SIZE
+
+    @query ||= params[:q].strip
+  end
+
+  def referentiel
+    @referentiel ||= Referentiel.find_by(id: params[:referentiel_id])
+  end
+
+  class RetryableError < StandardError; end
+end

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -71,6 +71,9 @@ class RootController < ApplicationController
                 "option C"
               ]
             type_de_champ.save
+          elsif type_de_champ.referentiel?
+            type_de_champ.referentiel = Referentiels::APIReferentiel.new(url: Referentiels::APIReferentiel.stub_url, mode: :autocomplete, name: SecureRandom.uuid)
+            type_de_champ.save
           end
         end
       end

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -610,6 +610,9 @@ module Users
     def update_dossier_and_compute_errors
       public_id, champ_attributes = champs_public_attributes_params.to_h.first
       champ = dossier.public_champ_for_update(public_id, updated_by: current_user.email)
+      if champ.referentiel? && champ.autocomplete?
+        champ_attributes = champ_attributes.merge(params.require(:dossier).require(:champs_public_attributes).require(public_id).permit(:data).to_h)
+      end
       champ.assign_attributes(champ_attributes)
       champ_changed = champ.changed_for_autosave?
 

--- a/app/lib/json_path_util.rb
+++ b/app/lib/json_path_util.rb
@@ -2,6 +2,22 @@
 
 # Extension de la classe JsonPath de la gem
 class JSONPathUtil
+  def self.array_paths_with_examples(hash, parent_path = '$')
+    hash.each_with_object({}) do |(key, value), result|
+      current_path = "#{parent_path}.#{key}"
+
+      case value
+      in [Hash => first, *]
+        result.merge!(current_path => first)
+      in Hash
+        nested = array_paths_with_examples(value, current_path)
+        result.merge!(nested)
+      else
+        result
+      end
+    end
+  end
+
   def self.hash_to_jsonpath(hash, parent_path = '$')
     hash.each_with_object({}) do |(key, value), result|
       current_path = "#{parent_path}.#{key}"

--- a/app/lib/json_path_util.rb
+++ b/app/lib/json_path_util.rb
@@ -1,16 +1,15 @@
 # frozen_string_literal: true
 
-# Extension de la classe JsonPath de la gem
 class JSONPathUtil
-  def self.array_paths_with_examples(hash, parent_path = '$')
+  def self.filter_selectable_datasources(hash, parent_path = '$')
     hash.each_with_object({}) do |(key, value), result|
-      current_path = "#{parent_path}.#{key}"
+      json_path = "#{parent_path}.#{key}"
 
       case value
-      in [Hash => first, *]
-        result.merge!(current_path => first)
+      in [Hash => first, *] => suggestions
+        result.merge!(json_path => suggestions)
       in Hash
-        nested = array_paths_with_examples(value, current_path)
+        nested = filter_selectable_datasources(value, json_path)
         result.merge!(nested)
       else
         result

--- a/app/models/champs/referentiel_champ.rb
+++ b/app/models/champs/referentiel_champ.rb
@@ -28,6 +28,20 @@ class Champs::ReferentielChamp < Champ
     end
   end
 
+  def data=(data)
+    if exact_match? || data.blank?
+      super(data)
+    else
+      message_encryptor_service = MessageEncryptorService.new
+      data = message_encryptor_service.decrypt_and_verify(data, purpose: :storage)
+      data = rewrap_selected_object_in_datasource(data)
+
+      super(data)
+      cast_displayable_values(data.with_indifferent_access)
+      propagate_prefill(data)
+    end
+  end
+
   def uses_external_data?
     exact_match?
   end
@@ -179,5 +193,17 @@ class Champs::ReferentielChamp < Champ
   def update_prefillable_champ(type_de_champ:, raw_value:, row_id: nil)
     prefill_champ = dossier.champ_for_update(type_de_champ, row_id:, updated_by: :api)
     prefill_champ.update(cast_value_for_type_de_champ(raw_value, type_de_champ))
+  end
+
+  def rewrap_selected_object_in_datasource(data)
+    full_jsonpath = type_de_champ.referentiel.datasource
+    path_keys_separated_with_dot = full_jsonpath.split("$.")[1]
+    path_keys = path_keys_separated_with_dot.split('.')
+    reversed_keys_to_rebuild_datasource = path_keys.reverse
+
+    # using reversed keys + reduce allows us to rebuild the original JSON structure
+    reversed_keys_to_rebuild_datasource.reduce([data]) do |accumulator, key|
+      { key => accumulator }
+    end
   end
 end

--- a/app/models/champs/referentiel_champ.rb
+++ b/app/models/champs/referentiel_champ.rb
@@ -6,7 +6,7 @@ class Champs::ReferentielChamp < Champ
            :referentiel_mapping_prefillable_with_stable_id,
            to: :type_de_champ
 
-  delegate :exact_match?, to: :referentiel
+  delegate :exact_match?, :autocomplete?, to: :referentiel, allow_nil: true
 
   before_save :clear_previous_result, if: -> { external_id_changed? }
 

--- a/app/models/champs/referentiel_champ.rb
+++ b/app/models/champs/referentiel_champ.rb
@@ -5,6 +5,9 @@ class Champs::ReferentielChamp < Champ
            :referentiel_mapping_displayable,
            :referentiel_mapping_prefillable_with_stable_id,
            to: :type_de_champ
+
+  delegate :exact_match?, to: :referentiel
+
   before_save :clear_previous_result, if: -> { external_id_changed? }
 
   validates_with ReferentielChampValidator, if: :validate_champ_value?
@@ -26,7 +29,7 @@ class Champs::ReferentielChamp < Champ
   end
 
   def uses_external_data?
-    true
+    exact_match?
   end
 
   def should_ui_auto_refresh?
@@ -50,6 +53,18 @@ class Champs::ReferentielChamp < Champ
       else
         champ.stable_id.in?(elligible_stable_ids)
       end
+    end
+  end
+
+  def selected_key
+    value
+  end
+
+  def selected_items
+    if selected_key.present?
+      [{ label: selected_key, value: selected_key, data: value_json }]
+    else
+      []
     end
   end
 

--- a/app/models/referentiels/api_referentiel.rb
+++ b/app/models/referentiels/api_referentiel.rb
@@ -19,11 +19,27 @@ class Referentiels::APIReferentiel < Referentiel
   validates :mode, inclusion: { in: modes.values }, allow_blank: true, allow_nil: true
   validate :url_allowed?
 
+  store_accessor :autocomplete_configuration, :datasource, :json_template
   before_save :name_as_uuid
+  before_save :resets_tiptap_template
+
   def self.csv_available?
     false
   end
 
+  def resets_tiptap_template
+    if datasource_changed? && !datasource_was.nil?
+      self.json_template = {}
+    end
+  end
+
+  def tiptap_template=(value)
+    self.json_template = JSON.parse(value)
+  end
+
+  def tiptap_template
+    json_template&.to_json
+  end
 
   def last_response_body
     (last_response || {}).fetch("body") { {} }

--- a/app/models/referentiels/api_referentiel.rb
+++ b/app/models/referentiels/api_referentiel.rb
@@ -24,9 +24,6 @@ class Referentiels::APIReferentiel < Referentiel
     false
   end
 
-  def self.autocomplete_available?
-    false
-  end
 
   def last_response_body
     (last_response || {}).fetch("body") { {} }

--- a/app/models/referentiels/api_referentiel.rb
+++ b/app/models/referentiels/api_referentiel.rb
@@ -16,8 +16,10 @@ class Referentiels::APIReferentiel < Referentiel
     autocomplete: 'autocomplete'
   }
 
-  validates :mode, inclusion: { in: modes.values }, allow_blank: true, allow_nil: true
+  validates :mode, inclusion: { in: modes.values }
   validate :url_allowed?
+  validates :test_data, presence: true
+  validates :url, presence: true
 
   store_accessor :autocomplete_configuration, :datasource, :json_template
   before_save :name_as_uuid

--- a/app/models/referentiels/api_referentiel.rb
+++ b/app/models/referentiels/api_referentiel.rb
@@ -23,6 +23,12 @@ class Referentiels::APIReferentiel < Referentiel
   before_save :name_as_uuid
   before_save :resets_tiptap_template
 
+  def self.stub_url
+    ENV.fetch('ALLOWED_API_DOMAINS_FROM_FRONTEND')
+      .split(',')
+      .last
+  end
+
   def self.csv_available?
     false
   end

--- a/app/services/referentiel_autocomplete_render_service.rb
+++ b/app/services/referentiel_autocomplete_render_service.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class ReferentielAutocompleteRenderService
+  attr_reader :api_response, :referentiel, :json_template
+  MAX_RENDERED_OBJECTS = 1000
+
+  def initialize(api_response, referentiel)
+    @api_response = api_response.with_indifferent_access
+    @referentiel = referentiel
+    @json_template = referentiel.json_template
+  end
+
+  def format_response
+    objects = JsonPath.on(api_response, referentiel.datasource).first
+    objects.take(MAX_RENDERED_OBJECTS).map do |data|
+      label = render_template(json_template, data).join("")
+      {
+        label:,
+        value: label,
+        data: message_encryptor_service.encrypt_and_sign(data, purpose: :storage, expires_in: 1.hour)
+      }
+    end
+  end
+
+  private
+
+  def message_encryptor_service
+    @message_encryptor_service ||= MessageEncryptorService.new
+  end
+
+  def render_template(template, obj, interpolations = [])
+    case template["type"]
+    when "mention"
+      interpolations << JsonPath.on(obj, template["attrs"]["id"]).first
+    when "text"
+      interpolations << template["text"]
+    when "doc", 'paragraph'
+      template['content'].each { |t| interpolations.concat(render_template(t, obj)) }
+    else
+      raise "Unknown template type: #{template['type']}. Expected one of: mention, text, doc, paragraph."
+    end
+    interpolations
+  end
+end

--- a/app/services/referentiel_service.rb
+++ b/app/services/referentiel_service.rb
@@ -27,7 +27,7 @@ class ReferentielService
   end
 
   def url(query_params)
-    referentiel.url.gsub('{id}', query_params)
+    referentiel.url.gsub('{id}', URI.encode_www_form_component(query_params.to_s))
   end
 
   def test_url

--- a/app/services/referentiel_service.rb
+++ b/app/services/referentiel_service.rb
@@ -5,16 +5,24 @@ class ReferentielService
 
   RETRYABLE_STATUS_CODES = [429, 500, 503, 408, 502].freeze
   NON_RETRYABLE_STATUS_CODES = [404, 400, 403, 401].freeze
-  API_TIMEOUT = 10
+
+  API_TIMEOUT = 4 # in seconds
+  MAX_FILE_SIZE = 1.megabyte
 
   attr_reader :referentiel, :service
 
-  def initialize(referentiel:)
+  def initialize(referentiel:, timeout: API_TIMEOUT)
     @referentiel = referentiel
+    @timeout = timeout
   end
 
   def call(query_params)
-    result = API::Client.new.call(url: url(query_params), timeout: API_TIMEOUT, headers:)
+    result = API::Client.new.call(
+      url: url(query_params),
+      timeout: @timeout,
+      headers:,
+      maxfilesize: MAX_FILE_SIZE
+    )
     handle_api_result(result)
   end
 

--- a/app/views/administrateurs/referentiels/autocomplete_configuration.html.haml
+++ b/app/views/administrateurs/referentiels/autocomplete_configuration.html.haml
@@ -1,0 +1,1 @@
+= render Referentiels::StepperComponent.new(referentiel: @referentiel, type_de_champ: @type_de_champ, procedure: @procedure, step_component: Referentiels::AutocompleteConfigurationComponent)

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -34,6 +34,10 @@ class Rack::Attack
     end
   end
 
+  throttle('referentiel_search_per_ip', limit: 60, period: 1.minute) do |req|
+    req.remote_ip if req.get? && req.path.match?(/data_sources\/referentiel/) && rack_attack_enabled?
+  end
+
   Rack::Attack.safelist('allow trusted ips') do |req|
     IPService.ip_trusted?(req.remote_ip)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -267,6 +267,7 @@ Rails.application.routes.draw do
   end
 
   namespace :data_sources do
+    get :referentiel, to: 'referentiel#search', as: :data_source_referentiel
     get :adresse, to: 'adresse#search', as: :data_source_adresse
     get :commune, to: 'commune#search', as: :data_source_commune
     get :education, to: 'education#search', as: :data_source_education

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -790,6 +790,7 @@ Rails.application.routes.draw do
         member do
           get :configuration_error
           patch :update_autocomplete_configuration
+          get :autocomplete_configuration
           get :mapping_type_de_champ
           patch :update_mapping_type_de_champ
           patch :update_prefill_and_display_type_de_champ

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -789,6 +789,7 @@ Rails.application.routes.draw do
       resources :referentiels, only: [:new, :create, :edit, :update], path: ':stable_id', constraints: { stable_id: /\d+/ } do
         member do
           get :configuration_error
+          patch :update_autocomplete_configuration
           get :mapping_type_de_champ
           patch :update_mapping_type_de_champ
           patch :update_prefill_and_display_type_de_champ

--- a/db/migrate/20250718123320_add_autocomplete_configuration_to_referentiels.rb
+++ b/db/migrate/20250718123320_add_autocomplete_configuration_to_referentiels.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAutocompleteConfigurationToReferentiels < ActiveRecord::Migration[7.1]
+  def change
+    add_column :referentiels, :autocomplete_configuration, :jsonb, default: {}, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1149,6 +1149,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_13_143947) do
   create_table "referentiels", force: :cascade do |t|
     t.jsonb "authentication_data", default: {}
     t.string "authentication_method"
+    t.jsonb "autocomplete_configuration", default: {}, null: false
     t.datetime "created_at", null: false
     t.string "digest"
     t.string "headers", default: [], array: true

--- a/spec/components/referentiels/autocomplete_configuration_component_spec.rb
+++ b/spec/components/referentiels/autocomplete_configuration_component_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+RSpec.describe Referentiels::AutocompleteConfigurationComponent, type: :component do
+  let(:component) { described_class.new(referentiel:, type_de_champ:, procedure:) }
+  let(:procedure) { create(:procedure, types_de_champ_public:) }
+  let(:types_de_champ_public) { [{ type: :referentiel, referentiel: }] }
+  let(:type_de_champ) { procedure.draft_revision.types_de_champ_public.first }
+  let(:referentiel) { create(:api_referentiel, :autocomplete, last_response:) }
+
+  describe 'render' do
+    delegate :url_helpers, to: :routes
+    delegate :routes, to: :application
+    delegate :application, to: Rails
+
+    before do
+      render_inline(component)
+    end
+
+    context 'when datasource is empty' do
+      let(:last_response) { { body: { "key" => "value" } } }
+      it 'renders alert error' do
+        expect(page).to have_content("Votre source de donnée ne semble pas compatible")
+      end
+    end
+
+    context 'when datasource count is 1' do
+      let(:last_response) { { body: { jsonpath: [{ id: 1, k1: :v1 }] } } }
+      it 'renders datasource' do
+        expect(page).to have_content("Sélectionnez la source de données à exploiter pour l'autocomplete")
+        expect(page).to have_selector("input[type=radio]")
+      end
+    end
+
+    context 'when datasource count more than 1' do
+      let(:last_response) do
+        {
+          body: {
+            datasource_1: [{ id: 1, k1: :v1 }],
+            datasource_2: [{ id: 1, k2: :v2 }]
+          }
+        }
+      end
+
+      it 'renders selectable datasources' do
+        expect(page).to have_content("Sélectionnez la source de données à exploiter pour l'autocomplete")
+        expect(page).not_to have_selector("input[type=radio][checked]", count: 2)
+      end
+    end
+  end
+end

--- a/spec/components/referentiels/mapping_form_component_spec.rb
+++ b/spec/components/referentiels/mapping_form_component_spec.rb
@@ -41,8 +41,20 @@ RSpec.describe Referentiels::MappingFormComponent, type: :component do
         # navigation
         expect(page).to have_selector("form[action=\"#{url_helpers.update_mapping_type_de_champ_admin_procedure_referentiel_path(procedure, type_de_champ.stable_id, referentiel)}\"]")
         expect(page).to have_selector('input[type=submit][value="Étape suivante"]')
-        expect(page).to have_link("Étape précédente", href: url_helpers.edit_admin_procedure_referentiel_path(procedure, type_de_champ.stable_id, referentiel.id))
         expect(page).to have_selector("input[type=submit]")
+      end
+
+      context 'when referentiel is autocomplete' do
+        let(:referentiel) { create(:api_referentiel, :with_autocomplete_response, :autocomplete) }
+
+        it 'rendrs the back to edit link' do
+          expect(page).to have_link("Étape précédente", href: url_helpers.autocomplete_configuration_admin_procedure_referentiel_path(procedure, type_de_champ.stable_id, referentiel.id))
+        end
+      end
+      context 'when referentiel is exact match' do
+        it 'renders the autocomplete configuration link' do
+          expect(page).to have_link("Étape précédente", href: url_helpers.edit_admin_procedure_referentiel_path(procedure, type_de_champ.stable_id, referentiel.id))
+        end
       end
     end
   end

--- a/spec/components/referentiels/new_form_component_spec.rb
+++ b/spec/components/referentiels/new_form_component_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe Referentiels::NewFormComponent, type: :component do
             hint: 1,
             url: 0
           }
-          input[:mode] = 2 if Referentiels::APIReferentiel.autocomplete_available?
           input[:type] = 2 if Referentiels::APIReferentiel.csv_available?
 
           expect(page).to have_css('form[method=post]')

--- a/spec/controllers/administrateurs/referentiels_controller_spec.rb
+++ b/spec/controllers/administrateurs/referentiels_controller_spec.rb
@@ -402,6 +402,24 @@ describe Administrateurs::ReferentielsController, type: :controller do
           end
         end
       end
+
+      context 'GET autocomplete_configuration' do
+        context 'when referentiel not ready' do
+          it 'redirects to configuration error' do
+            allow_any_instance_of(ReferentielService).to receive(:validate_referentiel).and_return(false)
+            get :autocomplete_configuration, params: { procedure_id: procedure.id, stable_id:, id: referentiel.id }
+            expect(response).to redirect_to(configuration_error_admin_procedure_referentiel_path(procedure, type_de_champ.stable_id, referentiel))
+          end
+        end
+
+        context 'when referentiel is ready' do
+          it 'renders successfully and returns the configuration' do
+            allow_any_instance_of(ReferentielService).to receive(:validate_referentiel).and_return(true)
+            get :autocomplete_configuration, params: { procedure_id: procedure.id, stable_id: type_de_champ.stable_id, id: referentiel.id }
+            expect(response).to have_http_status(:success)
+          end
+        end
+      end
     end
 
     context 'when update fails' do

--- a/spec/controllers/administrateurs/referentiels_controller_spec.rb
+++ b/spec/controllers/administrateurs/referentiels_controller_spec.rb
@@ -79,30 +79,57 @@ describe Administrateurs::ReferentielsController, type: :controller do
 
     context 'with commit params (submit save)' do
       subject { post :create, params: { commit: 'Étape suivante', procedure_id: procedure.id, stable_id:, referentiel: referentiel_params }, format: :turbo_stream }
+      context 'when referentiel is exact_match' do
+        let(:referentiel_params) do
+          {
+            type: 'Referentiels::APIReferentiel',
+            mode: 'exact_match',
+            url: 'https://rnb-api.beta.gouv.fr/api/alpha/buildings/{id}/',
+            hint: 'Identifiant unique du bâtiment dans le RNB, composé de 12 chiffre et lettre',
+            test_data: 'PG46YY6YWCX8'
+          }
+        end
 
-      let(:referentiel_params) do
-        {
-          type: 'Referentiels::APIReferentiel',
-          mode: 'exact_match',
-          url: 'https://rnb-api.beta.gouv.fr/api/alpha/buildings/{id}/',
-          hint: 'Identifiant unique du bâtiment dans le RNB, composé de 12 chiffre et lettre',
-          test_data: 'PG46YY6YWCX8'
-        }
+        it 'creates referentiel and continue redirect' do
+          expect { subject }.to change { Referentiel.count }.by(1)
+
+          referentiel = Referentiel.first
+
+          expect(response).to redirect_to(mapping_type_de_champ_admin_procedure_referentiel_path(procedure, stable_id, referentiel))
+
+          expect(referentiel.types_de_champ).to include(TypeDeChamp.find_by(stable_id:))
+          expect(referentiel.type).to eq(referentiel_params[:type])
+          expect(referentiel.mode).to eq(referentiel_params[:mode])
+          expect(referentiel.url).to eq(referentiel_params[:url])
+          expect(referentiel.hint).to eq(referentiel_params[:hint])
+          expect(referentiel.test_data).to eq(referentiel_params[:test_data])
+        end
       end
+      context 'when referentiel is autocomplete' do
+        let(:referentiel_params) do
+          {
+            type: 'Referentiels::APIReferentiel',
+            mode: 'autocomplete',
+            url: 'https://rnb-api.beta.gouv.fr/api/alpha/buildings/{id}/',
+            hint: 'Identifiant unique du bâtiment dans le RNB, composé de 12 chiffre et lettre',
+            test_data: 'PG46YY6YWCX8'
+          }
+        end
 
-      it 'creates referentiel and continue redirect' do
-        expect { subject }.to change { Referentiel.count }.by(1)
+        it 'creates referentiel and continue redirect' do
+          expect { subject }.to change { Referentiel.count }.by(1)
 
-        referentiel = Referentiel.first
+          referentiel = Referentiel.first
 
-        expect(response).to redirect_to(mapping_type_de_champ_admin_procedure_referentiel_path(procedure, stable_id, referentiel))
+          expect(response).to redirect_to(autocomplete_configuration_admin_procedure_referentiel_path(procedure, stable_id, referentiel))
 
-        expect(referentiel.types_de_champ).to include(TypeDeChamp.find_by(stable_id:))
-        expect(referentiel.type).to eq(referentiel_params[:type])
-        expect(referentiel.mode).to eq(referentiel_params[:mode])
-        expect(referentiel.url).to eq(referentiel_params[:url])
-        expect(referentiel.hint).to eq(referentiel_params[:hint])
-        expect(referentiel.test_data).to eq(referentiel_params[:test_data])
+          expect(referentiel.types_de_champ).to include(TypeDeChamp.find_by(stable_id:))
+          expect(referentiel.type).to eq(referentiel_params[:type])
+          expect(referentiel.mode).to eq(referentiel_params[:mode])
+          expect(referentiel.url).to eq(referentiel_params[:url])
+          expect(referentiel.hint).to eq(referentiel_params[:hint])
+          expect(referentiel.test_data).to eq(referentiel_params[:test_data])
+        end
       end
     end
   end

--- a/spec/controllers/administrateurs/referentiels_controller_spec.rb
+++ b/spec/controllers/administrateurs/referentiels_controller_spec.rb
@@ -35,8 +35,7 @@ describe Administrateurs::ReferentielsController, type: :controller do
 
   describe '#create' do
     context 'partial update (selecting type)' do
-      subject { post :create, params: { procedure_id: procedure.id, stable_id:, referentiel: referentiel_params }, format: :turbo_stream }
-
+      subject { post :create, params: { procedure_id: procedure.id, stable_id:, referentiel: referentiel_params, commit:	"Étape+suivante" }, format: :turbo_stream }
       let(:referentiel_params) { { type: 'Referentiels::APIReferentiel' } }
       it 're-render form' do
         expect { subject }.not_to change { Referentiel.count }
@@ -105,6 +104,7 @@ describe Administrateurs::ReferentielsController, type: :controller do
           expect(referentiel.test_data).to eq(referentiel_params[:test_data])
         end
       end
+
       context 'when referentiel is autocomplete' do
         let(:referentiel_params) do
           {
@@ -214,9 +214,10 @@ describe Administrateurs::ReferentielsController, type: :controller do
 
   describe "configuration_error" do
     let(:type_de_champ) { procedure.draft_revision.types_de_champ.first }
-    let(:referentiel) { create(:api_referentiel, types_de_champ: [type_de_champ]) }
+    let(:referentiel) { create(:api_referentiel, :exact_match, types_de_champ: [type_de_champ]) }
 
     it 'works' do
+      allow_any_instance_of(Referentiels::APIReferentiel).to receive(:save).and_return(false)
       get :configuration_error, params: { procedure_id: procedure.id, stable_id:, id: referentiel.id }
       expect(response).to have_http_status(:success)
     end

--- a/spec/controllers/data_sources/referentiel_controller_spec.rb
+++ b/spec/controllers/data_sources/referentiel_controller_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe DataSources::ReferentielController, type: :controller do
+  include Dry::Monads[:result]
+  describe 'GET #search' do
+      let(:procedure) { create(:procedure, types_de_champ_public:) }
+      let(:types_de_champ_public) { [{ type: :referentiel, referentiel: }] }
+      let(:referentiel) do
+        create(:api_referentiel,
+               :autocomplete,
+               :with_autocomplete_response,
+               datasource: '$.data',
+               url: "https://tabular-api.data.gouv.fr/api/resources/796dfff7-cf54-493a-a0a7-ba3c2024c6f3/data/?finess__contains={id}")
+      end
+      subject { get :search, params: { q: '010002699', referentiel_id: referentiel.id } }
+
+      context 'when success params' do
+        it 'returns formatted results', vcr: 'referentiel/datagouv-finess' do
+          expect(subject).to have_http_status(:ok)
+          expect(response.parsed_body).to be_an(Array)
+          expect(response.parsed_body.size).to eq(1)
+          expect(response.parsed_body.first["label"]).to eq("010002699 (CENTRE MEDICAL REGINA)")
+          expect(response.parsed_body.first["value"]).to eq("010002699 (CENTRE MEDICAL REGINA)")
+          expect(response.parsed_body.first["data"]).to be_an_instance_of(String)
+        end
+      end
+
+      context 'when failure' do
+        let(:referentiel_service) { double(call: service_respone) }
+
+        before do
+          expect(ReferentielService).to receive(:new).with(referentiel:, timeout: 2).and_return(referentiel_service)
+        end
+
+        context 'when service fails' do
+          let(:service_respone) { Failure(code: 404) }
+
+          it 'returns an empty array and logs the error' do
+            expect(subject).to have_http_status(:ok)
+            expect(response.parsed_body).to eq([])
+          end
+        end
+
+        context 'when service fails with retryable error' do
+          let(:service_respone) { Failure(retryable: true, code: 503) }
+          let(:retryable_failure) { service_respone }
+          let(:success_response) { Success(body: { 'result' => 'ok' }) }
+
+          it 'retries and succeeds' do
+            expect(referentiel_service).to receive(:call).and_return(retryable_failure, success_response)
+            expect(subject).to have_http_status(:ok)
+            expect(response.parsed_body).to eq([])
+          end
+
+          it 'retries and fails' do
+            expect(referentiel_service).to receive(:call).twice.and_return(retryable_failure, retryable_failure)
+            expect(subject).to have_http_status(:ok)
+            expect(response.parsed_body).to eq([])
+          end
+        end
+
+        context 'when service fails with non-retryable error' do
+          let(:service_respone) { Failure(retryable: false, code: 404) }
+
+          it 'does not retry and logs the error' do
+            expect(referentiel_service).to receive(:call).once.and_return(service_respone)
+            expect(subject).to have_http_status(:ok)
+            expect(response.parsed_body).to eq([])
+          end
+        end
+      end
+    end
+end

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -245,6 +245,10 @@ FactoryBot.define do
           end
           if type_champ == 'repetition'
             build(:type_de_champ_repetition, :with_types_de_champ, procedure: procedure, libelle: libelle, position: index)
+          elsif type_champ == 'referentiel'
+            referentiel = build(:api_referentiel, :exact_match)
+
+            build(:type_de_champ_referentiel, procedure: procedure, mandatory: true, libelle: libelle, position: index, referentiel:)
           else
             build(:"type_de_champ_#{type_champ}", procedure: procedure, libelle: libelle, position: index)
           end

--- a/spec/fixtures/cassettes/referentiel/datagouv-finess-partial-search.yml
+++ b/spec/fixtures/cassettes/referentiel/datagouv-finess-partial-search.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://tabular-api.data.gouv.fr/api/resources/796dfff7-cf54-493a-a0a7-ba3c2024c6f3/data/?finess__contains=01000269
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - demarches-simplifiees.fr
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Server:
+      - nginx/1.29.0
+      Date:
+      - Mon, 25 Aug 2025 16:11:06 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2981'
+      Cache-Control:
+      - no-cache
+      - public
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data": [{"__id": 2, "source": "DataSant\u00e9 (doc en ligne sur data.gouv.fr)",
+        "date_maj": "2025-07-07", "finess": "010002699", "finess8": "01000269", "etat":
+        "OBSOLETE", "date_extract_finess": "2004-12-31", "rs": "UNITE DIALYSE EN CENTRE
+        SITE BELLEY", "type": "ET", "ej_finess": "010000206", "ej_rs": "CENTRE MEDICAL
+        REGINA", "et_finess": "010002699", "et_rs": "UNITE DIALYSE EN CENTRE SITE
+        BELLEY", "siren": "546920075", "siret": "54692007500043", "date_autorisation":
+        "2003-05-14", "date_ouverture": "2004-01-23", "date_maj_finess": "2004-08-02",
+        "adresse_num_voie": "52", "adresse_comp_voie": null, "adresse_type_voie":
+        "R", "adresse_nom_voie": "GEORGES GIRERD", "adresse_lieuditbp": "BP 139",
+        "adresse_code_postal": "01300", "adresse_lib_routage": "BELLEY", "telephone":
+        null, "telecopie": null, "com_code": "01034", "statut_jur_code": "72", "statut_jur_lib":
+        "Soci\u00e9t\u00e9 A Responsabilit\u00e9 Limit\u00e9e (S.A.R.L.)", "statut_jur_etat":
+        null, "statut_jur_niv3_code": 2230, "statut_jur_niv3_lib": "Soci\u00e9t\u00e9
+        A Responsabilit\u00e9 Limit\u00e9e (S.A.R.L.)", "statut_jur_niv2_code": 2200,
+        "statut_jur_niv2_lib": "Organisme Priv\u00e9 \u00e0 Caract\u00e8re Commercial",
+        "statut_jur_niv1_code": 2000, "statut_jur_niv1_lib": "Organismes Priv\u00e9s",
+        "categ_code": 141, "categ_lib": "Centre de dialyse", "categ_lib_court": "Ctre.Dialyse",
+        "categ_etat": "O", "categ_niv3_code": 1203, "categ_niv3_lib": "Dialyse Ambulatoire",
+        "categ_niv2_code": 1200, "categ_niv2_lib": "Autres Etablissements Relevant
+        de la Loi Hospitali\u00e8re", "categ_niv1_code": 1000, "categ_niv1_lib": "Etablissements
+        Relevant de la Loi Hospitali\u00e8re", "categ_domaine": "Sanitaire", "esms":
+        null, "esms_capaTot_inst": ".", "esms_capaInternat_inst": ".", "esms_esh":
+        null, "esms_ash": null, "esms_pa": null, "san": null, "san_med": null, "san_chir":
+        null, "san_obs": null, "san_psy": null, "san_had": null, "san_sld": null,
+        "san_urg": null, "san_sc": null, "san_dialyse": null, "san_cancer": null,
+        "san_smr": null, "nb_scanners": ".", "nb_irm": ".", "gestion_ars": "X", "gestion_dreets":
+        null, "gestion_drihl": null, "version_nomenclature": "FINESS_Cat\u00e9gories
+        d''\u00e9tablissements_V2.6.xlsx (25/11/2024)", "tutelle": "ARS", "mft_code":
+        "07", "mft_lib": "ARH \u00e9tablissements de sant\u00e9 non financ\u00e9s
+        dotation globale", "sph_code": 0, "sph_lib": "non PSPH", "geoloc_source":
+        "BAN", "geoloc_precision": "1-Pr\u00e9cision parcelle, housenumber", "geoloc_legal_x":
+        "908642.187", "geoloc_legal_y": 6521545.083, "geoloc_legal_projection": "L93_METROPOLE",
+        "geoloc_3857_x": "632825.59", "geoloc_3857_y": 5742225.019, "geoloc_4326_long":
+        5.684769, "geoloc_4326_lat": 45.761585}], "links": {"profile": "https://tabular-api.data.gouv.fr/api/resources/796dfff7-cf54-493a-a0a7-ba3c2024c6f3/profile/",
+        "swagger": "https://tabular-api.data.gouv.fr/api/resources/796dfff7-cf54-493a-a0a7-ba3c2024c6f3/swagger/",
+        "next": null, "prev": null}, "meta": {"page": 1, "page_size": 20, "total":
+        1}}'
+  recorded_at: Mon, 25 Aug 2025 16:11:06 GMT
+recorded_with: VCR 6.3.1

--- a/spec/lib/json_path_util_spec.rb
+++ b/spec/lib/json_path_util_spec.rb
@@ -63,7 +63,39 @@ describe JSONPathUtil do
       ])
     end
   end
+  describe '.array_paths_with_examples' do
+    let(:hash) do
+      {
+        "foo" => [
+          { "bar" => 1 },
+          { "bar" => 2 }
+        ],
+        "baz" => {
+          "qux" => [
+            { "a" => "x" },
+            { "a" => "y" }
+          ]
+        },
+        "simple" => "value"
+      }
+    end
 
+    it 'extract all arrays' do
+      result = described_class.array_paths_with_examples(hash)
+      expect(result.keys).to contain_exactly('$.foo', '$.baz.qux')
+      expect(result['$.foo']).to eq(
+        { "bar" => 1 }
+      )
+      expect(result['$.baz.qux']).to eq(
+        { "a" => "x" }
+      )
+    end
+
+    it 'ignore les propriétés non-tableau' do
+      result = described_class.array_paths_with_examples(hash)
+      expect(result).not_to have_key('$.simple')
+    end
+  end
   describe '.extract_key_after_array' do
     it 'returns the string after the first bracket' do
       expect(JSONPathUtil.extract_key_after_array('foo[123].baz')).to eq('.baz')

--- a/spec/lib/json_path_util_spec.rb
+++ b/spec/lib/json_path_util_spec.rb
@@ -63,7 +63,7 @@ describe JSONPathUtil do
       ])
     end
   end
-  describe '.array_paths_with_examples' do
+  describe '.filter_selectable_datasources' do
     let(:hash) do
       {
         "foo" => [
@@ -80,19 +80,19 @@ describe JSONPathUtil do
       }
     end
 
-    it 'extract all arrays' do
-      result = described_class.array_paths_with_examples(hash)
+    it 'extracts all arrays including all their possible suggestions' do
+      result = described_class.filter_selectable_datasources(hash)
       expect(result.keys).to contain_exactly('$.foo', '$.baz.qux')
       expect(result['$.foo']).to eq(
-        { "bar" => 1 }
+        [{ "bar" => 1 }, { "bar" => 2 }]
       )
       expect(result['$.baz.qux']).to eq(
-        { "a" => "x" }
+        [{ "a" => "x" }, { "a" => "y" }]
       )
     end
 
     it 'ignore les propriétés non-tableau' do
-      result = described_class.array_paths_with_examples(hash)
+      result = described_class.filter_selectable_datasources(hash)
       expect(result).not_to have_key('$.simple')
     end
   end

--- a/spec/services/referentiel_autocomplete_render_service_spec.rb
+++ b/spec/services/referentiel_autocomplete_render_service_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ReferentielAutocompleteRenderService do
+  let(:referentiel) { create(:api_referentiel, :autocomplete, datasource: '$.items') }
+  let(:api_response) do
+    {
+      'items' => [
+        { 'finess' => 'Tango', 'ej_rs' => 'Charlie' },
+        { 'finess' => 'Bob', 'ej_rs' => 'Delta' }
+      ]
+    }
+  end
+
+  let(:subject) { described_class.new(api_response, referentiel) }
+
+  describe '.format_response' do
+    it 'formats the response for autocomplete' do
+      expect(subject.format_response).to match_array([
+        {
+          label: 'Tango (Charlie)',
+          value: 'Tango (Charlie)',
+          data: anything
+        },
+        {
+          label: 'Bob (Delta)',
+          value: 'Bob (Delta)',
+          data: anything
+        }
+      ])
+    end
+  end
+
+  describe '.render_template' do
+    it 'generates plain text from the template and the object' do
+      obj = {
+        'finess' => 'Tango',
+        'ej_rs' => "Charlie"
+      }
+      expect(
+        subject.send(:render_template, referentiel.json_template, obj).join('')
+      ).to include('Tango (Charlie)')
+    end
+  end
+end

--- a/spec/system/administrateurs/api_referentiel_spec.rb
+++ b/spec/system/administrateurs/api_referentiel_spec.rb
@@ -7,201 +7,244 @@ describe 'Referentiel API:' do
   let(:instructeur) { administrateur.instructeur }
   let(:service) { create(:service, administrateur:) }
   let!(:procedure) { create(:procedure, :for_individual, types_de_champ_public:, zones: [zone], service:, administrateurs: [administrateur], instructeurs: [instructeur]) }
-  let(:types_de_champ_public) do
-    [
-      { type: :referentiel, libelle: 'Numero de bâtiment', stable_id: referentiel_stable_id },
-      { type: :textarea, libelle: 'un autre champ' },
-      { type: :text, libelle: 'prefill with $.statut', stable_id: prefill_text_stable_id },
-      { type: :checkbox, libelle: 'prefill with $.is_active', stable_id: prefill_boolean_stable_id },
-      {
-        type: :repetition,
-        libelle: "repetition",
-        mandatory: false,
-        children: [
-          { type: :text, libelle: 'prefill with $.addresses[0].street', stable_id: prefill_repetition_children_stable_id }
-        ]
-      }
-    ]
-  end
   let(:referentiel_stable_id) { 21 }
   let(:prefill_text_stable_id) { 42 }
-  let(:prefill_boolean_stable_id) { 84 }
-  let(:prefill_repetition_children_stable_id) { 168 }
 
   before do
     Instructeur.where(user:).where.not(id: instructeur.id).destroy_all # remove other instructeurs
     login_as instructeur.user, scope: :user
   end
 
-  scenario 'Setup as admin, fill in as user, view it as instructeur', js: true, vcr: true do
-    visit champs_admin_procedure_path(procedure)
-    click_on('Configurer le champ')
+  context 'safely select url' do
+    let(:types_de_champ_public) do
+      [
+        { type: :referentiel, libelle: "qu'importe" }
+      ]
+    end
+    scenario 'Setup as admin, fails with invalid url', js: true do
+      visit champs_admin_procedure_path(procedure)
+      click_on('Configurer le champ')
 
-    # configure connection
-    VCR.use_cassette('referentiel/rnb_as_admin') do
-      if Referentiels::APIReferentiel.csv_available?
-        find('label[for="referentiel_type_referentielsapireferentiel"]').click
-      end
       find("#referentiel_url").fill_in(with: 'google.com')
       expect(page).to have_content("n'est pas au format d'une URL, saisissez une URL valide ex https://api_1.ext/")
       find("#referentiel_url").fill_in(with: 'https://google.com')
       expect(page).to have_content("doit être autorisée par notre équipe. Veuillez nous contacter par mail (contact@demarches-simplifiees.fr) et nous indiquer l'URL et la documentation de l'API que vous souhaitez intégrer.")
       find("#referentiel_url").fill_in(with: 'https://rnb-api.beta.gouv.fr/api/alpha/buildings/{id}/')
-      find('label[for="referentiel_mode_exact_match"]').click
-      fill_in("Indications à fournir à l’usager concernant le format de saisie attendu", with: "Saisir votre numero de bâtiment")
-      fill_in("Exemple de saisie valide (affiché à l'usager et utilisé pour tester la requête)", with: "PG46YY6YWCX8")
-      click_on('Étape suivante')
-      wait_until { Referentiel.count == 1 }
-      expect(page).to have_content("Pré remplissage des champs et/ou affichage des données récupérées")
+      expect(page).to have_content("Attention si vous appelez une API qui renvoie de la donnée personnelle, vous devez en informer votre DPO.")
     end
-    # check response and configure mapping
-    click_on("Afficher la réponse récupérée à partir de la requête configurée")
-    expect(page).to have_content("PG46YY6YWCX8") # check api was called
+  end
 
-    #
-    # map prefilled champs
-    #
-    custom_check("status")
-    custom_check('is_active')
-    custom_check('addresses-0-street')
-
-    ## fill a custom libelle to display to user
-    fill_in("type_de_champ_referentiel_mapping__.point.coordinates_libelle", with: "Coordonées du point")
-    fill_in("type_de_champ_referentiel_mapping__.point.type_libelle", with: "Type de point")
-
-    # submit and check values
-    click_on('Étape suivante')
-    expect(page).to have_content("La configuration du mapping a bien été enregistrée")
-    referentiel_tdc = Referentiel.first.types_de_champ.first
-    expect(referentiel_tdc.referentiel_mapping.dig("$.status", "prefill")).to eq("1")
-    expect(referentiel_tdc.referentiel_mapping.dig("$.is_active", "prefill")).to eq("1")
-
-    ##
-    # choose prefill stable ids
-    ###
-    expect(page).to have_content("$.status")
-    page.find("select[name='type_de_champ[referentiel_mapping][$.status][prefill_stable_id]']")
-      .select('prefill with $.statut')
-    # one boolean champ, nothing to select
-    expect(page).to have_content("$.is_active")
-    # choose another stable than the default one for the repetition
-    expect(page).to have_content("$.addresses[0].street")
-    page.find("select[name='type_de_champ[referentiel_mapping][$.addresses{0}.street][prefill_stable_id]']")
-      .select('repetition - prefill with $.addresses[0].street')
-    ##
-    # choose display_usager display_instructeur
-    ###
-    # choose string value for usager and instructeur
-    custom_check('point-type-display_usager')
-    custom_check('point-type-display_instructeur')
-    # choose array values only for usager
-    custom_check('point-coordinates-display_usager')
-    # choose string value only instructeur
-    custom_check('shape-type-display_instructeur')
-    click_on("Valider")
-
-    wait_until { referentiel_tdc.reload .referentiel_mapping.dig("$.status", "prefill_stable_id").present? }
-    # back to champs and check it's considered as configured
-    expect(page).to have_content("Configuré")
-
-    # check referentiel deep option exists
-    expect(referentiel_tdc.referentiel_mapping.dig("$.status", "prefill_stable_id").to_s).to eq(prefill_text_stable_id.to_s)
-    expect(referentiel_tdc.referentiel_mapping.dig("$.is_active", "prefill_stable_id").to_s).to eq(prefill_boolean_stable_id.to_s)
-    # now procedure should be publishable
-    visit admin_procedure_path(procedure)
-    click_on("Publier")
-
-    # publish
-    find("#procedure_path").fill_in(with: "htxbye")
-    find("#lien_site_web").fill_in(with: "google.fr")
-    within(".form") do
-      click_on("Publier")
-    end
-    wait_until { procedure.reload.published_revision.present? }
-
-    # start a dossier
-    visit commencer_path(procedure.path)
-    click_on("Commencer la démarche")
-    expect(page).to have_content("Votre identité")
-    fill_in("Prénom", with: "Jeanne")
-    fill_in("Nom", with: "Dupont")
-    within "#identite-form" do
-      click_on 'Continuer'
+  context 'exact_match' do
+    let(:prefill_boolean_stable_id) { 84 }
+    let(:prefill_repetition_children_stable_id) { 168 }
+    let(:types_de_champ_public) do
+      [
+        { type: :referentiel, libelle: 'Numero de bâtiment', stable_id: referentiel_stable_id },
+        { type: :textarea, libelle: 'un autre champ' },
+        { type: :text, libelle: 'prefill with $.statut', stable_id: prefill_text_stable_id },
+        { type: :checkbox, libelle: 'prefill with $.is_active', stable_id: prefill_boolean_stable_id },
+        {
+          type: :repetition,
+          libelle: "repetition",
+          mandatory: false,
+          children: [
+            { type: :text, libelle: 'prefill with $.addresses[0].street', stable_id: prefill_repetition_children_stable_id }
+          ]
+        }
+      ]
     end
 
-    expect(page).to have_content("Identité enregistrée")
+    scenario 'Setup as admin, fill in as user, view it as instructeur', js: true, vcr: true do
+      visit champs_admin_procedure_path(procedure)
+      click_on('Configurer le champ')
 
-    # fill in champ
-    fill_in("Numero de bâtiment", with: "okokok")
-    fill_in("un autre champ", with: "focus out for autosave")
-    # update champ should not trigger an error and render a feedback
-    expect(page).to have_content("Recherche en cours.")
-
-    # but submitting bef  ore API response was fetched should trigger an error
-    click_on("Déposer le dossier")
-    expect(page).to have_content("En attente de réponse...")
-
-    # reload page, if API response was not fetched, it's an error
-    visit dossier_path(Dossier.last)
-    expect(page).to have_content("En attente de réponse...")
-
-    # and the page starts polling
-    expect(page).to have_content("Recherche en cours.")
-
-    # failed search
-    VCR.use_cassette('referentiel/kthxbye_as_user') do
-      fill_in("Numero de bâtiment", with: "kthxbye")
-      fill_in("un autre champ", with: "focus out for autosave")
-
-      perform_enqueued_jobs do
-        # then the API response is fetched and tada... another error : bad data -> error
-        expect(page).to have_content("Résultat introuvable. Vérifiez vos informations.")
+      # configure connection
+      VCR.use_cassette('referentiel/rnb_as_admin') do
+        find("#referentiel_url").fill_in(with: 'https://rnb-api.beta.gouv.fr/api/alpha/buildings/{id}/')
+        find('label[for="referentiel_mode_exact_match"]').click
+        fill_in("Indications à fournir à l’usager concernant le format de saisie attendu", with: "Saisir votre numero de bâtiment")
+        fill_in("Exemple de saisie valide (affiché à l'usager et utilisé pour tester la requête)", with: "PG46YY6YWCX8")
+        click_on('Étape suivante')
+        wait_until { Referentiel.count == 1 }
+        expect(page).to have_content("Pré remplissage des champs et/ou affichage des données récupérées")
       end
-    end
+      # check response and configure mapping
+      click_on("Afficher la réponse récupérée à partir de la requête configurée")
+      expect(page).to have_content("PG46YY6YWCX8") # check api was called
 
-    # success search
-    VCR.use_cassette('referentiel/rnb_as_user') do
-      fill_in("Numero de bâtiment", with: "PG46YY6YWCX8")
-      perform_enqueued_jobs do
-        expect(page).to have_content("Référence trouvée : PG46YY6YWCX8")
-        dossier = Dossier.last
+      #
+      # map prefilled champs
+      #
+      custom_check("status")
+      custom_check('is_active')
+      custom_check('addresses-0-street')
 
-        # check prefill values in db
-        expect(dossier.project_champs_public_all.find { it.stable_id.to_s == referentiel_stable_id.to_s }.value).to eq("PG46YY6YWCX8")
-        expect(dossier.project_champs_public_all.find { it.stable_id.to_s == prefill_text_stable_id.to_s }.value).to eq("constructed")
-        expect(dossier.project_champs_public_all.find { it.stable_id.to_s == prefill_boolean_stable_id.to_s }.value).to eq("true")
-        repetition_values = dossier.project_champs_public_all.filter { it.stable_id.to_s == prefill_repetition_children_stable_id.to_s }.map(&:value)
-        expect(repetition_values).to include("rue du puits")
-        expect(repetition_values).to include("place de la bourse")
+      ## fill a custom libelle to display to user
+      fill_in("type_de_champ_referentiel_mapping__.point.coordinates_libelle", with: "Coordonées du point")
+      fill_in("type_de_champ_referentiel_mapping__.point.type_libelle", with: "Type de point")
 
-        # check webpage was also updated
-        expect(page).to have_content("Donnée remplie automatiquement.", count: 4)
+      # submit and check values
+      click_on('Étape suivante')
+      expect(page).to have_content("La configuration du mapping a bien été enregistrée")
+      referentiel_tdc = Referentiel.first.types_de_champ.first
+      expect(referentiel_tdc.referentiel_mapping.dig("$.status", "prefill")).to eq("1")
+      expect(referentiel_tdc.referentiel_mapping.dig("$.is_active", "prefill")).to eq("1")
 
-        # check display_usager populated web page too
-        page.find("button[aria-controls=display_usager]").click
-        within(".fr-collapse#display_usager") do
-          # now we check that the filled libelle for the mapping and the value are in the webpage, with the accordion
+      ##
+      # choose prefill stable ids
+      ###
+      expect(page).to have_content("$.status")
+      page.find("select[name='type_de_champ[referentiel_mapping][$.status][prefill_stable_id]']")
+        .select('prefill with $.statut')
+      # one boolean champ, nothing to select
+      expect(page).to have_content("$.is_active")
+      # choose another stable than the default one for the repetition
+      expect(page).to have_content("$.addresses[0].street")
+      page.find("select[name='type_de_champ[referentiel_mapping][$.addresses{0}.street][prefill_stable_id]']")
+        .select('repetition - prefill with $.addresses[0].street')
+      ##
+      # choose display_usager display_instructeur
+      ###
+      # choose string value for usager and instructeur
+      custom_check('point-type-display_usager')
+      custom_check('point-type-display_instructeur')
+      # choose array values only for usager
+      custom_check('point-coordinates-display_usager')
+      # choose string value only instructeur
+      custom_check('shape-type-display_instructeur')
+      click_on("Valider")
+
+      wait_until { referentiel_tdc.reload .referentiel_mapping.dig("$.status", "prefill_stable_id").present? }
+      # back to champs and check it's considered as configured
+      expect(page).to have_content("Configuré")
+
+      # check referentiel deep option exists
+      expect(referentiel_tdc.referentiel_mapping.dig("$.status", "prefill_stable_id").to_s).to eq(prefill_text_stable_id.to_s)
+      expect(referentiel_tdc.referentiel_mapping.dig("$.is_active", "prefill_stable_id").to_s).to eq(prefill_boolean_stable_id.to_s)
+      # now procedure should be publishable
+      visit admin_procedure_path(procedure)
+      click_on("Publier")
+
+      # publish
+      find("#procedure_path").fill_in(with: "htxbye")
+      find("#lien_site_web").fill_in(with: "google.fr")
+      within(".form") do
+        click_on("Publier")
+      end
+      wait_until { procedure.reload.published_revision.present? }
+
+      # start a dossier
+      visit commencer_path(procedure.path)
+      click_on("Commencer la démarche")
+      expect(page).to have_content("Votre identité")
+      fill_in("Prénom", with: "Jeanne")
+      fill_in("Nom", with: "Dupont")
+      within "#identite-form" do
+        click_on 'Continuer'
+      end
+
+      expect(page).to have_content("Identité enregistrée")
+
+      # fill in champ
+      fill_in("Numero de bâtiment", with: "okokok")
+      fill_in("un autre champ", with: "focus out for autosave")
+      # update champ should not trigger an error and render a feedback
+      expect(page).to have_content("Recherche en cours.")
+
+      # but submitting bef  ore API response was fetched should trigger an error
+      click_on("Déposer le dossier")
+      expect(page).to have_content("En attente de réponse...")
+
+      # reload page, if API response was not fetched, it's an error
+      visit dossier_path(Dossier.last)
+      expect(page).to have_content("En attente de réponse...")
+
+      # and the page starts polling
+      expect(page).to have_content("Recherche en cours.")
+
+      # failed search
+      VCR.use_cassette('referentiel/kthxbye_as_user') do
+        fill_in("Numero de bâtiment", with: "kthxbye")
+        fill_in("un autre champ", with: "focus out for autosave")
+
+        perform_enqueued_jobs do
+          # then the API response is fetched and tada... another error : bad data -> error
+          expect(page).to have_content("Résultat introuvable. Vérifiez vos informations.")
+        end
+      end
+
+      # success search
+      VCR.use_cassette('referentiel/rnb_as_user') do
+        fill_in("Numero de bâtiment", with: "PG46YY6YWCX8")
+        perform_enqueued_jobs do
+          expect(page).to have_content("Référence trouvée : PG46YY6YWCX8")
+          dossier = Dossier.last
+
+          # check prefill values in db
+          expect(dossier.project_champs_public_all.find { it.stable_id.to_s == referentiel_stable_id.to_s }.value).to eq("PG46YY6YWCX8")
+          expect(dossier.project_champs_public_all.find { it.stable_id.to_s == prefill_text_stable_id.to_s }.value).to eq("constructed")
+          expect(dossier.project_champs_public_all.find { it.stable_id.to_s == prefill_boolean_stable_id.to_s }.value).to eq("true")
+          repetition_values = dossier.project_champs_public_all.filter { it.stable_id.to_s == prefill_repetition_children_stable_id.to_s }.map(&:value)
+          expect(repetition_values).to include("rue du puits")
+          expect(repetition_values).to include("place de la bourse")
+
+          # check webpage was also updated
+          expect(page).to have_content("Donnée remplie automatiquement.", count: 4)
+
+          # check display_usager populated web page too
+          page.find("button[aria-controls=display_usager]").click
+          within(".fr-collapse#display_usager") do
+            # now we check that the filled libelle for the mapping and the value are in the webpage, with the accordion
+            expect(page).to have_content("Coordonées du point : -0.570505392116188, 44.841034137099996")
+            expect(page).to have_content("Type de point : Point")
+          end
+
+          # check we can create a dossier
+          click_on("Déposer le dossier")
+          wait_until { Dossier.en_construction.count == 1 }
+
+          created_dossier = Dossier.last
+          # check data is also visible on demande page as an usager
+          visit demande_dossier_path(created_dossier)
           expect(page).to have_content("Coordonées du point : -0.570505392116188, 44.841034137099996")
           expect(page).to have_content("Type de point : Point")
+          expect(page).not_to have_content("$.shape.type") # not displayed to usager
+
+          # check data is also visible on demande page as an usager
+          visit instructeur_dossier_path(procedure, created_dossier)
+          expect(page).to have_content("Sections du formulaire")
+          expect(page).not_to have_content("Coordonées du point")
+          expect(page).to have_content("Type de point")
+          expect(page).to have_content("$.shape.type")
         end
+      end
+    end
+  end
 
-        # check we can create a dossier
-        click_on("Déposer le dossier")
-        wait_until { Dossier.en_construction.count == 1 }
+  context 'autocomplete' do
+    let(:types_de_champ_public) do
+        [
+          { type: :referentiel, libelle: 'Numéro FINESS', stable_id: referentiel_stable_id },
+          { type: :textarea, libelle: 'un autre champ' },
+          { type: :text, libelle: 'prefill with $.source', stable_id: prefill_text_stable_id },
+          { type: :checkbox, libelle: 'prefill with $.date_extract_finess', stable_id: prefill_date_stable_id }
+        ]
+      end
+    let(:prefill_date_stable_id) { 84 }
 
-        created_dossier = Dossier.last
-        # check data is also visible on demande page as an usager
-        visit demande_dossier_path(created_dossier)
-        expect(page).to have_content("Coordonées du point : -0.570505392116188, 44.841034137099996")
-        expect(page).to have_content("Type de point : Point")
-        expect(page).not_to have_content("$.shape.type") # not displayed to usager
+    scenario 'Setup as admin, fill in as user, view it as instructeur', js: true, vcr: true do
+      visit champs_admin_procedure_path(procedure)
+      click_on('Configurer le champ')
 
-        # check data is also visible on demande page as an usager
-        visit instructeur_dossier_path(procedure, created_dossier)
-        expect(page).to have_content("Sections du formulaire")
-        expect(page).not_to have_content("Coordonées du point")
-        expect(page).to have_content("Type de point")
-        expect(page).to have_content("$.shape.type")
+      # configure connection
+      VCR.use_cassette('referentiel/datagouv-finess') do
+        find("#referentiel_url").fill_in(with: 'https://tabular-api.data.gouv.fr/api/resources/796dfff7-cf54-493a-a0a7-ba3c2024c6f3/data/?finess__contains={id}')
+        find('label[for="referentiel_mode_autocomplete"]').click
+        fill_in("Indications à fournir à l’usager concernant le format de saisie attendu", with: "Saisir votre finess")
+        fill_in("Exemple de saisie valide (affiché à l'usager et utilisé pour tester la requête)", with: "010002699")
+        click_on('Étape suivante')
+        wait_until { Referentiel.count == 1 }
+        expect(page).to have_content("Configuration de l'autocomplétion ")
       end
     end
   end

--- a/spec/system/administrateurs/api_referentiel_spec.rb
+++ b/spec/system/administrateurs/api_referentiel_spec.rb
@@ -47,9 +47,7 @@ describe 'Referentiel API:' do
       find("#referentiel_url").fill_in(with: 'https://google.com')
       expect(page).to have_content("doit être autorisée par notre équipe. Veuillez nous contacter par mail (contact@demarches-simplifiees.fr) et nous indiquer l'URL et la documentation de l'API que vous souhaitez intégrer.")
       find("#referentiel_url").fill_in(with: 'https://rnb-api.beta.gouv.fr/api/alpha/buildings/{id}/')
-      if Referentiels::APIReferentiel.autocomplete_available?
-        find('label[for="referentiel_mode_exact_match"]').click
-      end
+      find('label[for="referentiel_mode_exact_match"]').click
       fill_in("Indications à fournir à l’usager concernant le format de saisie attendu", with: "Saisir votre numero de bâtiment")
       fill_in("Exemple de saisie valide (affiché à l'usager et utilisé pour tester la requête)", with: "PG46YY6YWCX8")
       click_on('Étape suivante')


### PR DESCRIPTION
progress: https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/11161

# demo - 'complète'

https://github.com/user-attachments/assets/caa981e5-b4bd-4beb-a627-6236e738a997
(il y a 2/3 glitches sur la video qui ont été corrigé) 

# Cette PR permet de : 

- ETQ administrateur, configurer un champ API en mode autocomplete
  - ETQ administrateur, je peux choisir la source des suggestions
  - ETQ admin, je peux formatter mes suggestions
  - ETQ admin, je peux prefill/associer de la donnée a afficher a l'usager/instructeur

- ETQ usager
  - je peux utiliser le champ referentiel en mode autocomplete

côté secu/perf, on a pensé a : 
- on renvoie l'objet de l'autosuggestion chiffré a l'ui, leak pas.
- on rabaisse le timeout du client referentiel de 10 a 4 pour timeout avant de surchager nos threads puma
- on ajoute un taile limite a la reponse d'une api a 1mb
- on limite le jeu d'autosuggestion a 1000 entrées
- je prends toutes suggestion pr renforcer l'implem

la pr etant deja grosse on laisse de cote : 
- le caching (pr une autre PR)

# TODO , une fois en prod on a des admins au taquet
- [x] renforcer le endpoint de requetage directe des APIs
- [ ] notifier alain.thi****@developpement-durable.gouv.fr 