### PR TITLE
amélioration: ETQ administration/instructeur, je peux savoir qui a publié une revision

### DIFF
--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -289,7 +289,7 @@ module Administrateurs
     end
 
     def modifications
-      ProcedureRevisionPreloader.new(@procedure.revisions).all
+      ProcedureRevisionPreloader.new(@procedure.revisions.includes(administrateur: :user).reorder(published_at: :desc)).all
     end
 
     def update_jeton
@@ -390,7 +390,7 @@ module Administrateurs
     end
 
     def publish_revision
-      @procedure.publish_revision!
+      @procedure.publish_revision!(current_administrateur)
       flash.notice = "Nouvelle version de la démarche publiée"
 
       redirect_to admin_procedure_path(@procedure)

--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -356,6 +356,7 @@ module Instructeurs
     def history
       @procedure = procedure
       @revisions = @procedure.revisions
+        .includes(administrateur: :user)
         .where.not(published_at: nil)
         .reorder(published_at: :desc)
       @instructeur_procedure = find_or_create_instructeur_procedure(@procedure)

--- a/app/models/administrateur.rb
+++ b/app/models/administrateur.rb
@@ -35,14 +35,7 @@ class Administrateur < ApplicationRecord
   end
 
   delegate :rdv_connection, to: :instructeur
-
-  def email
-    user&.email
-  end
-
-  def active?
-    user&.active?
-  end
+  delegate :email, :active?, to: :user, allow_nil: true
 
   def self.find_inactive_by_token(reset_password_token)
     self.inactive.with_reset_password_token(reset_password_token)

--- a/app/models/concerns/procedure_publish_concern.rb
+++ b/app/models/concerns/procedure_publish_concern.rb
@@ -64,7 +64,7 @@ module ProcedurePublishConcern
     publish_new_revision(administrateur)
   end
 
-  def after_republish(canonical_procedure = nil, administrateur)
+  def after_republish(administrateur, canonical_procedure = nil)
     touch(:published_at)
   end
 

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -3,6 +3,7 @@
 class ProcedureRevision < ApplicationRecord
   include Logic
   self.implicit_order_column = :created_at
+  belongs_to :administrateur, optional: true
   belongs_to :procedure, -> { with_discarded }, inverse_of: :revisions, optional: false
   belongs_to :dossier_submitted_message, inverse_of: :revisions, optional: true, dependent: :destroy
 

--- a/app/views/administrateurs/procedures/modifications.html.haml
+++ b/app/views/administrateurs/procedures/modifications.html.haml
@@ -18,10 +18,10 @@
       - dossiers_en_instruction_count = dossiers.state_en_instruction.count
       .card.mb-4
         %h2.card-title
-          - if revision.administrateur.present? && revision.administrateur.user.present?
-            = "Modifications publiées le #{l(revision.published_at, format: '%d %B %Y à %R')} par #{revision.administrateur.user.email}"
+          - if revision.administrateur.present?
+            = "Modifications publiées le #{l(revision.published_at, format: :default)} par #{revision.administrateur.user.email}"
           - else
-            = "Modifications publiées le #{l(revision.published_at, format: '%d %B %Y à %R')}"
+            = "Modifications publiées le #{l(revision.published_at, format: :default)}"
         - if !dossiers_en_construction_count.zero? && !dossiers_en_instruction_count.zero?
           %p
             - if dossiers_en_construction_count == 1

--- a/app/views/administrateurs/procedures/modifications.html.haml
+++ b/app/views/administrateurs/procedures/modifications.html.haml
@@ -17,7 +17,11 @@
       - dossiers_en_construction_count = dossiers.state_en_construction.count
       - dossiers_en_instruction_count = dossiers.state_en_instruction.count
       .card.mb-4
-        %h2.card-title= "Modifications publiées le #{l(revision.published_at, format: '%d %B %Y à %R')}"
+        %h2.card-title
+          - if revision.administrateur.present? && revision.administrateur.user.present?
+            = "Modifications publiées le #{l(revision.published_at, format: '%d %B %Y à %R')} par #{revision.administrateur.user.email}"
+          - else
+            = "Modifications publiées le #{l(revision.published_at, format: '%d %B %Y à %R')}"
         - if !dossiers_en_construction_count.zero? && !dossiers_en_instruction_count.zero?
           %p
             - if dossiers_en_construction_count == 1

--- a/app/views/instructeurs/procedures/history.html.haml
+++ b/app/views/instructeurs/procedures/history.html.haml
@@ -16,7 +16,10 @@
     .fr-card.fr-mb-2w.fr-p-2w
       %div
         %h2.fr-card__title
-          = t('instructeurs.dossiers.header.banner.history.modification_published_at', date: l(current_revision.published_at, format: :human))
+          - if current_revision.administrateur.present? && current_revision.administrateur.user.present?
+            = t('instructeurs.dossiers.header.banner.history.modification_published_at_and_by', date: l(current_revision.published_at, format: :human), email: current_revision.administrateur.user.email)
+          - else
+            = t('instructeurs.dossiers.header.banner.history.modification_published_at', date: l(current_revision.published_at, format: :human))
           - if current_revision.id > @instructeur_procedure.last_revision_seen_id.to_i
             %span.fr-badge.fr-badge--sm.fr-badge--new= t('instructeurs.dossiers.header.banner.history.new')
       %div

--- a/app/views/instructeurs/procedures/history.html.haml
+++ b/app/views/instructeurs/procedures/history.html.haml
@@ -16,10 +16,10 @@
     .fr-card.fr-mb-2w.fr-p-2w
       %div
         %h2.fr-card__title
-          - if current_revision.administrateur.present? && current_revision.administrateur.user.present?
-            = t('instructeurs.dossiers.header.banner.history.modification_published_at_and_by', date: l(current_revision.published_at, format: :human), email: current_revision.administrateur.user.email)
+          - if current_revision.administrateur.present?
+            = t('instructeurs.dossiers.header.banner.history.modification_published_at_and_by', date: l(current_revision.published_at, format: :default), email: current_revision.administrateur.email)
           - else
-            = t('instructeurs.dossiers.header.banner.history.modification_published_at', date: l(current_revision.published_at, format: :human))
+            = t('instructeurs.dossiers.header.banner.history.modification_published_at', date: l(current_revision.published_at, format: :default))
           - if current_revision.id > @instructeur_procedure.last_revision_seen_id.to_i
             %span.fr-badge.fr-badge--sm.fr-badge--new= t('instructeurs.dossiers.header.banner.history.new')
       %div

--- a/config/locales/views/instructeurs/header/en.yml
+++ b/config/locales/views/instructeurs/header/en.yml
@@ -16,6 +16,7 @@ en:
           history:
             title: Form modification history
             modification_published_at: "Modifications published on %{date}"
+            modification_published_at_and_by: "Modifications published on %{date} by %{email}"
             new: New
             no_history: "No modification has been published"
           administrators_list: Administrators list

--- a/config/locales/views/instructeurs/header/fr.yml
+++ b/config/locales/views/instructeurs/header/fr.yml
@@ -17,6 +17,7 @@ fr:
           administrators_list: Administrateurs de la démarche
           history:
             title: Historique des modifications du formulaire
+            modification_published_at_and_by: "Modifications publiées le %{date} par %{email}"
             modification_published_at: "Modifications publiées le %{date}"
             new: Nouveau
             no_history: "Aucune modification n'a été publiée"

--- a/db/migrate/20250923100000_add_published_by_administrateur_to_procedure_revisions.rb
+++ b/db/migrate/20250923100000_add_published_by_administrateur_to_procedure_revisions.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddPublishedByAdministrateurToProcedureRevisions < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :procedure_revisions, :administrateur, null: true, default: nil, index: { algorithm: :concurrently }, foreign_key: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_09_22_200515) do
+ActiveRecord::Schema[7.1].define(version: 2025_09_23_100000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_stat_statements"
@@ -974,6 +974,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_22_200515) do
   end
 
   create_table "procedure_revisions", force: :cascade do |t|
+    t.bigint "administrateur_id"
     t.datetime "created_at", precision: nil, null: false
     t.bigint "dossier_submitted_message_id"
     t.boolean "ineligibilite_enabled", default: false, null: false
@@ -982,6 +983,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_22_200515) do
     t.bigint "procedure_id", null: false
     t.datetime "published_at", precision: nil
     t.datetime "updated_at", precision: nil, null: false
+    t.index ["administrateur_id"], name: "index_procedure_revisions_on_administrateur_id"
     t.index ["dossier_submitted_message_id"], name: "index_procedure_revisions_on_dossier_submitted_message_id"
     t.index ["procedure_id"], name: "index_procedure_revisions_on_procedure_id"
   end

--- a/spec/components/procedures/one_group_management_component_spec.rb
+++ b/spec/components/procedures/one_group_management_component_spec.rb
@@ -21,7 +21,7 @@ describe Procedure::OneGroupeManagementComponent, type: :component do
           libelle: 'Votre ville',
           drop_down_options: ["Paris", "Lyon", "Marseille"]
         })
-        procedure.publish_revision!
+        procedure.publish_revision!(procedure.administrateurs.first)
         procedure.reload
         subject
       end

--- a/spec/controllers/administrateurs/attestation_templates_controller_spec.rb
+++ b/spec/controllers/administrateurs/attestation_templates_controller_spec.rb
@@ -206,11 +206,11 @@ describe Administrateurs::AttestationTemplatesController, type: :controller do
       let(:body) { "body --#{type_de_champ.libelle}-- et --#{new_type_de_champ.libelle}--" }
 
       before do
-        procedure.publish!
+        procedure.publish!(procedure.administrateurs.first)
         procedure.reload
         procedure.draft_revision.remove_type_de_champ(removed_and_published_type_de_champ.stable_id)
         procedure.draft_revision.add_type_de_champ(libelle: 'new type de champ', type_champ: 'text', after_stable_id: procedure.draft_revision.types_de_champ_public.last.stable_id)
-        procedure.publish_revision!
+        procedure.publish_revision!(admin)
         procedure.reload
         procedure.draft_revision.remove_type_de_champ(removed_type_de_champ.stable_id)
         procedure.draft_revision.reload

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -1511,7 +1511,7 @@ describe Administrateurs::ProceduresController, type: :controller do
 
       context 'procedure was closed and is re opened' do
         before do
-          procedure.publish!
+          procedure.publish!(procedure.administrateurs.first)
           procedure.update!(closing_reason: 'internal_procedure', replaced_by_procedure_id: procedure2.id)
           procedure.close!
           procedure.update!(closing_notification_brouillon: true, closing_notification_en_cours: true)

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -644,7 +644,7 @@ describe Users::DossiersController, type: :controller do
 
         before do
           procedure.draft_revision.remove_type_de_champ(champ_repetition.stable_id)
