### PR TITLE
Tech: règle rubocop contre les blocks `it`consécutifs (avec similaire setup)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ require:
   - ./lib/cops/add_concurrent_index.rb
   - ./lib/cops/application_name.rb
   - ./lib/cops/unscoped.rb
+  - ./lib/cops/rspec/consecutive_it_blocks.rb
 
 inherit_mode:
   merge:
@@ -1006,6 +1007,9 @@ Rails/WhereNotWithMultipleConditions:
   Enabled: true
 
 RSpec/Focus:
+  Enabled: true
+
+RSpec/ConsecutiveItBlocks:
   Enabled: true
 
 Security/Eval:

--- a/lib/cops/rspec/consecutive_it_blocks.rb
+++ b/lib/cops/rspec/consecutive_it_blocks.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+if defined?(RuboCop)
+  module RuboCop
+    module Cop
+      module RSpec
+        # This cop detects consecutive `it` blocks in RSpec specs.
+        # Consecutive `it` blocks unnecessarily re-run the entire setup (before, let, etc.)
+        # instead of grouping related assertions in a single block.
+        #
+        # By default (OnlyWithoutDescription: true), only flags consecutive `it` blocks
+        # without descriptions or with empty string descriptions.
+        #
+        # @example OnlyWithoutDescription: true (default)
+        #   # bad - consecutive it blocks without description
+        #   describe 'User' do
+        #     let(:user) { User.create(name: 'John') }
+        #
+        #     it { expect(user.name).to eq('John') }
+        #     it { expect(user).to be_valid }
+        #   end
+        #
+        #   # good - group related assertions
+        #   describe 'User' do
+        #     let(:user) { User.create(name: 'John') }
+        #
+        #     it do
+        #       expect(user.name).to eq('John')
+        #       expect(user).to be_valid
+        #     end
+        #   end
+        #
+        #   # good - it blocks with descriptions are not flagged
+        #   describe 'User' do
+        #     let(:user) { User.create(name: 'John') }
+        #
+        #     it 'has a name' do
+        #       expect(user.name).to eq('John')
+        #     end
+        #
+        #     it 'is valid' do
+        #       expect(user).to be_valid
+        #     end
+        #   end
+        #
+        #   # good - using subject (may have side-effects)
+        #   describe 'User' do
+        #     subject { User.create(name: 'John') }
+        #
+        #     it { expect(subject.name).to eq('John') }
+        #     it { expect(subject).to be_valid }
+        #   end
+        #
+        # @example OnlyWithoutDescription: false
+        #   # bad - consecutive it blocks even with descriptions
+        #   describe 'User' do
+        #     let(:user) { User.create(name: 'John') }
+        #
+        #     it 'has a name' do
+        #       expect(user.name).to eq('John')
+        #     end
+        #
+        #     it 'is valid' do
+        #       expect(user).to be_valid
+        #     end
+        #   end
+        #
+        #   # good - separate with context or describe
+        #   describe 'User' do
+        #     let(:user) { User.create(name: 'John') }
+        #
+        #     it 'has a name' do
+        #       expect(user.name).to eq('John')
+        #     end
+        #
+        #     context 'when validating' do
+        #       it 'is valid' do
+        #         expect(user).to be_valid
+        #       end
+        #     end
+        #   end
+        #
+        # Autocorrection merges consecutive blocks and combines descriptions
+        # when OnlyWithoutDescription is false.
+        class ConsecutiveItBlocks < Base
+          MSG = 'Avoid consecutive `it` blocks. ' \
+                'Group related assertions in a single `it` ' \
+                'or separate them with `context` or `describe`.'
+
+          RESTRICT_ON_SEND = [:it].freeze
+
+          def on_send(node)
+            return unless node.method?(:it)
+            return unless node.block_node
+            return if only_without_description? && has_description?(node)
+            return if has_expect_with_block?(node.block_node)
+
+            next_sibling = find_next_it_sibling(node.parent)
+            return unless next_sibling&.block_type?
+            return unless next_sibling.send_node.method?(:it)
+            return if only_without_description? && has_description?(next_sibling.send_node)
+            return if has_expect_with_block?(next_sibling)
+
+            add_offense(next_sibling.send_node)
+          end
+
+          private
+
+          def only_without_description?
+            cop_config.fetch('OnlyWithoutDescription', true)
+          end
+
+          def has_description?(node)
+            first_arg = node.first_argument
+            return false unless first_arg&.str_type?
+            !first_arg.str_content.empty?
+          end
+
+          def has_expect_with_block?(block_node)
+            return false unless block_node&.body
+
+            # Check for expect { } pattern (expect with a block argument)
+            block_node.each_descendant(:block) do |inner_block|
+              next unless inner_block.send_node&.method?(:expect)
+              return true
+            end
+
+            false
+          end
+
+          def find_next_it_sibling(node)
+            return nil unless node
+
+            siblings = node.parent&.children || []
+            current_index = siblings.index(node)
+            return nil unless current_index
+
+            next_sibling = siblings[current_index + 1]
+            return nil unless next_sibling&.is_a?(RuboCop::AST::Node)
+
+            # Check if there are comments between the two nodes
+            current_end_line = node.last_line
+            next_start_line = next_sibling.first_line
+
+            # If there's more than one line between nodes, check for comments
+            if next_start_line - current_end_line > 1
+              processed_source.comments.any? do |comment|
+                comment_line = comment.location.line
+                comment_line > current_end_line && comment_line < next_start_line
+              end ? nil : next_sibling
+            else
+              next_sibling
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/components/instructeurs/column_filter_value_component_spec.rb
+++ b/spec/components/instructeurs/column_filter_value_component_spec.rb
@@ -37,7 +37,6 @@ describe Instructeurs::ColumnFilterValueComponent, type: :component do
   describe 'the input case' do
     let(:column) { double("Column", column: :value, type: :datetime, mandatory: true) }
 
-    it { puts "page: #{page.text}" }
     it { expect(page).to have_selector('input[name="filter[filter][value][]"][type="date"]', count: 1) }
   end
 
@@ -66,9 +65,8 @@ describe Instructeurs::ColumnFilterValueComponent, type: :component do
         expect(page).to have_selector('input[name="filter[filter][value][]"][type="radio"]', count: 3)
         expect(page).to have_selector('label[for="filter[filter][value][]_true"]', text: 'oui')
         expect(page).to have_selector('label[for="filter[filter][value][]_false"]', text: 'non')
+        expect(page).to have_selector('label[for="filter[filter][value][]_nil"]', text: 'Non renseigné')
       end
-
-      it { expect(page).to have_selector('label[for="filter[filter][value][]_nil"]', text: 'Non renseigné') }
     end
   end
 
@@ -83,8 +81,6 @@ describe Instructeurs::ColumnFilterValueComponent, type: :component do
         expect(page).to have_selector('label[for="filter[filter][value][]_true"]', text: 'coché')
         expect(page).to have_selector('label[for="filter[filter][value][]_false"]', text: 'non coché')
       end
-
-      # it { expect(page).to have_selector('input[name="filter[filter][value][]"][type="checkbox"]') }
     end
 
     context 'when the column is not mandatory' do

--- a/spec/components/simple_format_component_spec.rb
+++ b/spec/components/simple_format_component_spec.rb
@@ -29,8 +29,10 @@ TEXT
       TEXT
     end
 
