### PR TITLE
ETQ tech : je veux une contrainte d'unicité pour la table instructeurs sur le user_id

### DIFF
--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -32,6 +32,8 @@ class Instructeur < ApplicationRecord
 
   belongs_to :user
 
+  validates :user_id, uniqueness: true
+
   scope :with_instant_email_message_notifications, -> {
     includes(:assign_to).where(assign_tos: { instant_email_message_notifications_enabled: true })
   }

--- a/db/migrate/20250813143947_add_unique_index_to_instructeurs_on_user_id.rb
+++ b/db/migrate/20250813143947_add_unique_index_to_instructeurs_on_user_id.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexToInstructeursOnUserId < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    remove_index :instructeurs, :user_id, algorithm: :concurrently
+    add_index :instructeurs, :user_id, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_07_25_140753) do
+ActiveRecord::Schema[7.1].define(version: 2025_08_13_143947) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_stat_statements"
@@ -847,7 +847,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_25_140753) do
     t.datetime "login_token_created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.bigint "user_id", null: false
-    t.index ["user_id"], name: "index_instructeurs_on_user_id"
+    t.index ["user_id"], name: "index_instructeurs_on_user_id", unique: true
   end
 
   create_table "instructeurs_procedures", force: :cascade do |t|


### PR DESCRIPTION
Suite au constat de https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11971

Même si en base actuellement il n'apparaît pas de doublon, par précaution on ajoute une contrainte d'unicité sur user_id