### PR TITLE
Amélioration: ETQ admin, le hint est plus explicite sur le sujet de la methode d'authentification

### DIFF
--- a/app/components/referentiels/new_form_component/new_form_component.html.haml
+++ b/app/components/referentiels/new_form_component/new_form_component.html.haml
@@ -59,7 +59,10 @@
         %div{ data: { 'hide-target_target' => 'toHide' }, class: class_names('fr-hidden': !@referentiel.authentication_method.present?) }
           = form.hidden_field :authentication_method, value: 'header_token'
           = render Dsfr::InputComponent.new(form:, attribute: "authentication_data[header]", **authentication_data_header_opts)
-          = render Dsfr::InputComponent.new(form:, attribute: "authentication_data[value]", **authentication_data_header_value_opts)
+          = render Dsfr::InputComponent.new(form:, attribute: "authentication_data[value]", **authentication_data_header_value_opts) do |c|
+            - c.with_describedby do
+              .fr-messages-group
+                .fr-message.fr-message--info Le token est stocké de manière chiffrée et ne sera plus affiché après saisie
 
           %button{ type: 'button', class: 'fr-btn fr-btn--secondary', data: { action: 'click->referentiel-new-form#changeHeaderValue' } }
             Changer la valeur de l'en-tête

--- a/config/locales/models/referentiel/fr.yml
+++ b/config/locales/models/referentiel/fr.yml
@@ -17,7 +17,7 @@ fr:
         hints:
           url_html: "Format attendu : https://api_1.ext/<strong>{id}</strong>, la section <strong>{id}</strong> sera remplacée par la valeur du champ. L'appel se fera en HTTP GET"
           hint: "Exemple : Identifiant de 12 caractères comportant des chiffres et des lettres (exemple : PG46YY6YWCX8)"
-          "authentication_data[header]": "Exemple : Authorization"
-          "authentication_data[value]": "Exemple : Bearer your_token_here. Nous stockons ce token de manière chiffrée, une fois saisie il ne sera plus affiché."
+          "authentication_data[header]": "Exemples : Authorization, X-API-Key."
+          "authentication_data[value]": "Exemples : Bearer your_token_here, Basic base64(username:password). Veillez à respecter la casse et l’orthographe du préfixe (ex : Bearer, Basic), sans ajouter d’espaces superflus."
         "authentication_data[header]": "Nom de l'en-tête"
         "authentication_data[value]": "Valeur de l'en-tête"


### PR DESCRIPTION
progress: https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/11161

verbatim :
> pourquoi faire saisir "Bearer" et pas seulement le token ? En plus c'est sensible à la casse bearer (KO) vs Bearer (OK)

on est pas des bêtes, on peut essayer de mieux guider l'usager ;-) donc 1. on montre qu'il y a plusieurs methodes d'auth, 2. on essaie de bien cadrer la saisie pour eviter les probs

TODO
- [ ] relancer : https://secure.helpscout.net/conversation/2996767828/2212875