### PR TITLE
ETQ Tech : refacto les badges de notification attachés à un groupe instructeur

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -1222,7 +1222,6 @@ class Dossier < ApplicationRecord
   end
 
   def update_notifications(dossier, previous_groupe_instructeur, new_groupe_instructeur)
-    DossierNotification.update_notifications_groupe_instructeur(previous_groupe_instructeur, new_groupe_instructeur)
     DossierNotification.destroy_notifications_by_dossier_and_type(dossier, :dossier_depose)
     DossierNotification.create_notification(dossier, :dossier_depose) if dossier.en_construction? && dossier.follows.empty?
   end

--- a/app/models/dossier_notification.rb
+++ b/app/models/dossier_notification.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
 class DossierNotification < ApplicationRecord
+  self.ignored_columns += ["groupe_instructeur_id"]
+
   DELAY_DOSSIER_DEPOSE = 7.days
 
-  belongs_to :groupe_instructeur, optional: true
-  belongs_to :instructeur, optional: true
+  belongs_to :instructeur
   belongs_to :dossier
-
-  validates :groupe_instructeur_id, presence: true, if: -> { instructeur_id.nil? }
-  validates :instructeur_id, presence: true, if: -> { groupe_instructeur_id.nil? }
 
   enum :notification_type, {
     dossier_depose: 'dossier_depose',

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -12,7 +12,6 @@ class GroupeInstructeur < ApplicationRecord
   has_many :assignments, class_name: 'DossierAssignment', dependent: :nullify, inverse_of: :groupe_instructeur
   has_many :previous_assignments, class_name: 'DossierAssignment', dependent: :nullify, inverse_of: :previous_groupe_instructeur
   has_many :export_templates, dependent: :destroy
-  has_many :dossier_notifications, dependent: :destroy
   has_and_belongs_to_many :exports, dependent: :destroy
 
   has_one :defaut_procedure, -> { with_discarded }, class_name: 'Procedure', foreign_key: :defaut_groupe_instructeur_id, dependent: :nullify, inverse_of: :defaut_groupe_instructeur

--- a/db/migrate/20250829092219_update_index_on_dossier_notifications.rb
+++ b/db/migrate/20250829092219_update_index_on_dossier_notifications.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class UpdateIndexOnDossierNotifications < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :dossier_notifications, name: "unique_dossier_groupe_instructeur_notification"
+
+    remove_index :dossier_notifications, name: "unique_dossier_instructeur_notification"
+
+    add_index :dossier_notifications,
+              [:dossier_id, :notification_type, :instructeur_id],
+              unique: true,
+              name: "unique_dossier_instructeur_notification",
+              algorithm: :concurrently
+  end
+
+  def down
+    remove_index :dossier_notifications, name: "unique_dossier_instructeur_notification"
+
+    add_index :dossier_notifications,
+      [:dossier_id, :notification_type, :instructeur_id],
+      unique: true,
+      where: "instructeur_id IS NOT NULL AND groupe_instructeur_id IS NULL",
+      name: "unique_dossier_instructeur_notification"
+
+    add_index :dossier_notifications,
+      [:dossier_id, :notification_type, :groupe_instructeur_id],
+      unique: true,
+      where: "groupe_instructeur_id IS NOT NULL AND instructeur_id IS NULL",
+      name: "unique_dossier_groupe_instructeur_notification"
+  end
+end

--- a/db/migrate/20250829103554_add_check_constraint_on_dossier_notifications_instructeur_id.rb
+++ b/db/migrate/20250829103554_add_check_constraint_on_dossier_notifications_instructeur_id.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCheckConstraintOnDossierNotificationsInstructeurId < ActiveRecord::Migration[7.1]
+  def change
+    add_check_constraint :dossier_notifications, "instructeur_id IS NOT NULL", name: "dossier_notifications_instructeur_id_null", validate: false
+  end
+end

--- a/db/migrate/20250829103729_validate_change_instructeur_id_not_null_on_dossier_notifications.rb
+++ b/db/migrate/20250829103729_validate_change_instructeur_id_not_null_on_dossier_notifications.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ValidateChangeInstructeurIdNotNullOnDossierNotifications < ActiveRecord::Migration[7.1]
+  def up
+    validate_check_constraint :dossier_notifications, name: "dossier_notifications_instructeur_id_null"
+    change_column_null :dossier_notifications, :instructeur_id, false
+    remove_check_constraint :dossier_notifications, name: "dossier_notifications_instructeur_id_null"
+  end
+
+  def down
+    add_check_constraint :dossier_notifications, "instructeur_id IS NOT NULL", name: "dossier_notifications_instructeur_id_null", validate: false
+    change_column_null :dossier_notifications, :instructeur_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -434,11 +434,10 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_02_123820) do
     t.datetime "display_at"
     t.bigint "dossier_id", null: false
     t.bigint "groupe_instructeur_id"
