### PR TITLE
Amélioration: ETQ administrateur, lorsque je change l'url de mon referentiel api, le mapping de celui ci est remis a zero

### DIFF
--- a/app/controllers/administrateurs/referentiels_controller.rb
+++ b/app/controllers/administrateurs/referentiels_controller.rb
@@ -56,7 +56,14 @@ module Administrateurs
     end
 
     def handle_referentiel_save(referentiel)
+      cache_bust_last_response_and_mapping = referentiel.url_changed?
+
       if referentiel.configured? && referentiel.save && params[:commit].present?
+        if cache_bust_last_response_and_mapping
+          @type_de_champ.update!(referentiel_mapping: {})
+          referentiel.update!(last_response: nil)
+        end
+
         redirect_to mapping_type_de_champ_admin_procedure_referentiel_path(@procedure, @type_de_champ.stable_id, referentiel)
       else
         referentiel.validate


### PR DESCRIPTION
progress: https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/11161

verbatim : 
> Lorsqu’on modifie l’URL de l’API, le tableau lié à "Indiquez les données issues du référentiel..." s’actualise, mais les colonnes de la première URL sont conservées en cache et restent proposées.

TODO: 
- [ ] relancer: https://tchap.gouv.fr/#/room/!nnbPKmdWGGMekDHsPy:agent.dinum.tchap.gouv.fr/$175308057071jzBBz:agent.agriculture.tchap.gouv.fr?via=agent.dinum.tchap.gouv.fr&via=agent.tchap.gouv.fr&via=agent.interieur.tchap.gouv.fr