### PR TITLE
Tech : correction d'un flaky test dans brouillon spec

### DIFF
--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -198,8 +198,6 @@ describe 'The user', js: true do
     fill_in('IBAN', with: 'FR')
     wait_until { champ_value_for('IBAN') == 'FR' }
 
-    expect(page).not_to have_content 'est invalide. Saisissez un numéro IBAN valide. Exemple (France) : FR76 1234 1234 1234 1234 1234 123'
-    blur
     expect(page).to have_content 'est invalide. Saisissez un numéro IBAN valide. Exemple (France) : FR76 1234 1234 1234 1234 1234 123'
 
     fill_in('IBAN', with: 'FR7630006000011234567890189')


### PR DESCRIPTION
(enfin j'espère)
De ce que je comprends on a mis par erreur deux `expect` contradictoires à la suite.
Et le premier est un expect(page).**not_to** have_content qui vérifie immédiatement sans faire de retry (contrairement à expect(page).**to** have_content).
Donc quand la validation était lente, le test passait, on avait un faux positif.
Et quand la validation était rapide, le test échouait parce que le contenu de l'expect n'était pas bon.