### PR TITLE
ETQ tech : je veux une contrainte d'unicité pour la table experts sur le user_id 

### DIFF
--- a/app/models/concerns/procedure_clone_concern.rb
+++ b/app/models/concerns/procedure_clone_concern.rb
@@ -269,7 +269,7 @@ module ProcedureCloneConcern
     end
 
     if options[:clone_avis] && same_admin?(admin)
-      associations[:experts_procedures] = :expert
+      associations[:experts_procedures] = []
     end
 
     if options[:clone_instructeurs] && same_admin?(admin)

--- a/db/migrate/20250902123820_add_unique_index_to_experts_on_user_id.rb
+++ b/db/migrate/20250902123820_add_unique_index_to_experts_on_user_id.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexToExpertsOnUserId < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    remove_index :experts, :user_id, algorithm: :concurrently
+    add_index :experts, :user_id, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_08_13_143947) do
+ActiveRecord::Schema[7.1].define(version: 2025_09_02_123820) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_stat_statements"
@@ -626,7 +626,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_13_143947) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
-    t.index ["user_id"], name: "index_experts_on_user_id"
+    t.index ["user_id"], name: "index_experts_on_user_id", unique: true
   end
 
   create_table "experts_procedures", force: :cascade do |t|


### PR DESCRIPTION
Suite et fin de : https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11971 

Nécessite de faire passer d'abord la MT de la PR ci-dessus.

En ajoutant la contrainte d'unicité, cela a fait planter un test sur le clonage de procédure, ce qui laisse a penser que la source de duplication dans l'app se situait là, voir commit de fix.