### PR TITLE
ETQ Instructeur je ne veux plus pouvoir filtrer sur l'Etat du dossier 'en attente de correction' (mais utiliser les notifications à la place)

### DIFF
--- a/app/tasks/maintenance/t20250901migrate_en_attente_correction_filters_task.rb
+++ b/app/tasks/maintenance/t20250901migrate_en_attente_correction_filters_task.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20250901migrateEnAttenteCorrectionFiltersTask < MaintenanceTasks::Task
+    # Documentation: cette tâche migre les filtres sur l' Etat du dossier avec la valeur pending_correction vers le filtre notification équivalent
+
+    include RunnableOnDeployConcern
+    include StatementsHelpersConcern
+
+    # Uncomment only if this task MUST run imperatively on its first deployment.
+    # If possible, leave commented for manual execution later.
+    run_on_first_deploy
+
+    STATE_FILTERS = [
+      :tous_filters,
+      :suivis_filters,
+      :traites_filters,
+      :a_suivre_filters,
+      :archives_filters,
+      :expirant_filters,
+      :supprimes_filters,
+      :supprimes_recemment_filters
+    ].freeze
+
+    def collection
+      ProcedurePresentation.includes(assign_to: :procedure)
+    end
+
+    def process(pp)
+      pp_changed = false
+
+      STATE_FILTERS.each do |state_filter|
+        current_state_filters = pp.send(state_filter)
+        next unless current_state_filters.any? { is_en_attente_correction_legacy_filter(_1) }
+
+        new_state_filters = current_state_filters.map do |filter|
+          if is_en_attente_correction_legacy_filter(filter)
+            pp_changed = true
+            FilteredColumn.new(
+              column: pp.procedure.dossier_notifications_column,
+              filter: "attente_correction"
+            )
+          else
+            filter
+          end
+        end
+
+        pp.send("#{state_filter}=", new_state_filters)
+      end
+
+      pp.save! if pp_changed
+    end
+
+    def is_en_attente_correction_legacy_filter(filter)
+      filter.column.table == 'self' &&
+      filter.column.column == 'state' &&
+      (filter.filter == "pending_correction")
+    end
+  end
+end

--- a/config/locales/views/instructeurs/fr.yml
+++ b/config/locales/views/instructeurs/fr.yml
@@ -6,7 +6,6 @@ fr:
     dossiers:
       filterable_state:
         en_construction: "En construction"
-        pending_correction: "En attente"
         en_instruction: "En instruction"
         accepte: "Accepté"
         refuse: "Refusé"

--- a/spec/tasks/maintenance/t20250901migrate_en_attente_correction_filters_task_spec.rb
+++ b/spec/tasks/maintenance/t20250901migrate_en_attente_correction_filters_task_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe T20250901migrateEnAttenteCorrectionFiltersTask do
+    describe "#process" do
+      let(:procedure) { create(:procedure) }
+      let(:instructeur) { create(:instructeur) }
+      let(:assign_to) { create(:assign_to, procedure: procedure, instructeur: instructeur) }
+      let!(:procedure_presentation) { create(:procedure_presentation, assign_to: assign_to) }
+
+      subject(:process) { described_class.process(procedure_presentation) }
+
+      context "when procedure_presentation has filters" do
+        context "one is 'pending_correction' on state" do
+          before do
+            procedure_presentation.update!(
+              suivis_filters: [
+                FilteredColumn.new(
+                  column: procedure.dossier_state_column,
+                  filter: "pending_correction"
+                ),
+                FilteredColumn.new(
+                  column: procedure.dossier_id_column,
+                  filter: "1"
+                )
+              ]
+            )
+          end
+
+          it "updates filter to notification == 'attente_correction'" do
+            subject
+            expect(procedure_presentation.suivis_filters.first.column).to eq(procedure.dossier_notifications_column)
+            expect(procedure_presentation.suivis_filters.first.filter).to eq('attente_correction')
+          end
+
+          it "does not change other filter" do
+            subject
+            expect(procedure_presentation.suivis_filters.second.column).to eq(procedure.dossier_id_column)
+            expect(procedure_presentation.suivis_filters.second.filter).to eq('1')
+          end
+
+          it "keeps the same number of filters" do
+            subject
+            expect(procedure_presentation.suivis_filters.count).to eq(2)
+          end
+        end
+
+        context "one is not 'pending_correction' on state" do
+          before do
+            procedure_presentation.update!(
+              suivis_filters: [
+                FilteredColumn.new(
+                  column: procedure.dossier_state_column,
+                  filter: "en_construction"
+                )
+              ]
+            )
+          end
+
+          it "does not change filter" do
+            subject
+            expect(procedure_presentation.suivis_filters.count).to eq(1)
+            expect(procedure_presentation.suivis_filters.first.column).to eq(procedure.dossier_state_column)
+            expect(procedure_presentation.suivis_filters.first.filter).to eq('en_construction')
+          end
+        end
+      end
+
+      context "when procedure_presentation has no filter" do
+        it "does not change procedure_presentation" do
+          expect { subject }.not_to change { procedure_presentation }
+        end
+      end
+
+      context "when procedure_presentation has notification_type filter" do
+        context "which is already 'attente_correction'" do
+          before do
+            procedure_presentation.update!(
+              suivis_filters: [
+                FilteredColumn.new(
+                  column: procedure.dossier_notifications_column,
+                  filter: "attente_correction"
+                )
+              ]
+            )
+          end
+
+          it "does not change notification_type filter" do
+            expect { process }.not_to change { procedure_presentation.suivis_filters.map(&:to_json) }
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #12021

Avant la migration
<img width="1144" height="422" alt="Capture d’écran 2025-09-02 à 10 43 09" src="https://github.com/user-attachments/assets/61c43fbd-a1d8-4c65-a97d-80908f951419" />
Après la migration
<img width="1159" height="434" alt="Capture d’écran 2025-09-02 à 10 43 20" src="https://github.com/user-attachments/assets/c1a60972-5a64-45da-8377-ed47fb2ea063" />

Avant on pouvait filter sur l'état du dossier En attente
<img width="628" height="404" alt="Capture d’écran 2025-09-02 à 10 45 22" src="https://github.com/user-attachments/assets/f6366a55-2d2a-4d4f-ae20-b69d14a762b2" />
Après on ne peut plus (il faut passer par un filtre sur les notifications)
<img width="643" height="374" alt="Capture d’écran 2025-09-02 à 10 45 36" src="https://github.com/user-attachments/assets/79f2f0da-07e4-4d82-8506-620e72f46deb" />
