### PR TITLE
Tech: migration Crisp (étape 2: form de contact sous FF)

### DIFF
--- a/app/jobs/crisp_create_conversation_job.rb
+++ b/app/jobs/crisp_create_conversation_job.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+class CrispCreateConversationJob < ApplicationJob
+  include Dry::Monads[:result]
+
+  queue_as :critical # user feedback is critical
+
+  def max_attempts = 15 # ~10h
+
+  class FileNotScannedYetError < StandardError
+  end
+
+  retry_on FileNotScannedYetError, wait: :polynomially_longer, attempts: 10
+
+  attr_reader :contact_form
+  attr_reader :session_id
+  attr_reader :api
+
+  def perform(contact_form)
+    @contact_form = contact_form
+
+    if contact_form.piece_jointe.attached?
+      raise FileNotScannedYetError if contact_form.piece_jointe.virus_scanner.pending?
+    end
+
+    @api = Crisp::APIService.new
+
+    @session_id = create_conversation
+    send_message
+    send_file
+    update_metas
+
+    contact_form.delete
+  rescue StandardError
+    contact_form.delete if executions >= max_attempts
+
+    raise
+  end
+
+  private
+
+  def create_conversation
+    response = api.create_conversation
+    body = handle_api_response(response)
+    body.dig(:data, :session_id)
+  end
+
+  def send_message
+    body = {
+      type: "text",
+      from: "user",
+      origin: "email",
+      content: contact_form.text,
+      fingerprint: contact_form.id, # must be a number
+      timestamp: original_timestamp_ms,
+      user: {
+        type: "participant"
+      }
+    }
+
+    response = api.send_message(session_id:, body:)
+    handle_api_response(response)
+  end
+
+  def send_file
+    return unless contact_form.piece_jointe.attached?
+
+    attachment = safe_blob
+
+    return if attachment.blank?
+
+    body = {
+      type: "file",
+      from: "user",
+      origin: "email",
+      content: {
+        name: attachment.attachable_filename,
+        url: attachment.url(expires_in: 1.week),
+        type: attachment.content_type
+      },
+      fingerprint: attachment.id,
+      timestamp: original_timestamp_ms,
+      user: {
+        type: "participant"
+      }
+    }
+
+    response = api.send_message(session_id:, body:)
+    handle_api_response(response)
+  end
+
+  def update_metas
+    email, nickname = email_and_nickname
+
+    body = {
+      email:,
+      nickname:,
+      subject: contact_form.subject,
+      segments: contact_form.tags
+      # TODO: ip & device ?
+    }
+
+    body[:data] = { "Dossier" => dossier_link } if contact_form.dossier_id.present?
+    body[:ip] = contact_form.user.current_sign_in_ip if contact_form&.user&.current_sign_in_ip.present?
+    body[:phone] = contact_form.phone if contact_form.phone.present?
+
+    response = api.update_conversation_meta(session_id:, body:)
+    handle_api_response(response)
+  end
+
+  def handle_api_response(response, &block)
+    case response
+    in Success(body)
+      body
+    in Failure(reason:)
+      fail reason
+    end
+  end
+
+  def email_and_nickname
+    email = contact_form.email.presence || contact_form.user.email
+
+    nickname = email.split("@").first.titleize
+
+    [email, nickname]
+  end
+
+  def safe_blob
+    return if !contact_form.piece_jointe.virus_scanner&.safe?
+    return if contact_form.piece_jointe.byte_size.zero?
+
+    contact_form.piece_jointe
+  end
+
+  def original_timestamp_ms
+    (contact_form.created_at.to_f * 1000).to_i
+  end
+
+  def dossier_link
+    "[Dossier ##{contact_form.dossier_id}](#{Rails.application.routes.url_helpers.manager_dossier_url(contact_form.dossier_id)})"
+  end
+end

--- a/app/lib/api/client.rb
+++ b/app/lib/api/client.rb
@@ -44,7 +44,7 @@ class API::Client
       headers['authorization'] = "Bearer #{authorization_token}"
     end
 
-    headers['content-type'] = 'application/json' if json.present?
+    headers['content-type'] = 'application/json' if !json.nil?
     headers
   end
 

--- a/app/models/contact_form.rb
+++ b/app/models/contact_form.rb
@@ -57,7 +57,11 @@ class ContactForm < ApplicationRecord
   end
 
   def create_conversation_later
-    HelpscoutCreateConversationJob.perform_later(self)
+    if user.present? && Flipper.enabled?(:contact_crisp, user)
+      CrispCreateConversationJob.perform_later(self)
+    else
+      HelpscoutCreateConversationJob.perform_later(self)
+    end
   end
 
   def require_email? = user.blank?