-          procedure.publish_revision!
+          procedure.publish_revision!(procedure.administrateurs.first)
 
           champ_repetition.dossier.reload
           champ_repetition.dossier.rebase!
@@ -810,7 +810,7 @@ describe Users::DossiersController, type: :controller do
 
         before do
           procedure.draft_revision.remove_type_de_champ(champ_repetition.stable_id)
-          procedure.publish_revision!
+          procedure.publish_revision!(procedure.administrateurs.first)
 
           champ_repetition.dossier.reload
           champ_repetition.dossier.rebase!

--- a/spec/lib/recovery/revision_life_cycle_spec.rb
+++ b/spec/lib/recovery/revision_life_cycle_spec.rb
@@ -15,7 +15,7 @@ describe 'Recovery::Revision::LifeCycle' do
 
     before do
       cleanup_export_file
-      procedure.publish!
+      procedure.publish!(procedure.administrateurs.first)
       exporter.dump
     end
 

--- a/spec/models/concerns/champ_conditional_concern_spec.rb
+++ b/spec/models/concerns/champ_conditional_concern_spec.rb
@@ -86,7 +86,7 @@ describe ChampConditionalConcern do
 
     context 'when dossier not on submitted revision' do
       before {
-        procedure.publish_revision!
+        procedure.publish_revision!(procedure.administrateurs.first)
         dossier.rebase!
         dossier.reload
       }

--- a/spec/models/concerns/dossier_champs_concern_spec.rb
+++ b/spec/models/concerns/dossier_champs_concern_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe DossierChampsConcern do
     context 'given a type de champ repetition in another revision' do
       before do
         procedure.draft_revision.remove_type_de_champ(type_de_champ_repetition.stable_id)
-        procedure.publish_revision!
+        procedure.publish_revision!(procedure.administrateurs.first)
       end
 
       it { expect { subject }.not_to raise_error }
@@ -317,7 +317,7 @@ RSpec.describe DossierChampsConcern do
         before do
           tdc = dossier.procedure.draft_revision.find_and_ensure_exclusive_use(99)
           tdc.update!(type_champ: TypeDeChamp.type_champs.fetch(:checkbox))
-          dossier.procedure.publish_revision!
+          dossier.procedure.publish_revision!(procedure.administrateurs.first)
           perform_enqueued_jobs
           dossier.reload
         end
@@ -437,7 +437,7 @@ RSpec.describe DossierChampsConcern do
         before do
           tdc = dossier.procedure.draft_revision.find_and_ensure_exclusive_use(99)
           tdc.update!(type_champ: TypeDeChamp.type_champs.fetch(:linked_drop_down_list), drop_down_options: ["--primary--", "secondary"])
-          dossier.procedure.publish_revision!
+          dossier.procedure.publish_revision!(procedure.administrateurs.first)
           perform_enqueued_jobs
           dossier.reload
         end
@@ -462,7 +462,7 @@ RSpec.describe DossierChampsConcern do
         before do
           tdc = dossier.procedure.draft_revision.find_and_ensure_exclusive_use(99)
           tdc.update!(type_champ: TypeDeChamp.type_champs.fetch(:text))
-          dossier.procedure.publish_revision!
+          dossier.procedure.publish_revision!(procedure.administrateurs.first)
           perform_enqueued_jobs
           dossier.reload
         end
@@ -487,7 +487,7 @@ RSpec.describe DossierChampsConcern do
         before do
           tdc = dossier.procedure.draft_revision.find_and_ensure_exclusive_use(99)
           tdc.update!(type_champ: TypeDeChamp.type_champs.fetch(:checkbox))
-          dossier.procedure.publish_revision!
+          dossier.procedure.publish_revision!(procedure.administrateurs.first)
           perform_enqueued_jobs
           dossier.reload
         end
@@ -512,7 +512,7 @@ RSpec.describe DossierChampsConcern do
         before do
           tdc = dossier.procedure.draft_revision.find_and_ensure_exclusive_use(99)
           tdc.update!(type_champ: TypeDeChamp.type_champs.fetch(:text))
-          dossier.procedure.publish_revision!
+          dossier.procedure.publish_revision!(procedure.administrateurs.first)
           perform_enqueued_jobs
           dossier.reload
         end

--- a/spec/models/concerns/dossier_clone_concern_spec.rb
+++ b/spec/models/concerns/dossier_clone_concern_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe DossierCloneConcern do
   let(:procedure) do
-    create(:procedure, types_de_champ_public:, types_de_champ_private:).tap(&:publish!)
+    create(:procedure, types_de_champ_public:, types_de_champ_private:).tap { |it| it.publish!(it.administrateurs.first) }
   end
   let(:types_de_champ_public) do
     [
@@ -318,7 +318,7 @@ RSpec.describe DossierCloneConcern do
           libelle: "Un nouveau champ text"
         })
         procedure.draft_revision.remove_type_de_champ(removed_champ.stable_id)
-        procedure.publish_revision!
+        procedure.publish_revision!(procedure.administrateurs.first)
       end
 
       it {
@@ -399,7 +399,7 @@ RSpec.describe DossierCloneConcern do
         })
         procedure.draft_revision.remove_type_de_champ(removed_champ.stable_id)
         procedure.draft_revision.find_and_ensure_exclusive_use(updated_champ.stable_id).update(libelle: "Un nouveau libelle")
-        procedure.publish_revision!
+        procedure.publish_revision!(procedure.administrateurs.first)
         added_champ.update(value: 'new value for added champ')
         added_repetition_champ.update(value: "new value in repetition champ")
 
@@ -435,7 +435,7 @@ RSpec.describe DossierCloneConcern do
           champ.update(value: 'old value')
         end
         procedure.draft_revision.remove_type_de_champ(removed_champ.stable_id)
-        procedure.publish_revision!
+        procedure.publish_revision!(procedure.administrateurs.first)
       end
       it 'works' do
         expect { subject }.not_to raise_error

--- a/spec/models/concerns/dossier_rebase_concern_spec.rb
+++ b/spec/models/concerns/dossier_rebase_concern_spec.rb
@@ -23,7 +23,7 @@ describe DossierRebaseConcern do
       let(:dossier) { create(:dossier, :en_construction, procedure: procedure) }
 
       before do
-        procedure.publish!
+        procedure.publish!(procedure.administrateurs.first)
         procedure.reload
         dossier
       end
@@ -34,7 +34,7 @@ describe DossierRebaseConcern do
             type_champ: TypeDeChamp.type_champs.fetch(:text),
             libelle: "Un champ text"
           })
-          procedure.publish_revision!
+          procedure.publish_revision!(procedure.administrateurs.first)
           dossier.reload
         end
 
@@ -49,7 +49,7 @@ describe DossierRebaseConcern do
       let(:dossier) { create(:dossier, :en_instruction, procedure: procedure) }
 
       before do
-        procedure.publish!
+        procedure.publish!(procedure.administrateurs.first)
         procedure.reload
         dossier
       end
@@ -60,7 +60,7 @@ describe DossierRebaseConcern do
             type_champ: TypeDeChamp.type_champs.fetch(:text),
             libelle: "Un champ text"
           })
-          procedure.publish_revision!
+          procedure.publish_revision!(procedure.administrateurs.first)
           dossier.reload
         end
 
@@ -75,7 +75,7 @@ describe DossierRebaseConcern do
       let(:dossier) { create(:dossier, :accepte, procedure: procedure) }
 
       before do
-        procedure.publish!
+        procedure.publish!(procedure.administrateurs.first)
         procedure.reload
         dossier
       end
@@ -86,7 +86,7 @@ describe DossierRebaseConcern do
             type_champ: TypeDeChamp.type_champs.fetch(:text),
             libelle: "Un champ text"
           })
-          procedure.publish_revision!
+          procedure.publish_revision!(procedure.administrateurs.first)
           dossier.reload
         end
 
@@ -139,7 +139,7 @@ describe DossierRebaseConcern do
 
     context "when revision is published" do
       before do
