### PR TITLE
ETQ tech - fix : on ne créer pas de notif annotation instructeur pour un dossier de prévisualisation

### DIFF
--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -341,7 +341,7 @@ module Instructeurs
         end
 
         dossier.index_search_terms_later
-        DossierNotification.create_notification(dossier, :annotation_instructeur, except_instructeur: current_instructeur)
+        DossierNotification.create_notification(dossier, :annotation_instructeur, except_instructeur: current_instructeur) if !dossier.brouillon?
       end
 
       dossier.validate(:champs_private_value) if !annotation.waiting_for_external_data?


### PR DESCRIPTION
Sentry : https://demarches-simplifiees.sentry.io/issues/6882920847/?query=is%3Aunresolved%20notification&referrer=issue-stream

Cas du dossier de prévisualisation de l'admin, lorsqu'il teste les annotations privées