--- a/app/services/crisp/api_service.rb
+++ b/app/services/crisp/api_service.rb
@@ -9,7 +9,11 @@ module Crisp
       # https://docs.crisp.chat/references/rest-api/v1/#update-people-data
       "people_data" => '/v1/website/%{website_id}/people/data/%{email}',
       # https://docs.crisp.chat/references/rest-api/v1/#create-a-new-conversation
-      "create_conversation" => '/v1/website/%{website_id}/conversation'
+      "create_conversation" => '/v1/website/%{website_id}/conversation',
+      # https://docs.crisp.chat/references/rest-api/v1/#send-a-message-in-conversation
+      "send_message" => '/v1/website/%{website_id}/conversation/%{session_id}/message',
+      # https://docs.crisp.chat/references/rest-api/v1/#update-conversation-metas
+      "update_conversation_meta" => '/v1/website/%{website_id}/conversation/%{session_id}/meta'
     }.freeze
 
     def update_people_data(email:, body:)
@@ -17,13 +21,7 @@ module Crisp
       url = build_url(endpoint)
 
       result = call(url:, json: body, method: :patch)
-
-      case result
-      in Success(body:)
-        Success(body)
-      in Failure(code:, reason:)
-        Failure(API::Client::Error[:api_error, code, false, reason])
-      end
+      handle_result(result)
     end
 
     def create_conversation
@@ -34,12 +32,20 @@ module Crisp
       handle_result(result)
     end
 
-      case result
-      in Success(body:)
-        Success(body)
-      in Failure(code:, reason:)
-        Failure(API::Client::Error[:api_error, code, false, reason])
-      end
+    def send_message(session_id:, body:)
+      endpoint = format(ENDPOINTS['send_message'], website_id:, session_id:)
+      url = build_url(endpoint)
+
+      result = call(url:, json: body, method: :post)
+      handle_result(result)
+    end
+
+    def update_conversation_meta(session_id:, body:)
+      endpoint = format(ENDPOINTS['update_conversation_meta'], website_id:, session_id:)
+      url = build_url(endpoint)
+
+      result = call(url:, json: body, method: :patch)
+      handle_result(result)
     end
 
     private
@@ -68,6 +74,15 @@ module Crisp
       uri = URI(HOST)
       uri.path = endpoint
       uri
+    end
+
+    def handle_result(result)
+      case result
+      in Success(body:)
+        Success(body)
+      in Failure(code:, reason:)
+        Failure(API::Client::Error[:api_error, code, false, reason])
+      end
     end
   end
 end

--- a/app/services/crisp/api_service.rb
+++ b/app/services/crisp/api_service.rb
@@ -7,7 +7,9 @@ module Crisp
     HOST = 'https://api.crisp.chat'
     ENDPOINTS = {
       # https://docs.crisp.chat/references/rest-api/v1/#update-people-data
-      "people_data" => '/v1/website/%{website_id}/people/data/%{email}'
+      "people_data" => '/v1/website/%{website_id}/people/data/%{email}',
+      # https://docs.crisp.chat/references/rest-api/v1/#create-a-new-conversation
+      "create_conversation" => '/v1/website/%{website_id}/conversation'
     }.freeze
 
     def update_people_data(email:, body:)
@@ -15,6 +17,22 @@ module Crisp
       url = build_url(endpoint)
 
       result = call(url:, json: body, method: :patch)