-    t.bigint "instructeur_id"
+    t.bigint "instructeur_id", null: false
     t.string "notification_type", null: false
     t.datetime "updated_at", null: false
-    t.index ["dossier_id", "notification_type", "groupe_instructeur_id"], name: "unique_dossier_groupe_instructeur_notification", unique: true, where: "((groupe_instructeur_id IS NOT NULL) AND (instructeur_id IS NULL))"
-    t.index ["dossier_id", "notification_type", "instructeur_id"], name: "unique_dossier_instructeur_notification", unique: true, where: "((instructeur_id IS NOT NULL) AND (groupe_instructeur_id IS NULL))"
+    t.index ["dossier_id", "notification_type", "instructeur_id"], name: "unique_dossier_instructeur_notification", unique: true
     t.index ["dossier_id"], name: "index_dossier_notifications_on_dossier_id"
     t.index ["groupe_instructeur_id"], name: "index_dossier_notifications_on_groupe_instructeur_id"
     t.index ["instructeur_id"], name: "index_dossier_notifications_on_instructeur_id"

--- a/spec/controllers/experts/avis_controller_spec.rb
+++ b/spec/controllers/experts/avis_controller_spec.rb
@@ -325,7 +325,7 @@ describe Experts::AvisController, type: :controller do
       end
 
       context "when dossier had attente_avis notification" do
-        let!(:notification) { create(:dossier_notification, :for_instructeur, dossier:, instructeur:, notification_type: :attente_avis) }
+        let!(:notification) { create(:dossier_notification, dossier:, instructeur:, notification_type: :attente_avis) }
 
         it "destroy notification for all instructeurs" do
           subject

--- a/spec/controllers/instructeurs/avis_controller_spec.rb
+++ b/spec/controllers/instructeurs/avis_controller_spec.rb
@@ -16,7 +16,7 @@ describe Instructeurs::AvisController, type: :controller do
     before { sign_in(instructeur.user) }
 
     describe "#revoker" do
-      let!(:notification) { create(:dossier_notification, :for_instructeur, dossier:, instructeur:, notification_type: :attente_avis) }
+      let!(:notification) { create(:dossier_notification, dossier:, instructeur:, notification_type: :attente_avis) }
 
       before do
         patch :revoquer, params: { procedure_id: procedure.id, id: avis_without_answer.id, statut: 'a-suivre' }

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -727,8 +727,8 @@ describe Instructeurs::DossiersController, type: :controller do
 
     context "when the usager had sent a message" do
       let!(:other_instructeur) { create(:instructeur) }
-      let!(:notification_current_instructeur) { create(:dossier_notification, :for_instructeur, dossier:, instructeur:, notification_type: :message) }
-      let!(:notification_other_instructeur) { create(:dossier_notification, :for_instructeur, dossier:, instructeur: other_instructeur, notification_type: :message) }
+      let!(:notification_current_instructeur) { create(:dossier_notification, dossier:, instructeur:, notification_type: :message) }
+      let!(:notification_other_instructeur) { create(:dossier_notification, dossier:, instructeur: other_instructeur, notification_type: :message) }
 
       it "destroy message notification only for the current_instructeur" do
         subject
@@ -1042,8 +1042,8 @@ describe Instructeurs::DossiersController, type: :controller do
 
     context "when the dossier has been modified by the usager" do
       let!(:other_instructeur) { create(:instructeur) }
-      let!(:notification_current_instructeur) { create(:dossier_notification, :for_instructeur, dossier:, instructeur:, notification_type: :dossier_modifie) }
-      let!(:notification_other_instructeur) { create(:dossier_notification, :for_instructeur, dossier:, instructeur: other_instructeur, notification_type: :dossier_modifie) }
+      let!(:notification_current_instructeur) { create(:dossier_notification, dossier:, instructeur:, notification_type: :dossier_modifie) }
+      let!(:notification_other_instructeur) { create(:dossier_notification, dossier:, instructeur: other_instructeur, notification_type: :dossier_modifie) }
 
       it "destroy dossier_modifie notification only for the current_instructeur" do
         get :show, params: { procedure_id: procedure.id, dossier_id: dossier.id, statut: 'suivis' }
@@ -1386,8 +1386,8 @@ describe Instructeurs::DossiersController, type: :controller do
   describe "#annotations_privees" do
     context "when the dossier has an annotation_instructeur notification" do
       let!(:other_instructeur) { create(:instructeur) }
