### PR TITLE
perf: corrige un chargement de procédure sur users/dossier_controller#index

### DIFF
--- a/db/migrate/20250922200515_add_index_to_user_id_on_invite_table.rb
+++ b/db/migrate/20250922200515_add_index_to_user_id_on_invite_table.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddIndexToUserIdOnInviteTable < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :invites, :user_id, name: 'index_invites_on_user_id', algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_09_10_074841) do
+ActiveRecord::Schema[7.1].define(version: 2025_09_22_200515) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_stat_statements"
@@ -876,6 +876,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_10_074841) do
     t.integer "user_id"
     t.index ["dossier_id"], name: "index_invites_on_dossier_id"
     t.index ["email", "dossier_id"], name: "index_invites_on_email_and_dossier_id", unique: true
+    t.index ["user_id"], name: "index_invites_on_user_id"
   end
 
   create_table "labels", force: :cascade do |t|


### PR DESCRIPTION
[Selon skylight](https://www.skylight.io/app/applications/zAvWTaqO0mu1/recent/6h/endpoints/Users::DossiersController%23index?responseType=html) , ce endpoint est le second en terme d'agonie. 
Une  majorité du temps est passé en sql, plus précisément sur la méthode `all_dossier_procedures.distinct(:procedure_id).order(:libelle).pluck(:libelle, :id)`

<img width="1896" height="428" alt="Screenshot 2025-09-22 at 23-10-51 _dossiers (1279 3 ms) - Profiling Results" src="https://github.com/user-attachments/assets/7373eedf-00db-424b-babf-b1eebfc0055c" />

la première étape consiste à mettre un index sur la table invité pour accélérer `current_user.dossiers_invites.visible_by_user` (70ms -> 1ms)

<img width="1894" height="428" alt="Screenshot 2025-09-22 at 23-14-41 _dossiers (513 3 ms) - Profiling Results" src="https://github.com/user-attachments/assets/85b8dc80-07c3-46fe-b103-ef7dd4ccf6b7" />

puis élagage du sql `current_user.dossiers_invites.visible_by_user == current_user.dossiers_invites`

Finalement, le `or` est étonnant pas le top du top en terme d’optimisation (et rails étant pas d'accord avec ma syntaxe), on utilise (merci claude) l'union que [postgresql préfère](https://dba.stackexchange.com/questions/293836/why-is-an-or-statement-slower-than-union)

<img width="1892" height="380" alt="Screenshot 2025-09-22 at 23-21-15 _dossiers (465 7 ms) - Profiling Results" src="https://github.com/user-attachments/assets/e2ebbbca-0721-4635-982d-ed35b2804f1e" />
