### PR TITLE
ETQ tech : je veux une contrainte d'unicité pour la table administrateurs sur le user_id

### DIFF
--- a/app/models/administrateur.rb
+++ b/app/models/administrateur.rb
@@ -16,6 +16,8 @@ class Administrateur < ApplicationRecord
   belongs_to :user
   belongs_to :groupe_gestionnaire, optional: true
 
+  validates :user_id, uniqueness: true
+
   default_scope { eager_load(:user) }
 
   scope :inactive, -> { joins(:user).where(users: { last_sign_in_at: nil }) }

--- a/db/migrate/20250813140847_add_unique_index_to_administrateurs_on_user_id.rb
+++ b/db/migrate/20250813140847_add_unique_index_to_administrateurs_on_user_id.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexToAdministrateursOnUserId < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    remove_index :administrateurs, :user_id, algorithm: :concurrently
+    add_index :administrateurs, :user_id, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -71,7 +71,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_13_143947) do
     t.datetime "updated_at", precision: nil
     t.bigint "user_id", null: false
     t.index ["groupe_gestionnaire_id"], name: "index_administrateurs_on_groupe_gestionnaire_id"
-    t.index ["user_id"], name: "index_administrateurs_on_user_id"
+    t.index ["user_id"], name: "index_administrateurs_on_user_id", unique: true
   end
 
   create_table "administrateurs_instructeurs", id: false, force: :cascade do |t|


### PR DESCRIPTION
Suite au constat de https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11971

Même si en base actuellement il n'apparaît pas de doublon, par précaution on ajoute une contrainte d'unicité sur user_id