### PR TITLE
Tech: test, vérifie que redis fonctionne et retire la compilation d'assets pour les unitaires 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: launch redis
+        run: sudo apt-get install -y redis-server
+
       - name: Setup the app runtime and dependencies
         uses: ./.github/actions/ci-setup-rails
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,9 +90,6 @@ jobs:
       - name: Setup the app runtime and dependencies
         uses: ./.github/actions/ci-setup-rails
 
-      - name: Pre-compile assets
-        uses: ./.github/actions/ci-setup-assets
-
       - name: Setup split tests
         uses: ./.github/actions/ci-setup-split-tests
         with:

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -140,4 +140,8 @@ RSpec.configure do |config|
   config.include Devise::Test::IntegrationHelpers, type: :system
   config.include ViewComponent::TestHelpers, type: :component
   config.include Capybara::RSpecMatchers, type: :component
+
+  # early check to ensure redis is available for test
+  redis = Kredis::Connections.connections[:shared]
+  redis.ping
 end


### PR DESCRIPTION
otherwise `dossier_searchable_concern` and its `debounce_index_search_terms_flag` fails silently in rspec.