### PR TITLE
Correctif : etq instructeur je peux annuler la demande d'avis en masse

### DIFF
--- a/app/views/shared/avis/_form.html.haml
+++ b/app/views/shared/avis/_form.html.haml
@@ -79,7 +79,7 @@
     - if batch_action
       %ul.fr-btns-group.fr-btns-group--inline-md
         %li
-          %button.fr-btn.fr-btn--secondary{ aria: { controls: 'modal-avis-batch' }, "data-fr-js-modal-button" => "true" }
+          %button.fr-btn.fr-btn--secondary{ aria: { controls: 'modal-avis-batch' }, "data-fr-js-modal-button" => "true", type: 'button' }
             Annuler
         %li
           = f.submit "Envoyer la demande d’avis", class: 'fr-btn'

--- a/spec/system/instructeurs/batch_operation_spec.rb
+++ b/spec/system/instructeurs/batch_operation_spec.rb
@@ -211,6 +211,14 @@ describe 'BatchOperation a dossier:', js: true do
       expect(page).to have_content("Le champ « Email » est invalide : mljkzmljz")
 
       fill_in('avis_emails', with: 'test@test.com')
+      within('form#new_avis') { click_on "Annuler" }
+
+      expect(page).not_to have_content("Information : Une action de masse est en cours")
+
+      click_on "Autres actions multiples"
+      click_on "Demander un avis externe"
+
+      fill_in('avis_emails', with: 'test@test.com')
       click_on "Envoyer la demande d’avis"
       # ensure batched dossier is disabled
       expect(page).to have_selector("##{checkbox_id}[disabled]")


### PR DESCRIPTION
Le bouton "annuler" est dans le formulaire, donc quand on cliquait dessus ça soumettait le formulaire