### PR TITLE
Tech: corrige la tache de maintenace passant les pjs utilisant l'ocr à la machine à état

### DIFF
--- a/app/tasks/maintenance/t20250825backfill_champ_external_state_task.rb
+++ b/app/tasks/maintenance/t20250825backfill_champ_external_state_task.rb
@@ -37,9 +37,9 @@ module Maintenance
 
     def process(champ)
       begin
-        if champ.external_data_fetched?
+        if champ.external_data_fetched? && !champ.fetched?
           champ.external_data_fetched!
-        elsif champ.external_error_present?
+        elsif champ.external_error_present? && !champ.external_error?
           champ.external_data_error!
         end
       rescue => e

--- a/app/tasks/maintenance/t20250825backfill_pj_external_state_task.rb
+++ b/app/tasks/maintenance/t20250825backfill_pj_external_state_task.rb
@@ -20,7 +20,7 @@ module Maintenance
 
     def collection
       Procedure
-        .where(id: procedure_ids.split(",").map(&:strip)).map(&:dossiers)
+        .where(id: procedure_ids.split(",").map(&:strip)).flat_map(&:dossiers)
     end
 
     def process(dossier)
@@ -28,9 +28,9 @@ module Maintenance
         .filter { it.type == "Champs::PieceJustificativeChamp" && it.RIB? == true }
 
       pjs.each do |pj|
-        if pj.external_data_fetched?
+        if pj.external_data_fetched? && !pj.fetched?
           pj.external_data_fetched!
-        elsif pj.external_error_present?
+        elsif pj.external_error_present? && !pj.external_error?
           pj.external_data_error!
         end
       end


### PR DESCRIPTION
- process prend un record et pas une association
- certaines pjs utilise maintenant le nouveau système et ne sont plus dans l'´état `idle`, elle n'ont pas besoin d'être mise à jour