### PR TITLE
Tech: ne réessaie pas `FetchCadastreRealGeometryJob` pour tjs quand le GeoArea a été détruit avant le job

### DIFF
--- a/app/jobs/fetch_cadastre_real_geometry_job.rb
+++ b/app/jobs/fetch_cadastre_real_geometry_job.rb
@@ -2,6 +2,7 @@
 
 class FetchCadastreRealGeometryJob < ApplicationJob
   MAX_ATTEMPT = 10
+  discard_on ActiveRecord::RecordNotFound
   retry_on StandardError, attempts: MAX_ATTEMPT, wait: :polynomially_longer
 
   def perform(geo_area)


### PR DESCRIPTION
On a des dizaines de jobs qui retry encore et encore et polluent les queues avant de mourir,  autant les achever avant