### PR TITLE
ETQ Usager d'un lecteur d'écran, je veux que le balisage du menu d'aide ne soit pas surchargé

### DIFF
--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -248,7 +248,7 @@ ul.dropdown-items {
   content: none;
 }
 
-.help-content.fr-menu ul.fr-menu__list {
+.help-content.fr-menu .fr-menu__list {
   --text-decoration: underline;
   text-align: left;
   font-size: 1rem;
@@ -264,18 +264,19 @@ ul.dropdown-items {
   padding: 0.75rem 1rem;
 
   @media (min-width: 62em) {
-    padding-right: 2.5rem;
+    padding-right: 1rem;
     padding-left: 1rem;
   }
 }
 
-.help-content.fr-menu ul.fr-menu__list > li:not(:last-child) {
+.help-content.fr-menu .fr-menu__list > div:last-child,
+.help-content.fr-menu .fr-menu__list > li:last-child {
   @media (min-width: 62em) {
-    border-bottom: 1px solid $border-grey;
+    border-top: 1px solid $border-grey;
   }
 }
 
-.help-content.fr-menu ul.fr-menu__list {
+.help-content.fr-menu .fr-menu__list {
   h1,
   p {
     font-size: inherit;

--- a/app/views/shared/help/_help_dropdown_dossier.html.haml
+++ b/app/views/shared/help/_help_dropdown_dossier.html.haml
@@ -6,11 +6,11 @@
 
       #help-menu.help-content.fr-collapse.fr-menu
         - title = dossier.brouillon? ? t("help_dropdown.help_brouillon_title") : t("help_dropdown.help_filled_dossier")
-        %ul.fr-menu__list
+        .fr-menu__list
           - if dossier.service_or_contact_information.present?
-            %li.flex
+            .flex.fr-py-3v.fr-px-2w
               = render partial: 'shared/help/dropdown_items/service_item',
                 locals: { service: dossier.service_or_contact_information, title:, dossier: }
 
-          %li.flex
+          .flex.fr-py-3v.fr-px-2w
             = render partial: 'shared/help/dropdown_items/faq_item'

--- a/app/views/shared/help/_help_dropdown_instructeur.html.haml
+++ b/app/views/shared/help/_help_dropdown_instructeur.html.haml
@@ -4,8 +4,8 @@
       = t('help')
 
     #help-menu.help-content.fr-collapse.fr-menu
-      %ul.fr-menu__list
-        %li.flex
+      .fr-menu__list
+        .flex.fr-py-3v.fr-px-2w
           = render partial: 'shared/help/dropdown_items/faq_item'
-        %li.flex
+        .flex.fr-py-3v.fr-px-2w
           = render partial: 'shared/help/dropdown_items/email_item'

--- a/app/views/shared/help/_help_dropdown_procedure.html.haml
+++ b/app/views/shared/help/_help_dropdown_procedure.html.haml
@@ -4,9 +4,9 @@
       = t('help')
 
     #help-menu.help-content.fr-collapse.fr-menu
-      %ul.fr-menu__list
+      .fr-menu__list
         - if procedure.service.present?
-          %li.flex
+          .flex.fr-py-3v.fr-px-2w
             = render partial: 'shared/help/dropdown_items/service_item', locals: { service: procedure.service, title: t('help_dropdown.procedure_title'), dossier: nil }
-        %li.flex
+        .flex.fr-py-3v.fr-px-2w
           = render partial: 'shared/help/dropdown_items/faq_item'


### PR DESCRIPTION
# Suppression de la liste englobante dans le menu d'aide
## Après
<img width="1190" height="591" alt="" src="https://github.com/user-attachments/assets/47a222fd-8d1b-4f9a-8ab8-6fadfc610f62" />
<img width="492" height="809" alt="" src="https://github.com/user-attachments/assets/076fdf54-b49a-407a-8367-8eeaf0e40a87" />
<img width="614" height="229" alt="" src="https://github.com/user-attachments/assets/86c445a5-f059-4bb5-8103-363a1868744f" />
<img width="568" height="317" alt="" src="https://github.com/user-attachments/assets/458da048-8224-49d9-8607-5c3c95010609" />
<img width="493" height="898" alt="" src="https://github.com/user-attachments/assets/01cadb8f-ba61-430f-a56c-e611a93c54f4" />

## Avant
<img width="1186" height="357" alt="" src="https://github.com/user-attachments/assets/ab10ab2d-5b74-4ef0-b545-88ca9194572c" />

