### PR TITLE
ETQ tech- je veux améliorer les perfs lorsqu'un instructeur modifie ses préférences de badges de notifs

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -1239,11 +1239,11 @@ class Dossier < ApplicationRecord
   end
 
   def update_notifications(previous_groupe_instructeur, new_groupe_instructeur)
-    previous_groupe_instructeur.instructeurs.each do |instructeur|
-      if instructeur.groupe_instructeurs.exclude?(new_groupe_instructeur)
-        DossierNotification.destroy_notifications_instructeur_of_dossier(instructeur, self)
-      end
-    end
+    previous_instructeur_ids = previous_groupe_instructeur.instructeurs.ids
+    new_instructeur_ids = new_groupe_instructeur.instructeurs.ids
+    instructeur_removed_ids = previous_instructeur_ids - new_instructeur_ids
+
+    DossierNotification.destroy_notifications_instructeurs_of_old_dossier(instructeur_removed_ids, self) if instructeur_removed_ids.any?
 
     new_groupe_instructeur.instructeurs.each do |instructeur|
       if instructeur.groupe_instructeurs.exclude?(previous_groupe_instructeur)

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -1242,13 +1242,9 @@ class Dossier < ApplicationRecord
     previous_instructeur_ids = previous_groupe_instructeur.instructeurs.ids
     new_instructeur_ids = new_groupe_instructeur.instructeurs.ids
     instructeur_removed_ids = previous_instructeur_ids - new_instructeur_ids
+    instructeur_added_ids = new_instructeur_ids - previous_instructeur_ids
 
     DossierNotification.destroy_notifications_instructeurs_of_old_dossier(instructeur_removed_ids, self) if instructeur_removed_ids.any?
-
-    new_groupe_instructeur.instructeurs.each do |instructeur|
-      if instructeur.groupe_instructeurs.exclude?(previous_groupe_instructeur)
-        DossierNotification.refresh_notifications_instructeur_for_dossier_by_choice(instructeur, self, 'all')
-      end
-    end
+    DossierNotification.refresh_notifications_new_instructeurs_for_dossier(instructeur_added_ids, self) if instructeur_added_ids.any?
   end
 end

--- a/app/models/dossier_notification.rb
+++ b/app/models/dossier_notification.rb
@@ -80,13 +80,13 @@ class DossierNotification < ApplicationRecord
     DossierNotification
       .where(instructeur:)
       .where(dossier_id: groupe_instructeur.dossier_ids)
-      .destroy_all
+      .delete_all
   end
 
   def self.destroy_notifications_instructeur_of_dossier(instructeur, dossier)
     DossierNotification
       .where(instructeur:, dossier:)
-      .destroy_all
+      .delete_all
   end
 
   def self.destroy_notifications_instructeur_of_unfollowed_dossier(instructeur, dossier)
@@ -100,13 +100,13 @@ class DossierNotification < ApplicationRecord
 
     DossierNotification
       .where(instructeur:, dossier:, notification_type: notification_types_to_destroy)
-      .destroy_all
+      .delete_all
   end
 
   def self.destroy_notifications_by_dossier_and_type(dossier, notification_type)
     DossierNotification
       .where(dossier:, notification_type:)
-      .destroy_all
+      .delete_all
   end
 
   def self.destroy_notification_by_dossier_and_type_and_instructeur(dossier, notification_type, instructeur)
@@ -296,7 +296,7 @@ class DossierNotification < ApplicationRecord
   def self.destroy_notifications_by_dossiers_and_type_and_instructeur(dossiers, notification_type, instructeur_id)
     DossierNotification
       .where(dossier_id: dossiers, notification_type:, instructeur_id:)
-      .destroy_all
+      .delete_all
   end
 
   def self.refresh_notifications_instructeur_for_dossiers_and_type(dossiers, notification_type, instructeur_id)

--- a/app/models/dossier_notification.rb
+++ b/app/models/dossier_notification.rb
@@ -49,6 +49,8 @@ class DossierNotification < ApplicationRecord
   end
 
   def self.refresh_notifications_instructeur_for_dossiers(groupe_instructeur_ids, instructeur_id, notification_type, old_preference, new_preference)
+    # We use the scope state_not_brouillon rather than visible_by_administration in order to keep notifications up to date
+    # on hidden dossiers, so that there is no need to refresh notifications if the dossier is restored.
     all_dossiers = Dossier.where(groupe_instructeur_id: groupe_instructeur_ids).state_not_brouillon
     followed_dossiers = all_dossiers.joins(:follows).where(follows: { instructeur_id: }).distinct
     non_followed_dossiers = all_dossiers.where.not(id: followed_dossiers)

--- a/app/models/dossier_notification.rb
+++ b/app/models/dossier_notification.rb
@@ -105,9 +105,9 @@ class DossierNotification < ApplicationRecord
       .delete_all
   end
 
