### PR TITLE
ETQ opérateur, l'ensemble du form de contact passe sur Crisp

### DIFF
--- a/app/models/contact_form.rb
+++ b/app/models/contact_form.rb
@@ -57,11 +57,7 @@ class ContactForm < ApplicationRecord
   end
 
   def create_conversation_later
-    if user.present? && Flipper.enabled?(:contact_crisp, user)
-      CrispCreateConversationJob.perform_later(self)
-    else
-      HelpscoutCreateConversationJob.perform_later(self)
-    end
+    CrispCreateConversationJob.perform_later(self)
   end
 
   def require_email? = user.blank?

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -23,7 +23,6 @@ features = [
   :api_particulier,
   :blocking_pending_correction,
   :cojo_type_de_champ,
-  :contact_crisp,
   :dossier_pdf_vide,
   :engagement_juridique_type_de_champ,
   :export_avec_horodatage,


### PR DESCRIPTION
Il restait les users non connectés qui passaient sur HS

Je ferai une autre PR plus tard qui enlève complètement le code HS