### PR TITLE
Correctif : ETQ Instructeur le filtre sur l'Etat de dossier == En Construction retourne tous les dossier en construction même ceux avec des correction en attente

### DIFF
--- a/app/models/columns/dossier_column.rb
+++ b/app/models/columns/dossier_column.rb
@@ -34,10 +34,6 @@ class Columns::DossierColumn < Column
           .filter_map { |v| Time.zone.parse(v).beginning_of_day rescue nil }
 
         dossiers.filter_by_datetimes(column, dates)
-      elsif column == "state" && values.include?("pending_correction")
-        dossiers.joins(:corrections).where(corrections: DossierCorrection.pending)
-      elsif column == "state" && values.include?("en_construction")
-        dossiers.where("dossiers.#{column} IN (?)", values).includes(:corrections).where.not(corrections: DossierCorrection.pending)
       elsif type == :integer
         dossiers.where("dossiers.#{column} IN (?)", values.filter_map { Integer(_1) rescue nil })
       else

--- a/spec/models/columns/dossier_column_spec.rb
+++ b/spec/models/columns/dossier_column_spec.rb
@@ -127,6 +127,22 @@ describe Columns::DossierColumn do
 
         it { is_expected.to contain_exactly(dossier_en_construction.id) }
       end
+
+      context 'when searching for accepte' do
+        let(:search_terms) { { operator: 'match', value: ["accepte"] } }
+        it { is_expected.to contain_exactly(dossier_accepte.id) }
+      end
+
+      context 'when searching for en_instruction' do
+        let(:search_terms) { { operator: 'match', value: ["en_instruction"] } }
+        it { is_expected.to contain_exactly(dossier_en_instruction.id) }
+      end
+
+      context 'when searching for multiple states' do
+        let(:search_terms) { { operator: 'match', value: ["en_construction", "accepte"] } }
+
+        it { is_expected.to contain_exactly(dossier_en_construction.id, dossier_accepte.id) }
+      end
     end
   end
 end


### PR DESCRIPTION
Corrige le bug remonté par https://secure.helpscout.net/conversation/3045037117/2225195

~~Dans la version actuelle, si l'utilisateur veut définir un filtre par Etat du dossier avec plusieurs états possibles dont "En Co nstruction" ou "En attente", il n'y a que ces états qui sont pris en compte.~~