### PR TITLE
ETQ Tech: je veux vraiment adapter les champs avec de la donnée externe au système de machine à état

### DIFF
--- a/app/tasks/maintenance/t20250825backfill_champ_external_state_task.rb
+++ b/app/tasks/maintenance/t20250825backfill_champ_external_state_task.rb
@@ -36,10 +36,11 @@ module Maintenance
     end
 
     def process(champ)
+      return if !champ.idle?
       begin
-        if champ.external_data_fetched? && !champ.fetched?
+        if champ.external_data_fetched?
           champ.external_data_fetched!
-        elsif champ.external_error_present? && !champ.external_error?
+        elsif champ.external_error_present?
           champ.external_data_error!
         end
       rescue => e

--- a/app/tasks/maintenance/t20250825backfill_pj_external_state_task.rb
+++ b/app/tasks/maintenance/t20250825backfill_pj_external_state_task.rb
@@ -27,10 +27,10 @@ module Maintenance
       pjs = dossier.project_champs_public
         .filter { it.type == "Champs::PieceJustificativeChamp" && it.RIB? == true }
 
-      pjs.each do |pj|
-        if pj.external_data_fetched? && !pj.fetched?
+      pjs.filter(&:idle?).each do |pj|
+        if pj.external_data_fetched?
           pj.external_data_fetched!
-        elsif pj.external_error_present? && !pj.external_error?
+        elsif pj.external_error_present?
           pj.external_data_error!
         end
       end


### PR DESCRIPTION
On évite les changements d'état incohérents en ne traitant que le champs ayant besoin de rattrapage c'est à dire les champs en `idle?`