### PR TITLE
ETQ usager et instructeur: fix form qui disparait lorsqu'on clic sur le textearea

### DIFF
--- a/app/javascript/controllers/hide_target_controller.ts
+++ b/app/javascript/controllers/hide_target_controller.ts
@@ -1,10 +1,11 @@
 import { Controller } from '@hotwired/stimulus';
 
 export class HideTargetController extends Controller {
-  static targets = ['source', 'toHide', 'reveal'];
+  static targets = ['source', 'toHide', 'reveal', 'focus'];
   declare readonly toHideTargets: HTMLDivElement[];
   declare readonly sourceTargets: HTMLInputElement[];
   declare readonly revealTargets: HTMLElement[];
+  declare readonly focusTargets: HTMLElement[];
 
   connect() {
     this.sourceTargets.forEach((source) => {
@@ -27,11 +28,10 @@ export class HideTargetController extends Controller {
       source.classList.add('fr-hidden');
     }
 
-    if (this.revealTargets.length > 0) {
-      const elementToFocus = this.revealTargets[0];
-      const shouldFocus = elementToFocus.dataset.focusOnShow === 'true';
+    if (this.focusTargets.length > 0) {
+      const elementToFocus = this.focusTargets[0];
 
-      if (shouldFocus && typeof elementToFocus.focus === 'function') {
+      if (typeof elementToFocus.focus === 'function') {
         setTimeout(() => elementToFocus.focus(), 0);
       }
     }

--- a/app/views/shared/dossiers/_messagerie.html.haml
+++ b/app/views/shared/dossiers/_messagerie.html.haml
@@ -16,8 +16,8 @@
         .fr-col-12
           - if dossier.messagerie_available?
             %div{ data: { controller: 'hide-target' } }
-              %button.fr-btn.fr-icon-add-line.fr-btn--icon-left.fr-mb-2w.width-100-for-xs{ type: 'button', data: { 'hide-target_target': 'source', 'hide-target-hide-source': 'true' } } Nouveau message
-              .fr-hidden{ data: { hide_target_target: 'toHide' } }
+              %button.fr-btn.fr-icon-add-line.fr-btn--icon-left.fr-mb-2w.width-100-for-xs{ type: 'button', data: { 'hide-target-target': 'source', 'hide-target-hide-source': 'true' } } Nouveau message
+              .fr-hidden{ data: { 'hide-target-target': 'toHide' } }
                 .fr-grid-row
                   .fr-col-12.fr-col-offset-md-2.fr-col-md-8
                     = render partial: "shared/dossiers/messages/form", locals: { commentaire: new_commentaire, form_url: form_url, dossier: dossier }

--- a/app/views/shared/dossiers/messages/_form.html.haml
+++ b/app/views/shared/dossiers/messages/_form.html.haml
@@ -9,7 +9,7 @@
   = f.label :body, class: "fr-label" do
     = t('views.shared.dossiers.messages.form.message_label_mandatory')
     = render EditableChamp::AsteriskMandatoryComponent.new
-  = f.text_area :body, rows: '5', placeholder: placeholder, title: placeholder, required: true, class: 'fr-input message-textarea', data: { hide_target_target: 'reveal', focus_on_show: 'true'}
+  = f.text_area :body, rows: '5', placeholder: placeholder, title: placeholder, required: true, class: 'fr-input message-textarea', data: { 'hide-target-target': 'focus'}
 
   - if local_assigns.has_key?(:dossier)
     .fr-mt-3w.fr-input-group
@@ -21,6 +21,6 @@
   .fr-mt-3w
     %ul.fr-btns-group.fr-btns-group--inline-md
       %li
-        %button.fr-btn.fr-btn--tertiary.fr-mb-2w{ type: 'button', data: { 'hide-target_target': 'reveal'} } Annuler
+        %button.fr-btn.fr-btn--tertiary.fr-mb-2w{ type: 'button', data: { 'hide-target-target': 'reveal'} } Annuler
       %li
         = f.submit t('views.shared.dossiers.messages.form.send_message'), class: 'fr-btn', data: { disable: true }


### PR DESCRIPTION
Corrige un bug introduit par https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11909 : le texteaera était aussi un reveal, donc il agissait comme toggle


https://github.com/user-attachments/assets/bdabb2c2-294f-4f66-9bdd-eb25b877f7d0

