### PR TITLE
[UX] Ajout focus sur le formulaire après ouverture de la messagerie pour éviter un clic supplémentaire

### DIFF
--- a/app/javascript/controllers/hide_target_controller.ts
+++ b/app/javascript/controllers/hide_target_controller.ts
@@ -27,6 +27,15 @@ export class HideTargetController extends Controller {
       source.classList.add('fr-hidden');
     }
 
+    if (this.revealTargets.length > 0) {
+      const elementToFocus = this.revealTargets[0];
+      const shouldFocus = elementToFocus.dataset.focusOnShow === 'true';
+
+      if (shouldFocus && typeof elementToFocus.focus === 'function') {
+        setTimeout(() => elementToFocus.focus(), 0);
+      }
+    }
+
     const footer = document.querySelector('.fixed-footer') as HTMLElement;
     if (footer) {
       const height = footer.offsetHeight;

--- a/app/views/shared/dossiers/messages/_form.html.haml
+++ b/app/views/shared/dossiers/messages/_form.html.haml
@@ -9,7 +9,7 @@
   = f.label :body, class: "fr-label" do
     = t('views.shared.dossiers.messages.form.message_label_mandatory')
     = render EditableChamp::AsteriskMandatoryComponent.new
-  = f.text_area :body, rows: '5', placeholder: placeholder, title: placeholder, required: true, class: 'fr-input message-textarea'
+  = f.text_area :body, rows: '5', placeholder: placeholder, title: placeholder, required: true, class: 'fr-input message-textarea', data: { hide_target_target: 'reveal', focus_on_show: 'true'}
 
   - if local_assigns.has_key?(:dossier)
     .fr-mt-3w.fr-input-group


### PR DESCRIPTION
sujet remonté par @kvkq 

Au clic sur nouveau message, le formulaire s'ouvre et est focus directement sur le textarea.
<img width="945" height="578" alt="Capture d’écran 2025-07-24 à 15 09 34" src="https://github.com/user-attachments/assets/a4873437-c042-40bd-bb98-4ccb4507ab25" />
