### PR TITLE
Tech: fix tests instables mailer delivery methods

### DIFF
--- a/spec/lib/priority_delivery_spec.rb
+++ b/spec/lib/priority_delivery_spec.rb
@@ -71,13 +71,22 @@ RSpec.describe PriorityDeliveryConcern do
   end
 
   before do
+    ExampleMailer.delivery_method = :balancer
+    ImportantEmail.delivery_method = :balancer
+  end
+
+  around do |example|
+    original_delivery_methods = ActionMailer::Base.delivery_methods.dup
+
     ActionMailer::Base.add_delivery_method :mock_smtp, MockSmtp
     ActionMailer::Base.add_delivery_method :mock_sendmail, MockSendmail
     ActionMailer::Base.add_delivery_method :dolist_api, MockDoList
     ActionMailer::Base.add_delivery_method :balancer, BalancerDeliveryMethod
 
-    ExampleMailer.delivery_method = :balancer
-    ImportantEmail.delivery_method = :balancer
+    example.run
+
+    ActionMailer::Base.delivery_methods = original_delivery_methods
+    ActionMailer::Base.balancer_settings = nil
   end
 
   context 'when a single delivery method is provided' do


### PR DESCRIPTION
Les delivery methods étaient conservées pour d'autres tests suivants. Cas minimum reproductible : 

> bundle exec rspec './spec/lib/priority_delivery_spec.rb[1:1:1]' './spec/mailers/application_mailer_spec.rb[1:2:1:1,1:3:1]' --seed 23790
>