### PR TITLE
ETQ Instructeur, usager : lorsque je copie un texte, les longues urls ne sont pas raccourcies

### DIFF
--- a/app/assets/stylesheets/tags.scss
+++ b/app/assets/stylesheets/tags.scss
@@ -28,7 +28,7 @@ $colors:
   font-weight: normal;
   text-transform: none;
 
-  &.fr-icon-success-line {
+  &.fr-icon-check-line {
     color: $green;
   }
 }

--- a/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.html.haml
+++ b/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.html.haml
@@ -28,9 +28,6 @@
             = render partial: "shared/champs/siret/show", locals: { champ: champ, profile: @profile }
           - when TypeDeChamp.type_champs.fetch(:iban)
             = render partial: "shared/champs/iban/show", locals: { champ: champ }
-          - when TypeDeChamp.type_champs.fetch(:textarea)
-            .copy-btn{ role: "button" }
-              = render partial: "shared/champs/textarea/show", locals: { champ: champ }
           - when TypeDeChamp.type_champs.fetch(:annuaire_education)
             = render partial: "shared/champs/annuaire_education/show", locals: { champ: champ }
           - when TypeDeChamp.type_champs.fetch(:cnaf)

--- a/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.html.haml
+++ b/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.html.haml
@@ -66,5 +66,5 @@
             = render ViewableChamp::ReferentielDisplayComponent.new(champ: champ, profile: @profile)
 
           - else
-            .copy-btn{ role: "button" }
+            .copy-btn{ role: "button", 'data-to-copy': champ.to_s.strip }
               = helpers.format_text_value(champ.to_s.strip)

--- a/app/javascript/controllers/clipboard2_controller.ts
+++ b/app/javascript/controllers/clipboard2_controller.ts
@@ -3,7 +3,8 @@
  * 1. Add `{ "data-controller": "clipboard2" }` to a parent container
  * 2. Mark copyable elements with `.copy-btn`
  * 3. Optionally use `data-to-copy` attribute to specify exact text to copy
- * 4. Optionally use `data-copy-message-placeholder` to control message placement
+ * 4. Optionally use `.copy-btn{ 'data-to-copy': 'coucou' }` to copy specific text
+ * 5. Optionally use `data-copy-message-placeholder` to control message placement
  */
 import { Controller } from '@hotwired/stimulus';
 
@@ -63,6 +64,7 @@ export class Clipboard2Controller extends Controller {
     this.#copySpan.remove();
 
     const textToCopy = (
+      wrapper.dataset['toCopy'] ||
       wrapper.querySelector<HTMLElement>('[data-to-copy]')?.innerText ||
       wrapper.innerText ||
       ''

--- a/app/views/shared/champs/textarea/_show.html.haml
+++ b/app/views/shared/champs/textarea/_show.html.haml
@@ -1,1 +1,0 @@
-= format_text_value(champ.to_s)


### PR DESCRIPTION
Pour les champs text et textarea, on utilise le helper `format_text_value` qui réduit les longues urls pour alléger l'affichage.
Cela pose soucis pour les adaptes du copier coller qui souhaite avoir le texte original.

Du coup, cette pr rajoute un hook, l'attribut `data-to-copy`, dans lequel on place directement `champ.to_s` et qui sera lu en priorité par le controller `clipboard2`.

Aussi on supprime le partial `textearea` qui n'apportait rien.