### PR TITLE
ETQ instructeur, pas d'erreur JS si on copie rapidement 2x le même élément

### DIFF
--- a/app/javascript/controllers/clipboard2_controller.ts
+++ b/app/javascript/controllers/clipboard2_controller.ts
@@ -62,6 +62,7 @@ export class Clipboard2Controller extends Controller {
 
   private copyContent(wrapper: HTMLElement): void {
     this.#copySpan.remove();
+    this.#copiedSpan.remove();
 
     const textToCopy = (
       wrapper.dataset['toCopy'] ||

--- a/app/javascript/controllers/clipboard2_controller.ts
+++ b/app/javascript/controllers/clipboard2_controller.ts
@@ -83,6 +83,10 @@ export class Clipboard2Controller extends Controller {
     this.#timer = setTimeout(() => {
       this.#copiedSpan.remove();
     }, SUCCESS_MESSAGE_TIMEOUT);
+
+    wrapper.addEventListener('mouseleave', () => {
+      this.#copiedSpan.remove();
+    });
   }
 
   private insertSpan(wrapper: HTMLElement, span: HTMLElement): void {

--- a/app/javascript/controllers/clipboard2_controller.ts
+++ b/app/javascript/controllers/clipboard2_controller.ts
@@ -71,9 +71,11 @@ export class Clipboard2Controller extends Controller {
       ''
     ).trim();
 
-    navigator.clipboard
-      .writeText(textToCopy)
-      .then(() => this.showCopiedSpan(wrapper));
+    if (document.hasFocus()) {
+      navigator.clipboard
+        .writeText(textToCopy)
+        .then(() => this.showCopiedSpan(wrapper));
+    }
   }
 
   private showCopiedSpan(wrapper: HTMLElement): void {


### PR DESCRIPTION
https://demarches-simplifiees.sentry.io/issues/6880493711/

ça arrivait si on recopie une 2e fois juste après une première copie, alors que "Copié" est encore affiché. D'ailleurs on évite aussi d'avoir 2x simultanément "copié" puis "cliquer pour copier" car la 2nde copie copiait aussi le texte "copié" (dire ça très vite à voix haute)

Fix aussi https://demarches-simplifiees.sentry.io/issues/6880508988/ si le document a perdu le focus au moment de la copie (mais je sais pas comment reproduire)