-    it { expect(page).to have_selector("p", count: 2) }
-    it { text.split("\n").map(&:strip).map { expect(page).to have_text(_1) } }
+    it do
+      expect(page).to have_selector("p", count: 2)
+      text.split("\n").map(&:strip).map { expect(page).to have_text(_1) }
+    end
   end
 
   context 'unordered list items' do

--- a/spec/controllers/administrateurs/mail_templates_controller_spec.rb
+++ b/spec/controllers/administrateurs/mail_templates_controller_spec.rb
@@ -18,8 +18,6 @@ describe Administrateurs::MailTemplatesController, type: :controller do
 
     it '', :slow do
       expect(subject.status).to eq 200
-    end
-    it do
       expect(subject.body).to include("Configuration des emails")
       expect(subject.body).to include(Mails::InitiatedMail::DISPLAYED_NAME)
     end

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -622,12 +622,12 @@ describe Administrateurs::ProceduresController, type: :controller do
           subject { procedure }
 
           it "update attributes" do
-          expect(subject.libelle).to eq(libelle)
-          expect(subject.description).to eq(description)
-          expect(subject.organisation).to eq(organisation)
-          expect(subject.duree_conservation_dossiers_dans_ds).to eq(duree_conservation_dossiers_dans_ds)
-          expect(subject.procedure_expires_when_termine_enabled).to eq(true)
-        end
+            expect(subject.libelle).to eq(libelle)
+            expect(subject.description).to eq(description)
+            expect(subject.organisation).to eq(organisation)
+            expect(subject.duree_conservation_dossiers_dans_ds).to eq(duree_conservation_dossiers_dans_ds)
+            expect(subject.procedure_expires_when_termine_enabled).to eq(true)
+          end
         end
 
         it do

--- a/spec/controllers/api/public/v1/dossiers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/dossiers_controller_spec.rb
@@ -18,24 +18,15 @@ RSpec.describe API::Public::V1::DossiersController, type: :controller do
 
       shared_examples 'the procedure is found' do
         context 'when the dossier can be saved' do
-          it { expect(create_request).to have_http_status(:created) }
-
-          it { expect { create_request }.to change { Dossier.count }.by(1) }
-
-          it "marks the created dossier as prefilled" do
-            create_request
-            expect(Dossier.last.prefilled).to eq(true)
-          end
-
-          it "creates the dossier without a user" do
-            create_request
-            expect(Dossier.last.user).to eq(nil)
-          end
-
-          it "responds with the brouillon dossier url and id" do
-            create_request
+          it "marks the created dossier as prefilled and creates dossier without user" do
+            expect { create_request }.to change { Dossier.count }.by(1)
+            expect(create_request).to have_http_status(:created)
 
             dossier = Dossier.last
+            expect(dossier.prefilled).to eq(true)
+            expect(dossier.user).to eq(nil)
+
+            # responds with the brouillon dossier url and id" do
             dossier_url = "http://test.host#{commencer_path(procedure.path, prefill_token: dossier.prefill_token)}"
             expect(response.parsed_body["dossier_url"]).to eq(dossier_url)
             expect(response.parsed_body["dossier_id"]).to eq(dossier.to_typed_id)
@@ -105,18 +96,20 @@ RSpec.describe API::Public::V1::DossiersController, type: :controller do
             create_request
           end
 
-          it { expect(response).to have_http_status(:bad_request) }
-
-          it { expect(response).to have_failed_with("something went wrong") }
+          it do
+            expect(response).to have_http_status(:bad_request)
+            expect(response).to have_failed_with("something went wrong")
+          end
         end
       end
 
       shared_examples 'the procedure is not found' do
         before { create_request }
 
-        it { expect(response).to have_http_status(:not_found) }
-
-        it { expect(response).to have_failed_with("procedure #{procedure.id} is not found") }
+        it do
+          expect(response).to have_http_status(:not_found)
+          expect(response).to have_failed_with("procedure #{procedure.id} is not found")
+        end
       end
 
       context 'when the procedure is found' do
@@ -154,9 +147,10 @@ RSpec.describe API::Public::V1::DossiersController, type: :controller do
 
       before { create_request }
 
-      it { expect(response).to have_http_status(:bad_request) }
-
-      it { expect(response).to have_failed_with("Content-Type should be json") }
+      it do
+        expect(response).to have_http_status(:bad_request)
+        expect(response).to have_failed_with("Content-Type should be json")
+      end
     end
   end
 

--- a/spec/controllers/api/public/v1/json_description_procedures_controller_spec.rb
+++ b/spec/controllers/api/public/v1/json_description_procedures_controller_spec.rb
@@ -23,17 +23,19 @@ RSpec.describe API::Public::V1::JSONDescriptionProceduresController, type: :cont
           .to_h.dig("data", "demarcheDescriptor").to_json
       end
 
-      it { expect(response).to have_http_status(:success) }
-
-      it { expect(response.body).to eq(expected_response) }
+      it do
+        expect(response).to have_http_status(:success)
+        expect(response.body).to eq(expected_response)
+      end
     end
 
     context "the procedure is not found" do
       let(:params) { { path: "error" } }
 
-      it { expect(response).to have_http_status(:not_found) }
-
-      it { expect(response).to have_failed_with("procedure error is not found") }
+      it do
+        expect(response).to have_http_status(:not_found)
+        expect(response).to have_failed_with("procedure error is not found")
+      end
     end
   end
 end

--- a/spec/controllers/api/public/v1/stats_controller_spec.rb
+++ b/spec/controllers/api/public/v1/stats_controller_spec.rb
@@ -13,9 +13,8 @@ RSpec.describe API::Public::V1::StatsController, type: :controller do
         index_request
       end
 
