### PR TITLE
ETQ Usager d'un lecteur d'écran, je veux que les citations soient balisées comme telles

### DIFF
--- a/app/assets/stylesheets/messagerie.scss
+++ b/app/assets/stylesheets/messagerie.scss
@@ -52,6 +52,26 @@ ol.messages-list > li::marker {
   .date {
     float: right;
   }
+
+  blockquote {
+    quotes: '« ' ' »' '“' '”';
+    font-style: italic;
+  }
+
+  blockquote::before {
+    content: open-quote;
+    float: left;
+  }
+
+  blockquote::after {
+    content: close-quote;
+    display: inline;
+  }
+}
+
+.messages-list .message .rich-text blockquote p {
+  display: inline;
+  margin-bottom: 0;
 }
 
 .date-header {

--- a/app/assets/stylesheets/status_overview.scss
+++ b/app/assets/stylesheets/status_overview.scss
@@ -32,7 +32,7 @@
 
 .status-explanation {
   blockquote {
-    quotes: '« ' ' »' '“' '”';
+    quotes: '« ' ' »' '“' '”';
     margin-bottom: $default-padding * 3;
   }
 

--- a/app/views/notification_mailer/default_templates/refused_mail.html.haml
+++ b/app/views/notification_mailer/default_templates/refused_mail.html.haml
@@ -6,8 +6,8 @@
   %strong a été refusé
   le --date de décision--.
 
-%p
-  Le motif de refus est le suivant : « <i>--motivation--</i> ».
+<p>Le motif de refus est le suivant :</p>
+<blockquote>--motivation--</blockquote>
 
 %p
   Pour en savoir plus sur le motif du refus, vous pouvez consulter votre dossier et les éventuels messages de l'administration à cette adresse : --lien dossier--

--- a/app/views/notification_mailer/default_templates/without_continuation_mail.html.haml
+++ b/app/views/notification_mailer/default_templates/without_continuation_mail.html.haml
@@ -6,8 +6,8 @@
   %strong a été classé sans suite
   le --date de décision--.
 
-%p
-  Le motif est le suivant : « <i>--motivation--</i> ».
+<p>Le motif est le suivant :</p>
+<blockquote>--motivation--</blockquote>
 
 %p
   Pour en savoir plus sur les raisons de ce classement sans suite, vous pouvez consulter votre dossier et les éventuels messages de l'administration à cette adresse : --lien dossier--

--- a/app/views/users/dossiers/show/_status_overview.html.haml
+++ b/app/views/users/dossiers/show/_status_overview.html.haml
@@ -60,12 +60,12 @@
 
         - elsif dossier.accepte?
           .accepte
-            %p.fr-my-6w.fr-text--lead{ role: 'status' }
+            %h2.fr-h6.fr-my-6w
               = dsfr_icon('fr-icon-checkbox-circle-fill fr-text-default--success')
-              = t('views.users.dossiers.show.status_overview.acceptee_html')
+              = t('views.users.dossiers.show.status_overview.acceptee')
 
             - if dossier.motivation.present?
-              %h2.fr-h6.fr-mb-1w= t('views.users.dossiers.show.status_overview.accepte_motivation')
+              %p.fr-h6.fr-mb-1w= t('views.users.dossiers.show.status_overview.accepte_motivation')
               %blockquote.fr-mx-0.fr-mt-0.fr-mb-2w= format_text_value(dossier.motivation)
 
             = render partial: 'users/dossiers/show/download_justificatif', locals: { dossier: dossier }

--- a/app/views/users/dossiers/show/_status_overview.html.haml
+++ b/app/views/users/dossiers/show/_status_overview.html.haml
@@ -92,12 +92,12 @@
 
         - elsif dossier.sans_suite?
           .sans-suite
-            %p.fr-my-6w.fr-text--lead{ role: 'status' }
+            %h2.fr-h6.fr-my-6w
               = dsfr_icon('fr-icon-intermediate-circle-fill')
-              = t('views.users.dossiers.show.status_overview.sans_suite_html')
+              = t('views.users.dossiers.show.status_overview.sans_suite')
 
             - if dossier.motivation.present?
-              %h2.fr-h6.fr-mb-1w= t('views.users.dossiers.show.status_overview.sans_suite_motivation')
+              %p.fr-h6.fr-mb-1w= t('views.users.dossiers.show.status_overview.sans_suite_motivation')
               %blockquote.fr-mx-0.fr-mt-0.fr-mb-2w= format_text_value(dossier.motivation)
 
             = render partial: 'users/dossiers/show/download_justificatif', locals: { dossier: dossier }

--- a/app/views/users/dossiers/show/_status_overview.html.haml
+++ b/app/views/users/dossiers/show/_status_overview.html.haml
@@ -78,12 +78,12 @@
 
         - elsif dossier.refuse?
           .refuse
-            %p.fr-my-6w.fr-text--lead{ role: 'status' }
+            %h2.fr-h6.fr-my-6w
               = dsfr_icon('fr-icon-close-circle-fill fr-text-default--error')
-              = t('views.users.dossiers.show.status_overview.refuse_html')
+              = t('views.users.dossiers.show.status_overview.refuse')
 
             - if dossier.motivation.present?
-              %h2.fr-h6.fr-mb-1w= t('views.users.dossiers.show.status_overview.refuse_motivation')
+              %p.fr-h6.fr-mb-1w= t('views.users.dossiers.show.status_overview.refuse_motivation')
               %blockquote.fr-mx-0.fr-mt-0.fr-mb-2w= format_text_value(dossier.motivation)
 
             = render partial: 'users/dossiers/show/download_justificatif', locals: { dossier: dossier }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -514,7 +514,7 @@ en:
             acceptee: "Your file had been accepted"
             accepte_motivation: "Reason"
             accepte_attestation: "Download the attestation"
-            refuse_html: "Your file had been <strong>rejected</strong>."
+            refuse: "Your file had been rejected"
             refuse_motivation: "Reason"
             refuse_reply: "Send a message to the administration"
             sans_suite_html: "Your file had been <strong>closed, no further action</strong>."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -517,7 +517,7 @@ en:
             refuse: "Your file had been rejected"
             refuse_motivation: "Reason"
             refuse_reply: "Send a message to the administration"
-            sans_suite_html: "Your file had been <strong>closed, no further action</strong>."
+            sans_suite: "Your file had been closed, no further action"
             sans_suite_motivation: "Reason"
           latest_message:
             latest_message: "Latest message"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -511,7 +511,7 @@ en:
             motivation: "Motivation :"
             attestation: "Attestation :"
             justificatif: "Justification of decision :"
-            acceptee_html: "Your file had been <strong>accepted</strong>."
+            acceptee: "Your file had been accepted"
             accepte_motivation: "Reason"
             accepte_attestation: "Download the attestation"
             refuse_html: "Your file had been <strong>rejected</strong>."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -523,7 +523,7 @@ fr:
             acceptee: "Votre dossier a été accepté"
             accepte_motivation: "Motif de l’acceptation"
             accepte_attestation: "Télécharger l’attestation"
-            refuse_html: "Votre dossier a été <strong>refusé</strong>."
+            refuse: "Votre dossier a été refusé"
             refuse_motivation: "Motif du refus"
             refuse_reply: "Envoyer un message à l’administration"
             sans_suite_html: "Votre dossier a été classé <strong>sans suite</strong>."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -526,7 +526,7 @@ fr:
             refuse: "Votre dossier a été refusé"
             refuse_motivation: "Motif du refus"
             refuse_reply: "Envoyer un message à l’administration"
-            sans_suite_html: "Votre dossier a été classé <strong>sans suite</strong>."
+            sans_suite: "Votre dossier a été classé sans suite"
             sans_suite_motivation: "Motif du classement sans suite"
           latest_message:
             latest_message: "Dernier message"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -520,7 +520,7 @@ fr:
             motivation: "Motivation :"
             attestation: "Attestation :"
             justificatif: "Justificatif de décision :"
-            acceptee_html: "Votre dossier a été <strong>accepté</strong>."
+            acceptee: "Votre dossier a été accepté"
             accepte_motivation: "Motif de l’acceptation"
             accepte_attestation: "Télécharger l’attestation"
             refuse_html: "Votre dossier a été <strong>refusé</strong>."


### PR DESCRIPTION
# Ajout d'un élément `blockquote` autour des citations
## Après
<img width="987" height="907" alt="" src="https://github.com/user-attachments/assets/2ced04cf-fa67-496c-b606-10c6a0177a6d" />
<img width="986" height="915" alt="" src="https://github.com/user-attachments/assets/22cafbb4-2ccc-4571-9d95-0115ab230486" />

## Avant
<img width="1000" height="896" alt="" src="https://github.com/user-attachments/assets/14256883-e62a-4ed7-ab27-db56fd05d01d" />
<img width="988" height="877" alt="" src="https://github.com/user-attachments/assets/2dce4311-d60e-42e5-a9bc-b0b22a6606f1" />

# Modification de la hiérarchie de titres de la page "suivi de votre dossier"
## Après
<img width="737" height="609" alt="" src="https://github.com/user-attachments/assets/f852c8bb-8921-4082-b060-006c31194c46" />

## Avant
<img width="822" height="522" alt="" src="https://github.com/user-attachments/assets/7e627f73-6fa1-4d66-8ba6-415e5fab04dc" />
