### PR TITLE
Tech: ne remonte plus dans sentry les erreurs réseaux pour  la gaufre/ la suite numerique

### DIFF
--- a/app/javascript/shared/track/sentry.ts
+++ b/app/javascript/shared/track/sentry.ts
@@ -22,7 +22,10 @@ if (enabled && key) {
       'e.getModifierState is not a function',
 
       // Piwik/Matomo invasive error
-      "'get' on proxy: property 'javaEnabled' is a read-only and non-configurable data property on the proxy target but the proxy did not return its actual value"
+      "'get' on proxy: property 'javaEnabled' is a read-only and non-configurable data property on the proxy target but the proxy did not return its actual value",
+
+      // La gaufre script often triggers an error while loading other dependencies
+      'NetworkError when attempting to fetch resource. (integration.lasuite.numerique.gouv.fr)'
     ]
   });
 


### PR DESCRIPTION
Tentative pour ne plus remonter toutes ces erreurs dans sentry (domaine bloqué sur certains postes ?)
https://demarches-simplifiees.sentry.io/issues/6562990746/