### PR TITLE
ETQ Instructeur, si j'ai une erreur de connection avec RDV je ne suis plus bloqué, je peux me reconnecte seul

### DIFF
--- a/app/services/rdv_service.rb
+++ b/app/services/rdv_service.rb
@@ -175,6 +175,11 @@ class RdvService
       refresh_token: new_token.refresh_token,
       expires_at: Time.zone.at(new_token.expires_at)
     )
+  rescue OAuth2::Error => e
+    # Destroy the connection so the user needs to re-authorize
+    @rdv_connection.destroy!
+
+    raise e
   end
 
   def headers


### PR DESCRIPTION
Débloque les instructeurs coincés avec un refresh token expiré?/invalide? (problème en cours d'analyse coté RDV)
https://demarches-simplifiees.sentry.io/issues/6632914925/?environment=production&project=1429550&query=is%3Aunresolved%20OAuth2&referrer=issue-stream