### PR TITLE
Tech: respect des timezones dans le parsage de datetime au format iso8601

### DIFF
--- a/app/components/referentiels/mapping_form_component.rb
+++ b/app/components/referentiels/mapping_form_component.rb
@@ -57,10 +57,10 @@ class Referentiels::MappingFormComponent < Referentiels::MappingFormBase
   def value_to_type(value, jsonpath)
     if DateDetectionUtils.should_suggest_timestamp_mapping?(value, jsonpath)
       self.class::TYPES[:datetime]
-    elsif value.is_a?(String) && DateDetectionUtils.parsable_iso8601_datetime?(value)
-      self.class::TYPES[:datetime]
     elsif value.is_a?(String) && DateDetectionUtils.parsable_iso8601_date?(value)
       self.class::TYPES[:date]
+    elsif value.is_a?(String) && DateDetectionUtils.parsable_iso8601_datetime?(value)
+      self.class::TYPES[:datetime]
     elsif ReferentielMappingUtils.array_of_supported_simple_types?(value)
       self.class::TYPES[:array]
     elsif value.is_a?(Float)

--- a/app/lib/date_detection_utils.rb
+++ b/app/lib/date_detection_utils.rb
@@ -62,10 +62,8 @@ module DateDetectionUtils
       Time.zone.strptime(value, "%d/%m/%Y %H:%M").iso8601
     elsif /^\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}$/.match?(value)
       Time.zone.strptime(value, "%Y-%m-%d %H:%M").iso8601
-    elsif /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}[\+\-]\d{2}:\d{2})?$/.match?(value) # a correct iso8601 datetime
-      Time.zone.strptime(value, "%Y-%m-%dT%H:%M").iso8601
     else
-      nil
+      Time.zone.iso8601(value).iso8601 # ensure it is a valid ISO8601 datetime
     end
   rescue
     nil

--- a/app/lib/date_detection_utils.rb
+++ b/app/lib/date_detection_utils.rb
@@ -25,6 +25,12 @@ module DateDetectionUtils
   end
 
   def self.parsable_iso8601_date?(value)
+    return false if value.nil?
+    # we focus only on date, so we expect only 3 parts in the date string
+    return false if (value.split('-').count != 3 && value.split('/').count != 3)
+    # without time or timezone information
+    return false if value.include?('T') || value.include?(':')
+
     begin
       Date.iso8601(value)
       true

--- a/spec/components/instructeurs/cell_component_spec.rb
+++ b/spec/components/instructeurs/cell_component_spec.rb
@@ -91,7 +91,7 @@ describe Instructeurs::CellComponent do
       let(:types_de_champ_public) { [{ type: :datetime, libelle: 'datetime' }] }
       let(:column) { dossier.procedure.find_column(label: 'datetime') }
 
-      before { dossier.champs.first.update(value: Time.zone.parse("12/02/2025 09:19")) }
+      before { dossier.champs.first.update(value: Time.zone.parse("12/02/2025 09:19").iso8601) }
 
       it { is_expected.to eq('12 février 2025 09:19') }
     end

--- a/spec/components/instructeurs/cell_component_spec.rb
+++ b/spec/components/instructeurs/cell_component_spec.rb
@@ -91,7 +91,7 @@ describe Instructeurs::CellComponent do
       let(:types_de_champ_public) { [{ type: :datetime, libelle: 'datetime' }] }
       let(:column) { dossier.procedure.find_column(label: 'datetime') }
 
-      before { dossier.champs.first.update(value: DateTime.parse("12/02/2025 09:19")) }
+      before { dossier.champs.first.update(value: Time.zone.parse("12/02/2025 09:19")) }
 
       it { is_expected.to eq('12 février 2025 09:19') }
     end

--- a/spec/components/referentiels/mapping_form_component_spec.rb
+++ b/spec/components/referentiels/mapping_form_component_spec.rb
@@ -67,7 +67,10 @@ RSpec.describe Referentiels::MappingFormComponent, type: :component do
     it "does not detect invalid date as :date" do
       expect(convert_json_value_to_type(value: "martin", property_name: "$.records[0].fields.prenom")).to eq(:string)
       expect(convert_json_value_to_type(value: "2024-13-14")).to eq(:string)
-      expect(convert_json_value_to_type(value: "2024-06-31")).to eq(:string)
+      # do not take 31 juin example as the ruby parser allow
+      # Time.new(2024, 6, 31) # => 2024-07-01
+      # expect(convert_json_value_to_type(value: "2024-06-31")).to eq(:string)
+      expect(convert_json_value_to_type(value: "2024-06-32")).to eq(:string)
     end
 
     it "does not detect embedded date in string as :date" do

--- a/spec/models/champs/datetime_champ_spec.rb
+++ b/spec/models/champs/datetime_champ_spec.rb
@@ -27,9 +27,14 @@ describe Champs::DatetimeChamp do
       expect(champ.value).to be_nil
     end
 
-    it 'preserves if ISO8601' do
+    it 'preserves with current timezone if ISO8601 without timezone' do
       champ = champ_with_value("2023-12-21T03:20")
       expect(champ.value).to eq(Time.zone.parse("2023-12-21T03:20:00").iso8601)
+    end
+
+    it 'preserves timezone if ISO8601' do
+      champ = champ_with_value("2023-12-21T03:20:07+01:00")
+      expect(champ.value).to eq(Time.zone.parse("2023-12-21T03:20:07+01:00").iso8601)
     end
 
     it 'converts to ISO8601 if form format' do

--- a/spec/models/champs/referentiel_champ_cast_value_spec.rb
+++ b/spec/models/champs/referentiel_champ_cast_value_spec.rb
@@ -333,7 +333,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: datetime.to_f } }
           it 'convert to ISO8601 datetime' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:datetime?).value }.from(nil).to(datetime.change(sec: 0))
+              .to change { dossier.reload.project_champs.find(&:datetime?).value }.from(nil).to(datetime.iso8601)
           end
         end
 
@@ -342,7 +342,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: datetime.to_f.to_s } }
           it 'convert to ISO8601 datetime' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:datetime?).value }.from(nil).to(datetime.change(sec: 0))
+              .to change { dossier.reload.project_champs.find(&:datetime?).value }.from(nil).to(datetime.iso8601)
           end
         end
 


### PR DESCRIPTION
Le début de l'histoire commence par un bug qui sur les champ datetime qui n'affichait pas d'erreur lorsqu'il était vide mais obligatoire (#11969) . Ce qui a amené plusieurs test sur `date_detection_utils` concernant des timezone.

puis :
- correction du parsage des datetimes directement `Time.zone.iso8601(value)` ce qui permet de garder les timezones
- le parsage devient plus permissif, il accepte maintenant `yyyy-dd-mm` . Cela impacte le code de casting des valeurs json retournées par les ref externes
- on reprécise alors que les champs date ne doivent pas comporter d'heure et on essaye d'abords de caster une valeur en date puis en datetime.