### PR TITLE
Fix: affiche également un placeholder pour le champ carte

### DIFF
--- a/app/components/editable_champ/carte_component.rb
+++ b/app/components/editable_champ/carte_component.rb
@@ -16,6 +16,7 @@ class EditableChamp::CarteComponent < EditableChamp::EditableChampBaseComponent
       translations: {
         address_input_label: t(".address_input_label"),
         address_input_description: t(".address_input_description"),
+        address_placeholder: t(".address_placeholder"),
         pin_input_label: t(".pin_input_label"),
         pin_input_description: t(".pin_input_description"),
         show_pin: t(".show_pin"),

--- a/app/components/editable_champ/carte_component/carte_component.en.yml
+++ b/app/components/editable_champ/carte_component/carte_component.en.yml
@@ -1,7 +1,8 @@
 ---
 en:
-  address_input_label: "Find an address"
-  address_input_description: "Enter at least 2 characters"
+  address_input_label: "Center the map by searching for an address"
+  address_input_description: "Enter an address, a street, a city. Example: 11 rue Réaumur, Paris"
+  address_placeholder: "Start typing"
   pin_input_label: "Add a point to the map"
   pin_input_description: "Example: "
   show_pin: "Show your location on the map"

--- a/app/components/editable_champ/carte_component/carte_component.fr.yml
+++ b/app/components/editable_champ/carte_component/carte_component.fr.yml
@@ -1,7 +1,8 @@
 ---
 fr:
-  address_input_label: "Rechercher une adresse"
-  address_input_description: "Saisissez au moins 2 caractères"
+  address_input_label: "Centrer la carte en recherchant une adresse"
+  address_input_description: "Saisissez une adresse, une voie, un lieu-dit ou une commune. Exemple : 11 rue Réaumur, Paris"
+  address_placeholder: "Commencez à saisir"
   pin_input_label: "Ajouter un point sur la carte"
   pin_input_description: "Exemple : "
   show_pin: "Afficher votre position sur la carte"

--- a/app/javascript/components/MapEditor/components/AddressInput.tsx
+++ b/app/javascript/components/MapEditor/components/AddressInput.tsx
@@ -22,6 +22,7 @@ export function AddressInput({
         loader={source}
         label={translations.address_input_label}
         description={translations.address_input_description}
+        placeholder={translations.address_placeholder}
         onChange={(item) => {
           if (item && item.data) {
             fire(document, 'map:zoom', {


### PR DESCRIPTION
Issue : https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/10188

Complément pour le champ carte de la PR : https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11863

Résultat :
<img width="1223" height="297" alt="Capture d’écran 2025-07-21 à 15 56 34" src="https://github.com/user-attachments/assets/f6a62642-f8a2-468f-ac19-1811fd3415de" />