-        procedure.publish!
+        procedure.publish!(procedure.administrateurs.first)
         procedure.draft_revision.add_type_de_champ({
           type_champ: TypeDeChamp.type_champs.fetch(:text),
           libelle: "Un champ text"
@@ -191,7 +191,7 @@ describe DossierRebaseConcern do
         expect(repetition_champ.rows[0].size).to eq(1)
         expect(repetition_champ.rows[1].size).to eq(1)
 
-        procedure.publish_revision!
+        procedure.publish_revision!(procedure.administrateurs.first)
         perform_enqueued_jobs
         procedure.reload
         dossier.reload
@@ -216,7 +216,7 @@ describe DossierRebaseConcern do
 
         dossier.passer_en_construction!
         procedure.draft_revision.find_and_ensure_exclusive_use(private_text_type_de_champ.stable_id).update(type_champ: TypeDeChamp.type_champs.fetch(:textarea))
-        procedure.publish_revision!
+        procedure.publish_revision!(procedure.administrateurs.first)
         perform_enqueued_jobs
         procedure.reload
         dossier.reload
@@ -243,7 +243,7 @@ describe DossierRebaseConcern do
 
   context 'small grained' do
     subject do
-      procedure.publish_revision!
+      procedure.publish_revision!(procedure.administrateurs.first)
       perform_enqueued_jobs
 
       dossier.reload
@@ -253,7 +253,7 @@ describe DossierRebaseConcern do
       let!(:procedure) do
         create(:procedure).tap do |p|
           p.draft_revision.add_type_de_champ(type_champ: :drop_down_list, libelle: 'l1', drop_down_options: ["option", "v1"])
-          p.publish!
+          p.publish!(p.administrateurs.first)
         end
       end
       let!(:dossier) { create(:dossier, procedure: procedure) }
@@ -299,7 +299,7 @@ describe DossierRebaseConcern do
       let!(:procedure) do
         create(:procedure).tap do |p|
           p.draft_revision.add_type_de_champ(type_champ: :multiple_drop_down_list, libelle: 'l1', drop_down_options: ["option", "v1"])
-          p.publish!
+          p.publish!(p.administrateurs.first)
         end
       end
       let!(:dossier) { create(:dossier, procedure: procedure) }
@@ -345,7 +345,7 @@ describe DossierRebaseConcern do
       let!(:procedure) do
         create(:procedure).tap do |p|
           p.draft_revision.add_type_de_champ(type_champ: :linked_drop_down_list, libelle: 'l1', drop_down_options: ["--titre1--", "option", "v1", "--titre2--", "option2", "v2"])
-          p.publish!
+          p.publish!(p.administrateurs.first)
         end
       end
       let!(:dossier) { create(:dossier, procedure: procedure) }
@@ -391,7 +391,7 @@ describe DossierRebaseConcern do
       let!(:procedure) do
         create(:procedure).tap do |p|
           champ = p.draft_revision.add_type_de_champ(type_champ: :carte, libelle: 'l1', cadastres: true)
-          p.publish!
+          p.publish!(p.administrateurs.first)
         end
       end
       let!(:dossier) { create(:dossier, procedure: procedure) }
@@ -513,7 +513,7 @@ describe DossierRebaseConcern do
           last_child = procedure.draft_revision.children_of(repetition).last
           added_tdc = procedure.draft_revision.add_type_de_champ(type_champ: :text, libelle: 'c3', parent_stable_id: repetition.stable_id, after_stable_id: last_child)
           procedure.draft_revision.move_type_de_champ(added_tdc.stable_id, 1)
-          # procedure.publish_revision!
+          # procedure.publish_revision!(procedure.administrateurs.first)
         end
 
         it 'does somehting' do

--- a/spec/models/concerns/dossier_state_concern_spec.rb
+++ b/spec/models/concerns/dossier_state_concern_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe DossierStateConcern do
       procedure.draft_revision.remove_type_de_champ(91)
       procedure.draft_revision.remove_type_de_champ(95)
       procedure.draft_revision.remove_type_de_champ(942)
-      procedure.publish_revision!
+      procedure.publish_revision!(procedure.administrateurs.first)
       perform_enqueued_jobs
       dossier.reload
       champ_repetition = dossier.project_champs_public.find { _1.stable_id == 94 }

--- a/spec/models/concerns/pieces_jointes_list_concern_spec.rb
+++ b/spec/models/concerns/pieces_jointes_list_concern_spec.rb
@@ -70,7 +70,7 @@ describe PiecesJointesListConcern do
     before do
       procedure.draft_revision.remove_type_de_champ(1)
       procedure.draft_revision.add_type_de_champ(type_champ: :piece_justificative, libelle: 'new', mandatory: false)
-      procedure.publish_revision!
+      procedure.publish_revision!(procedure.administrateurs.first)
     end
 
     it do

--- a/spec/models/concerns/tags_substitution_concern_spec.rb
+++ b/spec/models/concerns/tags_substitution_concern_spec.rb
@@ -512,7 +512,7 @@ describe TagsSubstitutionConcern, type: :model do
       before do
         draft_type_de_champ.update(libelle: 'mon nouveau libellé')
         dossier.project_champs_public.first.update(value: 'valeur')
-        procedure.publish_revision!
+        procedure.publish_revision!(procedure.administrateurs.first)
       end
 
       context "when using the champ's original label" do

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -2351,14 +2351,14 @@ describe Dossier, type: :model do
 
       context "when procedure published" do
         before do
-          procedure.publish!
+          procedure.publish!(procedure.administrateurs.first)
           dossier
           procedure.draft_revision.remove_type_de_champ(text_type_de_champ.stable_id)
           coordinate = procedure.draft_revision.add_type_de_champ(type_champ: TypeDeChamp.type_champs.fetch(:text), libelle: 'New text field', after_stable_id: repetition_type_de_champ.stable_id)
           procedure.draft_revision.find_and_ensure_exclusive_use(yes_no_type_de_champ.stable_id).update(libelle: 'Updated yes/no')
           procedure.draft_revision.find_and_ensure_exclusive_use(commune_type_de_champ.stable_id).update(libelle: 'Commune de naissance')
           procedure.draft_revision.find_and_ensure_exclusive_use(repetition_type_de_champ.stable_id).update(libelle: 'Repetition')
-          procedure.publish_revision!
+          procedure.publish_revision!(procedure.administrateurs.first)
           dossier.reload
           procedure.reload
         end

--- a/spec/models/export_template_tabular_spec.rb
+++ b/spec/models/export_template_tabular_spec.rb
@@ -47,7 +47,7 @@ describe ExportTemplate do
 
             type_de_champ = procedure.draft_revision.find_and_ensure_exclusive_use(previous_tdc.stable_id)
             type_de_champ.update(changed_tdc)
-            procedure.publish_revision!
+            procedure.publish_revision!(procedure.administrateurs.first)
           end
 
           it 'update columns with original libelle for champs with new revision' do
@@ -65,7 +65,7 @@ describe ExportTemplate do
         before do
           type_de_champ = procedure.draft_revision.find_and_ensure_exclusive_use(previous_tdc.stable_id)
           type_de_champ.update(changed_tdc)
-          procedure.publish_revision!
+          procedure.publish_revision!(procedure.administrateurs.first)
 
           export_template.exported_columns = [
             ExportedColumn.new(libelle: 'Ça roule ?', column: procedure.find_column(label: "Ca roule ?"))

--- a/spec/models/mail_template_spec.rb
+++ b/spec/models/mail_template_spec.rb
@@ -31,7 +31,7 @@ describe Mails::InitiatedMail, type: :model do
 
       before do
         procedure.draft_revision.add_type_de_champ(type_champ: :integer_number, libelle: 'age')
-        procedure.publish_revision!
+        procedure.publish_revision!(procedure.administrateurs.first)
       end
 
       it { expect(subject.errors).to be_empty }
@@ -68,7 +68,7 @@ describe Mails::InitiatedMail, type: :model do
 
       before do
         procedure.draft_revision.remove_type_de_champ(type_de_champ.stable_id)
-        procedure.publish_revision!
+        procedure.publish_revision!(procedure.administrateurs.first)
       end
 
       it { expect(subject.errors.full_messages).to eq(["Le champ « Corps de l’email » contient la balise \"nom\" qui a été supprimée. Supprimer la balise"]) }
@@ -80,7 +80,7 @@ describe Mails::InitiatedMail, type: :model do
       before do
         create(:dossier, :en_construction, procedure: procedure)
         procedure.draft_revision.add_type_de_champ(type_champ: :integer_number, libelle: 'age')
-        procedure.publish_revision!
+        procedure.publish_revision!(procedure.administrateurs.first)
       end
 
       it { expect(subject.errors.full_messages).to eq(["Le champ « Corps de l’email » contient la balise \"age\" qui n’existe pas sur un des dossiers en cours de traitement. Supprimer la balise"]) }

--- a/spec/models/procedure_presentation_and_revisions_spec.rb
+++ b/spec/models/procedure_presentation_and_revisions_spec.rb
@@ -17,7 +17,7 @@ describe ProcedurePresentation do
       let!(:tdc) { procedure.draft_revision.add_type_de_champ({ type_champ: :number, libelle: 'libelle 1' }) }
 
       before do
-        procedure.publish_revision!
+        procedure.publish_revision!(procedure.administrateurs.first)
       end
 
       it { is_expected.to match(['libelle 1']) }
@@ -27,7 +27,7 @@ describe ProcedurePresentation do
 
         before do
           procedure.draft_revision.add_type_de_champ(added_tdc)
-          procedure.publish_revision!
+          procedure.publish_revision!(procedure.administrateurs.first)
         end
 
         it { is_expected.to match(['libelle 1', 'libelle 2']) }
@@ -39,7 +39,7 @@ describe ProcedurePresentation do
         before do
           created_tdc0 = procedure.draft_revision.add_type_de_champ(tdc0)
           procedure.draft_revision.reload.move_type_de_champ(created_tdc0.stable_id, 0)
-          procedure.publish_revision!
+          procedure.publish_revision!(procedure.administrateurs.first)
         end
 
         it { is_expected.to match(['libelle 0', 'libelle 1']) }
@@ -50,7 +50,7 @@ describe ProcedurePresentation do
           before do
             procedure.draft_revision.remove_type_de_champ(previous_tdc0.stable_id)
 
-            procedure.publish_revision!
+            procedure.publish_revision!(procedure.administrateurs.first)
           end
 
           it { is_expected.to match(['libelle 1', 'libelle 0']) }
@@ -65,7 +65,7 @@ describe ProcedurePresentation do
           type_de_champ = procedure.draft_revision.find_and_ensure_exclusive_use(previous_tdc.id)
           type_de_champ.update(changed_tdc)
 
-          procedure.publish_revision!
+          procedure.publish_revision!(procedure.administrateurs.first)
         end
 
         it { is_expected.to match(['changed libelle 1']) }

--- a/spec/models/procedure_revision_spec.rb
+++ b/spec/models/procedure_revision_spec.rb
@@ -327,7 +327,7 @@ describe ProcedureRevision do
 
     context 'bug with duplicated repetition child' do
       before do
-        procedure.publish!
+        procedure.publish!(procedure.administrateurs.first)
         procedure.reload
         draft.find_and_ensure_exclusive_use(last_type_de_champ.stable_id).update(libelle: 'new libelle')
         procedure.reload
@@ -911,7 +911,7 @@ describe ProcedureRevision do
       context 'with multiple revision' do
         let(:new_child) { create(:type_de_champ_text) }
         let(:new_draft) do
-          procedure.publish!
+          procedure.publish!(procedure.administrateurs.first)
           procedure.draft_revision
         end
 
@@ -1251,12 +1251,12 @@ describe ProcedureRevision do
 
     it {
       expect(type_de_champ.only_present_on_draft?).to be_truthy
-      procedure.publish!
+      procedure.publish!(procedure.administrateurs.first)
       expect(type_de_champ.only_present_on_draft?).to be_falsey
       procedure.draft_revision.remove_type_de_champ(type_de_champ.stable_id)
       expect(type_de_champ.only_present_on_draft?).to be_falsey
       expect(type_de_champ.revisions.count).to eq(1)
-      procedure.publish_revision!
+      procedure.publish_revision!(procedure.administrateurs.first)
       expect(type_de_champ.only_present_on_draft?).to be_falsey
       expect(type_de_champ.revisions.count).to eq(1)
     }

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -707,7 +707,7 @@ describe Procedure do
     context 'when publishing a new procedure' do
       before do
         travel_to(now) do
-          procedure.publish!
+          procedure.publish!(procedure.administrateurs.first)
         end
       end
 
@@ -735,7 +735,7 @@ describe Procedure do
 
       before do
         travel_to(now) do
-          procedure.publish!(canonical_procedure)
+          procedure.publish!(procedure.administrateurs.first, canonical_procedure)
         end
       end
 
@@ -853,7 +853,8 @@ describe Procedure do
   end
 
   describe "#publish_revision!" do
-    let(:procedure) { create(:procedure, :published) }
+    let(:administrateur) { create(:administrateur) }
+    let(:procedure) { create(:procedure, :published, administrateurs: [administrateur]) }
     let(:tdc_attributes) { { type_champ: :number, libelle: 'libelle 1' } }
     let(:publication_date) { Time.zone.local(2021, 1, 1, 12, 00, 00) }
 
@@ -863,7 +864,7 @@ describe Procedure do
 
     subject do
       travel_to(publication_date) do
-        procedure.publish_revision!
+        procedure.publish_revision!(administrateur)
       end
     end
 
@@ -880,6 +881,13 @@ describe Procedure do
       expect(procedure.draft_revision.revision_types_de_champ_public).to be_present
       expect(procedure.draft_revision.types_de_champ_public).to be_present
       expect(procedure.draft_revision.types_de_champ_public.first.libelle).to eq('libelle 1')
+    end
+
+    it 'records the publishing administrateur' do
+      subject
+
+      expect(procedure.published_revision.administrateur).to eq(administrateur)
+      expect(procedure.draft_revision.administrateur).to be_nil
     end
 
     context 'when the procedure has dossiers' do

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -308,7 +308,7 @@ describe TypeDeChamp do
 
       before do
         type_de_champ.update!(options: { 'header_section_level' => '1', 'key' => 'value' })
-        procedure.publish_revision!
+        procedure.publish_revision!(procedure.administrateurs.first)
       end
 
       it 'keeping only the header_section_level' do
@@ -321,7 +321,7 @@ describe TypeDeChamp do
 
       before do
         type_de_champ.update!(options: { 'collapsible_explanation_enabled' => '1', 'collapsible_explanation_text' => 'hello', 'key' => 'value' })
-        procedure.publish_revision!
+        procedure.publish_revision!(procedure.administrateurs.first)
       end
 
       it 'keeping only the collapsible_explanation keys' do
@@ -334,7 +334,7 @@ describe TypeDeChamp do
 
       before do
         type_de_champ.update!(options: { 'character_limit' => '400', 'key' => 'value' })
-        procedure.publish_revision!
+        procedure.publish_revision!(procedure.administrateurs.first)
       end
 
       it 'keeping only the character limit' do
@@ -347,7 +347,7 @@ describe TypeDeChamp do
 
       before do
         type_de_champ.update!(options: { 'unesco' => '0', 'key' => 'value' })
-        procedure.publish_revision!
+        procedure.publish_revision!(procedure.administrateurs.first)
       end
 
       it 'keeping only the layers' do
@@ -360,7 +360,7 @@ describe TypeDeChamp do
 
       before do
         type_de_champ.update!(options: { 'drop_down_other' => '0', 'drop_down_options' => ['Premier choix', 'Deuxième choix'], 'key' => 'value' })
-        procedure.publish_revision!
+        procedure.publish_revision!(procedure.administrateurs.first)
       end
 
       it 'keeping only the drop_down_other and drop_down_options' do
@@ -373,7 +373,7 @@ describe TypeDeChamp do
 
       before do
         type_de_champ.update!(options: { 'drop_down_options' => ['Premier choix', 'Deuxième choix'], 'key' => 'value' })
-        procedure.publish_revision!
+        procedure.publish_revision!(procedure.administrateurs.first)
       end
 
       it 'keeping only the drop_down_options' do
@@ -386,7 +386,7 @@ describe TypeDeChamp do
 
       before do
         type_de_champ.update!(options: { 'drop_down_options' => ['--Fromage--', 'bleu de sassenage', 'picodon', '--Dessert--', 'éclair', 'tarte aux pommes'], 'key' => 'value' })
-        procedure.publish_revision!
+        procedure.publish_revision!(procedure.administrateurs.first)
       end
 
       it 'keeping only the drop_down_options' do
@@ -399,7 +399,7 @@ describe TypeDeChamp do
 
       before do
         type_de_champ.update!(options: { "positive_number" => "1", "range_number" => '1', "min_number" => '2', "max_number" => '18' })
-        procedure.publish_revision!
+        procedure.publish_revision!(procedure.administrateurs.first)
       end
 
       it 'keeping the positive number options' do
@@ -412,7 +412,7 @@ describe TypeDeChamp do
 
       before do
         type_de_champ.update!(options: { "positive_number" => "1", "range_number" => '1', "min_number" => '2.5', "max_number" => '18' })
-        procedure.publish_revision!
+        procedure.publish_revision!(procedure.administrateurs.first)
       end
 
       it 'keeping the positive number options' do
@@ -425,7 +425,7 @@ describe TypeDeChamp do
 
       before do
         type_de_champ.update!(options: { 'old_pj' => '123', 'skip_pj_validation' => '1', 'skip_content_type_pj_validation' => '1', 'key' => 'value' })
-        procedure.publish_revision!
+        procedure.publish_revision!(procedure.administrateurs.first)
       end
 
       it 'keeping only the old_pj, skip_validation_pj and skip_content_type_pj_validation' do
@@ -438,7 +438,7 @@ describe TypeDeChamp do
 
       before do
         type_de_champ.update!(options: { 'formatted_mode' => 'simple', 'letters_accepted' => "1", 'numbers_accepted' => '1', "special_characters_accepted" => "0", 'min_character_length' => "4", 'max_character_length' => "5", "key" => "value" })
-        procedure.publish_revision!
+        procedure.publish_revision!(procedure.administrateurs.first)
       end
 
       it 'keeping only the formatted mode, letters_accepted, numbers_accepted, special_characters_accepted' do
@@ -451,7 +451,7 @@ describe TypeDeChamp do
 
       before do
         type_de_champ.update!(options: { 'formatted_mode' => 'advanced', 'expression_reguliere' => '\d{9}', 'expression_reguliere_error_message' => 'error', 'expression_reguliere_exemple_text' => '123456789', 'key' => 'value' })
-        procedure.publish_revision!
+        procedure.publish_revision!(procedure.administrateurs.first)
       end
 
       it 'keeping only the expression_reguliere, expression_reguliere_error_message and expression_reguliere_exemple_text' do
@@ -467,7 +467,7 @@ describe TypeDeChamp do
 
       before do
         type_de_champ.update!(options: { 'referentiel_mapping' => { 'kikoo' => 'lol' } })
-        procedure.publish_revision!
+        procedure.publish_revision!(procedure.administrateurs.first)
       end
 
       it 'keeping only the expression_reguliere, expression_reguliere_error_message and expression_reguliere_exemple_text' do

--- a/spec/services/dossier_filter_service_spec.rb
+++ b/spec/services/dossier_filter_service_spec.rb
@@ -173,7 +173,7 @@ describe DossierFilterService do
         before do
           nothing_dossier
           procedure.draft_revision.add_type_de_champ(tdc)
-          procedure.publish_revision!
+          procedure.publish_revision!(procedure.administrateurs.first)
           beurre_dossier.project_champs_public.last.update(value: 'beurre')
           tartine_dossier.project_champs_public.last.update(value: 'tartine')
         end

--- a/spec/system/administrateurs/procedure_attestation_template_spec.rb
+++ b/spec/system/administrateurs/procedure_attestation_template_spec.rb
@@ -139,7 +139,7 @@ describe 'As an administrateur, I want to manage the procedure’s attestation',
     context "tag in error" do
       before do
         tdc = procedure.active_revision.add_type_de_champ(type_champ: :integer_number, libelle: 'age')
-        procedure.publish_revision!
+        procedure.publish_revision!(procedure.administrateurs.first)
 
         attestation = procedure.build_attestation_template(version: 2, json_body: AttestationTemplate::TIPTAP_BODY_DEFAULT, label_logo: "test")
         attestation.json_body["content"] << { type: :mention, attrs: { id: "tdc#{tdc.stable_id}", label: tdc.libelle } }

--- a/spec/views/administrateurs/procedures/show.html.haml_spec.rb
+++ b/spec/views/administrateurs/procedures/show.html.haml_spec.rb
@@ -32,7 +32,7 @@ describe 'administrateurs/procedures/show', type: :view do
 
   describe 'procedure is published' do
     before do
-      procedure.publish!
+      procedure.publish!(procedure.administrateurs.first)
       procedure.reload
       render
     end
@@ -49,7 +49,7 @@ describe 'administrateurs/procedures/show', type: :view do
 
   describe 'procedure is closed' do
     before do
-      procedure.publish!
+      procedure.publish!(procedure.administrateurs.first)
       procedure.close!
       procedure.reload
       render

--- a/spec/views/shared/_procedure_description.html.haml_spec.rb
+++ b/spec/views/shared/_procedure_description.html.haml_spec.rb
@@ -71,7 +71,7 @@ describe 'shared/_procedure_description', type: :view do
     end
 
     it 'shows the pieces jointes list for published procedure' do
-      procedure.publish!
+      procedure.publish!(procedure.administrateurs.first)
       subject
       expect(rendered).to have_text('Quelles sont les pièces justificatives à fournir')
       expect(rendered).to have_text('Libelle du champ')
@@ -123,7 +123,7 @@ describe 'shared/_procedure_description', type: :view do
       travel(1.minute)
 
       procedure.draft_revision.add_type_de_champ(type_champ: :piece_justificative, libelle: 'new pj')
-      procedure.publish_revision!
+      procedure.publish_revision!(procedure.administrateurs.first)
 
       render partial: 'shared/procedure_description', locals: { procedure: }
       expect(rendered).to have_text('new pj')


### PR DESCRIPTION
Autre tentative ac codex. Je lui avait juste donné l'issue. c'etait pas mal, mais j'ai qd meme bien retravaillé le truc (dmg j'ai perdu le commit distinct de mon refacto : mais il avait ete ultra verbeux sur les trads, du naming a rallonge, il s'est perdu sur le publish! [de la demarche], publish_revision)

https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/12063

## Summary
- store the administrator who publishes a procedure revision and keep that metadata when cloning drafts
- display the publishing administrator in the administrateur and instructeur revision history views while preloading the association
- add the migration, schema change and unit test coverage for the new publication tracking

## Testing
- bundle exec rspec spec/models/procedure_spec.rb *(fails: pending migration because the database is not configured in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d26bde9ff88321985cdb3226a956fe

_____

**apres**
> <img width="2496" height="1218" alt="Screenshot 2025-09-23 at 18-55-37 demarches-simplifiees fr" src="https://github.com/user-attachments/assets/4b9b27ae-53dc-4094-ab64-bf237fe61f88" />

> <img width="2496" height="1118" alt="Screenshot 2025-09-23 at 18-55-25 Historique des modifications du formulaire · demarches-simplifiees fr" src="https://github.com/user-attachments/assets/cd1acf63-c30a-4fb4-93f3-aaa73f0bb00f" />


___

voici le patch initial

```git
diff --git a/app/controllers/administrateurs/procedures_controller.rb b/app/controllers/administrateurs/procedures_controller.rb
index 6964f686c259acdf73a1ef7d9234cca493810d3a..d5bf98caf85be6f9c4cce45757a674dcdc1f948a 100644
--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -370,51 +370,51 @@ module Administrateurs
         current_administrateur
           .procedures
           .with_discarded
           .closes
           .find(params[:old_procedure])
           .update!(replaced_by_procedure: @procedure)
       end
 
       # TO DO after data backfill add this condition before reset :
       # if @procedure.closing_reason.present?
       @procedure.reset_closing_params
 
       redirect_to admin_procedure_confirmation_path(@procedure)
     rescue ActiveRecord::RecordInvalid
       flash.alert = @procedure.errors.full_messages
       redirect_to admin_procedure_publication_path(@procedure)
     end
 
     def reset_draft
       @procedure.reset_draft_revision!
       flash.notice = 'Les modifications ont été annulées'
       redirect_to admin_procedure_path(@procedure)
     end
 
     def publish_revision
-      @procedure.publish_revision!
+      @procedure.publish_revision!(current_administrateur)
       flash.notice = "Nouvelle version de la démarche publiée"
 
       redirect_to admin_procedure_path(@procedure)
     rescue ActiveRecord::RecordInvalid
       redirect_to admin_procedure_publication_path(@procedure)
     end
 
     def transfert
     end
 
     def close
       @published_procedures = current_administrateur.procedures.publiees.to_h { |p| ["#{p.libelle} (#{p.id})", p.id] }
       @closing_reason_options = Procedure.closing_reasons.values.map { |reason| [I18n.t("activerecord.attributes.procedure.closing_reasons.#{reason}", app_name: Current.application_name), reason] }
     end
 
     def confirmation
     end
 
     def allow_expert_review
       @procedure.update!(allow_expert_review: !@procedure.allow_expert_review)
       flash.notice = @procedure.allow_expert_review? ? "Avis externes activés" : "Avis externes désactivés"
       redirect_to admin_procedure_experts_path(@procedure)
     end
 
     def allow_expert_messaging
diff --git a/app/controllers/instructeurs/procedures_controller.rb b/app/controllers/instructeurs/procedures_controller.rb
index de59e5afcdb7e16387581a73a127890e6534e952..43dae1fb570330267deb3f8e41cbc841e880e4db 100644
--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -319,50 +319,51 @@ module Instructeurs
       )
       bulk_message.save!
 
       if errors.empty?
         flash[:notice] = "Tous les messages ont été envoyés avec succès"
       else
         flash[:alert] = "Envoi terminé. Cependant #{errors.count} messages n'ont pas été envoyés"
       end
       redirect_to instructeur_procedure_path(@procedure)
     end
 
     def administrateurs
       @procedure = procedure
       @administrateurs = procedure.administrateurs
     end
 
     def apercu
       @procedure = procedure
       @dossier = procedure.active_revision.dossier_for_preview(current_user)
       @dossier.with_champs
     end
 
     def history
       @procedure = procedure
       @revisions = @procedure.revisions
+        .includes(published_by_administrateur: :user)
         .where.not(published_at: nil)
         .reorder(published_at: :desc)
       @instructeur_procedure = find_or_create_instructeur_procedure(@procedure)
     end
 
     private
 
     def mark_latest_revision_as_seen
       return if @procedure.published_revision_id.blank?
       @instructeur_procedure.update(last_revision_seen_id: @procedure.published_revision_id)
     end
 
     def groupe_instructeur_ids_params
       bulk_message_params = params.require(:bulk_message).permit(:without_group, groupe_instructeur_ids: {}).to_h
       bulk_message_params
         .fetch(:groupe_instructeur_ids) { [] }
         .filter_map { |id, selected| selected == "true" ? id : nil }
         .concat(bulk_message_params.dig(:without_group).eql?('1') ? [nil] : [])
     end
 
     def reachable_brouillons
       if procedure.routing_enabled?
         procedure.dossiers.state_brouillon.visible_by_user.where(groupe_instructeur_id: groupe_instructeur_ids_params)
       else
         procedure.dossiers.state_brouillon.visible_by_user
diff --git a/app/models/concerns/procedure_publish_concern.rb b/app/models/concerns/procedure_publish_concern.rb
index fd23d72f9fc85ecbcbf3657fcb4be74ad81212e2..4b1ffbaf5c7fce714815ac08a3ff6f8526e2a85b 100644
--- a/app/models/concerns/procedure_publish_concern.rb
+++ b/app/models/concerns/procedure_publish_concern.rb
@@ -1,56 +1,64 @@
 # frozen_string_literal: true
 
 module ProcedurePublishConcern
   extend ActiveSupport::Concern
 
   def publish_or_reopen!(administrateur, path)
+    self.publishing_administrateur = administrateur
+
     Procedure.transaction do
       if brouillon?
         reset!
       end
 
       other_procedure = other_procedure_with_path(path)
       claim_path!(administrateur, path)
       if other_procedure.present?
         other_procedure.unpublish! if other_procedure.may_unpublish?
 
         publish!(other_procedure.canonical_procedure || other_procedure)
       else
         publish!
       end
     end
+  ensure
+    self.publishing_administrateur = nil
   end
 
-  def publish_revision!
+  def publish_revision!(administrateur = nil)
+    self.publishing_administrateur = administrateur
+
     reset!
 
     transaction { publish_new_revision }
 
     dossiers
       .state_not_termine
       .find_each(&:rebase_later)
+  ensure
+    self.publishing_administrateur = nil
   end
 
   def reset_draft_revision!
     if published_revision.present? && draft_changed?
       reset!
       transaction do
         draft_revision.types_de_champ.filter(&:only_present_on_draft?).each(&:destroy)
         draft_revision.update(dossier_submitted_message: nil)
         draft_revision.destroy
         update!(draft_revision: create_new_revision(published_revision))
       end
     end
   end
 
   def reset!
     if !locked? || draft_changed?
       dossier_ids_to_destroy = draft_revision.dossiers.ids
       if dossier_ids_to_destroy.present?
         Rails.logger.info("Resetting #{dossier_ids_to_destroy.size} dossiers on procedure #{id}: #{dossier_ids_to_destroy}")
         draft_revision.dossiers.destroy_all
       end
     end
   end
 
   def before_publish
@@ -59,68 +67,77 @@ module ProcedurePublishConcern
 
   def after_publish(canonical_procedure = nil)
     self.canonical_procedure = canonical_procedure
 
     touch(:published_at)
     publish_new_revision
   end
 
   def after_republish(canonical_procedure = nil)
     touch(:published_at)
   end
 
   def after_close
     touch(:closed_at)
   end
 
   def after_unpublish
     touch(:unpublished_at)
   end
 
   def create_new_revision(revision = nil)
     transaction do
       new_revision = (revision || draft_revision)
         .deep_clone(include: [:revision_types_de_champ])
         .tap { |revision| revision.published_at = nil }
+        .tap { |revision| revision.published_by_administrateur_id = nil }
         .tap(&:save!)
 
       move_new_children_to_new_parent_coordinate(new_revision)
 
       new_revision
     end
   end
 
   private
 
   def publish_new_revision
     cleanup_types_de_champ_options!
     cleanup_types_de_champ_children!
     nullify_unused_referentiels
     self.published_revision = draft_revision
     self.draft_revision = create_new_revision
     save!(context: :publication)
-    published_revision.touch(:published_at)
+    publication_time = Time.zone.now
+    published_revision.update_columns(
+      published_at: publication_time,
+      published_by_administrateur_id: publishing_administrateur&.id,
+      updated_at: publication_time
+    )
+    published_revision.published_at = publication_time
+    published_revision.updated_at = publication_time
+    published_revision.association(:published_by_administrateur).target = publishing_administrateur
   end
 
   def move_new_children_to_new_parent_coordinate(new_draft)
     children = new_draft.revision_types_de_champ
       .includes(parent: :type_de_champ)
       .where.not(parent_id: nil)
     coordinates_by_stable_id = new_draft.revision_types_de_champ
       .includes(:type_de_champ)
       .index_by(&:stable_id)
 
     children.each do |child|
       child.update!(parent: coordinates_by_stable_id.fetch(child.parent.stable_id))
     end
     new_draft.reload
   end
 
   def cleanup_types_de_champ_options!
     draft_revision.types_de_champ.each do |type_de_champ|
       type_de_champ.update!(options: type_de_champ.clean_options)
     end
   end
 
   def cleanup_types_de_champ_children!
     draft_revision.revision_types_de_champ
       .filter(&:orphan?)
diff --git a/app/models/procedure.rb b/app/models/procedure.rb
index 50bd8b6f452cfc09e97a38d05ab7da217e5e10ef..d0aa9ff106980ae7cdd01f85d562ebba887488df 100644
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -1,43 +1,45 @@
 # frozen_string_literal: true
 
 class Procedure < ApplicationRecord
   include APIEntrepriseTokenConcern
   include ProcedureStatsConcern
   include InitiationProcedureConcern
   include ProcedureGroupeInstructeurAPIHackConcern
   include ProcedureSVASVRConcern
   include ProcedureChorusConcern
   include ProcedurePublishConcern
   include ProcedurePathConcern
   include ProcedureCloneConcern
   include PiecesJointesListConcern
   include ColumnsConcern
 
   include Discard::Model
   self.discard_column = :hidden_at
 
+  attr_accessor :publishing_administrateur
+
   self.ignored_columns += ["api_entreprise_token_expires_at"]
 
   default_scope -> { kept }
 
   OLD_MAX_DUREE_CONSERVATION = 36
 
   MIN_WEIGHT = 350000
 
   DOSSIERS_COUNT_EXPIRING = 1.hour
 
   encrypts :api_particulier_token
 
   has_many :revisions, -> { order(:id) }, class_name: 'ProcedureRevision', inverse_of: :procedure
   belongs_to :draft_revision, class_name: 'ProcedureRevision', optional: false
   belongs_to :published_revision, class_name: 'ProcedureRevision', optional: true
   has_many :deleted_dossiers, dependent: :destroy
 
   def draft_types_de_champ_public = draft_revision&.types_de_champ_public || []
   def draft_types_de_champ_private = draft_revision&.types_de_champ_private || []
   def published_types_de_champ_public = published_revision&.types_de_champ_public || []
   def published_types_de_champ_private = published_revision&.types_de_champ_private || []
 
   has_one :published_dossier_submitted_message, dependent: :destroy, through: :published_revision, source: :dossier_submitted_message
   has_one :draft_dossier_submitted_message, dependent: :destroy, through: :draft_revision, source: :dossier_submitted_message
   has_many :dossier_submitted_messages, through: :revisions, source: :dossier_submitted_message
diff --git a/app/models/procedure_revision.rb b/app/models/procedure_revision.rb
index d3418b9f233063f30065f56a6afeee030c8ea398..5740ddf778cfdfdf98a6474aa057f33d7ae21301 100644
--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -1,32 +1,33 @@
 # frozen_string_literal: true
 
 class ProcedureRevision < ApplicationRecord
   include Logic
   self.implicit_order_column = :created_at
   belongs_to :procedure, -> { with_discarded }, inverse_of: :revisions, optional: false
   belongs_to :dossier_submitted_message, inverse_of: :revisions, optional: true, dependent: :destroy
+  belongs_to :published_by_administrateur, class_name: 'Administrateur', optional: true
 
   has_many :dossiers, inverse_of: :revision, foreign_key: :revision_id
   has_many :revision_types_de_champ, -> { order(:position, :id) }, class_name: 'ProcedureRevisionTypeDeChamp', foreign_key: :revision_id, dependent: :destroy, inverse_of: :revision
 
   def revision_types_de_champ_public = revision_types_de_champ.filter { _1.root? && _1.public? }.sort_by(&:position)
   def revision_types_de_champ_private = revision_types_de_champ.filter { _1.root? && _1.private? }.sort_by(&:position)
   def types_de_champ = revision_types_de_champ.map(&:type_de_champ)
   def types_de_champ_public = revision_types_de_champ_public.map(&:type_de_champ)
   def types_de_champ_private = revision_types_de_champ_private.map(&:type_de_champ)
 
   has_one :draft_procedure, -> { with_discarded }, class_name: 'Procedure', foreign_key: :draft_revision_id, dependent: :nullify, inverse_of: :draft_revision
   has_one :published_procedure, -> { with_discarded }, class_name: 'Procedure', foreign_key: :published_revision_id, dependent: :nullify, inverse_of: :published_revision
 
   scope :ordered, -> { order(:created_at) }
 
   validates :ineligibilite_message, presence: true, if: -> { ineligibilite_enabled? }
 
   delegate :path, to: :procedure, prefix: true
 
   validate :ineligibilite_rules_are_valid?,
     on: [:ineligibilite_rules_editor, :publication]
   validates :ineligibilite_message,
     presence: true,
     if: -> { ineligibilite_enabled? },
     on: [:ineligibilite_rules_editor, :publication]
diff --git a/app/models/procedure_revision_preloader.rb b/app/models/procedure_revision_preloader.rb
index 944ede6d40b0487239dbb7b07330df44a6c9b71f..a130cd75808a3b431f50000a818798585df15158 100644
--- a/app/models/procedure_revision_preloader.rb
+++ b/app/models/procedure_revision_preloader.rb
@@ -1,49 +1,56 @@
 # frozen_string_literal: true
 
 class ProcedureRevisionPreloader
   def initialize(revisions)
     @revisions = revisions
   end
 
   def all
     revisions = @revisions.to_a
     load_revisions(revisions)
   end
 
   def self.load_one(revision)
     ProcedureRevisionPreloader.new([revision]).all.first # rubocop:disable Rails/RedundantActiveRecordAllMethod
   end
 
   private
 
   def load_revisions(revisions)
     load_procedure_revision_types_de_champ(revisions)
+    load_published_by_administrateur(revisions)
   end
 
   def load_procedure_revision_types_de_champ(revisions)
     revisions_by_id = revisions.index_by(&:id)
     coordinates_by_revision_id = ProcedureRevisionTypeDeChamp
       .where(revision_id: revisions.map(&:id))
       .includes(type_de_champ: { notice_explicative_attachment: :blob, piece_justificative_template_attachment: :blob })
       .order(:position, :id)
       .to_a
       .group_by(&:revision_id)
 
     coordinates_by_revision_id.each_pair do |revision_id, coordinates|
       revision = revisions_by_id[revision_id]
 
       coordinates.each do |coordinate|
         coordinate.association(:revision).target = revision
         coordinate.association(:procedure).target = revision.procedure
       end
     end
 
     assign_revision_type_de_champ(revisions_by_id, coordinates_by_revision_id)
   end
 
   def assign_revision_type_de_champ(revisions_by_id, coordinates_by_revision_id)
     revisions_by_id.each_pair do |revision_id, revision|
       revision.association(:revision_types_de_champ).target = coordinates_by_revision_id[revision_id] || []
     end
   end
+
+  def load_published_by_administrateur(revisions)
+    return if revisions.empty?
+
+    ActiveRecord::Associations::Preloader.new(records: revisions, associations: { published_by_administrateur: :user }).call
+  end
 end
diff --git a/app/views/administrateurs/procedures/modifications.html.haml b/app/views/administrateurs/procedures/modifications.html.haml
index 73b8673bd6781db96ade48cc17d1c89d2316c3e3..cf8ce968ba839249207c93578ad23976b64432c4 100644
--- a/app/views/administrateurs/procedures/modifications.html.haml
+++ b/app/views/administrateurs/procedures/modifications.html.haml
@@ -1,36 +1,38 @@
 = render partial: 'administrateurs/breadcrumbs',
   locals: { steps: [['Démarches', admin_procedures_back_path(@procedure)],
                     [@procedure.libelle.truncate_words(10), admin_procedure_path(@procedure)],
                     ['Champs du formulaire', champs_admin_procedure_path(@procedure)],
                     ['Historique des modifications du formulaire']] }
 .fr-container
   .fr-mb-3w
     = link_to "Champs du formulaire", champs_admin_procedure_path(@procedure), class: "fr-link fr-icon-arrow-left-line fr-link--icon-left"
   %h1.fr-h2
     Historique des modifications du formulaire
 
 .fr-container
   - previous_revision = nil
   - @procedure.revisions.each do |revision|
     - if previous_revision.present? && !revision.draft?
       - dossiers = revision.dossiers.visible_by_administration
       - dossiers_en_construction_count = dossiers.state_en_construction.count
       - dossiers_en_instruction_count = dossiers.state_en_instruction.count
       .card.mb-4
         %h2.card-title= "Modifications publiées le #{l(revision.published_at, format: '%d %B %Y à %R')}"
+        - if revision.published_by_administrateur.present?
+          %p.fr-text--sm.fr-mb-2w= t('.published_by_html', email: mail_to(revision.published_by_administrateur.email))
         - if !dossiers_en_construction_count.zero? && !dossiers_en_instruction_count.zero?
           %p
             - if dossiers_en_construction_count == 1
               = t('.dossier_en_construction_and_dossiers_en_instruction', count: dossiers_en_instruction_count)
             - elsif dossiers_en_instruction_count == 1
               = t('.dossier_en_instruction_and_dossiers_en_construction', count: dossiers_en_construction_count)
             - else
               = t('.dossiers_en_construction_and_dossiers_en_instruction', en_construction_count: dossiers_en_construction_count, en_instruction_count: dossiers_en_instruction_count)
         - elsif !dossiers_en_construction_count.zero?
           %p= t('.dossiers_en_construction', count: dossiers_en_construction_count)
         - elsif !dossiers_en_instruction_count.zero?
           %p= t('.dossiers_en_instruction', count: dossiers_en_instruction_count)
         = render Procedure::RevisionChangesComponent.new new_revision: revision, previous_revision:
     - previous_revision = revision
 
 = render Procedure::FixedFooterComponent.new(procedure: @procedure)
diff --git a/app/views/instructeurs/procedures/history.html.haml b/app/views/instructeurs/procedures/history.html.haml
index d9d3dc6020e624534ff8ee3ed9447b1af483a314..a3b07bb2793f26e9920170a18be532cfe5ef2319 100644
--- a/app/views/instructeurs/procedures/history.html.haml
+++ b/app/views/instructeurs/procedures/history.html.haml
@@ -1,26 +1,28 @@
 - title = t('instructeurs.dossiers.header.banner.history.title', procedure_libelle: @procedure.libelle)
 - content_for(:title, title)
 
 .sub-header
   .fr-container.flex.column
     = render partial: 'instructeurs/breadcrumbs',
       locals: { steps: [[@procedure.libelle.truncate_words(10), instructeur_procedure_path(@procedure)],
                         [t('instructeurs.dossiers.header.banner.history.title')]] }
 
     = render partial: 'instructeurs/procedures/header',
       locals: { procedure: @procedure }
 
 .fr-container
   %h1.fr-h4= t('instructeurs.dossiers.header.banner.history.title')
   - @revisions.each_cons(2) do |current_revision, previous_revision|
     .fr-card.fr-mb-2w.fr-p-2w
       %div
         %h2.fr-card__title
           = t('instructeurs.dossiers.header.banner.history.modification_published_at', date: l(current_revision.published_at, format: :human))
           - if current_revision.id > @instructeur_procedure.last_revision_seen_id.to_i
             %span.fr-badge.fr-badge--sm.fr-badge--new= t('instructeurs.dossiers.header.banner.history.new')
+        - if current_revision.published_by_administrateur.present?
+          %p.fr-text--sm.fr-mb-2w= t('instructeurs.dossiers.header.banner.history.published_by_html', email: mail_to(current_revision.published_by_administrateur.email))
       %div
         = render Procedure::RevisionChangesComponent.new new_revision: current_revision, previous_revision: previous_revision
   - if @revisions.size < 2
     .fr-alert.fr-alert--info
       %p= t('instructeurs.dossiers.header.banner.history.no_history')
diff --git a/config/locales/views/administrateurs/procedures/en.yml b/config/locales/views/administrateurs/procedures/en.yml
index cbc81774f16c8393bdc5dd5f0cbd25dc09d51222..691f116e7ffa750407443fdf3f84ec2f12e9760d 100644
--- a/config/locales/views/administrateurs/procedures/en.yml
+++ b/config/locales/views/administrateurs/procedures/en.yml
@@ -20,50 +20,51 @@ en:
         page_subtitle_with_redirection: Your procedure has been successfully closed. The link of the procedure now redirects to this <a href="%{redirection_path}" target="_blank" rel="noopener noreferrer">procedure</a>.
         callout_content: You can continue to examine the submitted files. If you do not intend to examine these files, we invite you to inform users
         email_toggle_brouillon:
           one: You want to send an email to the user with a draft folder
           other: You want to send an email to %{count} users with a draft folder
         email_content_brouillon: You want to send an email to users with a draft file
         email_toggle_en_cours:
           one: You want to send an email to the user with a submitted file
           other: You want to send an email to %{count} users with a submitted file
         email_content_en_cours: You want to send an email to users with a file « in construction » or « instructing »
       preview_unavailable: Preview is unavailable due to procedure misconfiguration
       modifications:
         dossiers_en_construction_and_dossiers_en_instruction: "%{en_construction_count} files « in construction » and %{en_instruction_count} files « instructing » on this procedure version."
         dossier_en_construction_and_dossiers_en_instruction:
           one: One file « in construction » and one file « instructing » on this procedure version.
           other: One file « in construction » and %{count} files « instructing » on this procedure version.
         dossier_en_instruction_and_dossiers_en_construction:
           one: One file « instructing » and one file « in construction » on this procedure version.
           other: One file « instructing » and %{count} files « in construction » on this procedure version.
         dossiers_en_construction:
           one: One file « in construction » on this procedure version.
           other: "%{count} files « in construction » on this procedure version."
         dossiers_en_instruction:
           one: One file « instructing » on this procedure version.
           other: "%{count} files « instructing » on this procedure version."
+        published_by_html: Published by %{email}
       publication:
         publish_title: Publish your procedure
         confirmation: Your procedure is now published !
         copy_url: Copy procedure URL
         share_link: "To share your procedure, always use the full link below:"
         closed_procedure_html: "This procedure is <strong>closed</strong> and is therefore no longer accessible to the public. You can publish it back"
         draft_changed_procedure_html: "This procedure is already <strong>published</strong>. It has been <strong>edited</strong> since publication. You can publish the changes made in a new version."
         published_procedure_html: "This procedure is <strong>published</strong>, some elements can no longer be modified. To access it you can use the link:"
         public_link_procedure_html: "Be careful, always post the <strong>full link</strong> displayed above, and not a generic link to %{link}"
         missing_information_title: missing information
         missing_information_content: "To be able to publish this procedure, you must first assign it:"
         missing_information_service: You must provide the contact details of your Administrative Department before you can publish your procedure.
         missing_information_instructeurs: You must assign instructors before you can publish your procedure.
         missing_link: This procedure does not yet have a link, and is not accessible to the public.
         dubious_fields: "Please note that some fields cannot be requested by the administration. Here are the fields that look suspicious to us:"
         click_here: Click here
         back_to_procedure: Return to the procedure page
         new_procedure: Create a new procedure
       publication_form:
         faq_test_alert: Have you thought about testing your procedure before publishing it? To help you in this test phase, you can
         faq_test_alert_link: consult our best practices guide.
         faq_test_alert_link_url: "/faq#accordion-administrateur-2"
         draft_changed_procedure_alert: "Publish a new version of your procedure. The following changes will be applied:"
         dpd_title: Before publishing
         dpd_part_1: Have you thought about informing your Personal Data Protection Officer (DPO).
diff --git a/config/locales/views/administrateurs/procedures/fr.yml b/config/locales/views/administrateurs/procedures/fr.yml
index 52ba578bd1f1921400b6277e7b4f5a1bf2747f0b..322bf8dfe612809e711aa0118796db748b4bd263 100644
--- a/config/locales/views/administrateurs/procedures/fr.yml
+++ b/config/locales/views/administrateurs/procedures/fr.yml
@@ -20,50 +20,51 @@ fr:
         page_subtitle_with_redirection: Votre démarche est close. Le lien public redirige désormais vers cette <a href="%{redirection_path}" target="_blank" rel="noopener noreferrer">démarche</a>.
         callout_content: Vous avez la possibilité de continuer à instruire les dossiers déposés. Si vous n’avez pas l’intention d’instruire ces dossiers, nous vous invitons à en informer les usagers.
         email_toggle_brouillon:
           one: Souhaitez-vous envoyer un email à l'utilisateur avec un dossier en brouillon ?
           other: Souhaitez-vous envoyer un email aux %{count} utilisateurs avec un dossier en brouillon ?
         email_content_brouillon: Contenu de l'email
         email_toggle_en_cours:
           one: Souhaitez-vous envoyer un email à l'utilisateur avec un dossier déposé ?
           other: Souhaitez-vous envoyer un email aux %{count} utilisateurs avec un dossier déposé ?
         email_content_en_cours: Contenu de l'email
       preview_unavailable: Aperçu non disponible car la démarche est mal configurée
       modifications:
         dossiers_en_construction_and_dossiers_en_instruction: Il y a %{en_construction_count} dossiers « en construction » et %{en_instruction_count} dossiers « en instruction » sur cette version de la démarche.
         dossier_en_construction_and_dossiers_en_instruction:
           one: Il y a un dossier « en construction » et un dossier « en instruction » sur cette version de la démarche.
           other: Il y a un dossier « en construction » et %{count} dossiers « en instruction » sur cette version de la démarche.
         dossier_en_instruction_and_dossiers_en_construction:
           one: Il y a un dossier « en instruction » et un dossier « en construction » sur cette version de la démarche.
           other: Il y a un dossier « en instruction » et %{count} dossiers « en construction » sur cette version de la démarche.
         dossiers_en_construction:
           one: Il y a un dossier « en construction » sur cette version de la démarche.
           other: Il y a %{count} dossiers « en construction » sur cette version de la démarche.
         dossiers_en_instruction:
           one: Il y a un dossier « en instruction » sur cette version de la démarche.
           other: Il y a %{count} dossiers « en instruction » sur cette version de la démarche.
+        published_by_html: Publié par %{email}
       publication:
         publish_title: Publier votre démarche
         confirmation: Votre démarche est désormais publiée !
         copy_url: Copiez le lien de la procédure
         share_link: "Pour partager votre démarche, utilisez toujours le lien complet ci-dessous :"
         closed_procedure_html: "Cette démarche est <strong>close</strong> et n’est donc plus accessible par le public. Vous pouvez la réactiver :"
         draft_changed_procedure_html: "Cette démarche est déjà <strong>publiée</strong>. Elle a été <strong>modifiée</strong> depuis sa publication. Vous pouvez publier les changements effectués dans une nouvelle version de cette démarche :"
         published_procedure_html: "Cette démarche est <strong>publiée</strong>, certains éléments ne peuvent plus être modifiés. Pour y accéder vous pouvez utiliser le lien :"
         public_link_procedure_html: "Attention, diffusez toujours le <strong>lien complet</strong> affiché ci-dessus, et non pas un lien générique vers %{link}"
         missing_information_title: informations manquantes
         missing_information_content: "Pour pouvoir publier cette démarche, vous devez d’abord lui affecter :"
         missing_information_service: Vous devez renseigner les coordonnées de votre Service administratif avant de pouvoir publier votre démarche.
         missing_information_instructeurs: Vous devez affecter des instructeurs avant de pouvoir publier votre démarche.
         missing_link: Cette démarche n’a pas encore de lien, et n’est pas accessible par le public.
         dubious_fields: "Attention, certains champs ne peuvent être demandés par l’administration. Voici les champs qui nous semblent suspects :"
         click_here: Cliquez ici.
         back_to_procedure: Revenir à la page de la démarche
         new_procedure: Créer une nouvelle démarche
       publication_form:
         faq_test_alert: Avez-vous bien pensé à tester votre démarche avant de la publier ? Pour vous aider dans cette phase de test, vous pouvez
         faq_test_alert_link: consulter notre guide de bonnes pratiques.
         faq_test_alert_link_url: "/faq#accordion-administrateur-2"
         draft_changed_procedure_alert: "Publiez une nouvelle version de votre démarche. Les modifications suivantes seront appliquées :"
         dpd_title: Avant de publier
         dpd_part_1: Avez-vous bien pensé à informer votre Délégué à la Protection des Données personnelles (DPD).
diff --git a/config/locales/views/instructeurs/header/en.yml b/config/locales/views/instructeurs/header/en.yml
index 71f9d94d57c12025c312bfa7efe3525921c49f1b..cc7ab0ce07b98f7ab88b049e6c8c8e88d3868177 100644
--- a/config/locales/views/instructeurs/header/en.yml
+++ b/config/locales/views/instructeurs/header/en.yml
@@ -1,30 +1,31 @@
 en:
   instructeurs:
     dossiers:
       header:
         banner:
           expiration_date_extended: " – the expiration date had already been extended"
           title: This file will expire
           states:
             brouillon: "" # not applicable, instructeur does not see brouillons
             en_construction: This file is pending for instruction. The maximum delay is 6 months, you can extend the duration by a month by clicking on the underneath button.
             termine: This file had been processed and will soon expire. So it will be deleted soon. If you want to keep it, you can dowload a PDF file of it.
           button_delay_expiration: "Keep for one more month"
           follow_up: File tracking
           procedure_management: File management
           history:
             title: Form modification history
             modification_published_at: "Modifications published on %{date}"
+            published_by_html: Published by %{email}
             new: New
             no_history: "No modification has been published"
           notification_management: notification management
           administrators_list: administrators list
           exports_list: Exports and export templates
           export_templates: Export templates
           exports_notification_label: A new export is ready to download
           statistics: statistics
           instructeurs: instructors
           contact_users: Contact users with a draft file
           downloads: Downloads
           user_support: User support
           users_with_rdvs: Users with appointments
diff --git a/config/locales/views/instructeurs/header/fr.yml b/config/locales/views/instructeurs/header/fr.yml
index 6a978652decf6efc3305c3b9b38e9800b4e76c14..8553fcf21afbc40f93c27c0dcaaadedb015685d5 100644
--- a/config/locales/views/instructeurs/header/fr.yml
+++ b/config/locales/views/instructeurs/header/fr.yml
@@ -1,35 +1,36 @@
 fr:
   instructeurs:
     dossiers:
       header:
         banner:
           expiration_date_extended: " – la date de conservation a déjà été étendue"
           title: Ce dossier va expirer
           title_expired: Ce dossier a expiré
           states:
             brouillon: "" # not applicable, instructeur does not see brouillons
             en_construction: Ce dossier est en attente de prise en charge. Vous pouvez toutefois étendre cette durée d’un mois en cliquant sur le bouton suivant.
             termine: Le traitement de ce dossier est terminé, mais il va bientôt être supprimé. Si vous souhaitez en conserver une trace, vous pouvez le télécharger au format PDF.
           button_delay_expiration: "Conserver un mois de plus"
           notification_management: Gestion des notifications par email
           follow_up: Suivi des dossiers
           procedure_management: Gestion de la démarche
           administrators_list: Administrateurs de la démarche
           history:
             title: Historique des modifications du formulaire
             modification_published_at: "Modifications publiées le %{date}"
+            published_by_html: Publié par %{email}
             new: Nouveau
             no_history: "Aucune modification n'a été publiée"
           exports_list: Liste des exports
           export_templates: Modèles d’export
           exports_notification_label: Un nouvel export est prêt à être téléchargé
           statistics: Statistiques de la démarche
           user_support: Accompagnement des usagers
           instructeurs: Gestion des instructeurs
           contact_users: Contacter les usagers avec un dossier "brouillon"
           users_with_rdvs: Rendez-vous avec les usagers
           preview: Prévisualiser le formulaire
           copy_link_button: Copier le lien usager de la démarche
           downloads: Téléchargements
           archives: Téléchargement mensuel
           procedure_navigation: "Navigation dans la démarche"
diff --git a/db/migrate/20250923100000_add_published_by_administrateur_to_procedure_revisions.rb b/db/migrate/20250923100000_add_published_by_administrateur_to_procedure_revisions.rb
new file mode 100644
index 0000000000000000000000000000000000000000..a91831d323a871ba8ef4c180dd2b62ac1bc9a860
--- /dev/null
+++ b/db/migrate/20250923100000_add_published_by_administrateur_to_procedure_revisions.rb
@@ -0,0 +1,5 @@
+class AddPublishedByAdministrateurToProcedureRevisions < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :procedure_revisions, :published_by_administrateur, foreign_key: { to_table: :administrateurs }
+  end
+end
diff --git a/db/schema.rb b/db/schema.rb
index 7f8c9709fda0f39ff601a032526ea00bba5967f2..190a01402813bd7937ddfd82ed06ea3ba4b5b1a5 100644
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -949,53 +949,55 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_10_074841) do
     t.jsonb "traites_filters", default: [], null: false, array: true
     t.datetime "updated_at", precision: nil
     t.index ["assign_to_id"], name: "index_procedure_presentations_on_assign_to_id", unique: true
   end
 
   create_table "procedure_revision_types_de_champ", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.bigint "parent_id"
     t.integer "position", null: false
     t.bigint "revision_id", null: false
     t.bigint "type_de_champ_id", null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["parent_id"], name: "index_procedure_revision_types_de_champ_on_parent_id"
     t.index ["revision_id"], name: "index_procedure_revision_types_de_champ_on_revision_id"
     t.index ["type_de_champ_id"], name: "index_procedure_revision_types_de_champ_on_type_de_champ_id"
   end
 
   create_table "procedure_revisions", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.bigint "dossier_submitted_message_id"
     t.boolean "ineligibilite_enabled", default: false, null: false
     t.text "ineligibilite_message"
     t.jsonb "ineligibilite_rules"
     t.bigint "procedure_id", null: false
     t.datetime "published_at", precision: nil
+    t.bigint "published_by_administrateur_id"
     t.datetime "updated_at", precision: nil, null: false
     t.index ["dossier_submitted_message_id"], name: "index_procedure_revisions_on_dossier_submitted_message_id"
     t.index ["procedure_id"], name: "index_procedure_revisions_on_procedure_id"
+    t.index ["published_by_administrateur_id"], name: "index_procedure_revisions_on_published_by_administrateur_id"
   end
 
   create_table "procedure_tags", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.text "description"
     t.string "name", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_procedure_tags_on_name", unique: true
   end
 
   create_table "procedure_tags_procedures", id: false, force: :cascade do |t|
     t.bigint "procedure_id", null: false
     t.bigint "procedure_tag_id", null: false
     t.index ["procedure_id", "procedure_tag_id"], name: "index_procedures_tags_on_procedure_id_and_tag_id"
     t.index ["procedure_tag_id", "procedure_id"], name: "index_procedures_tags_on_tag_id_and_procedure_id"
   end
 
   create_table "procedures", id: :serial, force: :cascade do |t|
     t.string "aasm_state", default: "brouillon"
     t.boolean "accuse_lecture", default: false, null: false
     t.boolean "allow_expert_messaging", default: true, null: false
     t.boolean "allow_expert_review", default: true, null: false
     t.string "api_entreprise_token"
     t.datetime "api_entreprise_token_expires_at", precision: nil
     t.text "api_particulier_scopes", default: [], array: true
@@ -1430,48 +1432,49 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_10_074841) do
   add_foreign_key "dossiers", "procedure_revisions", column: "revision_id"
   add_foreign_key "dossiers", "users"
   add_foreign_key "etablissements", "dossiers"
   add_foreign_key "experts", "users"
   add_foreign_key "experts_procedures", "experts"
   add_foreign_key "experts_procedures", "procedures"
   add_foreign_key "export_templates", "groupe_instructeurs"
   add_foreign_key "exports", "export_templates"
   add_foreign_key "exports", "instructeurs"
   add_foreign_key "follows", "dossiers"
   add_foreign_key "follows", "instructeurs"
   add_foreign_key "france_connect_informations", "users"
   add_foreign_key "geo_areas", "champs"
   add_foreign_key "groupe_instructeurs", "procedures"
   add_foreign_key "initiated_mails", "procedures"
   add_foreign_key "instructeurs", "users"
   add_foreign_key "instructeurs_procedures", "instructeurs"
   add_foreign_key "instructeurs_procedures", "procedures"
   add_foreign_key "labels", "procedures"
   add_foreign_key "merge_logs", "users"
   add_foreign_key "procedure_paths", "procedures"
   add_foreign_key "procedure_presentations", "assign_tos"
   add_foreign_key "procedure_revision_types_de_champ", "procedure_revision_types_de_champ", column: "parent_id"
   add_foreign_key "procedure_revision_types_de_champ", "procedure_revisions", column: "revision_id"
   add_foreign_key "procedure_revision_types_de_champ", "types_de_champ"
+  add_foreign_key "procedure_revisions", "administrateurs", column: "published_by_administrateur_id"
   add_foreign_key "procedure_revisions", "dossier_submitted_messages"
   add_foreign_key "procedure_revisions", "procedures"
   add_foreign_key "procedures", "groupe_instructeurs", column: "defaut_groupe_instructeur_id"
   add_foreign_key "procedures", "procedure_revisions", column: "draft_revision_id"
   add_foreign_key "procedures", "procedure_revisions", column: "published_revision_id"
   add_foreign_key "procedures", "services"
   add_foreign_key "procedures", "zones"
   add_foreign_key "rdv_connections", "instructeurs"
   add_foreign_key "rdvs", "dossiers"
   add_foreign_key "rdvs", "instructeurs"
   add_foreign_key "received_mails", "procedures"
   add_foreign_key "referentiel_items", "referentiels"
   add_foreign_key "refused_mails", "procedures"
   add_foreign_key "services", "administrateurs"
   add_foreign_key "targeted_user_links", "users"
   add_foreign_key "traitements", "dossiers"
   add_foreign_key "traitements", "procedure_revisions", column: "revision_id"
   add_foreign_key "trusted_device_tokens", "instructeurs"
   add_foreign_key "types_de_champ", "referentiels"
   add_foreign_key "users", "users", column: "requested_merge_into_id"
   add_foreign_key "without_continuation_mails", "procedures"
   add_foreign_key "zone_labels", "zones"
 end
diff --git a/spec/models/procedure_spec.rb b/spec/models/procedure_spec.rb
index ef19fad734524603cfa41ef75d2e9e1c0d43041f..c803a536411d2343178366bcc98bba6345a9b8ee 100644
--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -816,79 +816,87 @@ describe Procedure do
       it 'changes the procedure state to published' do
         expect(procedure.closed_at).to be_nil
         expect(procedure.published_at).to eq(now)
         expect(procedure.published_revision.published_at).not_to eq(now)
       end
 
       it "doesn't create a new revision" do
         expect(procedure.published_revision).not_to be_nil
         expect(procedure.draft_revision).not_to be_nil
         expect(procedure.revisions.count).to eq(2)
         expect(procedure.revisions).to eq([procedure.published_revision, procedure.draft_revision])
       end
     end
 
     context 'when publishing a procedure with the same path as another procedure from another admin' do
       let(:procedure) { create(:procedure, path: 'example-path', administrateurs: [administrateur]) }
       let(:other_procedure) { create(:procedure, path: 'example-path', administrateurs: [create(:administrateur)]) }
 
       it 'raises an error' do
         expect { procedure.publish_or_reopen!(administrateur, other_procedure.path) }.to raise_error(ActiveRecord::RecordInvalid)
       end
     end
   end
 
   describe "#publish_revision!" do
-    let(:procedure) { create(:procedure, :published) }
+    let(:administrateur) { create(:administrateur) }
+    let(:procedure) { create(:procedure, :published, administrateurs: [administrateur]) }
     let(:tdc_attributes) { { type_champ: :number, libelle: 'libelle 1' } }
     let(:publication_date) { Time.zone.local(2021, 1, 1, 12, 00, 00) }
 
     before do
       procedure.draft_revision.add_type_de_champ(tdc_attributes)
     end
 
     subject do
       travel_to(publication_date) do
-        procedure.publish_revision!
+        procedure.publish_revision!(administrateur)
       end
     end
 
     it 'publishes the new revision' do
       subject
       expect(procedure.published_revision).to be_present
       expect(procedure.published_revision.published_at).to eq(publication_date)
       expect(procedure.published_revision.types_de_champ_public.first.libelle).to eq('libelle 1')
     end
 
     it 'creates a new draft revision' do
       expect { subject }.to change(ProcedureRevision, :count).by(1)
       expect(procedure.draft_revision).to be_present
       expect(procedure.draft_revision.revision_types_de_champ_public).to be_present
       expect(procedure.draft_revision.types_de_champ_public).to be_present
       expect(procedure.draft_revision.types_de_champ_public.first.libelle).to eq('libelle 1')
     end
 
+    it 'records the publishing administrateur' do
+      subject
+
+      expect(procedure.published_revision.published_by_administrateur).to eq(administrateur)
+      expect(procedure.draft_revision.published_by_administrateur).to be_nil
+    end
+
     context 'when the procedure has dossiers' do
       let(:dossier_draft) { create(:dossier, :brouillon, procedure: procedure) }
       let(:dossier_submitted) { create(:dossier, :en_construction, procedure: procedure) }
       let(:dossier_termine) { create(:dossier, :accepte, procedure: procedure) }
 
       before { [dossier_draft, dossier_submitted, dossier_termine] }
 
       it 'enqueues rebase jobs for draft dossiers' do
         subject
         expect(DossierRebaseJob).to have_been_enqueued.with(dossier_draft)
         expect(DossierRebaseJob).to have_been_enqueued.with(dossier_submitted)
         expect(DossierRebaseJob).not_to have_been_enqueued.with(dossier_termine)
       end
     end
 
     context 'when a type de champ is transformed from a drop_down_list with referentiel to a textarea' do
       let(:procedure) { create(:procedure, types_de_champ_public:) }
       let(:types_de_champ_public) { [{ type: :drop_down_list, referentiel:, drop_down_mode: 'advanced' }] }
       let(:referentiel) { create(:csv_referentiel, :with_items) }
       let(:tdc) { procedure.draft_revision.types_de_champ_public.last }
 
       before do
         procedure.draft_revision.types_de_champ_public.last.update(type_champ: :textarea, options: { "character_limit" => "" })
       end
```

