### PR TITLE
Tech: fix synchro metadonnées Crisp lorsque la conversation est initiée par Chat

### DIFF
--- a/app/services/crisp/api_service.rb
+++ b/app/services/crisp/api_service.rb
@@ -12,6 +12,8 @@ module Crisp
       "create_conversation" => '/v1/website/%{website_id}/conversation',
       # https://docs.crisp.chat/references/rest-api/v1/#send-a-message-in-conversation
       "send_message" => '/v1/website/%{website_id}/conversation/%{session_id}/message',
+      # https://docs.crisp.chat/references/rest-api/v1/#get-conversation-metas
+      "get_conversation_meta" => '/v1/website/%{website_id}/conversation/%{session_id}/meta',
       # https://docs.crisp.chat/references/rest-api/v1/#update-conversation-metas
       "update_conversation_meta" => '/v1/website/%{website_id}/conversation/%{session_id}/meta'
     }.freeze
@@ -37,6 +39,14 @@ module Crisp
       url = build_url(endpoint)
 
       result = call(url:, json: body, method: :post)
+      handle_result(result)
+    end
+
+    def get_conversation_meta(session_id:)
+      endpoint = format(ENDPOINTS['get_conversation_meta'], website_id:, session_id:)
+      url = build_url(endpoint)
+
+      result = call(url:, method: :get)
       handle_result(result)
     end
 

--- a/app/services/crisp/webhook_processor.rb
+++ b/app/services/crisp/webhook_processor.rb
@@ -2,13 +2,18 @@
 
 module Crisp
   class WebhookProcessor
+    include Dry::Monads[:result]
+
     def initialize(params)
       @params = params
-      @email = extract_email
+      @email = extract_email_from_params
     end
 
     def process
       return unless processable_event?
+
+      @email = fetch_email_from_session if email.blank?
+
       return if user.blank?
 
       CrispUpdatePeopleDataJob.perform_later(user)
@@ -19,15 +24,29 @@ module Crisp
     attr_reader :params, :email
 
     def processable_event?
-      params[:event] == "message:send"
+      params[:event] == "message:send" && params.dig(:data, :from) == "user"
     end
 
-    def extract_email
-      params.dig(:data, :user, :user_id)
+    def extract_email_from_params
+      # conversations from chat does not use an email as user id
+      maybe_email = params.dig(:data, :user, :user_id)
+      maybe_email&.include?("@") ? maybe_email : nil
     end
 
     def user
       @user ||= User.find_by(email:)
+    end
+
+    def fetch_email_from_session
+      session_id = params.dig(:data, :session_id)
+
+      result = Crisp::APIService.new.get_conversation_meta(session_id:)
+      case result
+      in Success(data: {email:})
+        email
+      in Failure(reason:)
+        fail reason
+      end
     end
   end
 end

--- a/spec/controllers/webhook_controller_spec.rb
+++ b/spec/controllers/webhook_controller_spec.rb
@@ -100,7 +100,16 @@ describe WebhookController, type: :controller do
   end
 
   describe '#crisp' do
-    let(:payload) { { "event" => "message:send" } }
+    let(:payload) do
+      {
+        "event" => "message:send",
+        "data" => {
+          "from" => "user",
+          "user" => { "user_id" => "default_user@user.com" }
+        }
+      }
+    end
+
     let(:body) { payload }
     let(:timestamp) { Time.current }
 

--- a/spec/services/crisp/webhook_processor_spec.rb
+++ b/spec/services/crisp/webhook_processor_spec.rb
@@ -6,10 +6,13 @@ RSpec.describe Crisp::WebhookProcessor do
   let!(:user) { users(:default_user) }
   let(:event) { "message:send" }
   let(:email) { user.email }
+  let(:session_id) { "session_d57cb2d9-4607-42fe-a6be-000001112222" }
   let(:params) do
     {
       event:,
       data: {
+        session_id:,
+        from: "user",
         user: {
           user_id: email
         }
@@ -32,6 +35,20 @@ RSpec.describe Crisp::WebhookProcessor do
 
       it 'does not handle webhook' do
         expect { subject }.not_to have_enqueued_job
+      end
+    end
+
+    context 'with a session id instead of email' do
+      let(:email) { session_id } # simulate real payload !
+      before do
+        stub_request(:get, %r{^https://api.crisp.chat/v1/website/.+/conversation/.+/meta$})
+          .and_return(
+            body: { "error" => false, "reason" => "resolved", "data" => { "email" => user.email } }.to_json
+          )
+      end
+
+      it 'fetch email from API' do
+        expect { subject }.to have_enqueued_job.with(user)
       end
     end
 


### PR DESCRIPTION
Dans ce cas là, le webhook ne renvoie pas l'email en tant que user id, donc on doit aller chercher l'email par API pour savoir de quel user il s'agit