### PR TITLE
Fix - assure la cohérence de la valeur secondaire des menus déroulants liés lorsque la valeur primaire est modifiée

### DIFF
--- a/app/components/editable_champ/linked_drop_down_list_component/linked_drop_down_list_component.html.haml
+++ b/app/components/editable_champ/linked_drop_down_list_component/linked_drop_down_list_component.html.haml
@@ -15,6 +15,6 @@
       - if @champ.drop_down_secondary_description.present?
         .fr-hint-text.fr-mb-1w{ id: "#{@champ.describedby_id}-secondary" }
           = render SimpleFormatComponent.new(@champ.drop_down_secondary_description, allow_a: true)
-      = @form.select :secondary_value, @champ.secondary_options[@champ.primary_value], select_options, required: @champ.required?, class: 'fr-select', id: "#{@champ.focusable_input_id}-secondary", aria: { describedby: "#{@champ.describedby_id}-secondary" }, translate: 'no'
+      = @form.select :secondary_value, @champ.secondary_options[@champ.primary_value], select_options, required: @champ.required?, class: 'fr-select', id: "#{@champ.focusable_input_id}-secondary", aria: { describedby: "#{@champ.describedby_id}-secondary" }, translate: 'no', data: { turbo_force: :server }
 - else
   = @form.hidden_field :secondary_value, value: ''

--- a/app/models/champs/linked_drop_down_list_champ.rb
+++ b/app/models/champs/linked_drop_down_list_champ.rb
@@ -23,12 +23,14 @@ class Champs::LinkedDropDownListChamp < Champ
     if value.blank?
       pack_value("", "")
     else
-      pack_value(value, secondary_value)
+      new_secondary_value = secondary_options[value]&.include?(secondary_value) ? secondary_value : ""
+      pack_value(value, new_secondary_value)
     end
   end
 
   def secondary_value=(value)
-    pack_value(primary_value, value)
+    new_secondary_value = secondary_options[primary_value].include?(value) ? value : ""
+    pack_value(primary_value, new_secondary_value)
   end
 
   def main_value_name

--- a/spec/models/champs/linked_drop_down_list_champ_spec.rb
+++ b/spec/models/champs/linked_drop_down_list_champ_spec.rb
@@ -23,15 +23,34 @@ describe Champs::LinkedDropDownListChamp do
   end
 
   describe '#primary_value=' do
-    before { champ.primary_value = '' }
+    let(:options) { ["--1--", "11", "0", "--2--", "22", "0"] }
+    let(:value) { '["", ""]' }
 
     it {
-      champ.primary_value = 'primary'
-      expect(champ.value).to eq('["primary",""]')
-      champ.secondary_value = 'secondary'
-      expect(champ.value).to eq('["primary","secondary"]')
+      champ.primary_value = '1'
+      expect(champ.value).to eq('["1",""]')
+      champ.secondary_value = '11'
+      expect(champ.value).to eq('["1","11"]')
+      champ.primary_value = '2'
+      expect(champ.value).to eq('["2",""]')
+      champ.secondary_value = '0'
+      expect(champ.value).to eq('["2","0"]')
+      champ.primary_value = '1'
+      expect(champ.value).to eq('["1","0"]')
       champ.primary_value = ''
       expect(champ.value).to eq('["",""]')
+    }
+  end
+
+  describe '#secondary_value=' do
+    let(:options) { ["--1--", "11", "0", "--2--", "22", "0"] }
+    let(:value) { '["1", "11"]' }
+
+    it {
+      champ.secondary_value = '0'
+      expect(champ.value).to eq('["1","0"]')
+      champ.secondary_value = '22'
+      expect(champ.value).to eq('["1",""]')
     }
   end
 


### PR DESCRIPTION
Crisp : https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_dec1b127-5839-49aa-9202-0dedc2fd8d9e/

Lorsque l'usager modifie la valeur primaire d'un menu déroulant lié, on laisse en base la valeur secondaire qui avait été donc au préalable choisie "sous" la précédente valeur primaire. Ce qui est tordu c'est que les options dans le select sont bien actualisées, mais si l'usager ne modifie rien en valeur secondaire, on n'enregistre pas en base l'option affichée. Donc l'usager "voit" qu'il dépose une certaine valeur, mais l'instructeur en constate une autre, qui plus est est incohérente avec la valeur primaire.

Il est proposé ici, de regarder si la valeur secondaire est incluse dans les options de la nouvelle valeur primaire, si oui on laisse donc cette valeur secondaire, si non, on réinitialise la valeur secondaire. 

Et je crois bien idem que @mmagn (avec le radio button), faut ajouter un turbo force pour que le "placeholder" se remette bien après la réinitialisation de la valeur secondaire ...