### PR TITLE
ETQ Agent public, je m'identifie avec un 2nd facteur si mon fournisseur d'identité est compatible

### DIFF
--- a/app/controllers/pro_connect_controller.rb
+++ b/app/controllers/pro_connect_controller.rb
@@ -14,7 +14,7 @@ class ProConnectController < ApplicationController
   end
 
   def login
-    uri, state, nonce = ProConnectService.authorization_uri
+    uri, state, nonce = ProConnectService.authorization_uri(force_2fa: true)
 
     cookies.encrypted[STATE_COOKIE_NAME] = { value: state, secure: Rails.env.production?, httponly: true }
     cookies.encrypted[NONCE_COOKIE_NAME] = { value: nonce, secure: Rails.env.production?, httponly: true }


### PR DESCRIPTION
A discuter avec Pro Connect :
- Le deuxième facteur doit être demandé au début de la séquence avant mm de connaître l'email de l'agent. On ne peut pas conditionner la demande au domain de l'email. On demande alors du 2FA pour tout le monde. Que se passe-t-il si le FI ne propose pas de 2FA ? Il faudrait que ProConnect soit qd mm passant et nous indique lors du callback que le 2FA n'est pas dispo
- [la doc](https://partenaires.proconnect.gouv.fr/docs/fournisseur-service/double_authentification) précise que nous devons vérifier les `acr` au niveau du callback. Cela veut-il dire que ProConnect est passant si le 2fa est indispo ?