### PR TITLE
ETQ Tech: les tests ne sont pas lancés une fois une pr mergée

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,5 @@
 name: Continuous Integration
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
   merge_group:


### PR DESCRIPTION
Actuellement, le workflow de test est lancé pour chaque PR, pour chaque merge queue, à chaque fois qu'il y a un change sur main.

Du coup, un changement nominal implique au minimum 3 passes de tests (PR + merge + main) !

Dans les cas exceptionnel de merge direct sur la main, les résultats des tests ne sont de tout façon pas bloquants pour déployer ni relus (je suppose).

Du coup, cette PR propose de retirer les tests sur les push de main et de gagner du temps de CI.