-      it { expect(response).to be_successful }
-
       it {
+        expect(response).to be_successful
         expect(response.parsed_body).to match({
           funnel: procedure.stats_dossiers_funnel.as_json,
           processed: procedure.stats_termines_states.as_json,
@@ -29,9 +28,10 @@ RSpec.describe API::Public::V1::StatsController, type: :controller do
     shared_examples 'the procedure is not found' do
       before { index_request }
 
-      it { expect(response).to have_http_status(:not_found) }
-
-      it { expect(response).to have_failed_with("procedure #{procedure.id} is not found") }
+      it do
+        expect(response).to have_http_status(:not_found)
+        expect(response).to have_failed_with("procedure #{procedure.id} is not found")
+      end
     end
 
     context 'when the procedure is found' do

--- a/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
@@ -1490,14 +1490,6 @@ describe API::V2::GraphqlController do
 
       it {
         expect(message.discarded?).to be_falsey
-        expect(gql_errors).to be_nil
-        expect(gql_data[:dossierSupprimerMessage][:errors]).to be_nil
-        expect(gql_data[:dossierSupprimerMessage][:message][:id]).to eq(message.to_typed_id)
-        expect(gql_data[:dossierSupprimerMessage][:message][:discardedAt]).not_to be_nil
-        expect(message.reload.discarded?).to be_truthy
-      }
-
-      it {
         expect(dossier_correction.commentaire.discarded?).to be_falsey
         expect(dossier.pending_correction?).to be_truthy
         expect(gql_errors).to be_nil

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -33,12 +33,12 @@ describe ApplicationController, type: :controller do
     end
 
     context 'when no one is logged in' do
-      it do
+      it "configure sentry guest" do
         expect(Sentry).to have_received(:set_user)
           .with({ id: 'Guest' })
       end
 
-      it do
+      it "configure loggable context" do
         [:db_runtime, :view_runtime, :variant, :rendered_format].each do |key|
           payload.delete(key)
         end
@@ -52,12 +52,12 @@ describe ApplicationController, type: :controller do
     context 'when a user is logged in' do
       let(:current_user) { create(:user) }
 
-      it do
+      it "configure sentry user" do
         expect(Sentry).to have_received(:set_user)
           .with({ id: "User##{current_user.id}" })
       end
 
-      it do
+      it "configure loggable context" do
         [:db_runtime, :view_runtime, :variant, :rendered_format].each do |key|
           payload.delete(key)
         end
@@ -75,12 +75,12 @@ describe ApplicationController, type: :controller do
       let(:current_administrateur) { administrateurs(:default_admin) }
       let(:current_super_admin) { create(:super_admin) }
 
-      it do
+      it "configure sentry user" do
         expect(Sentry).to have_received(:set_user)
           .with({ id: "User##{current_user.id}" })
       end
 
-      it do
+      it "configure loggable context" do
         [:db_runtime, :view_runtime, :variant, :rendered_format].each do |key|
           payload.delete(key)
         end

--- a/spec/controllers/france_connect_controller_spec.rb
+++ b/spec/controllers/france_connect_controller_spec.rb
@@ -183,9 +183,10 @@ describe FranceConnectController, type: :controller do
         subject
       end
 
-      it { expect(response).to redirect_to(new_user_session_path) }
-
-      it { expect(flash[:alert]).to be_present }
+      it do
+        expect(response).to redirect_to(new_user_session_path)
+        expect(flash[:alert]).to be_present
+      end
     end
   end
 

--- a/spec/controllers/instructeurs/procedures_controller_spec.rb
+++ b/spec/controllers/instructeurs/procedures_controller_spec.rb
@@ -629,9 +629,10 @@ describe Instructeurs::ProceduresController, type: :controller do
 
           context 'with cookie in past' do
             let(:exports_seen_at) { 1.hour.ago }
-            it { expect(assigns(:has_export_notification)).to be(true) }
-
-            it { expect(response.body).to match(/Un nouvel export est prêt/) }
+            it do
+              expect(assigns(:has_export_notification)).to be(true)
+              expect(response.body).to match(/Un nouvel export est prêt/)
+            end
           end
 
           context 'with cookie set after last generated export' do

--- a/spec/controllers/manager/administrateur_confirmations_controller_spec.rb
+++ b/spec/controllers/manager/administrateur_confirmations_controller_spec.rb
@@ -30,9 +30,10 @@ RSpec.describe Manager::AdministrateurConfirmationsController, type: :controller
     shared_examples "current admin isn't allowed to confirm adding another one" do
       before { new_request }
 
-      it { expect(flash[:alert]).to match(/Veuillez partager ce lien avec un autre super administrateur/) }
-
-      it { expect(response).to redirect_to(manager_procedure_path(procedure)) }
+      it do
+        expect(flash[:alert]).to match(/Veuillez partager ce lien avec un autre super administrateur/)
+        expect(response).to redirect_to(manager_procedure_path(procedure))
+      end
     end
 
     context 'when the current admin is the invited' do
@@ -107,9 +108,10 @@ RSpec.describe Manager::AdministrateurConfirmationsController, type: :controller
     shared_examples "current admin isn't allowed to confirm adding another one" do
       before { create_request }
 
-      it { expect(flash[:alert]).to match(/Veuillez partager ce lien avec un autre super administrateur/) }
-
-      it { expect(response).to redirect_to(manager_procedure_path(procedure)) }
+      it do
+        expect(flash[:alert]).to match(/Veuillez partager ce lien avec un autre super administrateur/)
+        expect(response).to redirect_to(manager_procedure_path(procedure))
+      end
     end
 
     context 'when the current admin is the invited' do

--- a/spec/controllers/manager/confirmation_urls_controller_spec.rb
+++ b/spec/controllers/manager/confirmation_urls_controller_spec.rb
@@ -23,11 +23,11 @@ describe Manager::ConfirmationUrlsController, type: :controller do
 
     before { get :new, params: params }
 
-    it { expect(response).to render_template(:new) }
-
-    it { expect(response.body).to match(/Veuillez partager ce lien/) }
-
     it "shows the confirmation url with encrypted parameters" do
+      expect(response).to render_template(:new)
+
+      expect(response.body).to match(/Veuillez partager ce lien/)
+
       path_base = new_manager_procedure_administrateur_confirmation_path(procedure)
       expect(response.body).to match(
         %r{#{Regexp.escape(path_base)}\?q=\S{30,}}m
@@ -43,9 +43,10 @@ describe Manager::ConfirmationUrlsController, type: :controller do
           }
         end
 
-        it { expect(flash[:alert]).to match(/Cet administrateur n'existe pas/) }
-
-        it { expect(response).to redirect_to(manager_procedure_path(procedure)) }
+        it do
+          expect(flash[:alert]).to match(/Cet administrateur n'existe pas/)
+          expect(response).to redirect_to(manager_procedure_path(procedure))
+        end
       end
 
       context 'when the administrateur has already been added to the procedure' do
@@ -56,9 +57,10 @@ describe Manager::ConfirmationUrlsController, type: :controller do
           }
         end
 
-        it { expect(flash[:alert]).to match(/Cet administrateur a déjà été ajouté/) }
-
-        it { expect(response).to redirect_to(manager_procedure_path(procedure)) }
+        it do
+          expect(flash[:alert]).to match(/Cet administrateur a déjà été ajouté/)
+          expect(response).to redirect_to(manager_procedure_path(procedure))
+        end
       end
     end
   end

--- a/spec/lib/cops/rspec/consecutive_it_blocks_spec.rb
+++ b/spec/lib/cops/rspec/consecutive_it_blocks_spec.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+require 'rubocop/rspec/support'
+require_relative '../../../../lib/cops/rspec/consecutive_it_blocks'
+
+RSpec.describe RuboCop::Cop::RSpec::ConsecutiveItBlocks do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) do
+    RuboCop::Config.new('RSpec/ConsecutiveItBlocks' => {})
+  end
+
+  context 'with OnlyWithoutDescription: true (default)' do
+    it 'registers an offense for consecutive it blocks without description' do
+      expect_offense(<<~RUBY)
+        describe 'User' do
+          it { expect(user.name).to eq('John') }
+          it { expect(user).to be_valid }
+          ^^ Avoid consecutive `it` blocks. Group related assertions in a single `it` or separate them with `context` or `describe`.
+        end
+      RUBY
+    end
+
+    it 'registers an offense for multiple consecutive it blocks' do
+      expect_offense(<<~RUBY)
+        describe 'User' do
+          it { expect(user.name).to eq('John') }
+          it { expect(user).to be_valid }
+          ^^ Avoid consecutive `it` blocks. Group related assertions in a single `it` or separate them with `context` or `describe`.
+          it { expect(user.active?).to be(true) }
+          ^^ Avoid consecutive `it` blocks. Group related assertions in a single `it` or separate them with `context` or `describe`.
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for it blocks with descriptions' do
+      expect_no_offenses(<<~RUBY)
+        describe 'User' do
+          it 'has a name' do
+            expect(user.name).to eq('John')
+          end
+
+          it 'is valid' do
+            expect(user).to be_valid
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for it blocks with expect blocks' do
+      expect_no_offenses(<<~RUBY)
+        describe 'User' do
+          it { expect { user.save }.to change { User.count }.by(1) }
+          it { expect { user.destroy }.to change { User.count }.by(-1) }
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for single it block' do
+      expect_no_offenses(<<~RUBY)
+        describe 'User' do
+          it { expect(user.name).to eq('John') }
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for it blocks separated by context' do
+      expect_no_offenses(<<~RUBY)
+        describe 'User' do
+          it { expect(user.name).to eq('John') }
+
+          context 'when validating' do
+            it { expect(user).to be_valid }
+          end
+        end
+      RUBY
+    end
+
+    it 'detects consecutive multiline it blocks' do
+      expect_offense(<<~RUBY)
+        describe 'User' do
+          it do
+            expect(user.name).to eq('John')
+            expect(user.email).to be_present
+          end
+          it do
+          ^^ Avoid consecutive `it` blocks. Group related assertions in a single `it` or separate them with `context` or `describe`.
+            expect(user).to be_valid
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for it blocks separated by comments' do
+      expect_no_offenses(<<~RUBY)
+        describe 'User' do
+          it { expect(user.name).to eq('John') }
+          # Some comment explaining the next test
+          it { expect(user).to be_valid }
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when it blocks contain expect with blocks' do
+      expect_no_offenses(<<~RUBY)
+        describe 'User' do
+          it { expect { user.save! }.to change { User.count }.by(1) }
+          it { expect { user.update!(name: 'Jane') }.to change { user.name } }
+        end
+      RUBY
+    end
+  end
+
+  context 'with OnlyWithoutDescription: false' do
+    let(:config) do
+      RuboCop::Config.new('RSpec/ConsecutiveItBlocks' => { 'OnlyWithoutDescription' => false })
+    end
+
+    it 'registers an offense for consecutive it blocks with descriptions' do
+      expect_offense(<<~RUBY)
+        describe 'User' do
+          it 'has a name' do
+            expect(user.name).to eq('John')
+          end
+          it 'is valid' do
+          ^^^^^^^^^^^^^ Avoid consecutive `it` blocks. Group related assertions in a single `it` or separate them with `context` or `describe`.
+            expect(user).to be_valid
+          end
+        end
+      RUBY
+    end
+
+    it 'detects multiple consecutive blocks with descriptions' do
+      expect_offense(<<~RUBY)
+        describe 'User' do
+          it 'has a name' do
+            expect(user.name).to eq('John')
+          end
+          it 'has an email' do
+          ^^^^^^^^^^^^^^^^^ Avoid consecutive `it` blocks. Group related assertions in a single `it` or separate them with `context` or `describe`.
+            expect(user.email).to be_present
+          end
+          it 'is valid' do
+          ^^^^^^^^^^^^^ Avoid consecutive `it` blocks. Group related assertions in a single `it` or separate them with `context` or `describe`.
+            expect(user).to be_valid
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for it blocks with expect blocks' do
+      expect_no_offenses(<<~RUBY)
+        describe 'User' do
+          it 'creates a user' do
+            expect { User.create(name: 'John') }.to change { User.count }.by(1)
+          end
+          it 'validates the user' do
+            expect { user.save! }.not_to raise_error
+          end
+        end
+      RUBY
+    end
+
+    it 'detects mixed descriptions and no descriptions' do
+      expect_offense(<<~RUBY)
+        describe 'User' do
+          it 'has a name' do
+            expect(user.name).to eq('John')
+          end
+          it do
+          ^^ Avoid consecutive `it` blocks. Group related assertions in a single `it` or separate them with `context` or `describe`.
+            expect(user).to be_valid
+          end
+        end
+      RUBY
+    end
+  end
+end

--- a/spec/mailers/avis_mailer_spec.rb
+++ b/spec/mailers/avis_mailer_spec.rb
@@ -10,11 +10,16 @@ RSpec.describe AvisMailer, type: :mailer do
 
     subject { described_class.avis_invitation(avis.reload) }
 
-    it { expect(subject.subject).to eq("Donnez votre avis sur le dossier n° #{avis.dossier.id} (#{avis.dossier.procedure.libelle})") }
-    it { expect(subject.body).to have_text("Vous avez été invité par\r\n#{avis.claimant.email}\r\nà donner votre avis sur le dossier n° #{avis.dossier.id} de la démarche :\r\n#{avis.dossier.procedure.libelle}") }
-    it { expect(subject.body).to include(avis.introduction) }
-    it { expect(subject.body).to include(targeted_user_link_url(TargetedUserLink.where(target_model: avis).first)) }
-    it { expect { subject.body }.to change { TargetedUserLink.where(target_model: avis).count }.from(0).to(1) }
+    it do
+      expect(subject.subject).to eq("Donnez votre avis sur le dossier n° #{avis.dossier.id} (#{avis.dossier.procedure.libelle})")
+      expect(subject.body).to have_text("Vous avez été invité par\r\n#{avis.claimant.email}\r\nà donner votre avis sur le dossier n° #{avis.dossier.id} de la démarche :\r\n#{avis.dossier.procedure.libelle}")
+      expect(subject.body).to include(avis.introduction)
+      expect(subject.body).to include(targeted_user_link_url(TargetedUserLink.where(target_model: avis).first))
+    end
+
+    it do
+      expect { subject.body }.to change { TargetedUserLink.where(target_model: avis).count }.from(0).to(1)
+    end
 
     context 'when the dossier has been deleted before the avis was sent' do
       before { dossier.update(hidden_by_user_at: 1.hour.ago) }

--- a/spec/models/attestation_template_spec.rb
+++ b/spec/models/attestation_template_spec.rb
@@ -37,9 +37,7 @@ describe AttestationTemplate, type: :model do
         expect(subject.logo.attachment).not_to eq(attestation_template.logo.attachment)
         expect(subject.logo.blob).to eq(attestation_template.logo.blob)
         expect(subject.logo.attached?).to be_truthy
-      end
 
-      it do
         expect(subject.signature.attachment).not_to eq(attestation_template.signature.attachment)
         expect(subject.signature.blob).to eq(attestation_template.signature.blob)
         expect(subject.signature.attached?).to be_truthy

--- a/spec/models/champs/engagement_juridique_champ_spec.rb
+++ b/spec/models/champs/engagement_juridique_champ_spec.rb
@@ -42,9 +42,8 @@ describe Champs::EngagementJuridiqueChamp do
 
     context 'with *' do
       let(:value) { "*" }
-      it { is_expected.to be_falsey }
-      it '' do
-        subject
+      it do
+        is_expected.to be_falsey
         expect(champ.errors.full_messages_for(:value).first.starts_with?("Le numéro d'EJ")).to be_truthy
       end
     end

--- a/spec/models/concerns/tags_substitution_concern_spec.rb
+++ b/spec/models/concerns/tags_substitution_concern_spec.rb
@@ -585,9 +585,6 @@ describe TagsSubstitutionConcern, type: :model do
       it do
         is_expected.not_to include(include({ libelle: 'motivation' }))
         is_expected.not_to include(include({ libelle: 'date de décision' }))
-      end
-
-      it do
         is_expected.to include(include({ libelle: 'public' }))
         is_expected.to include(include({ libelle: 'privé' }))
       end
@@ -600,9 +597,8 @@ describe TagsSubstitutionConcern, type: :model do
         is_expected.not_to include(include({ libelle: 'motivation' }))
         is_expected.not_to include(include({ libelle: 'date de décision' }))
         is_expected.not_to include(include({ libelle: 'privé' }))
+        is_expected.to include(include({ libelle: 'public' }))
       end
-
-      it { is_expected.to include(include({ libelle: 'public' })) }
     end
 
     context 'when generating document for dossier having conditional' do

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -136,9 +136,10 @@ describe Dossier, type: :model do
     let(:procedure) { create(:procedure, :for_individual) }
     subject(:dossier) { create(:dossier, procedure: procedure) }
 
-    it { is_expected.to validate_presence_of(:individual) }
-
-    it { is_expected.to validate_presence_of(:user) }
+    it 'validates presence of required attributes' do
+      is_expected.to validate_presence_of(:individual)
+      is_expected.to validate_presence_of(:user)
+    end
 
     context 'when dossier has deleted_user_email_never_send' do
       subject(:dossier) { create(:dossier, procedure: procedure, deleted_user_email_never_send: "seb@totoro.org") }
@@ -168,9 +169,7 @@ describe Dossier, type: :model do
       is_expected.to include(expiring_dossier)
       is_expected.to include(just_expired_dossier)
       is_expected.to include(long_expired_dossier)
-    end
 
-    it do
       expect(expiring_dossier.close_to_expiration?).to be_truthy
       expect(expiring_dossier_with_notification.close_to_expiration?).to be_truthy
     end
@@ -183,8 +182,9 @@ describe Dossier, type: :model do
         expiring_dossier_with_notification.reload
       end
 
-      it { is_expected.not_to include(expiring_dossier) }
       it do
+        is_expected.not_to include(expiring_dossier)
+
         expect(expiring_dossier.close_to_expiration?).to be_falsey
         expect(expiring_dossier_with_notification.close_to_expiration?).to be_falsey
 
@@ -219,9 +219,7 @@ describe Dossier, type: :model do
       is_expected.to include(expiring_dossier)
       is_expected.to include(just_expired_dossier)
       is_expected.to include(long_expired_dossier)
-    end
 
-    it do
       expect(expiring_dossier.close_to_expiration?).to be_truthy
       expect(expiring_dossier_with_notification.close_to_expiration?).to be_truthy
     end
@@ -234,8 +232,9 @@ describe Dossier, type: :model do
         expiring_dossier_with_notification.reload
       end
 
-      it { is_expected.not_to include(expiring_dossier) }
       it do
+        is_expected.not_to include(expiring_dossier)
+
         expect(expiring_dossier.close_to_expiration?).to be_falsey
         expect(expiring_dossier_with_notification.close_to_expiration?).to be_falsey
 
@@ -279,9 +278,7 @@ describe Dossier, type: :model do
       is_expected.to include(expiring_dossier)
       is_expected.to include(just_expired_dossier)
       is_expected.to include(long_expired_dossier)
-    end
 
-    it do
       expect(expiring_dossier.close_to_expiration?).to be_truthy
       expect(expiring_dossier_with_notification.close_to_expiration?).to be_truthy
     end
@@ -294,8 +291,9 @@ describe Dossier, type: :model do
         expiring_dossier_with_notification.reload
       end
 
-      it { is_expected.not_to include(expiring_dossier) }
       it do
+        is_expected.not_to include(expiring_dossier)
+
         expect(expiring_dossier.close_to_expiration?).to be_falsey
         expect(expiring_dossier_with_notification.close_to_expiration?).to be_falsey
 
@@ -1443,17 +1441,11 @@ describe Dossier, type: :model do
       expect(operation_serialized['executed_at']).to eq(last_operation.executed_at.iso8601)
     end
 
-    it { expect { passer_en_instruction }.to change { dossier.commentaires.count }.by(1) }
-
-    it "resolve pending correction" do
-      passer_en_instruction
+    it "resolves pending correction and creates commentaire with expected wording" do
+      expect { passer_en_instruction }.to change { dossier.commentaires.count }.by(1)
 
       expect(dossier.pending_correction?).to be_falsey
       expect(correction.reload.resolved_at).to be_present
-    end
-
-    it 'creates a commentaire in the messagerie with expected wording' do
-      passer_en_instruction
 
       email_template = dossier.procedure.email_template_for(dossier.state)
       commentaire = dossier.commentaires.last

--- a/spec/models/instructeur_spec.rb
+++ b/spec/models/instructeur_spec.rb
@@ -347,8 +347,7 @@ describe Instructeur, type: :model do
       it do
         expect(procedure_to_assign.declarative_with_state).to eq("en_instruction")
         expect(dossier.state).to eq("en_instruction")
-      end
-      it do
+
         expect(instructeur.email_notification_data).to eq([
           {
             nb_en_construction: 0,
@@ -373,9 +372,6 @@ describe Instructeur, type: :model do
       it do
         expect(procedure_to_assign.declarative_with_state).to eq("accepte")
         expect(dossier.state).to eq("accepte")
-      end
-
-      it do
         expect(instructeur.email_notification_data).to eq([])
       end
     end
@@ -392,9 +388,6 @@ describe Instructeur, type: :model do
       it do
         expect(procedure_to_assign.declarative_with_state).to eq("accepte")
         expect(dossier.state).to eq("accepte")
-      end
-
-      it do
         expect(instructeur.email_notification_data).to eq([
           {
             nb_en_construction: 0,

--- a/spec/models/logic/eq_spec.rb
+++ b/spec/models/logic/eq_spec.rb
@@ -11,8 +11,9 @@ describe Logic::Eq do
   end
 
   describe '#errors' do
-    it { expect(ds_eq(constant(true), constant(true)).errors).to be_empty }
-    it do
+    it "constants" do
+      expect(ds_eq(constant(true), constant(true)).errors).to be_empty
+
       expected = {
         operator_name: "Logic::Eq",
         right: constant(1),
@@ -22,7 +23,7 @@ describe Logic::Eq do
       expect(ds_eq(constant(true), constant(1)).errors).to eq([expected])
     end
 
-    it do
+    it "multiple drop down" do
       multiple_drop_down = create(:type_de_champ_multiple_drop_down_list)
       first_option = multiple_drop_down.drop_down_options.first
 

--- a/spec/models/logic/exclude_operator_spec.rb
+++ b/spec/models/logic/exclude_operator_spec.rb
@@ -16,8 +16,9 @@ describe Logic::ExcludeOperator do
   end
 
   describe '#errors' do
-    it { expect(ds_exclude(champ_value(champ.stable_id), constant('val1')).errors([champ.type_de_champ])).to be_empty }
-    it do
+    it "constants" do
+      expect(ds_exclude(champ_value(champ.stable_id), constant('val1')).errors([champ.type_de_champ])).to be_empty
+
       expected = {
         right: constant('something else'),
         stable_id: champ.stable_id,
@@ -25,9 +26,9 @@ describe Logic::ExcludeOperator do
       }
 
       expect(ds_exclude(champ_value(champ.stable_id), constant('something else')).errors([champ.type_de_champ])).to eq([expected])
-    end
 
-    it { expect(ds_exclude(constant(1), constant('val1')).errors([])).to eq([{ type: :required_list }]) }
+      expect(ds_exclude(constant(1), constant('val1')).errors([])).to eq([{ type: :required_list }])
+    end
   end
 
   describe '#==' do

--- a/spec/models/logic/include_operator_spec.rb
+++ b/spec/models/logic/include_operator_spec.rb
@@ -16,6 +16,7 @@ describe Logic::IncludeOperator do
   end
 
   describe '#errors' do
+    # rubocop:disable RSpec/ConsecutiveItBlocks
     it { expect(ds_include(champ_value(champ.stable_id), constant('val1')).errors([champ.type_de_champ])).to be_empty }
     it do
       expected = {
@@ -28,6 +29,7 @@ describe Logic::IncludeOperator do
     end
 
     it { expect(ds_include(constant(1), constant('val1')).errors([])).to eq([{ type: :required_list }]) }
+    # rubocop:enable RSpec/ConsecutiveItBlocks
   end
 
   describe '#==' do

--- a/spec/models/logic/not_eq_spec.rb
+++ b/spec/models/logic/not_eq_spec.rb
@@ -11,8 +11,9 @@ describe Logic::NotEq do
   end
 
   describe '#errors' do
-    it { expect(ds_not_eq(constant(true), constant(true)).errors).to be_empty }
-    it do
+    it "constants" do
+      expect(ds_not_eq(constant(true), constant(true)).errors).to be_empty
+
       expected = {
         operator_name: "Logic::NotEq",
         right: constant(1),
@@ -22,7 +23,7 @@ describe Logic::NotEq do
       expect(ds_not_eq(constant(true), constant(1)).errors).to eq([expected])
     end
 
-    it do
+    it "multiple drop down" do
       multiple_drop_down = create(:type_de_champ_multiple_drop_down_list)
       first_option = multiple_drop_down.drop_down_options.first
 

--- a/spec/models/prefill_description_spec.rb
+++ b/spec/models/prefill_description_spec.rb
@@ -23,9 +23,10 @@ RSpec.describe PrefillDescription, type: :model do
 
     subject(:types_de_champ) { prefill_description.types_de_champ }
 
-    it { expect(types_de_champ.count).to eq(1) }
-
-    it { expect(types_de_champ.first).to eql(TypesDeChamp::PrefillTypeDeChamp.build(type_de_champ, procedure.active_revision)) }
+    it do
+      expect(types_de_champ.count).to eq(1)
+      expect(types_de_champ.first).to eql(TypesDeChamp::PrefillTypeDeChamp.build(type_de_champ, procedure.active_revision))
+    end
 
     shared_examples "filters out non fillable types de champ" do |type_de_champ_name|
       context "when the procedure has a #{type_de_champ_name} champ" do

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -52,9 +52,10 @@ describe Procedure do
         subject.save
         subject.reload
       end
-      it { expect(subject.passer_en_construction_email_template.body).to eq('toto') }
-
-      it { expect(Mails::InitiatedMail.count).to eq(1) }
+      it do
+        expect(subject.passer_en_construction_email_template.body).to eq('toto')
+        expect(Mails::InitiatedMail.count).to eq(1)
+      end
     end
   end
 

--- a/spec/models/super_admin_spec.rb
+++ b/spec/models/super_admin_spec.rb
@@ -7,13 +7,11 @@ describe SuperAdmin, type: :model do
 
     subject { super_admin.invite_admin(valid_email) }
 
-    it {
+    it "has no errors" do
       user = subject
       expect(user.errors).to be_empty
       expect(user).to be_persisted
-    }
 
-    it do
       expect(super_admin.invite_admin(nil).errors).not_to be_empty
       expect(super_admin.invite_admin('toto').errors).not_to be_empty
     end

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -127,9 +127,8 @@ describe TypeDeChamp do
 
       before { subject.instance_variable_set(:@dynamic_type, dynamic_type) }
 
-      it { is_expected.to be_invalid }
       it do
-        subject.validate
+        is_expected.to be_invalid
         expect(subject.errors.full_messages.to_sentence).to eq("Le champ « Troll » always invalid")
       end
     end

--- a/spec/models/types_de_champ/linked_drop_down_list_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/linked_drop_down_list_type_de_champ_spec.rb
@@ -31,8 +31,8 @@ describe TypesDeChamp::LinkedDropDownListTypeDeChamp do
 
       context 'invalid menus' do
         shared_examples 'missing primary option' do
-          it { is_expected.to be_invalid }
           it do
+            is_expected.to be_invalid
             subject.validate
             expect(subject.errors.full_messages).to eq ["Le champ « #{subject.libelle} » doit commencer par une entrée de menu primaire de la forme <code style='white-space: pre-wrap;'>--texte--</code>"]
           end
@@ -92,9 +92,8 @@ describe TypesDeChamp::LinkedDropDownListTypeDeChamp do
               'Primary 2' => ['secondary 2.1', 'secondary 2.2', 'secondary 2.3']
             }
           )
+          expect(subject.primary_options).to eq(['Primary 1', 'Primary 2'])
         end
-
-        it { expect(subject.primary_options).to eq(['Primary 1', 'Primary 2']) }
       end
 
       context "not mandatory" do
@@ -107,9 +106,8 @@ describe TypesDeChamp::LinkedDropDownListTypeDeChamp do
               'Primary 2' => ['secondary 2.1', 'secondary 2.2', 'secondary 2.3']
             }
           )
+          expect(subject.primary_options).to eq(['Primary 1', 'Primary 2'])
         end
-
-        it { expect(subject.primary_options).to eq(['Primary 1', 'Primary 2']) }
       end
     end
   end

--- a/spec/models/types_de_champ/prefill_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_type_de_champ_spec.rb
@@ -111,17 +111,19 @@ RSpec.describe TypesDeChamp::PrefillTypeDeChamp, type: :model do
         context 'when there is too many possible values' do
           before { type_de_champ.drop_down_options = (1..described_class::POSSIBLE_VALUES_THRESHOLD + 1).map(&:to_s) }
 
-          it { expect(possible_values).to include(link_to_all_possible_values) }
-
-          it { expect(possible_values).not_to include(built.all_possible_values.to_sentence) }
+          it do
+            expect(possible_values).to include(link_to_all_possible_values)
+            expect(possible_values).not_to include(built.all_possible_values.to_sentence)
+          end
         end
 
         context 'when there is not too many possible values' do
           before { type_de_champ.drop_down_options = (1..described_class::POSSIBLE_VALUES_THRESHOLD - 1).map(&:to_s) }
 
-          it { expect(possible_values).not_to include(link_to_all_possible_values) }
-
-          it { expect(possible_values).to include(built.all_possible_values.to_sentence) }
+          it do
+            expect(possible_values).not_to include(link_to_all_possible_values)
+            expect(possible_values).to include(built.all_possible_values.to_sentence)
+          end
         end
       end
     end

--- a/spec/services/expired/expired_dossiers_deletion_service_spec.rb
+++ b/spec/services/expired/expired_dossiers_deletion_service_spec.rb
@@ -144,9 +144,8 @@ describe Expired::DossiersDeletionService do
       context 'when a notice has been sent a long time ago' do
         let(:notice_sent_at) { (warning_period + 4.days).ago }
 
-        it { expect { dossier.reload }.to raise_error(ActiveRecord::RecordNotFound) }
-
-        it do
+        it "works" do
+          expect { dossier.reload }.to raise_error(ActiveRecord::RecordNotFound)
           expect(DossierMailer).to have_received(:notify_brouillon_deletion).once
           expect(DossierMailer).to have_received(:notify_brouillon_deletion).with([dossier.hash_for_deletion_mail], dossier.user.email)
         end
@@ -159,7 +158,7 @@ describe Expired::DossiersDeletionService do
 
       before { service.delete_expired_brouillons_and_notify }
 
-      it do
+      it "works" do
         expect(DossierMailer).to have_received(:notify_brouillon_deletion).once
         expect(DossierMailer).to have_received(:notify_brouillon_deletion).with(match_array([dossier_1.hash_for_deletion_mail, dossier_2.hash_for_deletion_mail]), user.email)
       end
@@ -182,7 +181,7 @@ describe Expired::DossiersDeletionService do
       context 'when the dossier is not near deletion' do
         let(:en_construction_at) { (conservation_par_defaut - 2.weeks - 1.day).ago }
 
-        it do
+        it "works" do
           expect(dossier.reload.en_construction_close_to_expiration_notice_sent_at).to be_nil
           expect(DossierMailer).not_to have_received(:notify_near_deletion_to_user)
           expect(DossierMailer).not_to have_received(:notify_near_deletion_to_administration)
@@ -192,9 +191,8 @@ describe Expired::DossiersDeletionService do
       context 'when the dossier is near deletion' do
         let(:en_construction_at) { (conservation_par_defaut - 2.weeks + 1.day).ago }
 
-        it { expect(dossier.reload.en_construction_close_to_expiration_notice_sent_at).not_to be_nil }
-
-        it do
+        it "works" do
+          expect(dossier.reload.en_construction_close_to_expiration_notice_sent_at).not_to be_nil
           expect(DossierMailer).to have_received(:notify_near_deletion_to_user).once
           expect(DossierMailer).to have_received(:notify_near_deletion_to_administration).once
           expect(DossierMailer).to have_received(:notify_near_deletion_to_user).with([dossier], dossier.user.email)
@@ -217,9 +215,8 @@ describe Expired::DossiersDeletionService do
         service.send_en_construction_expiration_notices
       end
 
-      it { expect(groupe.reload.instructeurs).to include(instructeur) }
-
       it "sends a notification email to the administration including the admin instructor" do
+        expect(groupe.reload.instructeurs).to include(instructeur)
         expect(DossierMailer)
           .to have_received(:notify_near_deletion_to_administration)
           .with([dossier], admin.user.email)
@@ -254,7 +251,7 @@ describe Expired::DossiersDeletionService do
         service.send_en_construction_expiration_notices
       end
 
-      it do
+      it "works" do
         expect(DossierMailer).to have_received(:notify_near_deletion_to_user).once
         expect(DossierMailer).to have_received(:notify_near_deletion_to_administration).exactly(1).times
         expect(DossierMailer).to have_received(:notify_near_deletion_to_user).with(match_array([dossier_1, dossier_2]), user.email)
@@ -271,7 +268,7 @@ describe Expired::DossiersDeletionService do
         service.send_en_construction_expiration_notices
       end
 
-      it do
+      it "works" do
         expect(DossierMailer).to have_received(:notify_near_deletion_to_user).once
         expect(DossierMailer).to have_received(:notify_near_deletion_to_user).with([dossier], dossier.user.email)
         expect(DossierMailer).to have_received(:notify_near_deletion_to_administration).with([dossier], administrateur.email)
@@ -297,7 +294,7 @@ describe Expired::DossiersDeletionService do
       context 'when no notice has been sent' do
         let(:notice_sent_at) { nil }
 
-        it do
+        it "works" do
           expect { dossier.reload }.not_to raise_error
           expect(DossierMailer).not_to have_received(:notify_automatic_deletion_to_user)
           expect(DossierMailer).not_to have_received(:notify_automatic_deletion_to_administration)
@@ -307,7 +304,7 @@ describe Expired::DossiersDeletionService do
       context 'when a notice has been sent not so long ago' do
         let(:notice_sent_at) { (warning_period - 4.days).ago }
 
-        it do
+        it "works" do
           expect { dossier.reload }.not_to raise_error
           expect(DossierMailer).not_to have_received(:notify_automatic_deletion_to_user)
           expect(DossierMailer).not_to have_received(:notify_automatic_deletion_to_administration)
@@ -317,18 +314,18 @@ describe Expired::DossiersDeletionService do
       context 'when a notice has been sent a long time ago' do
         let(:notice_sent_at) { (warning_period + 4.days).ago }
 
-        it do
+        it "works" do
           expect(DossierMailer).to have_received(:notify_automatic_deletion_to_user).once
           expect(DossierMailer).to have_received(:notify_automatic_deletion_to_user).with([dossier], dossier.user.email)
         end
 
-        it do
+        it "works" do
           expect(DossierMailer).to have_received(:notify_automatic_deletion_to_administration).once
           expect(DossierMailer).not_to have_received(:notify_automatic_deletion_to_administration).with([dossier], dossier.procedure.administrateurs.first.email)
           expect(DossierMailer).to have_received(:notify_automatic_deletion_to_administration).with([dossier], dossier.followers_instructeurs.first.email)
         end
 
-        it do
+        it "works" do
           expect(dossier.reload.hidden_by_user_at).to eq(nil)
           expect(dossier.reload.hidden_by_administration_at).to eq(nil)
           expect(dossier.reload.hidden_by_expired_at).to be_an_instance_of(ActiveSupport::TimeWithZone)
@@ -348,19 +345,19 @@ describe Expired::DossiersDeletionService do
         service.delete_expired_en_construction_and_notify
       end
 
-      it do
+      it "works" do
         expect(DossierMailer).to have_received(:notify_automatic_deletion_to_user).once
         expect(DossierMailer).to have_received(:notify_automatic_deletion_to_user).with(match_array([dossier_1, dossier_2]), user.email)
       end
 
-      it do
+      it "works" do
         expect(DossierMailer).to have_received(:notify_automatic_deletion_to_administration).once
         expect(DossierMailer).to have_received(:notify_automatic_deletion_to_administration).with(match_array([dossier_1, dossier_2]), instructeur.email)
         expect(DossierMailer).not_to have_received(:notify_automatic_deletion_to_administration).with([dossier_1], dossier_1.procedure.administrateurs.first.email)
         expect(DossierMailer).not_to have_received(:notify_automatic_deletion_to_administration).with([dossier_2], dossier_2.procedure.administrateurs.first.email)
       end
 
-      it do
+      it "works" do
         expect(dossier_1.reload.hidden_by_expired_at).to be_an_instance_of(ActiveSupport::TimeWithZone)
         expect(dossier_1.reload.hidden_by_reason).to eq('expired')
         expect(dossier_2.reload.hidden_by_expired_at).to be_an_instance_of(ActiveSupport::TimeWithZone)
@@ -399,9 +396,8 @@ describe Expired::DossiersDeletionService do
       context 'when the dossier is near deletion' do
         let(:processed_at) { (conservation_par_defaut - 2.weeks + 1.day).ago }
 
-        it { expect(dossier.reload.termine_close_to_expiration_notice_sent_at).not_to be_nil }
-
-        it do
+        it "works" do
+          expect(dossier.reload.termine_close_to_expiration_notice_sent_at).not_to be_nil
           expect(DossierMailer).to have_received(:notify_near_deletion_to_user).once
           expect(DossierMailer).to have_received(:notify_near_deletion_to_administration).once
           expect(DossierMailer).to have_received(:notify_near_deletion_to_user).with([dossier], dossier.user.email)
@@ -424,7 +420,7 @@ describe Expired::DossiersDeletionService do
         service.send_termine_expiration_notices
       end
 
-      it do
+      it "works" do
         expect(DossierMailer).to have_received(:notify_near_deletion_to_user).once
         expect(DossierMailer).to have_received(:notify_near_deletion_to_administration).exactly(2).times
         expect(DossierMailer).to have_received(:notify_near_deletion_to_user).with(match_array([dossier_1, dossier_2]), user.email)
@@ -443,7 +439,7 @@ describe Expired::DossiersDeletionService do
         service.send_termine_expiration_notices
       end
 
-      it do
+      it "works" do
         expect(DossierMailer).to have_received(:notify_near_deletion_to_user).once
         expect(DossierMailer).to have_received(:notify_near_deletion_to_user).with([dossier], dossier.user.email)
         expect(DossierMailer).to have_received(:notify_near_deletion_to_administration).with([dossier], administrateur.email)
@@ -473,7 +469,7 @@ describe Expired::DossiersDeletionService do
       context 'when no notice has been sent' do
         let(:notice_sent_at) { nil }
 
-        it do
+        it "works" do
           expect { dossier.reload }.not_to raise_error
           expect(DossierMailer).not_to have_received(:notify_automatic_deletion_to_user)
           expect(DossierMailer).not_to have_received(:notify_automatic_deletion_to_administration)
@@ -483,7 +479,7 @@ describe Expired::DossiersDeletionService do
       context 'when a notice has been sent not so long ago' do
         let(:notice_sent_at) { (warning_period - 4.days).ago }
 
-        it do
+        it "works" do
           expect { dossier.reload }.not_to raise_error
           expect(DossierMailer).not_to have_received(:notify_automatic_deletion_to_user)
           expect(DossierMailer).not_to have_received(:notify_automatic_deletion_to_administration)
@@ -493,17 +489,17 @@ describe Expired::DossiersDeletionService do
       context 'when a notice has been sent a long time ago' do
         let(:notice_sent_at) { (warning_period + 4.days).ago }
 
-        it do
+        it "works" do
           expect(dossier.reload.hidden_by_expired_at).to be_an_instance_of(ActiveSupport::TimeWithZone)
           expect(dossier.reload.hidden_by_reason).to eq('expired')
         end
 
-        it do
+        it "works" do
           expect(DossierMailer).to have_received(:notify_automatic_deletion_to_user).once
           expect(DossierMailer).to have_received(:notify_automatic_deletion_to_user).with([dossier], dossier.user.email)
         end
 
-        it do
+        it "works" do
           expect(DossierMailer).to have_received(:notify_automatic_deletion_to_administration).once
           expect(DossierMailer).not_to have_received(:notify_automatic_deletion_to_administration).with([dossier], dossier.procedure.administrateurs.first.email)
           expect(DossierMailer).to have_received(:notify_automatic_deletion_to_administration).with([dossier], dossier.followers_instructeurs.first.email)
@@ -522,19 +518,19 @@ describe Expired::DossiersDeletionService do
         service.delete_expired_termine_and_notify
       end
 
-      it do
+      it "works" do
         expect(DossierMailer).to have_received(:notify_automatic_deletion_to_user).once
         expect(DossierMailer).to have_received(:notify_automatic_deletion_to_user).with(match_array([dossier_1, dossier_2]), user.email)
       end
 
-      it do
+      it "works" do
         expect(DossierMailer).to have_received(:notify_automatic_deletion_to_administration).once
         expect(DossierMailer).to have_received(:notify_automatic_deletion_to_administration).with(match_array([dossier_1, dossier_2]), instructeur.email)
         expect(DossierMailer).not_to have_received(:notify_automatic_deletion_to_administration).with([dossier_1], dossier_1.procedure.administrateurs.first.email)
         expect(DossierMailer).not_to have_received(:notify_automatic_deletion_to_administration).with([dossier_2], dossier_2.procedure.administrateurs.first.email)
       end
 
-      it do
+      it "works" do
         expect(dossier_1.reload.hidden_by_expired_at).to be_an_instance_of(ActiveSupport::TimeWithZone)
         expect(dossier_1.reload.hidden_by_reason).to eq('expired')
         expect(dossier_2.reload.hidden_by_expired_at).to be_an_instance_of(ActiveSupport::TimeWithZone)
@@ -553,12 +549,12 @@ describe Expired::DossiersDeletionService do
         service.delete_expired_termine_and_notify
       end
 
-      it do
+      it "works" do
         expect(DossierMailer).to have_received(:notify_automatic_deletion_to_user).once
         expect(DossierMailer).to have_received(:notify_automatic_deletion_to_user).with(match_array([dossier_1]), user.email)
       end
 
-      it do
+      it "works" do
         expect(DossierMailer).to have_received(:notify_automatic_deletion_to_administration).once
         expect(DossierMailer).to have_received(:notify_automatic_deletion_to_administration).with(match_array([dossier_2]), instructeur.email)
         expect(DossierMailer).not_to have_received(:notify_automatic_deletion_to_administration).with([dossier_2], dossier_2.procedure.administrateurs.first.email)

--- a/spec/views/prefill_descriptions/_prefillable_entities.html.haml_spec.rb
+++ b/spec/views/prefill_descriptions/_prefillable_entities.html.haml_spec.rb
@@ -9,16 +9,18 @@ describe 'prefill_descriptions/prefillable_entities.html.haml', type: :view do
   context 'when a type de champ has too many values' do
     let(:options) { (1..20).map(&:to_s) }
 
-    it { is_expected.to have_content(type_de_champ.libelle) }
-
-    it { is_expected.to have_link(text: "Voir toutes les valeurs possibles", href: prefill_type_de_champ_path(prefill_description.path, type_de_champ)) }
+    it do
+      is_expected.to have_content(type_de_champ.libelle)
+      is_expected.to have_link(text: "Voir toutes les valeurs possibles", href: prefill_type_de_champ_path(prefill_description.path, type_de_champ))
+    end
   end
 
   context 'when a type de champ does not have too many values' do
     let(:options) { (1..2).map(&:to_s) }
 
-    it { is_expected.to have_content(type_de_champ.libelle) }
-
-    it { is_expected.not_to have_link(text: "Voir toutes les valeurs possibles", href: prefill_type_de_champ_path(prefill_description.path, type_de_champ)) }
+    it do
+      is_expected.to have_content(type_de_champ.libelle)
+      is_expected.not_to have_link(text: "Voir toutes les valeurs possibles", href: prefill_type_de_champ_path(prefill_description.path, type_de_champ))
+    end
   end
 end


### PR DESCRIPTION
Reprise d'un vieux cop que j'avais commencé, mais en amélioration les perfs pour la codebase de DS.

Disclaimer: en grande partie généré par LLM, certainement perfectible, j'ai surtout fait manuellement un controle des tests du cop pour répondre au besoin.
Pas d'autocorrect car galère avec l'indentation.
Il est surtout là pour éviter d'en réintroduire à l'avenir.

Une 50aine d'exemples ont été fusionnés dans le second commit.

## Fonctionnement (cf les exemples et les specs, c'est plus parlant) : 
Les `it` consécutifs, c'est à dire s'exécutant dans le même contexte, doivent être mergés, **sauf dans les situations suivantes** : 
- dans l'exemple, un `expect` est écrit avec la syntaxe `block` (l'expectaction est dépendante du subject ou d'autre chose)
- un `it` contient une description. Ça peut être pratique pour documenter des cas particuliers, et c'est un bon moyen pour désactiver le cop élégamment si nécessaire.
- des commentaires sont écrits entre les `it`. Même remarque.

Il ya une option qui n'est pas encore activée par défaut qui remonte les `it` avec description. On en a des centaines donc on verra si on veut s'en servir plus tard.