### PR TITLE
ETQ Tech: je veux que la MT de suppression des follows orphelins soit plus rapide

### DIFF
--- a/app/tasks/maintenance/t20250721destroy_orphan_follows_task.rb
+++ b/app/tasks/maintenance/t20250721destroy_orphan_follows_task.rb
@@ -16,15 +16,18 @@ module Maintenance
       Follow
         .left_joins(:instructeur, :dossier)
         .where('instructeurs.id IS NULL OR dossiers.id IS NULL')
+        .in_batches
     end
 
-    def process(follow)
-      follow.destroy!
+    def process(batch_of_follows)
+      batch_of_follows.delete_all
     end
 
     def count
       with_statement_timeout("5min") do
-        collection.count(:id)
+        Follow
+          .left_joins(:instructeur, :dossier)
+          .where('instructeurs.id IS NULL OR dossiers.id IS NULL').count(:id) / 1000
       end
     end
   end

--- a/spec/tasks/maintenance/t20250721destroy_orphan_follows_task_spec.rb
+++ b/spec/tasks/maintenance/t20250721destroy_orphan_follows_task_spec.rb
@@ -17,8 +17,18 @@ module Maintenance
       end
 
       it "includes follows with missing instructeur or dossier" do
-        expect(collection).to include(orphan_instructeur_follow, orphan_dossier_follow)
-        expect(collection).not_to include(valid_follow)
+        expect(collection.flat_map(&:to_a)).to include(orphan_instructeur_follow, orphan_dossier_follow)
+        expect(collection.flat_map(&:to_a)).not_to include(valid_follow)
+      end
+    end
+
+    describe "#process" do
+      subject(:process) { described_class.process(Follow.where(id: orphan_follows)) }
+
+      let!(:orphan_follows) { create_list(:follow, 3) }
+
+      it 'destroy follow' do
+        expect { process }.to change { Follow.count }.by(-3)
       end
     end
   end


### PR DESCRIPTION
Suite de : https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11891

On a besoin d'optimiser via des batch car beaucoup de records à supprimer.