+
+      case result
+      in Success(body:)
+        Success(body)
+      in Failure(code:, reason:)
+        Failure(API::Client::Error[:api_error, code, false, reason])
+      end
+    end
+
+    def create_conversation
+      endpoint = format(ENDPOINTS['create_conversation'], website_id:)
+      url = build_url(endpoint)
+
+      result = call(url:, json: {}, method: :post)
+      handle_result(result)
+    end
 
       case result
       in Success(body:)

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -23,6 +23,7 @@ features = [
   :api_particulier,
   :blocking_pending_correction,
   :cojo_type_de_champ,
+  :contact_crisp,
   :dossier_pdf_vide,
   :engagement_juridique_type_de_champ,
   :export_avec_horodatage,

--- a/spec/jobs/crisp_create_conversation_job_spec.rb
+++ b/spec/jobs/crisp_create_conversation_job_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CrispCreateConversationJob, type: :job do
+  let(:api) { instance_double(Crisp::APIService) }
+  let(:email) { 'test@example.com' }
+  let(:subject_text) { 'Test Subject' }
+  let(:text) { 'Test message content' }
+  let(:tags) { ['test tag'] }
+  let(:question_type) { 'lost_user' }
+  let(:phone) { nil }
+  let(:user) { nil }
+  let(:contact_form) { create(:contact_form, email:, user:, subject: subject_text, text:, tags:, phone:, question_type:) }
+  let(:session_id) { 'session_test-123-456' }
+
+  before do
+    allow(Crisp::APIService).to receive(:new).and_return(api)
+  end
+
+  describe '#perform' do
+    subject { described_class.perform_now(contact_form) }
+
+    context 'cas général - succès complet' do
+      before do
+        allow(api).to receive(:create_conversation)
+          .and_return(Dry::Monads::Success(data: { session_id: session_id }))
+
+        allow(api).to receive(:send_message)
+          .and_return(Dry::Monads::Success({}))
+
+        allow(api).to receive(:update_conversation_meta)
+          .and_return(Dry::Monads::Success({}))
+      end
+
+      it 'create conversation and message, destroy contact form' do
+        subject
+
+        expect(api).to have_received(:create_conversation)
+
+        expect(api).to have_received(:send_message).with(
+          session_id: session_id,
+          body: hash_including(
+            type: 'text',
+            from: 'user',
+            origin: 'email',
+            content: text,
+            fingerprint: contact_form.id,
+            user: { type: 'participant' }
+          )
+        )
+
+        expect(api).to have_received(:update_conversation_meta).with(
+          session_id: session_id,
+          body: hash_including(
+            email: email,
+            nickname: 'Test',
+            subject: subject_text,
+            segments: match_array(['test tag', 'contact form', question_type])
+          )
+        )
+
+        expect(contact_form).to be_destroyed
+      end
+    end
+
+    context 'avec pièce jointe saine' do
+      before do
+        file = fixture_file_upload('spec/fixtures/files/white.png', 'image/png')
+        contact_form.piece_jointe.attach(file)
+
+        allow_any_instance_of(ActiveStorage::Blob).to receive(:virus_scanner)
+          .and_return(double('VirusScanner', pending?: false, safe?: true))
+
+        allow(api).to receive(:create_conversation)
+          .and_return(Dry::Monads::Success(data: { session_id: session_id }))
+
+        allow(api).to receive(:send_message)
+          .and_return(Dry::Monads::Success({}))
+
+        allow(api).to receive(:update_conversation_meta)
+          .and_return(Dry::Monads::Success({}))
+      end
+
+      it 'envoie deux messages (texte et fichier)' do
+        subject
+
+        expect(api).to have_received(:send_message).twice
+
+        # Vérifier le message de type fichier
+        expect(api).to have_received(:send_message).with(
+          session_id: session_id,
+          body: hash_including(
+            type: 'file',
+            from: 'user',
+            origin: 'email',
+            content: hash_including(
+              name: 'white.png',
+              type: 'image/png'
+            )
+          )
+        )
+      end
+    end
+
+    context 'when the file has not been scanned yet' do
+      before do
+        file = fixture_file_upload('spec/fixtures/files/white.png', 'image/png')
+        contact_form.piece_jointe.attach(file)
+
+        allow_any_instance_of(ActiveStorage::Blob).to receive(:virus_scanner).and_return(double('VirusScanner', pending?: true, safe?: false))
+      end
+
+      it 'reenqueues job' do
+        expect { subject }.to have_enqueued_job(described_class).with(contact_form)
+      end
+    end
+
+    context 'conversation creation error' do
+      before do
+        allow(api).to receive(:create_conversation)
+          .and_return(Dry::Monads::Failure(reason: 'API Error'))
+      end
+
+      it 'raise an error so job will retry later' do
+        allow_any_instance_of(described_class).to receive(:executions).and_return(5)
+
+        expect { subject }.to raise_error('API Error')
+        expect(contact_form).not_to be_destroyed
+      end
+
+      it 'destroy contact form when max executions is reached' do
+        allow_any_instance_of(described_class).to receive(:executions).and_return(16)
+
+        expect { subject }.to raise_error('API Error')
+        expect(contact_form).to be_destroyed
+      end
+    end
+
+    context 'cas d\'erreur - échec d\'envoi de message' do
+      before do
+        allow(api).to receive(:create_conversation)
+          .and_return(Dry::Monads::Success(data: { session_id: session_id }))
+
+        allow(api).to receive(:send_message)
+          .and_return(Dry::Monads::Failure(reason: 'Message send failed'))
+      end
+
+      it 'lève une exception' do
+        expect { subject }.to raise_error('Message send failed')
+      end
+    end
+  end
+end


### PR DESCRIPTION
On commence sous FF et uniquement pour les users connectés, le temps de créer tous les outils sur crisp et avoir un peu de matière. C'est l'équivalent du job qui créé une conversation sur HS à partir d'un même ContactForm.

La création d'une conversation se fait en plusieurs temps : 

- création d'une session
- on y envoie un message
- on y envoie un éventuel fichier
- on update des metadonnées comme l'email du visiteur

Il resterait éventuellement à remonter les infos du navigateur pour faciliter le debug.