### PR TITLE
ETQ Usager, je veux que l'étiquette du champ de recherche indique les données éligibles à la recherche

### DIFF
--- a/app/components/dossiers/user_procedure_filter_component/user_procedure_filter_component.fr.yml
+++ b/app/components/dossiers/user_procedure_filter_component/user_procedure_filter_component.fr.yml
@@ -1,5 +1,5 @@
 fr:
   procedures:
     label: Afficher les dossiers par démarche
-    prompt: Sélectionner une démarche
+    prompt: Sélectionnez une démarche
     button: Afficher

--- a/app/components/select_procedure_drop_down_list_component/select_procedure_drop_down_list_component.fr.yml
+++ b/app/components/select_procedure_drop_down_list_component/select_procedure_drop_down_list_component.fr.yml
@@ -1,4 +1,4 @@
 ---
 fr:
   label: Accès direct
-  placeholder: Sélectionner une démarche
+  placeholder: Sélectionnez une démarche

--- a/app/views/users/dossiers/index.html.haml
+++ b/app/views/users/dossiers/index.html.haml
@@ -29,9 +29,9 @@
                 = hidden_field_tag :procedure_id, params[:procedure_id]
                 = label_tag "q", t('views.users.dossiers.search.label'), class: 'fr-label fr-mb-1w'
                 .flex
-                  = text_field_tag "q", "#{@search_terms if @search_terms.present?}", placeholder: t('views.users.dossiers.search.prompt'), class: "fr-input"
+                  = text_field_tag "q", "#{@search_terms if @search_terms.present?}", placeholder: t('views.users.dossiers.search.placeholder'), class: "fr-input"
                   %button.fr-btn.fr-btn--sm
-                    = t('views.users.dossiers.search.label')
+                    = t('views.users.dossiers.search.button')
         - if @procedures_for_select.size > 1
           .fr-col-12.fr-col-md
             = render Dossiers::UserProcedureFilterComponent.new(procedures_for_select: @procedures_for_select)

--- a/app/views/users/dossiers/index.html.haml
+++ b/app/views/users/dossiers/index.html.haml
@@ -24,7 +24,7 @@
       .fr-grid-row.fr-grid-row--gutters
         - if current_user.dossiers.count > 2 || current_user.dossiers_invites.count > 2
           #search-2.fr-search-bar.fr-col-12.fr-col-md
-            = form_tag dossiers_path, method: :get, :role => "search", class: "width-100 fr-mb-5w" do
+            = form_tag dossiers_path, method: :get, :role => "search", class: "width-100 fr-mb-5w", "aria-label": t('views.users.dossiers.dossiers_menu') do
               = hidden_field_tag :procedure_id, params[:procedure_id]
               = label_tag "q", t('views.users.dossiers.search.label'), class: 'fr-label fr-mb-1w'
               .flex

--- a/app/views/users/dossiers/index.html.haml
+++ b/app/views/users/dossiers/index.html.haml
@@ -23,15 +23,14 @@
     - if current_user.dossiers.count > 2 || current_user.dossiers_invites.count > 2  || @procedures_for_select.size > 1
       .fr-grid-row.fr-grid-row--gutters
         - if current_user.dossiers.count > 2 || current_user.dossiers_invites.count > 2
-          .fr-col-12.fr-col-md
-            #search-2.fr-search-bar
-              = form_tag dossiers_path, method: :get, :role => "search", class: "width-100 fr-mb-5w" do
-                = hidden_field_tag :procedure_id, params[:procedure_id]
-                = label_tag "q", t('views.users.dossiers.search.label'), class: 'fr-label fr-mb-1w'
-                .flex
-                  = text_field_tag "q", "#{@search_terms if @search_terms.present?}", placeholder: t('views.users.dossiers.search.placeholder'), class: "fr-input"
-                  %button.fr-btn.fr-btn--sm
-                    = t('views.users.dossiers.search.button')
+          #search-2.fr-search-bar.fr-col-12.fr-col-md
+            = form_tag dossiers_path, method: :get, :role => "search", class: "width-100 fr-mb-5w" do
+              = hidden_field_tag :procedure_id, params[:procedure_id]
+              = label_tag "q", t('views.users.dossiers.search.label'), class: 'fr-label fr-mb-1w'
+              .flex
+                = text_field_tag "q", "#{@search_terms if @search_terms.present?}", placeholder: t('views.users.dossiers.search.placeholder'), class: "fr-input"
+                %button.fr-btn.fr-btn--sm
+                  = t('views.users.dossiers.search.button')
         - if @procedures_for_select.size > 1
           .fr-col-12.fr-col-md
             = render Dossiers::UserProcedureFilterComponent.new(procedures_for_select: @procedures_for_select)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -530,9 +530,10 @@ en:
           edit_dossier: Edit my file
           edit_dossier_title: "Edit my file - You can modify your file as long as it has not been sent for processing"
         search:
-          search_file: Search a file (File number, keywords)
-          prompt: (File number, last name / first name, keywords)
-          label: Search a file
+          search_file: Search a file (by file number, keywords)
+          label: Search a file (by file number, last name / first name, keywords…)
+          placeholder: Enter your search
+          button: Search a file
           simple: Search
           result_term_title: Search result for « %{search_terms} »
           result_procedure_title: and procedure « %{procedure_libelle} »

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -539,9 +539,10 @@ fr:
           edit_dossier: Modifier le dossier
           edit_dossier_title: "Modifier le dossier - Vous pouvez modifier votre dossier tant qu’il n’est pas passé en instruction"
         search:
-          search_file: Rechercher un dossier (n° de dossier, mots-clés)
-          prompt: (n° de dossier, nom / prénom, mots-clés)
-          label: Rechercher un dossier
+          search_file: Rechercher un dossier (par n° de dossier, mots-clés)
+          label: Rechercher un dossier (par n° de dossier, nom / prénom, mots-clés…)
+          placeholder: Saisissez votre recherche
+          button: Rechercher un dossier
           simple: Rechercher
           result_term_title: Résultat de la recherche pour « %{search_terms} »
           result_procedure_title: et pour la procédure « %{procedure_libelle} »

--- a/spec/system/users/list_dossiers_spec.rb
+++ b/spec/system/users/list_dossiers_spec.rb
@@ -346,7 +346,7 @@ describe 'user access to the list of their dossiers', js: true do
       it "can filter by procedure" do
         expect(page).to have_text('7 en cours')
         expect(page).to have_text('3 traités')
-        expect(page).to have_select('procedure_id', selected: 'Sélectionner une démarche')
+        expect(page).to have_select('procedure_id', selected: 'Sélectionnez une démarche')
         select dossier_brouillon.procedure.libelle, from: 'procedure_id'
         click_on 'Afficher'
         expect(page).to have_text('1 en cours')


### PR DESCRIPTION
# Mise à jour de l'étiquette et des `placeholder`
## Après
<img width="1228" height="149" alt="" src="https://github.com/user-attachments/assets/ae4c1be5-6115-4598-ba03-200f7413a205" />

## Avant
<img width="1226" height="155" alt="" src="https://github.com/user-attachments/assets/a0436c86-66c5-4d06-9104-f64cf6fd4e0b" />

# Ajout d'une étiquette au formulaire de recherche
## Après
<img width="1258" height="443" alt="" src="https://github.com/user-attachments/assets/f2240b18-c5e8-475d-8117-8358b9ddfe75" />

## Avant
<img width="1202" height="438" alt="" src="https://github.com/user-attachments/assets/48e25085-fa92-4cd1-9834-a5eee3de0aeb" />