-      let!(:notification_current_instructeur) { create(:dossier_notification, :for_instructeur, dossier:, instructeur:, notification_type: :annotation_instructeur) }
-      let!(:notification_other_instructeur) { create(:dossier_notification, :for_instructeur, dossier:, instructeur: other_instructeur, notification_type: :annotation_instructeur) }
+      let!(:notification_current_instructeur) { create(:dossier_notification, dossier:, instructeur:, notification_type: :annotation_instructeur) }
+      let!(:notification_other_instructeur) { create(:dossier_notification, dossier:, instructeur: other_instructeur, notification_type: :annotation_instructeur) }
 
       it "destroy annotation_instructeur notification only for the current_instructeur" do
         get :annotations_privees, params: { procedure_id: procedure.id, dossier_id: dossier.id, statut: 'suivis' }
@@ -1406,8 +1406,8 @@ describe Instructeurs::DossiersController, type: :controller do
   describe "#avis" do
     context "when the dossier has an avis_externe notification" do
       let!(:other_instructeur) { create(:instructeur) }
-      let!(:notification_current_instructeur) { create(:dossier_notification, :for_instructeur, dossier:, instructeur:, notification_type: :avis_externe) }
-      let!(:notification_other_instructeur) { create(:dossier_notification, :for_instructeur, dossier:, instructeur: other_instructeur, notification_type: :avis_externe) }
+      let!(:notification_current_instructeur) { create(:dossier_notification, dossier:, instructeur:, notification_type: :avis_externe) }
+      let!(:notification_other_instructeur) { create(:dossier_notification, dossier:, instructeur: other_instructeur, notification_type: :avis_externe) }
 
       it "destroy avis_externe notification only for the current_instructeur" do
         get :avis, params: { procedure_id: procedure.id, dossier_id: dossier.id, statut: 'suivis' }

--- a/spec/controllers/recherche_controller_spec.rb
+++ b/spec/controllers/recherche_controller_spec.rb
@@ -150,7 +150,7 @@ describe RechercheController, type: :controller do
       end
 
       context 'when dossier has notification' do
-        let!(:notification) { create(:dossier_notification, :for_instructeur, dossier:, instructeur:, notification_type: :dossier_modifie) }
+        let!(:notification) { create(:dossier_notification, dossier:, instructeur:, notification_type: :dossier_modifie) }
 
         it 'assigns notification' do
           subject

--- a/spec/factories/dossier_notification.rb
+++ b/spec/factories/dossier_notification.rb
@@ -3,17 +3,8 @@
 FactoryBot.define do
   factory :dossier_notification do
     dossier { association :dossier }
+    instructeur { association :instructeur }
     notification_type { "dossier_depose" }
     display_at { 1.day.ago }
-
-    trait :for_groupe_instructeur do
-      groupe_instructeur { association :groupe_instructeur }
-      instructeur { nil }
-    end
-
-    trait :for_instructeur do
-      instructeur { association :instructeur }
-      groupe_instructeur { nil }
-    end
   end
 end

--- a/spec/helpers/dossier_helper_spec.rb
+++ b/spec/helpers/dossier_helper_spec.rb
@@ -271,9 +271,9 @@ RSpec.describe DossierHelper, type: :helper do
     subject { tags_notification([notification]) }
 
     context "with dossier_depose notification" do