-  def self.destroy_notifications_instructeur_of_dossier(instructeur, dossier)
+  def self.destroy_notifications_instructeurs_of_old_dossier(instructeur_ids, dossier)
     DossierNotification
-      .where(instructeur:, dossier:)
+      .where(instructeur_id: instructeur_ids, dossier:)
       .delete_all
   end
 

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -40,7 +40,7 @@ class GroupeInstructeur < ApplicationRecord
 
     default_notification_settings = instructeur.notification_settings(procedure_id)
     instructeur.assign_to.create(groupe_instructeur: self, **default_notification_settings)
-    create_notifications_instructeur(self, instructeur)
+    DossierNotification.refresh_notifications_new_instructeur_for_dossiers(self, instructeur)
   end
 
   def remove(instructeur)
@@ -135,10 +135,4 @@ class GroupeInstructeur < ApplicationRecord
   end
 
   serialize :routing_rule, coder: LogicSerializer
-
-  def create_notifications_instructeur(groupe_instructeur, instructeur)
-    groupe_instructeur.dossiers.each do |dossier|
-      DossierNotification.refresh_notifications_instructeur_for_dossier_by_choice(instructeur, dossier, 'all')
-    end
-  end
 end

--- a/app/models/instructeurs_procedure.rb
+++ b/app/models/instructeurs_procedure.rb
@@ -56,16 +56,10 @@ class InstructeursProcedure < ApplicationRecord
   def refresh_notifications(groupe_instructeur_ids, old_preferences, new_preferences)
     return if old_preferences == new_preferences
 
