### PR TITLE
ETQ : je ne veux plus d'experts dupliqués pour un même user_id

### DIFF
--- a/app/tasks/maintenance/t20250813remove_duplicate_experts_task.rb
+++ b/app/tasks/maintenance/t20250813remove_duplicate_experts_task.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20250813removeDuplicateExpertsTask < MaintenanceTasks::Task
+    # Documentation: cette tâche permet de supprimer les experts qui ont un même
+    # user_id en ne conservant que le plus ancien.
+    include RunnableOnDeployConcern
+    include StatementsHelpersConcern
+
+    # Uncomment only if this task MUST run imperatively on its first deployment.
+    # If possible, leave commented for manual execution later.
+    run_on_first_deploy
+
+    def collection
+      duplicate_user_ids = Expert
+        .group(:user_id)
+        .having('COUNT(*) > 1')
+        .pluck(:user_id)
+
+      Expert
+        .where(user_id: duplicate_user_ids)
+        .order(:created_at)
+        .group_by(&:user_id)
+        .flat_map { |_, experts| experts.drop(1) }
+    end
+
+    def process(expert)
+      expert.destroy!
+    end
+  end
+end

--- a/spec/tasks/maintenance/t20250813remove_duplicate_experts_task_spec.rb
+++ b/spec/tasks/maintenance/t20250813remove_duplicate_experts_task_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe T20250813removeDuplicateExpertsTask do
+    describe "#collection" do
+      subject(:collection) { described_class.collection }
+
+      let(:user_with_duplicates) { create(:user) }
+      let!(:oldest_expert) { create(:expert, user: user_with_duplicates, created_at: 3.days.ago) }
+      let!(:newer_expert) { create(:expert, user: user_with_duplicates, created_at: 1.day.ago) }
+      let(:user_without_duplicates) { create(:user) }
+      let!(:single_expert) { create(:expert, user: user_without_duplicates) }
+
+      it 'returns only the experts that are duplicates' do
+        expect(collection).to include(newer_expert)
+        expect(collection).not_to include(oldest_expert, single_expert)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Sur la table experts, on a pas de contrainte d'unicité en base. Et on a malheureusement eu des loupés, dont les stats sont celles ci : 72 457 experts en comptabilisant sur des user_id distincts vs 73740 records dans la base.
On fait donc dans cette première PR un nettoyage des duplications (on garde l'expert le plus ancien), puis dans une seconde PR on ajoutera la contrainte en base
