### PR TITLE
Tech: fix flaky test sur la liste des zones disponibles

### DIFF
--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -489,20 +489,15 @@ describe Administrateurs::ProceduresController, type: :controller do
     let(:procedure) { create(:procedure, administrateur: admin) }
     let(:procedure_id) { procedure.id }
 
-    let(:last_zone) { create(:zone, labels: [{ designated_on: '1981-05-08', name: 'Autre' }]) }
-    let(:other_zone_1) { create(:zone, labels: [{ designated_on: '1981-05-08', name: 'Zone 1' }]) }
-    let(:other_zone_2) { create(:zone, labels: [{ designated_on: '1981-05-08', name: 'Zone 2' }]) }
+    let(:last_zone) { create(:zone, labels: [{ designated_on: '1981-05-08', name: 'Autre' }], acronym: "OTHER") }
+    let(:other_zone_1) { create(:zone, labels: [{ designated_on: '1981-05-08', name: 'Zone 1' }], acronym: "Z1") }
+    let(:other_zone_2) { create(:zone, labels: [{ designated_on: '1981-05-08', name: 'Zone 2' }], acronym: "Z2") }
 
     before do
       procedure.zones << [last_zone, other_zone_1, other_zone_2]
     end
 
     subject { get :zones, params: { id: procedure_id } }
-
-    it 'returns a successful response' do
-      subject
-      expect(response).to have_http_status(:success)
-    end
 
     it 'assigns @zones with the correct order' do
       subject


### PR DESCRIPTION
~~Les zones n'ont pas d'ordre déterminé, hormis la zone "autre" qui doit être à la fin, et c'est ce que test veut vérifier.~~
Les zones sont censées suivre l'ordre de leur acronyme, hormis "autre" qui doit être à la fin

https://github.com/demarches-simplifiees/demarches-simplifiees.fr/actions/runs/17397242453/job/49381816456