### PR TITLE
ETQ Admin non instructeur, je ne veux pas être notifié de la suppression d’un dossier

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -861,8 +861,13 @@ class Dossier < ApplicationRecord
     end
 
     if en_construction? && !hidden_by_administration?
-      administration_emails = followers_instructeurs.present? ? followers_instructeurs.map(&:email) : procedure.administrateurs.map(&:email)
-      administration_emails.each do |email|
+      followers_emails = followers_instructeurs.map(&:email)
+      admin_emails = procedure.administrateurs.map(&:email)
+      instructeurs_emails = procedure.groupe_instructeurs.flat_map { |g| g.instructeurs.map(&:email) }
+      admin_instructeur_emails = admin_emails.filter { |email| instructeurs_emails.include?(email) }
+      emails = (followers_emails + admin_instructeur_emails).uniq
+
+      emails.each do |email|
         DossierMailer.notify_en_construction_deletion_to_administration(self, email).deliver_later
       end
     end

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -1796,9 +1796,16 @@ describe Users::DossiersController, type: :controller do
 
     context 'when dossier is owned by signed in user' do
       let(:dossier) { create(:dossier, :en_construction, user: user, autorisation_donnees: true) }
+      let(:common_user) { create(:user) }
+      let!(:admin_and_instructeur_admin) { create(:administrateur, user: common_user) }
+
+      before do
+        dossier.procedure.administrateurs << admin_and_instructeur_admin
+        dossier.procedure.defaut_groupe_instructeur.instructeurs << admin_and_instructeur_admin.user.instructeur
+      end
 
       it "notifies the user and the admin of the deletion" do
-        expect(DossierMailer).to receive(:notify_en_construction_deletion_to_administration).with(kind_of(Dossier), dossier.procedure.administrateurs.first.email).and_return(double(deliver_later: nil))
+        expect(DossierMailer).to receive(:notify_en_construction_deletion_to_administration).with(kind_of(Dossier), common_user.email).and_return(double(deliver_later: nil))
         subject
       end
 


### PR DESCRIPTION
- Aligne la notification “suppression par l’usager” sur la logique des mails groupés : destinataires = instructeurs suiveurs ET administrateurs qui sont aussi instructeurs.

- Ne notifie plus les administrateurs  qui ne sont pas instructeurs
