### PR TITLE
ETQ usager, les titres de section >= 2 sont légèrement plus aérés

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -48,7 +48,7 @@
   .section-5,
   .section-6,
   .section-7 {
-    margin-bottom: 1rem;
+    margin-bottom: 1.25rem;
   }
 
   // Keep only bottom margin in nested (consecutive) header sections, ie. first legend for a same level


### PR DESCRIPTION
Cf échanges
https://mattermost.incubateur.net/betagouv/pl/btw3hi75gjdaj866df3nmb8bir

Suite de https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11338/commits/dafbab0ee911c5c246a8819a592f0948619ac55b

on coupe la poire en 2 : c'était 1.5rem jusqu'en février, 1rem maintenant, on passe à 1.25rem. La perception dépend aussi bcp de ce qu'il y a avant/après le titre, et du niveau de titre.
## APRES
<img width="795" height="449" alt="Capture d’écran 2025-10-02 à 16 03 23" src="https://github.com/user-attachments/assets/e55965f2-239e-40a6-9d41-77c83ac45e36" />


## AVANT
<img width="795" height="449" alt="Capture d’écran 2025-10-02 à 16 07 11" src="https://github.com/user-attachments/assets/671476d8-017d-44db-bff5-c0e0e570a468" />

