### PR TITLE
Correctif : etq admin je vois le numéro de ma démarche dans l'encadré sur l'identité des instructeurs 

### DIFF
--- a/app/components/procedure/instructeurs_options_component/instructeurs_options_component.en.yml
+++ b/app/components/procedure/instructeurs_options_component/instructeurs_options_component.en.yml
@@ -19,6 +19,6 @@ en:
   anonymisation_callout:
     title: Instructor Identity
     content_part_1: Any decision made by an administration includes the signature of its author as well as the first name, last name, and title of the person making the decision in legible characters.
-    content_part_2_html: To activate the option to <strong>not disclose the identity of instructors</strong> during email communications with users, contact us at contact@demarches-simplifiees.fr, stating your procedure number (104221).
+    content_part_2_html: To activate the option to <strong>not disclose the identity of instructors</strong> during email communications with users, contact us at contact@demarches-simplifiees.fr, stating your procedure number (%{id}).
     link_text: Text on LegiFrance
     link_url: https://www.legifrance.gouv.fr/codes/section_lc/LEGITEXT000031366350/LEGISCTA000031367523/

--- a/app/components/procedure/instructeurs_options_component/instructeurs_options_component.fr.yml
+++ b/app/components/procedure/instructeurs_options_component/instructeurs_options_component.fr.yml
@@ -19,6 +19,6 @@ fr:
   anonymisation_callout:
     title: Identité des instructeurs
     content_part_1: Toute décision prise par une administration comporte la signature de son auteur ainsi que la mention, en caractères lisibles, du prénom, du nom et de la qualité de celui-ci.
-    content_part_2_html: Pour activer l’option permettant de <strong>ne pas divulguer l’identité des instructeurs</strong> lors des échanges avec l’usager par le biais de la messagerie, contactez-nous sur contact@demarches-simplifiees.fr en indiquant votre numéro de démarche (104221).
+    content_part_2_html: Pour activer l’option permettant de <strong>ne pas divulguer l’identité des instructeurs</strong> lors des échanges avec l’usager par le biais de la messagerie, contactez-nous sur contact@demarches-simplifiees.fr en indiquant votre numéro de démarche (%{id}).
     link_text: Texte sur LegiFrance
     link_url: https://www.legifrance.gouv.fr/codes/section_lc/LEGITEXT000031366350/LEGISCTA000031367523/

--- a/app/components/procedure/instructeurs_options_component/instructeurs_options_component.html.haml
+++ b/app/components/procedure/instructeurs_options_component/instructeurs_options_component.html.haml
@@ -79,7 +79,7 @@
         = t('.anonymisation_callout.content_part_1')
         = link_to t('.anonymisation_callout.link_text'), t('.anonymisation_callout.link_url'), title: helpers.new_tab_suffix(t('.anonymisation_callout.link_text')), **helpers.external_link_attributes
       %p
-        = t('.anonymisation_callout.content_part_2_html')
+        = t('.anonymisation_callout.content_part_2_html', id: @procedure.id)
 
   .padded-fixed-footer
     .fixed-footer


### PR DESCRIPTION
On avait mis un id de démarche en dur

![Capture d’écran 2025-07-24 à 16 05 47](https://github.com/user-attachments/assets/7b351978-cbde-4d76-93d4-2c463680a5b9)
