### PR TITLE
Correctif : ETQ Instructeur lorsque je filtre les dossiers sur l'onglet "au total" le compteur de dossier archivés à télécharger doit tenir compte des filtres

### DIFF
--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -129,6 +129,14 @@ module Instructeurs
 
       begin
         @filtered_sorted_ids = DossierFilterService.filtered_sorted_ids(dossiers, statut, procedure_presentation.filters_for(statut), procedure_presentation.sorted_column, current_instructeur, count: dossiers_count)
+
+        @archived_dossiers_count = if statut == 'tous'
+          all_filtered_sorted_ids = DossierFilterService.filtered_sorted_ids(dossiers, statut, procedure_presentation.filters_for(statut), procedure_presentation.sorted_column, current_instructeur, count: dossiers_count, include_archived: true)
+
+          all_filtered_sorted_ids.size - @filtered_sorted_ids.size
+        else
+          0
+        end
       rescue ActiveRecord::StatementInvalid => e
         raise e if !(e.message =~ /PG::UndefinedFunction/) # StatementInvalid is too generic, we'll add more cases if needed
 
@@ -149,11 +157,6 @@ module Instructeurs
       page = params[:page].presence || 1
 
       @dossiers_count = @filtered_sorted_ids.size
-      @archived_dossiers_count = if statut == 'tous'
-        @counts[:archives]
-      else
-        0
-      end
 
       @filtered_sorted_paginated_ids = Kaminari
         .paginate_array(@filtered_sorted_ids)


### PR DESCRIPTION
Fixes #12039

C'était juste un problème de compteur, l'export prenait déjà bien en compte les filtres

Avant
<img width="1234" height="468" alt="Capture d’écran 2025-09-04 à 18 51 10" src="https://github.com/user-attachments/assets/55952d80-8c57-447f-b0cd-124a4c7544c1" />

Après
<img width="1238" height="509" alt="Capture d’écran 2025-09-04 à 18 51 24" src="https://github.com/user-attachments/assets/873c37f5-62b1-4576-bc39-3a2897794917" />
