### PR TITLE
Tech: corrige les tests instables concernant des combobox

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -24,15 +24,6 @@ def setup_driver(app, download_path, options)
   end
 end
 
-Capybara.register_driver :playwright do |app|
-  Capybara::Playwright::Driver.new(app,
-    browser_type: (ENV['PLAYWRIGHT_BROWSER'] || 'chromium').to_sym, # :chromium (default) or :firefox, :webkit
-    headless: ENV['NO_HEADLESS'].blank?,
-    locale: Rails.application.config.i18n.default_locale,
-    downloadsPath: Capybara.save_path,
-    playwright_cli_executable_path: 'bun playwright')
-end
-
 Capybara.register_driver :chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
   options.add_argument('--no-sandbox') unless ENV['SANDBOX']
@@ -82,7 +73,15 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :system, js: true) do
-    driven_by :playwright
+    options = {
+      browser_type: (ENV['PLAYWRIGHT_BROWSER'] || 'chromium').to_sym, # :chromium (default) or :firefox, :webkit
+      headless: ENV['NO_HEADLESS'].blank?,
+      locale: Rails.application.config.i18n.default_locale,
+      downloadsPath: Capybara.save_path,
+      playwright_cli_executable_path: 'bun playwright'
+    }
+
+    driven_by(:playwright, options:)
   end
 
   config.before(:each, type: :system, chrome: true) do

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -107,8 +107,11 @@ module SystemHelpers
 
   def select_combobox(libelle, value, custom_value: false)
     fill_in libelle, with: custom_value ? "#{value}," : value
+
     if !custom_value
-      find_field(libelle).send_keys(:down, :enter)
+      option = find('[role="option"]', text: value)
+      expect(option).to be_visible
+      option.click
     end
   end
 

--- a/spec/system/instructeurs/expert_spec.rb
+++ b/spec/system/instructeurs/expert_spec.rb
@@ -113,7 +113,7 @@ describe 'Inviting an expert:', js: true do
         within('.fr-sidemenu') { click_on 'Demander un avis' }
         expect(page).to have_current_path(avis_new_instructeur_dossier_path(procedure, dossier))
 
-        select_combobox 'Emails', expert.email
+        select_combobox :avis_emails, expert.email
         fill_in 'avis_introduction', with: 'Bonjour, merci de me donner votre avis sur ce dossier.'
         check 'avis_invite_linked_dossiers'
         choose 'confidentiel_true', allow_label_click: true


### PR DESCRIPTION
1. config

On ne pouvait plus débug en les tests systèmes en mettant la variable NO_HEADLESS.
C'est du à l'utilisation de

```
  config.before(:each, type: :system, js: true) do
    driven_by(:playwright)
  end
```

qui override notre config aux ptits oignons. La correction consiste à y réinjecter la conf.

2. Dans les tests systèmes, pour interagir avec les combobox, on envoyait des évènements claviers `down enter` qui étaient attrapés une fois sur deux par le navigateur qui au lieu de selectionner le premier choix de la liste, soumettait le formulaire. On corrige en cliquant sur la bonne option. 