-    all_dossiers = Dossier.where(groupe_instructeur_id: groupe_instructeur_ids).state_not_brouillon
-    followed_dossiers = all_dossiers.joins(:follows).where(follows: { instructeur_id: }).distinct
-    non_followed_dossiers = all_dossiers.where.not(id: followed_dossiers)
-
     old_preferences.keys.each do |notification_type|
       if old_preferences[notification_type] != new_preferences[notification_type]
         DossierNotification.refresh_notifications_instructeur_for_dossiers(
-          all_dossiers,
-          followed_dossiers,
-          non_followed_dossiers,
+          groupe_instructeur_ids,
           instructeur_id,
           notification_type,
           old_preferences[notification_type],

--- a/spec/models/dossier_notification_spec.rb
+++ b/spec/models/dossier_notification_spec.rb
@@ -277,6 +277,23 @@ RSpec.describe DossierNotification, type: :model do
     end
   end
 
+  describe '.instructeur_ids_to_notify_by_notification_type' do
+    subject { DossierNotification.instructeur_ids_to_notify_by_notification_type(dossier, notification_type, instructeur_ids) }
+
+    context "when notification_type is message" do
+      let(:notification_type) { :message }
+      let(:dossier) { create(:dossier) }
+      let(:instructeur_to_notify) { create(:instructeur) }
+      let(:instructeur_not_to_notify) { create(:instructeur) }
+      let!(:commentaire_not_to_notify) { create(:commentaire, dossier:, instructeur: instructeur_not_to_notify) }
+      let(:instructeur_ids) { [instructeur_to_notify, instructeur_not_to_notify].map(&:id) }
+
+      it "returns instructeur_ids to notify" do
+        expect(subject).to eq([instructeur_to_notify.id])
+      end
+    end
+  end
+
   describe '.destroy_notifications' do
     context 'when instructeur unfollow a dossier' do
       subject { DossierNotification.destroy_notifications_instructeur_of_unfollowed_dossier(instructeur, dossier) }

--- a/spec/models/dossier_notification_spec.rb
+++ b/spec/models/dossier_notification_spec.rb
@@ -190,6 +190,93 @@ RSpec.describe DossierNotification, type: :model do
     end
   end
 
+  describe '.dossiers_to_notify' do
+    subject { DossierNotification.dossiers_to_notify(Dossier.all, notification_type, instructeur.id) }
+
+    let(:instructeur) { create(:instructeur) }
+
+    context "when notification_type is dossier_depose" do
+      let(:notification_type) { :dossier_depose }
+      let!(:dossier_to_notify) { create(:dossier, state: :en_construction, follows: []) }
+      let!(:dossier_not_to_notify_1) { create(:dossier, :en_construction) }
+      let!(:follow) { create(:follow, instructeur:, dossier: dossier_not_to_notify_1) }
+      let!(:dossier_not_to_notify_2) { create(:dossier, :accepte) }
+
+      it "returns only dossiers en_construction without followers" do
+        expect(subject).to contain_exactly(dossier_to_notify)
+      end
+    end
+
+    context "when notification_type is dossier_modifie" do
+      let(:notification_type) { :dossier_modifie }
+      let!(:dossier_to_notify) { create(:dossier, depose_at: 2.days.ago, last_champ_updated_at: 1.day.ago) }
+      let!(:dossier_not_to_notify_1) { create(:dossier, depose_at: 1.day.ago, last_champ_updated_at: nil) }
+      let!(:dossier_not_to_notify_2) { create(:dossier, depose_at: 1.day.ago, last_champ_updated_at: 2.days.ago) }
+
+      it "returns only dossiers modified after the submission" do
+        expect(subject).to contain_exactly(dossier_to_notify)
+      end
+    end
+
+    context "when notification_type is message" do
+      let(:notification_type) { :message }
+      let!(:dossier_to_notify) { create(:dossier) }
+      let!(:commentaire_to_notify) { create(:commentaire, dossier: dossier_to_notify, instructeur_id: nil, email: "test@exemple.fr") }
+      let!(:dossier_not_to_notify) { create(:dossier) }
+      let!(:commentaire_not_to_notify) { create(:commentaire, dossier: dossier_not_to_notify, instructeur:) }
+
+      it "returns dossiers with commentaires to notify" do
+        expect(subject).to contain_exactly(dossier_to_notify)
+      end
+    end
+
+    context "when notification_type is annotation_instructeur" do
+      let(:notification_type) { :annotation_instructeur }
+      let!(:dossier_to_notify) { create(:dossier, last_champ_private_updated_at: Time.current) }
+      let!(:dossier_not_to_notify) { create(:dossier, last_champ_private_updated_at: nil) }
+
+      it "returns dossiers with last_champ_private_updated_at present" do
+        expect(subject).to contain_exactly(dossier_to_notify)
+      end
+    end
+
+    context "when notification_type is avis_externe" do
+      let(:notification_type) { :avis_externe }
+      let!(:dossier_to_notify) { create(:dossier) }
+      let!(:avis_with_answer) { create(:avis, :with_answer, dossier: dossier_to_notify) }
+      let!(:dossier_not_to_notify) { create(:dossier) }
+      let!(:avis_without_answer) { create(:avis, dossier: dossier_not_to_notify) }
+
+      it "returns dossiers with avis answered" do
+        expect(subject).to contain_exactly(dossier_to_notify)
+      end
+    end
+
+    context "when notification_type is attente_correction" do
+      let(:notification_type) { :attente_correction }
+      let!(:dossier_to_notify) { create(:dossier) }
+      let!(:commentaire_correction) { create(:commentaire, dossier: dossier_to_notify, instructeur:) }
+      let!(:correction) { create(:dossier_correction, dossier: dossier_to_notify, commentaire: commentaire_correction) }
+      let!(:dossier_not_to_notify) { create(:dossier) }
+
+      it "returns dossiers with pending corrections" do
+        expect(subject).to contain_exactly(dossier_to_notify)
+      end
+    end
+
+    context "when notification_type is attente_avis" do
+      let(:notification_type) { :attente_avis }
+      let!(:dossier_to_notify) { create(:dossier) }
+      let!(:avis_without_answer) { create(:avis, dossier: dossier_to_notify) }
+      let!(:dossier_not_to_notify) { create(:dossier) }
+      let!(:avis_with_answer) { create(:avis, :with_answer, dossier: dossier_not_to_notify) }
+
+      it "returns dossiers with avis without answer" do
+        expect(subject).to contain_exactly(dossier_to_notify)
+      end
+    end
+  end
+
   describe '.destroy_notifications' do
     context 'when instructeur unfollow a dossier' do
       subject { DossierNotification.destroy_notifications_instructeur_of_unfollowed_dossier(instructeur, dossier) }
@@ -329,22 +416,6 @@ RSpec.describe DossierNotification, type: :model do
           traites: [procedure.id]
         })
       end
-    end
-  end
-
-  describe '.refresh_notifications_instructeur_for_dossiers_and_type' do
-    let(:dossier) { create(:dossier, last_champ_updated_at: Time.zone.now, depose_at: Time.zone.yesterday) }
-    let(:dossier_with_notification) { create(:dossier, last_champ_updated_at: Time.zone.now, depose_at: Time.zone.yesterday) }
-    let(:dossiers) { [dossier, dossier_with_notification] }
-    let(:instructeur) { create(:instructeur) }
-    let!(:notification) { create(:dossier_notification, dossier: dossier_with_notification, instructeur:, notification_type: :dossier_modifie) }
-
-    subject { DossierNotification.refresh_notifications_instructeur_for_dossiers_and_type(dossiers, :dossier_modifie, instructeur.id) }
-
-    it 'inserts notifications and ignore those already present in the database' do
-      subject
-
-      expect(DossierNotification.count).to eq(2)
     end
   end
 end


### PR DESCRIPTION
Vient améliorer les perfs sur les badges de notification, suite notamment à https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11906

Aucune modification de fonctionnement métier donc, on cherche à éviter les N+1 qu'on a pu identifier, en particulier :
- le find_or_create pris dans une boucle d'instructeurs ou de dossiers ;
- la vérification des conditions de création des notifications prise dans une boucle d'instructeurs ou de dossiers.