### PR TITLE
Tech: plus d'erreur JS avec crisp qui ne trouve pas de session data

### DIFF
--- a/app/javascript/shared/track/crisp.ts
+++ b/app/javascript/shared/track/crisp.ts
@@ -33,7 +33,6 @@ if (enabled) {
 
   window.$crisp.push(['set', 'user:email', [administrateur.email]]);
   window.$crisp.push(['set', 'session:segments', [['administrateur']]]);
-  window.$crisp.push(['set', 'session:data']);
 
   // Prevent Crisp to log warnings about Sentry overriding document.addEventListener
   window.$crisp.push(['safe', true]);


### PR DESCRIPTION
Pb que j'ai introduit il y a 2 semaines et qui pop pas mal : les data sont maintenant récupérées autrement