-      let(:groupe_instructeur) { create(:groupe_instructeur) }
-      let(:dossier) { create(:dossier, groupe_instructeur:, depose_at: 10.days.ago) }
-      let!(:notification) { create(:dossier_notification, :for_groupe_instructeur, groupe_instructeur:, dossier:, notification_type: :dossier_depose, display_at: (dossier.depose_at + DossierNotification::DELAY_DOSSIER_DEPOSE)) }
+      let(:instructeur) { create(:instructeur) }
+      let(:dossier) { create(:dossier, depose_at: 10.days.ago) }
+      let!(:notification) { create(:dossier_notification, instructeur:, dossier:, notification_type: :dossier_depose, display_at: (dossier.depose_at + DossierNotification::DELAY_DOSSIER_DEPOSE)) }
 
       it {
         expect(subject).to have_text("Déposé depuis 10 J.")

--- a/spec/models/concerns/dossier_correctable_concern_spec.rb
+++ b/spec/models/concerns/dossier_correctable_concern_spec.rb
@@ -176,7 +176,7 @@ describe DossierCorrectableConcern do
     context "when dossier has attente_correction notification" do
       let!(:correction) { create(:dossier_correction, dossier:) }
       let!(:instructeur) { create(:instructeur) }
-      let!(:notification) { create(:dossier_notification, :for_instructeur, dossier:, instructeur:, notification_type: :attente_correction) }
+      let!(:notification) { create(:dossier_notification, dossier:, instructeur:, notification_type: :attente_correction) }
 
       it "destroy notification for all instructeurs" do
         subject

--- a/spec/models/concerns/dossier_state_concern_spec.rb
+++ b/spec/models/concerns/dossier_state_concern_spec.rb
@@ -184,7 +184,8 @@ RSpec.describe DossierStateConcern do
     describe 'en_instruction' do
       context "when dossier has a dossier_depose notification" do
         let(:auto_archive_on) { 1.day.from_now }
-        let!(:notification) { create(:dossier_notification, :for_groupe_instructeur, groupe_instructeur_id: dossier.groupe_instructeur_id, dossier:) }
+        let(:instructeur) { create(:instructeur) }
+        let!(:notification) { create(:dossier_notification, dossier:, instructeur:) }
 
         it "destroy the notification" do
           travel_to(2.days.from_now)

--- a/spec/models/dossier_notification_spec.rb
+++ b/spec/models/dossier_notification_spec.rb
@@ -2,8 +2,8 @@
 
 RSpec.describe DossierNotification, type: :model do
   describe '.to_display' do
-    let(:past_notification) { create(:dossier_notification, :for_groupe_instructeur) }
-    let(:future_notification) { create(:dossier_notification, :for_groupe_instructeur, display_at: 1.day.from_now) }
+    let(:past_notification) { create(:dossier_notification) }
+    let(:future_notification) { create(:dossier_notification, display_at: 1.day.from_now) }
 
     it 'includes notifications where display_at is in the past or now' do
       expect(DossierNotification.to_display).to include(past_notification)
@@ -33,7 +33,6 @@ RSpec.describe DossierNotification, type: :model do
         notification = DossierNotification.first
         expect(notification.dossier).to eq(dossier)
         expect(notification.instructeur).to eq(instructeur)
-        expect(notification.groupe_instructeur).to be_nil
         expect(notification.notification_type).to eq('dossier_depose')
         expect(notification.display_at.to_date).to eq(dossier.depose_at.to_date + DossierNotification::DELAY_DOSSIER_DEPOSE)
       end
@@ -91,7 +90,6 @@ RSpec.describe DossierNotification, type: :model do
 
           notification = DossierNotification.first
           expect(notification.dossier).to eq(dossier)
-          expect(notification.groupe_instructeur).to be_nil
           expect(notification.instructeur).to eq(other_instructeur_follower)
           expect(notification.notification_type).to eq('message')
           expect(DossierNotification.to_display).to include(notification)
@@ -106,8 +104,8 @@ RSpec.describe DossierNotification, type: :model do
     let!(:other_groupe_instructeur) { create(:groupe_instructeur, instructeurs: [instructeur]) }
     let!(:dossier) { create(:dossier, :accepte, groupe_instructeur:) }
     let!(:other_dossier) { create(:dossier, :en_construction, groupe_instructeur: other_groupe_instructeur) }
-    let!(:notification_instructeur) { create(:dossier_notification, :for_instructeur, dossier:, instructeur:, notification_type: :dossier_modifie) }
-    let!(:other_notification_instructeur) { create(:dossier_notification, :for_instructeur, dossier: other_dossier, instructeur:, notification_type: :dossier_modifie) }
+    let!(:notification_instructeur) { create(:dossier_notification, dossier:, instructeur:, notification_type: :dossier_modifie) }
+    let!(:other_notification_instructeur) { create(:dossier_notification, dossier: other_dossier, instructeur:, notification_type: :dossier_modifie) }
 
     context 'a given instructeur and one dossier' do
       subject { DossierNotification.notifications_for_instructeur_dossier(instructeur, dossier) }
@@ -148,10 +146,10 @@ RSpec.describe DossierNotification, type: :model do
     let(:other_groupe_instructeur) { create(:groupe_instructeur, instructeurs: [instructeur]) }
     let(:dossier) { create(:dossier, :accepte, procedure:, groupe_instructeur:) }
     let(:other_dossier) { create(:dossier, :en_construction, procedure:, groupe_instructeur: other_groupe_instructeur) }
-    let!(:notification_news_instructeur) { create(:dossier_notification, :for_instructeur, dossier:, instructeur:, notification_type: :dossier_modifie) }
-    let!(:notification_not_news_instructeur) { create(:dossier_notification, :for_instructeur, dossier:, instructeur:) }
-    let!(:other_notification_news_instructeur) { create(:dossier_notification, :for_instructeur, dossier: other_dossier, instructeur:, notification_type: :annotation_instructeur) }
-    let!(:other_notification_not_news_instructeur) { create(:dossier_notification, :for_instructeur, dossier: other_dossier, instructeur:) }
+    let!(:notification_news_instructeur) { create(:dossier_notification, dossier:, instructeur:, notification_type: :dossier_modifie) }
+    let!(:notification_not_news_instructeur) { create(:dossier_notification, dossier:, instructeur:) }
+    let!(:other_notification_news_instructeur) { create(:dossier_notification, dossier: other_dossier, instructeur:, notification_type: :annotation_instructeur) }
+    let!(:other_notification_not_news_instructeur) { create(:dossier_notification, dossier: other_dossier, instructeur:) }
 
     context 'a given instructeur on one dossier' do
       subject { DossierNotification.notifications_sticker_for_instructeur_dossier(instructeur, dossier) }

--- a/spec/models/groupe_instructeur_spec.rb
+++ b/spec/models/groupe_instructeur_spec.rb
@@ -118,8 +118,8 @@ describe GroupeInstructeur, type: :model do
       let(:groupe_instructeur) { procedure_to_remove.defaut_groupe_instructeur }
       let!(:dossier) { create(:dossier, groupe_instructeur:) }
       let!(:other_instructeur) { create(:instructeur) }
-      let!(:notification_instructeur) { create(:dossier_notification, :for_instructeur, dossier:, instructeur:) }
-      let!(:notification_other_instructeur) { create(:dossier_notification, :for_instructeur, dossier:, instructeur: other_instructeur) }
+      let!(:notification_instructeur) { create(:dossier_notification, dossier:, instructeur:) }
+      let!(:notification_other_instructeur) { create(:dossier_notification, dossier:, instructeur: other_instructeur) }
 
       before { procedure_to_remove.defaut_groupe_instructeur.add(other_instructeur) }
 

--- a/spec/models/instructeur_spec.rb
+++ b/spec/models/instructeur_spec.rb
@@ -40,7 +40,7 @@ describe Instructeur, type: :model do
     end
 
     context "when a instructeur is the first to follow a dossier" do
-      let!(:notification) { create(:dossier_notification, :for_instructeur, dossier:, instructeur:, notification_type: :dossier_depose) }
+      let!(:notification) { create(:dossier_notification, dossier:, instructeur:, notification_type: :dossier_depose) }
 
       before { instructeur.follow(dossier) }
 
@@ -114,7 +114,7 @@ describe Instructeur, type: :model do
     end
 
     context "when a instructeur has notifications on the dossier" do
-      let!(:notification) { create(:dossier_notification, :for_instructeur, dossier: already_followed_dossier, instructeur:) }
+      let!(:notification) { create(:dossier_notification, dossier: already_followed_dossier, instructeur:) }
 
       it "destroy all notifications of the instructeur/dossier" do
         instructeur.unfollow(already_followed_dossier)
@@ -308,8 +308,8 @@ describe Instructeur, type: :model do
 
     context 'when a notification exists' do
       let(:dossier) { create(:dossier, :en_construction, procedure: procedure_to_assign) }
-      let!(:notification_to_count) { create(:dossier_notification, :for_instructeur, instructeur:, dossier:, notification_type: :dossier_modifie) }
-      let!(:notification_not_count) { create(:dossier_notification, :for_instructeur, instructeur:, dossier:) }
+      let!(:notification_to_count) { create(:dossier_notification, instructeur:, dossier:, notification_type: :dossier_modifie) }
+      let!(:notification_not_count) { create(:dossier_notification, instructeur:, dossier:) }
 
       it do
         expect(instructeur.email_notification_data).to eq([

--- a/spec/services/dossier_filter_service_spec.rb
+++ b/spec/services/dossier_filter_service_spec.rb
@@ -93,13 +93,12 @@ describe DossierFilterService do
         let(:order) { 'desc' }
 
         let!(:dossier_notif) { create(:dossier, :en_construction, procedure:) }
-        let!(:notif_instructeur) { create(:dossier_notification, :for_instructeur, instructeur:, dossier: dossier_notif, notification_type: :attente_avis) }
+        let!(:notif_instructeur_1) { create(:dossier_notification, instructeur:, dossier: dossier_notif, notification_type: :attente_avis) }
         let(:other_instructeur) { create(:instructeur) }
-        let!(:notif_other_instructeur) { create(:dossier_notification, :for_instructeur, instructeur: other_instructeur, dossier: recent_dossier) }
+        let!(:notif_other_instructeur) { create(:dossier_notification, instructeur: other_instructeur, dossier: recent_dossier) }
         let!(:dossier_2_notif) { create(:dossier, :en_construction, procedure:) }
-        let(:groupe_instructeur) { procedure.defaut_groupe_instructeur }
-        let!(:notif_groupe) { create(:dossier_notification, :for_groupe_instructeur, groupe_instructeur:, dossier: dossier_2_notif) }
-        let!(:notif_not_display) { create(:dossier_notification, :for_groupe_instructeur, groupe_instructeur:, dossier: older_dossier, display_at: 1.day.from_now) }
+        let!(:notif_instructeur_2) { create(:dossier_notification, instructeur:, dossier: dossier_2_notif) }
+        let!(:notif_not_display) { create(:dossier_notification, instructeur:, dossier: older_dossier, display_at: 1.day.from_now) }
 
         it { is_expected.to eq([dossier_2_notif, dossier_notif, recent_dossier, older_dossier].map(&:id)) }
       end

--- a/spec/services/notification_service_spec.rb
+++ b/spec/services/notification_service_spec.rb
@@ -91,7 +91,7 @@ describe NotificationService do
 
       context 'when there is a notification on this procedure' do
         let(:dossier) { create(:dossier, :en_construction, procedure:) }
-        let!(:notification) { create(:dossier_notification, :for_instructeur, instructeur: instructeur_with_email_notifications, dossier:, notification_type: :dossier_modifie) }
+        let!(:notification) { create(:dossier_notification, instructeur: instructeur_with_email_notifications, dossier:, notification_type: :dossier_modifie) }
 
         it do
           subject

--- a/spec/tasks/maintenance/t20250410backfill_dossier_notification_for_dossier_depose_task_spec.rb
+++ b/spec/tasks/maintenance/t20250410backfill_dossier_notification_for_dossier_depose_task_spec.rb
@@ -44,24 +44,28 @@ module Maintenance
     end
 
     describe "#process" do
-      subject(:process) { described_class.process(dossier) }
+      # Since PR#12013, we cannot call groupe_instructeur on an instance of DossierNotification,
+      # and since PR#11949 we create dossier_depose notification only on instructeur_id.
+      # See T20250804backfillDossierDeposeNotificationForInstructeurTask to backfill dossier_depose notification.
 
-      let!(:dossier) { create(:dossier, depose_at: 10.days.ago) }
-      let!(:groupe_instructeur) { dossier.groupe_instructeur }
+      # subject(:process) { described_class.process(dossier) }
 
-      context "when a notification already exists for an instructeur" do
-        let!(:notification) { create(:dossier_notification, :for_groupe_instructeur, dossier:, groupe_instructeur:) }
+      # let!(:dossier) { create(:dossier, depose_at: 10.days.ago) }
+      # let!(:groupe_instructeur) { dossier.groupe_instructeur }
 
-        it "does not create duplicate notification" do
-          expect { process }.not_to change(DossierNotification, :count)
-        end
-      end
+      # context "when a notification already exists for an instructeur" do
+      #   let!(:notification) { create(:dossier_notification, :for_groupe_instructeur, dossier:, groupe_instructeur:) }
 
-      context "when there are no existing notification" do
-        it "creates notification" do
-          expect { process }.to change(DossierNotification, :count).by(1)
-        end
-      end
+      #   it "does not create duplicate notification" do
+      #     expect { process }.not_to change(DossierNotification, :count)
+      #   end
+      # end
+
+      # context "when there are no existing notification" do
+      #   it "creates notification" do
+      #     expect { process }.to change(DossierNotification, :count).by(1)
+      #   end
+      # end
     end
   end
 end

--- a/spec/tasks/maintenance/t20250417backfill_dossier_notification_for_attente_correction_task_spec.rb
+++ b/spec/tasks/maintenance/t20250417backfill_dossier_notification_for_attente_correction_task_spec.rb
@@ -37,7 +37,7 @@ module Maintenance
 
       context 'when dossier has pending correction but not attente_correction notification' do
         let!(:dossier_correction) { create(:dossier_correction, dossier:) }
-        let!(:notification) { create(:dossier_notification, :for_instructeur, dossier:, instructeur: follow_instructeur) }
+        let!(:notification) { create(:dossier_notification, dossier:, instructeur: follow_instructeur) }
 
         it do
           expect(collection).to eq([[dossier.id, []]])
@@ -58,7 +58,7 @@ module Maintenance
       end
 
       context "when a notification already exists for an instructeur" do
-        let!(:notification) { create(:dossier_notification, :for_instructeur, dossier:, instructeur:, notification_type: :attente_correction) }
+        let!(:notification) { create(:dossier_notification, dossier:, instructeur:, notification_type: :attente_correction) }
 
         it "does not create duplicate notification" do
           expect {

--- a/spec/tasks/maintenance/t20250424backfill_dossier_notification_for_attente_avis_task_spec.rb
+++ b/spec/tasks/maintenance/t20250424backfill_dossier_notification_for_attente_avis_task_spec.rb
@@ -37,7 +37,7 @@ module Maintenance
 
       context 'when dossier has avis without answer but not attente_avis notification' do
         let!(:avis) { create(:avis, dossier:) }
-        let!(:notification) { create(:dossier_notification, :for_instructeur, dossier:, instructeur: follow_instructeur) }
+        let!(:notification) { create(:dossier_notification, dossier:, instructeur: follow_instructeur) }
 
         it do
           expect(collection).to eq([dossier])
@@ -58,7 +58,7 @@ module Maintenance
       end
 
       context "when a notification already exists for an instructeur" do
-        let!(:notification) { create(:dossier_notification, :for_instructeur, dossier:, instructeur:, notification_type: :attente_avis) }
+        let!(:notification) { create(:dossier_notification, dossier:, instructeur:, notification_type: :attente_avis) }
 
         it "does not create duplicate notification" do
           expect {

--- a/spec/tasks/maintenance/t20250522backfill_dossier_notification_for_annotation_instructeur_task_spec.rb
+++ b/spec/tasks/maintenance/t20250522backfill_dossier_notification_for_annotation_instructeur_task_spec.rb
@@ -28,7 +28,7 @@ module Maintenance
       let!(:follow) { create(:follow, dossier:, instructeur:) }
 
       context "when a notification already exists for an instructeur" do
-        let!(:notification) { create(:dossier_notification, :for_instructeur, dossier:, instructeur:, notification_type: :annotation_instructeur) }
+        let!(:notification) { create(:dossier_notification, dossier:, instructeur:, notification_type: :annotation_instructeur) }
 
         it "does not create duplicate notification" do
           expect {

--- a/spec/tasks/maintenance/t20250522backfill_dossier_notification_for_avis_externe_task_spec.rb
+++ b/spec/tasks/maintenance/t20250522backfill_dossier_notification_for_avis_externe_task_spec.rb
@@ -28,7 +28,7 @@ module Maintenance
       let!(:follow) { create(:follow, dossier:, instructeur:) }
 
       context "when a notification already exists for an instructeur" do
-        let!(:notification) { create(:dossier_notification, :for_instructeur, dossier:, instructeur:, notification_type: :avis_externe) }
+        let!(:notification) { create(:dossier_notification, dossier:, instructeur:, notification_type: :avis_externe) }
 
         it "does not create duplicate notification" do
           expect {

--- a/spec/tasks/maintenance/t20250522backfill_dossier_notification_for_dossier_modifie_task_spec.rb
+++ b/spec/tasks/maintenance/t20250522backfill_dossier_notification_for_dossier_modifie_task_spec.rb
@@ -28,7 +28,7 @@ module Maintenance
       let!(:follow) { create(:follow, dossier:, instructeur:) }
 
       context "when a notification already exists for an instructeur" do
-        let!(:notification) { create(:dossier_notification, :for_instructeur, dossier:, instructeur:, notification_type: :dossier_modifie) }
+        let!(:notification) { create(:dossier_notification, dossier:, instructeur:, notification_type: :dossier_modifie) }
 
         it "does not create duplicate notification" do
           expect {

--- a/spec/tasks/maintenance/t20250522backfill_dossier_notification_for_message_task_spec.rb
+++ b/spec/tasks/maintenance/t20250522backfill_dossier_notification_for_message_task_spec.rb
@@ -28,7 +28,7 @@ module Maintenance
       let!(:follow) { create(:follow, dossier:, instructeur:) }
 
       context "when a notification :messsage already exists" do
-        let!(:notification) { create(:dossier_notification, :for_instructeur, dossier:, instructeur:, notification_type: :message) }
+        let!(:notification) { create(:dossier_notification, dossier:, instructeur:, notification_type: :message) }
 
         it "does not create duplicate notification" do
           expect {

--- a/spec/tasks/maintenance/t20250618destroy_dossier_notification_for_dossier_depose_task_spec.rb
+++ b/spec/tasks/maintenance/t20250618destroy_dossier_notification_for_dossier_depose_task_spec.rb
@@ -8,12 +8,11 @@ module Maintenance
       subject(:collection) { described_class.collection }
 
       let(:dossier) { create(:dossier, dossier_state) }
-      let(:groupe_instructeur) { dossier.groupe_instructeur }
       let(:instructeur) { create(:instructeur) }
 
       context "when dossier is en_construction with dossier_depose notification" do
         let(:dossier_state) { :en_construction }
-        let!(:notification_dossier_depose) { create(:dossier_notification, :for_groupe_instructeur, groupe_instructeur:, dossier:) }
+        let!(:notification_dossier_depose) { create(:dossier_notification, instructeur:, dossier:) }
 
         it "not include the notification" do
           expect(collection).not_to include(notification_dossier_depose)
@@ -22,7 +21,7 @@ module Maintenance
 
       context "when dossier is not en_construction with other notification" do
         let(:dossier_state) { :en_instruction }
-        let!(:other_notification) { create(:dossier_notification, :for_instructeur, instructeur:, dossier:, notification_type: :dossier_modifie) }
+        let!(:other_notification) { create(:dossier_notification, instructeur:, dossier:, notification_type: :dossier_modifie) }
 
         it "not include the other notification" do
           expect(collection).not_to include(other_notification)
@@ -31,8 +30,8 @@ module Maintenance
 
       context "when dossier is not en_construction with dossier_depose and other notification" do
         let(:dossier_state) { :accepte }
-        let!(:notification_dossier_depose) { create(:dossier_notification, :for_groupe_instructeur, groupe_instructeur:, dossier:) }
-        let!(:other_notification) { create(:dossier_notification, :for_instructeur, instructeur:, dossier:, notification_type: :dossier_modifie) }
+        let!(:notification_dossier_depose) { create(:dossier_notification, instructeur:, dossier:) }
+        let!(:other_notification) { create(:dossier_notification, instructeur:, dossier:, notification_type: :dossier_modifie) }
 
         it "include only dossier_depose notification" do
           expect(collection).to include(notification_dossier_depose)

--- a/spec/tasks/maintenance/t20250625update_dossier_notification_message_usager_to_message_task_spec.rb
+++ b/spec/tasks/maintenance/t20250625update_dossier_notification_message_usager_to_message_task_spec.rb
@@ -15,7 +15,7 @@ module Maintenance
     describe "#collection" do
       subject(:collection) { described_class.collection }
 
-      let!(:other_notification) { create(:dossier_notification, :for_instructeur, dossier:, instructeur:, notification_type: :dossier_modifie) }
+      let!(:other_notification) { create(:dossier_notification, dossier:, instructeur:, notification_type: :dossier_modifie) }
 
       it "includes only :message_usager notification" do
         expect(collection).to include(notification_message_usager)

--- a/spec/tasks/maintenance/t20250709destroy_dossier_notification_for_annotation_instructeur_task_spec.rb
+++ b/spec/tasks/maintenance/t20250709destroy_dossier_notification_for_annotation_instructeur_task_spec.rb
@@ -9,7 +9,7 @@ module Maintenance
 
       let(:dossier) { create(:dossier, last_champ_private_updated_at: last_champ_private_updated_at) }
       let(:instructeur) { create(:instructeur) }
-      let!(:notification) { create(:dossier_notification, :for_instructeur, dossier:, instructeur:, notification_type: :annotation_instructeur) }
+      let!(:notification) { create(:dossier_notification, dossier:, instructeur:, notification_type: :annotation_instructeur) }
 
       context "when dossier has a private champ filled in" do
         let(:last_champ_private_updated_at) { 1.day.ago }

--- a/spec/tasks/maintenance/t20250804destroy_dossier_depose_notification_of_groupe_instructeur_task_spec.rb
+++ b/spec/tasks/maintenance/t20250804destroy_dossier_depose_notification_of_groupe_instructeur_task_spec.rb
@@ -7,16 +7,18 @@ module Maintenance
     describe "#collection" do
       subject(:collection) { described_class.collection }
 
-      context 'dossier_depose notification is linked to a groupe_instructeur' do
-        let!(:notification) { create(:dossier_notification, :for_groupe_instructeur, groupe_instructeur: create(:groupe_instructeur), dossier: create(:dossier)) }
+      # Since PR#12013, we cannot call groupe_instructeur on an instance of DossierNotification
+      #
+      # context 'dossier_depose notification is linked to a groupe_instructeur' do
+      #   let!(:notification) { create(:dossier_notification, :for_groupe_instructeur, groupe_instructeur: create(:groupe_instructeur), dossier: create(:dossier)) }
 
-        it do
-          expect(collection.flat_map(&:to_a)).to include(notification)
-        end
-      end
+      #   it do
+      #     expect(collection.flat_map(&:to_a)).to include(notification)
+      #   end
+      # end
 
       context 'dossier_depose notification is linked to an instructeur' do
-        let!(:notification) { create(:dossier_notification, :for_instructeur, instructeur: create(:instructeur), dossier: create(:dossier)) }
+        let!(:notification) { create(:dossier_notification, instructeur: create(:instructeur), dossier: create(:dossier)) }
 
         it do
           expect(collection.flat_map(&:to_a)).not_to include(notification)

--- a/spec/views/instructeur/dossiers/show.html.haml_spec.rb
+++ b/spec/views/instructeur/dossiers/show.html.haml_spec.rb
@@ -55,7 +55,7 @@ describe 'instructeurs/dossiers/show', type: :view do
     end
 
     context 'with pending correction' do
-      let!(:notification) { create(:dossier_notification, :for_instructeur, dossier:, instructeur:, notification_type: 'attente_correction') }
+      let!(:notification) { create(:dossier_notification, dossier:, instructeur:, notification_type: 'attente_correction') }
 
       before do
         create(:dossier_correction, dossier:)
@@ -79,7 +79,7 @@ describe 'instructeurs/dossiers/show', type: :view do
     end
 
     context 'with resolved correction' do
-      let!(:notification) { create(:dossier_notification, :for_instructeur, dossier:, instructeur:, notification_type: 'dossier_modifie') }
+      let!(:notification) { create(:dossier_notification, dossier:, instructeur:, notification_type: 'dossier_modifie') }
 
       before { assign(:notifications, [notification]) }
 


### PR DESCRIPTION
Dans la suite de https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11949

Il faut d'abord faire passer les 2 MT de la PR ci-dessus!

On pourra ensuite finir le refacto par la suppression de la colonne groupe_instructeur_id dans la table dossier_notification.